### PR TITLE
Add clarity to a few of the docs

### DIFF
--- a/docs/pages/autorc.md
+++ b/docs/pages/autorc.md
@@ -31,6 +31,24 @@ Auto can load `extends` configs in the following ways:
 - from a scoped package `@YOUR_SCOPE/auto-config`
 - from a package `auto-config-YOUR_NAME`
 
+```json
+{
+  "extends": "@YOUR_SCOPE"
+}
+```
+
+Will use the package `@YOUR_SCOPE/auto-config`
+
+```json
+{
+  "extends": "joe"
+}
+```
+
+Will use the package `auto-config-joe`
+
+::: message is-warning If extending from a config package make sure it's a dependency of your project :::
+
 ### Labels
 
 To override any of the default labels use the `labels` seciton in the `.autorc`.

--- a/docs/pages/plugins.md
+++ b/docs/pages/plugins.md
@@ -17,7 +17,7 @@ There are three ways to load a plugin.
 
 ### 1. Official Plugins
 
-To use an official plugin all you have to do is supply the name. Currently the only supported plugin is the `npm` plugin.
+To use an official plugin all you have to do is supply the name.
 
 ```sh
 auto shipit --plugins npm

--- a/docs/pages/plugins.md
+++ b/docs/pages/plugins.md
@@ -11,7 +11,7 @@ Current official plugins:
 
 ## Using Plugins
 
-To use a plugin you can either supply the plugin via a CLI arg or in your [.autorc](./autorc.md#plugins).
+To use a plugin you can either supply the plugin via a CLI arg or in your [.autorc](./autorc.md#plugins). Specifying a plugin overrides the defaults.
 
 There are three ways to load a plugin.
 
@@ -25,7 +25,7 @@ auto shipit --plugins npm
 
 ### 2. `npm` package
 
-If you are using a plugin distributed on `npm` simply supply the name.
+If you are using a plugin distributed on `npm` simply supply the name. Ensure that the plugin is added as a dependency of your project. 
 
 ```sh
 auto shipit --plugins NPM_PACKAGE_NAME

--- a/docs/pages/released.md
+++ b/docs/pages/released.md
@@ -17,7 +17,7 @@ To use the plugin include it in your `.autorc`
 
 ```json
 {
-  "plugins": ["released"]
+  "plugins": ["npm", "released"]
 }
 ```
 
@@ -30,6 +30,7 @@ Customize the label this plugin attaches to merged pull requests.
 ```json
 {
   "plugins": [
+    "npm",
     [
       "released",
       {
@@ -50,6 +51,7 @@ To customize the message this plugin uses on issues and pull requests use the fo
 ```json
 {
   "plugins": [
+    "npm",
     [
       "released",
       {
@@ -66,6 +68,6 @@ Lock issues that have been merged in PRs.
 
 ```json
 {
-  "plugins": [["released", { "lockIssues": true }]]
+  "plugins": ["npm", ["released", { "lockIssues": true }]]
 }
 ```


### PR DESCRIPTION
# What Changed

Doc updates

# Why

House keeping

---

I think while I'm here we could potentially add some more clarification around behavior. Here's general questions I had while reading through the plugin docs...

1. If you specify a plugin, does that clear out the default plugin? i.e. if I want to use `release` do I have to add `npm` as well so I don't lose that?
2. For the [npm package plugin](https://intuit.github.io/auto/pages/plugins.html#2.-npm-package), is it required that said plugin be installed as a dependency of the project? That same question probably extends to extensions. Pretty sure that _do_ have to be dependencies.
