### PR TITLE
release plugin: do nothing when skip-release present

### DIFF
--- a/src/plugins/released/__tests__/released-label.test.ts
+++ b/src/plugins/released/__tests__/released-label.test.ts
@@ -55,6 +55,45 @@ describe('release label plugin', () => {
     expect(git.createComment).not.toHaveBeenCalled();
   });
 
+  test('should do nothing without commits', async () => {
+    const releasedLabel = new ReleasedLabelPlugin();
+    const autoHooks = makeHooks();
+    releasedLabel.apply({
+      hooks: autoHooks,
+      labels: defaultLabelDefinition,
+      logger: dummyLog(),
+      git
+    } as Auto);
+
+    await autoHooks.afterShipIt.promise('1.0.0', []);
+
+    expect(git.createComment).not.toHaveBeenCalled();
+  });
+
+  test('should do nothing with skip release label', async () => {
+    const releasedLabel = new ReleasedLabelPlugin();
+    const autoHooks = makeHooks();
+    releasedLabel.apply({
+      hooks: autoHooks,
+      labels: defaultLabelDefinition,
+      release: {
+        options: { skipReleaseLabels: ['skip-release'] }
+      },
+      logger: dummyLog(),
+      git
+    } as Auto);
+
+    const commit = makeCommitFromMsg('normal commit with no bump (#123)', {
+      labels: ['skip-release']
+    });
+    await autoHooks.afterShipIt.promise(
+      '1.0.0',
+      await log.normalizeCommits([commit])
+    );
+
+    expect(git.createComment).not.toHaveBeenCalled();
+  });
+
   test('should comment and label PRs', async () => {
     const releasedLabel = new ReleasedLabelPlugin();
     const autoHooks = makeHooks();

--- a/src/plugins/released/index.ts
+++ b/src/plugins/released/index.ts
@@ -35,6 +35,20 @@ export default class ReleasedLabelPlugin implements IPlugin {
           return;
         }
 
+        const head = commits[0];
+
+        if (!head) {
+          return;
+        }
+
+        const isSkipped = head.labels.find(label =>
+          auto.release!.options.skipReleaseLabels.includes(label)
+        );
+
+        if (isSkipped) {
+          return;
+        }
+
         await Promise.all(
           commits.map(async commit =>
             this.addReleased(auto, commit, newVersion)


### PR DESCRIPTION
# What Changed

dont post comments when skip-release

# Why

closes #258 

Todo:

- [x] Add tests
