### PR TITLE
Fix `Push to Master` Changelog entries newline

### DIFF
--- a/src/__tests__/changelog.test.ts
+++ b/src/__tests__/changelog.test.ts
@@ -239,7 +239,7 @@ describe('generateReleaseNotes', () => {
         hash: '1',
         authorName: 'Adam Dierkens',
         authorEmail: 'adam@dierkens.com',
-        subject: 'I was a push to master',
+        subject: 'I was a push to master\n\n',
         labels: ['pushToMaster']
       },
       {

--- a/src/__tests__/release.test.ts
+++ b/src/__tests__/release.test.ts
@@ -432,7 +432,7 @@ describe('Release', () => {
       getGitLog.mockReturnValueOnce(
         await logParse.normalizeCommits([
           makeCommitFromMsg('Feature (#124)'),
-          makeCommitFromMsg('I was rebased', {
+          makeCommitFromMsg('I was rebased\n\n', {
             hash: '1a2b'
           }),
           {


### PR DESCRIPTION
# What Changed

Trim all commit messages for changelog

# Why

changelogs were a little funky

Todo:

- [x] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
