### PR TITLE
Plugins and Configs: import from CWD

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "dependencies": {
     "@hutson/set-npm-auth-token-for-ci": "^3.0.2",
     "@octokit/rest": "^16.13.1",
-    "@types/tinycolor2": "^1.4.1",
     "chalk": "^2.4.2",
     "chrome-webstore-upload-cli": "^1.2.0",
     "command-line-args": "^5.0.2",
@@ -50,6 +49,7 @@
     "enquirer": "^2.3.0",
     "get-monorepo-packages": "^1.1.0",
     "gitlog": "^3.1.2",
+    "import-cwd": "^2.1.0",
     "is-ci": "^2.0.0",
     "node-fetch": "2.3.0",
     "parse-author": "^2.0.0",
@@ -76,6 +76,7 @@
     "@types/parse-github-url": "1.0.0",
     "@types/semver": "^5.5.0",
     "@types/signale": "^1.2.0",
+    "@types/tinycolor2": "^1.4.1",
     "@types/url-join": "^4.0.0",
     "all-contributors-cli": "^5.10.2",
     "husky": "^1.3.1",

--- a/src/types/import-cwd.d.ts
+++ b/src/types/import-cwd.d.ts
@@ -1,0 +1,4 @@
+declare module 'import-cwd' {
+  function importCwd(path: string): any;
+  export = importCwd;
+}

--- a/src/utils/__tests__/load-plugin.test.ts
+++ b/src/utils/__tests__/load-plugin.test.ts
@@ -12,8 +12,10 @@ describe('loadPlugins', () => {
     expect(loadPlugin(['npm', {}], logger)).toEqual({ name: 'NPM' });
   });
 
-  test('should require custom plugins', async () => {
-    expect(loadPlugin(['./__tests__/test-plugin.ts', {}], logger)).toEqual({
+  test('should require custom plugins -- fallback to cwd', async () => {
+    expect(
+      loadPlugin(['./src/utils/__tests__/test-plugin.ts', {}], logger)
+    ).toEqual({
       name: 'foo',
       config: {}
     });
@@ -21,19 +23,13 @@ describe('loadPlugins', () => {
 
   test('should load config', async () => {
     expect(
-      loadPlugin(['./__tests__/test-plugin.ts', 'do the thing'], logger)
+      loadPlugin(
+        ['./src/utils/__tests__/test-plugin.ts', 'do the thing'],
+        logger
+      )
     ).toEqual({
       name: 'foo',
       config: 'do the thing'
-    });
-  });
-
-  test('should require custom plugins -- fallback to cwd', async () => {
-    expect(
-      loadPlugin(['./src/utils/__tests__/test-plugin.ts', {}], logger)
-    ).toEqual({
-      name: 'foo',
-      config: {}
     });
   });
 });

--- a/src/utils/try-require.ts
+++ b/src/utils/try-require.ts
@@ -1,6 +1,8 @@
+import importCwd from 'import-cwd';
+
 export default function tryRequire(tryPath: string) {
   try {
-    return require(tryPath);
+    return importCwd(tryPath);
   } catch (error) {
     return;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5673,7 +5673,7 @@ imagemin@^5.3.1:
     pify "^2.3.0"
     replace-ext "^1.0.0"
 
-import-cwd@^2.0.0:
+import-cwd@^2.0.0, import-cwd@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-2.1.0.tgz#aa6cf36e722761285cb371ec6519f53e2435b0a9"
   integrity sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=


### PR DESCRIPTION
# What Changed

Require from the cwd rather than where `auto` is installed. 

# Why

For `extends` configs and plugins it makes sense to import from the project's directory. This allows `npx` to run with configs/plugins installed to a project.

Todo:

- [x] Add tests
