### PR TITLE
load extends config from path

### DIFF
--- a/src/__tests__/__snapshots__/auto.test.ts.snap
+++ b/src/__tests__/__snapshots__/auto.test.ts.snap
@@ -109,3 +109,57 @@ Object {
   "token": "XXXX",
 }
 `;
+
+exports[`Auto should extend local config 1`] = `
+Object {
+  "command": "init",
+  "extends": "./fake.json",
+  "labels": Object {
+    "documentation": Object {
+      "description": "Changes only affect the documentation",
+      "name": "documentation",
+      "title": "📝  Documentation",
+    },
+    "internal": Object {
+      "description": "Changes only affect the internal API",
+      "name": "internal",
+      "title": "🏠  Internal",
+    },
+    "major": Object {
+      "description": "Increment the major version when merged",
+      "name": "major",
+      "title": "💥  Breaking Change",
+    },
+    "minor": Object {
+      "description": "Increment the minor version when merged",
+      "name": "minor",
+      "title": "🚀  Enhancement",
+    },
+    "patch": Object {
+      "description": "Increment the patch version when merged",
+      "name": "patch",
+      "title": "🐛  Bug Fix",
+    },
+    "prerelease": Object {
+      "description": "Create a pre-release version when merged",
+      "name": "prerelease",
+      "title": "🚧 Prerelease",
+    },
+    "release": Object {
+      "description": "Create a release when this pr is merged",
+      "name": "release",
+    },
+    "skip-release": Object {
+      "description": "Preserve the current version when merged",
+      "name": "skip-release",
+    },
+  },
+  "owner": "foo",
+  "repo": "bar",
+  "skipReleaseLabels": Array [
+    "skip-release",
+  ],
+  "slack": "foo",
+  "token": "XXXX",
+}
+`;

--- a/src/__tests__/auto.test.ts
+++ b/src/__tests__/auto.test.ts
@@ -27,6 +27,15 @@ jest.mock(
   { virtual: true }
 );
 
+process.cwd = () => '/foo/';
+jest.mock(
+  '/foo/fake.json',
+  () => ({
+    slack: 'foo'
+  }),
+  { virtual: true }
+);
+
 jest.mock(
   '../fake/path.js',
   () => () => ({
@@ -89,6 +98,15 @@ describe('Auto', () => {
 
   test('should extend config', async () => {
     search.mockReturnValueOnce({ config: { ...defaults, extends: '@artsy' } });
+    const auto = new Auto({ command: 'init' });
+    await auto.loadConfig();
+    expect(auto.release!.options).toMatchSnapshot();
+  });
+
+  test.only('should extend local config', async () => {
+    search.mockReturnValueOnce({
+      config: { ...defaults, extends: './fake.json' }
+    });
     const auto = new Auto({ command: 'init' });
     await auto.loadConfig();
     expect(auto.release!.options).toMatchSnapshot();

--- a/src/auto.ts
+++ b/src/auto.ts
@@ -2,6 +2,7 @@ import cosmiconfig from 'cosmiconfig';
 import merge from 'deepmerge';
 import env from 'dotenv';
 import isCI from 'is-ci';
+import * as path from 'path';
 import { gt, inc, ReleaseType } from 'semver';
 import { AsyncParallelHook, AsyncSeriesBailHook, SyncHook } from 'tapable';
 
@@ -126,6 +127,10 @@ export default class Auto {
       const scope = `auto-config-${extend}`;
       config = tryRequire(scope);
       this.logger.verbose.note(`${scope} found: ${config}`);
+    }
+
+    if (!config) {
+      config = tryRequire(path.join(process.cwd(), extend));
     }
 
     if (typeof config === 'function') {


### PR DESCRIPTION
# Why

fall back to requiring from the current directory

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
