### PR TITLE
Released plugin: add released label to issue too

### DIFF
--- a/docs/pages/released.md
+++ b/docs/pages/released.md
@@ -5,6 +5,7 @@ This plugin
 - comments on the merged PR with the new version
 - comments on closed issues with the new version
 - adds a `released` label to the pull request
+- adds a `released` label to closed issues
 
 ::: message is-warning
 Make sure that you create the `released` label on you project


### PR DESCRIPTION
# What Changed

see title

# Why

it makes sense

Todo:

- [x] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
