### PR TITLE
Custom labels still resolve changelog titles

### DIFF
--- a/src/__tests__/__snapshots__/changelog.test.ts.snap
+++ b/src/__tests__/__snapshots__/changelog.test.ts.snap
@@ -33,6 +33,16 @@ exports[`generateReleaseNotes should be able to customize "Push To Master" title
 - Adam Dierkens (adam@dierkens.com)"
 `;
 
+exports[`generateReleaseNotes should be able to customize titles 1`] = `
+"#### Woo Woo New Features
+
+- First Feature [#1235](https://github.custom.com/foobar/auto/pull/1235) (adam@dierkens.com)
+
+#### Authors: 1
+
+- Adam Dierkens (adam@dierkens.com)"
+`;
+
 exports[`generateReleaseNotes should combine pr w/no label and labelled pr 1`] = `
 "#### 🐛  Bug Fix
 

--- a/src/__tests__/changelog.test.ts
+++ b/src/__tests__/changelog.test.ts
@@ -281,4 +281,28 @@ describe('generateReleaseNotes', () => {
 
     expect(await changelog.generateReleaseNotes(commits)).toMatchSnapshot();
   });
+
+  test('should be able to customize titles', async () => {
+    const options = testOptions();
+    options.labels.minor = {
+      name: 'Version: Minor',
+      title: 'Woo Woo New Features',
+      description: 'N/A'
+    };
+
+    const changelog = new Changelog(dummyLog(), testOptions());
+    changelog.loadDefaultHooks();
+
+    const commits = await logParse.normalizeCommits([
+      {
+        hash: '2',
+        authorName: 'Adam Dierkens',
+        authorEmail: 'adam@dierkens.com',
+        subject: 'First Feature (#1235)',
+        labels: ['Version: Minor']
+      }
+    ]);
+
+    expect(await changelog.generateReleaseNotes(commits)).toMatchSnapshot();
+  });
 });

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -242,9 +242,9 @@ export default class Changelog {
     sections: string[]
   ) {
     const changelogTitles = Object.entries(this.options.labels).reduce(
-      (titles, [label, labelDef]) => {
+      (titles, [, labelDef]) => {
         if (labelDef.title) {
-          titles[label] = labelDef.title;
+          titles[labelDef.name] = labelDef.title;
         }
 
         return titles;


### PR DESCRIPTION
# What Changed

When using custom versioning labels the changelog titles broke

# Why

closes #268

Todo:

- [x] Add tests
