### PR TITLE
Fix docs publishing

### DIFF
--- a/docs/pages/chrome.md
+++ b/docs/pages/chrome.md
@@ -1,6 +1,6 @@
 # Chrome Web Store
 
-This plugin allows you to automate the publishing of chrome extensions.
+This plugin allows you to automate the publishing of chrome extensions
 
 ::: message is-success
 Example Repo: [here](https://github.com/hipstersmoothie/auto-chrome)

--- a/scripts/publish-docs.sh
+++ b/scripts/publish-docs.sh
@@ -2,10 +2,11 @@ chmod +x ./dist/bin/auto.js
 
 export PATH=$(npm bin):$PATH
 
-SHOULD_PUBLISH=`git diff --name-only master | grep -F 'docs/'`
+SHOULD_PUBLISH=`git diff \`git tag --sort version:refname | tail -n 1\` HEAD --name-only | grep -F 'docs/'`
 
-echo $SHOULD_PUBLISH
-
-# if [ ! -z "$SHOULD_PUBLISH" ]; then
-ignite --publish
-# fi
+if [ ! -z "$SHOULD_PUBLISH" ]; then
+  echo $SHOULD_PUBLISH
+  ignite --publish
+else
+  echo No documentation files changed since last tagged release.
+fi


### PR DESCRIPTION
# What Changed

git diff since last tag

# Why

last command was failing because it was comparing master to master

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
