### PR TITLE
Split up `publish` hook into `version` and `publish`

### DIFF
--- a/docs/pages/writing-plugins.md
+++ b/docs/pages/writing-plugins.md
@@ -50,7 +50,7 @@ Plugins work by hooking into various actions that `auto` has to do in order to f
 
 ---
 
-#### Main Hooks
+### Main Hooks
 
 #### beforeRun
 
@@ -122,29 +122,6 @@ auto.hooks.getRepository.tapPromise('NPM', async () => {
 });
 ```
 
-#### publish
-
-Publish the package to some package distributor. You must push the tags to github!
-
-```ts
-auto.hooks.publish.tapPromise('NPM', async (version: SEMVER) => {
-  await execPromise('npm', [
-    'version',
-    version,
-    '-m',
-    'Bump version to: %s [skip ci]'
-  ]);
-  await execPromise('npm', ['publish']);
-  await execPromise('git', [
-    'push',
-    '--follow-tags',
-    '--set-upstream',
-    'origin',
-    '$branch'
-  ]);
-});
-```
-
 #### onCreateRelease
 
 Tap into the things the Release class makes. This isn't the same as `auto release`, but the main class that does most of the work.
@@ -176,6 +153,44 @@ This is where you hook into the changelog's hooks. See usage [below](#changelog-
 #### onCreateLogParse
 
 This is where you hook into the LogParse's hooks. See usage [below](#logparse-hooks). This hook is exposed for convenience on during `this.hooks.onCreateRelease` and at the root `this.hooks`
+
+#### version
+
+Version the package. This is a good opportunity to `git tag` the release also. Here `npm` does it for us.
+
+```ts
+auto.hooks.version.tapPromise('NPM', async (version: SEMVER) => {
+  await execPromise('npm', [
+    'version',
+    version,
+    '-m',
+    'Bump version to: %s [skip ci]'
+  ]);
+});
+```
+
+#### publish
+
+Publish the package to some package distributor. You must push the tags to github!
+
+```ts
+auto.hooks.publish.tapPromise('NPM', async (version: SEMVER) => {
+  await execPromise('npm', [
+    'version',
+    version,
+    '-m',
+    'Bump version to: %s [skip ci]'
+  ]);
+  await execPromise('npm', ['publish']);
+  await execPromise('git', [
+    'push',
+    '--follow-tags',
+    '--set-upstream',
+    'origin',
+    '$branch'
+  ]);
+});
+```
 
 ---
 

--- a/src/plugins/npm/__tests__/npm.test.ts
+++ b/src/plugins/npm/__tests__/npm.test.ts
@@ -260,7 +260,7 @@ describe('publish', () => {
       }
     `;
 
-    await hooks.publish.promise(SEMVER.patch);
+    await hooks.version.promise(SEMVER.patch);
     expect(exec).toHaveBeenCalledWith('npm', [
       'version',
       SEMVER.patch,
@@ -284,7 +284,7 @@ describe('publish', () => {
       }
     `;
 
-    await hooks.publish.promise(SEMVER.patch);
+    await hooks.version.promise(SEMVER.patch);
     expect(exec).toHaveBeenCalledWith('npx', [
       'lerna',
       'version',
@@ -292,9 +292,18 @@ describe('publish', () => {
       '--force-publish',
       '--yes',
       '-m',
-      "'%v [skip ci]'"
+      "'Bump version to: %v [skip ci]'"
     ]);
+  });
+  test('monorepo - should publish', async () => {
+    const plugin = new NPMPlugin();
+    const hooks = makeHooks();
 
+    plugin.apply({ hooks, logger: dummyLog() } as Auto);
+
+    existsSync.mockReturnValueOnce(true);
+
+    await hooks.publish.promise(SEMVER.patch);
     expect(exec).toHaveBeenCalledWith('npx', [
       'lerna',
       'publish',
@@ -318,7 +327,7 @@ describe('publish', () => {
       }
     `;
 
-    await hooks.publish.promise(SEMVER.patch);
+    await hooks.version.promise(SEMVER.patch);
     expect(exec).toHaveBeenCalledWith('npm', [
       'version',
       '1.0.1',
@@ -343,7 +352,7 @@ describe('publish', () => {
       }
     `;
 
-    await hooks.publish.promise(SEMVER.patch);
+    await hooks.version.promise(SEMVER.patch);
     expect(exec).toHaveBeenNthCalledWith(2, 'npx', [
       'lerna',
       'version',
@@ -351,13 +360,7 @@ describe('publish', () => {
       '--force-publish',
       '--yes',
       '-m',
-      "'%v [skip ci]'"
-    ]);
-    expect(exec).toHaveBeenNthCalledWith(3, 'npx', [
-      'lerna',
-      'publish',
-      '--yes',
-      'from-git'
+      "'Bump version to: %v [skip ci]'"
     ]);
   });
 

--- a/src/utils/make-hooks.ts
+++ b/src/utils/make-hooks.ts
@@ -1,6 +1,6 @@
 import {
+  AsyncParallelHook,
   AsyncSeriesBailHook,
-  AsyncSeriesHook,
   AsyncSeriesWaterfallHook,
   SyncHook
 } from 'tapable';
@@ -18,7 +18,8 @@ export const makeHooks = (): IAutoHooks => ({
   getAuthor: new AsyncSeriesBailHook([]),
   getPreviousVersion: new AsyncSeriesBailHook(['prefixRelease']),
   getRepository: new AsyncSeriesBailHook([]),
-  publish: new AsyncSeriesHook(['version'])
+  version: new AsyncParallelHook(['version']),
+  publish: new AsyncParallelHook(['publish'])
 });
 
 export const makeReleaseHooks = (): IReleaseHooks => ({


### PR DESCRIPTION
# What Changed

see title

# Why

This will enable plugins that need finer granularity when publishing. related to discussion in #127 

Todo:

- [x] Add tests
- [x] Add docs
