### PR TITLE
afterRelease hook

### DIFF
--- a/docs/pages/writing-plugins.md
+++ b/docs/pages/writing-plugins.md
@@ -76,6 +76,23 @@ auto.hooks.beforeRun.tapPromise('NPM', async config => {
 });
 ```
 
+#### afterRelease
+
+Ran after the `release` command has run. This hooks gets the following arguments:
+
+- version - version that was just released
+- commits - the commits in the release
+
+```ts
+auto.hooks.afterRelease.tap('MyPlugin', async (version, commits) => {
+  // do something
+});
+```
+
+#### afterShipIt
+
+Ran after the `shipit` command has run.
+
 #### getAuthor
 
 Get git author. Typically from a package distribution description file.

--- a/src/auto.ts
+++ b/src/auto.ts
@@ -56,6 +56,7 @@ export interface IAutoHooks {
   beforeRun: SyncHook<[IReleaseOptions]>;
   beforeShipIt: SyncHook<[]>;
   afterShipIt: AsyncParallelHook<[string | undefined, IExtendedCommit[]]>;
+  afterRelease: AsyncParallelHook<[string | undefined, IExtendedCommit[]]>;
   getAuthor: AsyncSeriesBailHook<[], IAuthor | void>;
   getPreviousVersion: AsyncSeriesBailHook<
     [(release: string) => string],
@@ -618,6 +619,9 @@ export default class Auto {
 
     this.logger.log.info('Last used release:', lastRelease);
 
+    const commitsInRelease = await this.release.getCommitsInRelease(
+      lastRelease
+    );
     const releaseNotes = await this.release.generateReleaseNotes(lastRelease);
 
     this.logger.log.info(`Using release notes:\n${releaseNotes}`);
@@ -642,6 +646,8 @@ export default class Auto {
     } else {
       this.logger.verbose.info('Release dry run complete.');
     }
+
+    await this.hooks.afterRelease.promise(prefixed, commitsInRelease);
 
     return prefixed;
   }

--- a/src/plugins/released/__tests__/released-label.test.ts
+++ b/src/plugins/released/__tests__/released-label.test.ts
@@ -34,7 +34,7 @@ describe('release label plugin', () => {
     } as Auto);
 
     const commit = makeCommitFromMsg('normal commit with no bump');
-    await autoHooks.afterShipIt.promise('1.0.0', [commit]);
+    await autoHooks.afterRelease.promise('1.0.0', [commit]);
 
     expect(git.createComment).not.toHaveBeenCalled();
   });
@@ -50,7 +50,7 @@ describe('release label plugin', () => {
     } as Auto);
 
     const commit = makeCommitFromMsg('normal commit with no bump');
-    await autoHooks.afterShipIt.promise(undefined, [commit]);
+    await autoHooks.afterRelease.promise(undefined, [commit]);
 
     expect(git.createComment).not.toHaveBeenCalled();
   });
@@ -65,7 +65,7 @@ describe('release label plugin', () => {
       git
     } as Auto);
 
-    await autoHooks.afterShipIt.promise('1.0.0', []);
+    await autoHooks.afterRelease.promise('1.0.0', []);
 
     expect(git.createComment).not.toHaveBeenCalled();
   });
@@ -86,7 +86,7 @@ describe('release label plugin', () => {
     const commit = makeCommitFromMsg('normal commit with no bump (#123)', {
       labels: ['skip-release']
     });
-    await autoHooks.afterShipIt.promise(
+    await autoHooks.afterRelease.promise(
       '1.0.0',
       await log.normalizeCommits([commit])
     );
@@ -105,7 +105,7 @@ describe('release label plugin', () => {
     } as Auto);
 
     const commit = makeCommitFromMsg('normal commit with no bump (#123)');
-    await autoHooks.afterShipIt.promise(
+    await autoHooks.afterRelease.promise(
       '1.0.0',
       await log.normalizeCommits([commit])
     );
@@ -134,7 +134,7 @@ describe('release label plugin', () => {
     const commit = makeCommitFromMsg(
       'normal commit with no bump closes (#123)'
     );
-    await autoHooks.afterShipIt.promise(
+    await autoHooks.afterRelease.promise(
       '1.0.0',
       await log.normalizeCommits([commit])
     );

--- a/src/plugins/released/index.ts
+++ b/src/plugins/released/index.ts
@@ -28,7 +28,7 @@ export default class ReleasedLabelPlugin implements IPlugin {
   }
 
   apply(auto: Auto) {
-    auto.hooks.afterShipIt.tapPromise(
+    auto.hooks.afterRelease.tapPromise(
       this.name,
       async (newVersion, commits) => {
         if (!newVersion) {

--- a/src/utils/make-hooks.ts
+++ b/src/utils/make-hooks.ts
@@ -13,6 +13,7 @@ export const makeHooks = (): IAutoHooks => ({
   beforeRun: new SyncHook(['config']),
   beforeShipIt: new SyncHook([]),
   afterShipIt: new AsyncParallelHook(['version', 'commits']),
+  afterRelease: new AsyncParallelHook(['version', 'commits']),
   onCreateRelease: new SyncHook(['options']),
   onCreateChangelog: new SyncHook(['changelog']),
   onCreateLogParse: new SyncHook(['logParse']),


### PR DESCRIPTION
# What Changed

Add an `afterRelease` hook and move over `released` plugin to using it.

# Why

`afterShipit` only runs after `shipit`. Users might be using atomic commands so it should work with just `auto release` too

Todo:

- [x] Add docs

