### PR TITLE
afterShipit hook

### DIFF
--- a/src/utils/make-hooks.ts
+++ b/src/utils/make-hooks.ts
@@ -12,6 +12,7 @@ import { IReleaseHooks } from '../release';
 export const makeHooks = (): IAutoHooks => ({
   beforeRun: new SyncHook(['config']),
   beforeShipIt: new SyncHook([]),
+  afterShipIt: new AsyncParallelHook(['version', 'commits']),
   onCreateRelease: new SyncHook(['options']),
   onCreateChangelog: new SyncHook(['changelog']),
   onCreateLogParse: new SyncHook(['logParse']),


### PR DESCRIPTION
# What Changed

see title

# Why

Some plugins might want to do something after shipit has run (released-label)

Todo:

- [ ] Add tests
- [x] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
