### PR TITLE
Pin parse-commit-message to v4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "is-ci": "^2.0.0",
     "node-fetch": "2.3.0",
     "parse-author": "^2.0.0",
-    "parse-commit-message": "^4.0.0",
+    "parse-commit-message": "4.0.0",
     "parse-github-url": "1.0.2",
     "registry-url": "4.0.0",
     "semver": "^5.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8624,7 +8624,7 @@ parse-bmfont-xml@^1.1.4:
     xml-parse-from-string "^1.0.0"
     xml2js "^0.4.5"
 
-parse-commit-message@^4.0.0:
+parse-commit-message@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse-commit-message/-/parse-commit-message-4.0.0.tgz#e24d53231c720224a96086ac33c8e9e0a3dae557"
   integrity sha512-i06BJjUoGvIGJaiaLKW4WEM9V8+b98dLxxXCmK5mM2egKMnP29kTlweW2uMnwVJjG0v0W7kPGt/K4sSZVlLmvA==


### PR DESCRIPTION
# What Changed

Pinned `parse-commit-message` to v4.0.0

# Why

v4.0.1 is missing its `dist` directory and thus will fail for any global or non-yarn installations. This just pins it temporarily until we can get a better fix.
