### PR TITLE
Released Plugin: lock merged issues

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,7 @@
 - [Plugins](pages/plugins.md)
   - [Writing Plugins](pages/writing-plugins.md)
   - [Chrome Web Store](pages/chrome.md)
+  - [Released](pages/released.md)
 - [Troubleshooting](pages/troubleshooting.md)
 
 ---

--- a/docs/pages/released.md
+++ b/docs/pages/released.md
@@ -43,7 +43,7 @@ Customize the label this plugin attaches to merged pull requests.
 
 To customize the message this plugin uses on issues and pull requests use the following format.
 
-- `%TYPE` - Either `PR` or `Issu`
+- `%TYPE` - Either `PR` or `Issue`
 - `%VERSION` - The version that was just published
 
 ```json
@@ -56,5 +56,15 @@ To customize the message this plugin uses on issues and pull requests use the fo
       }
     ]
   ]
+}
+```
+
+### Lock Issue
+
+Lock issues that have been merged in PRs.
+
+```json
+{
+  "plugins": [["released", { "lockIssues": true }]]
 }
 ```

--- a/src/__tests__/git.test.ts
+++ b/src/__tests__/git.test.ts
@@ -18,6 +18,7 @@ const issuesAndPullRequests = jest.fn();
 const createLabel = jest.fn();
 const addLabels = jest.fn();
 const list = jest.fn();
+const lock = jest.fn();
 
 jest.mock('@octokit/rest', () => () => ({
   authenticate,
@@ -33,7 +34,8 @@ jest.mock('@octokit/rest', () => () => ({
     deleteComment,
     listLabelsForRepo,
     createLabel,
-    addLabels
+    addLabels,
+    lock
   },
   repos: {
     createStatus,
@@ -120,6 +122,12 @@ describe('github', () => {
     const gh = new Git(options);
     await gh.addLabelToPr(123, 'foo bar');
     expect(addLabels).toHaveBeenCalled();
+  });
+
+  test('lockIssue ', async () => {
+    const gh = new Git(options);
+    await gh.lockIssue(123);
+    expect(lock).toHaveBeenCalled();
   });
 
   test('getCommitDate ', async () => {

--- a/src/git.ts
+++ b/src/git.ts
@@ -290,6 +290,21 @@ export default class Git {
     return result;
   }
 
+  async lockIssue(issue: number) {
+    this.logger.verbose.info(`Locking #${issue} issue...`);
+
+    const result = await this.ghub.issues.lock({
+      number: issue,
+      owner: this.options.owner,
+      repo: this.options.repo
+    });
+
+    this.logger.veryVerbose.info('Got response from lock\n', result);
+    this.logger.verbose.info('Locked issue.');
+
+    return result;
+  }
+
   @Memoize()
   async getProject() {
     this.logger.verbose.info('Getting project from GitHub');

--- a/src/plugins/released/index.ts
+++ b/src/plugins/released/index.ts
@@ -5,12 +5,14 @@ import { Auto, IPlugin } from '../../main';
 interface IReleasedLabelPluginOptions {
   message: string;
   label: string;
+  lockIssues: boolean;
 }
 
 const TYPE = '%TYPE';
 const VERSION = '%VERSION';
 const defaultOptions = {
   label: 'released',
+  lockIssues: false,
   message: `:rocket: ${TYPE} was released in ${VERSION} :rocket:`
 };
 
@@ -85,6 +87,10 @@ export default class ReleasedLabelPlugin implements IPlugin {
       issues.map(async issue => {
         // comment on issues closed with PR with new version
         await auto.git!.createComment(prComment, issue, 'released');
+
+        if (this.options.lockIssues) {
+          await auto.git!.lockIssue(issue);
+        }
       })
     );
   }


### PR DESCRIPTION
# What Changed

see title

# Why

it's handy

Todo:

- [x] Add tests
- [x] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
