### PR TITLE
can't warn here or else `version` will fail

### DIFF
--- a/src/plugins/npm/index.ts
+++ b/src/plugins/npm/index.ts
@@ -155,12 +155,6 @@ export default class NPMPlugin implements IPlugin {
   name = 'NPM';
 
   apply(auto: Auto) {
-    auto.hooks.beforeRun.tap(this.name, async () => {
-      if (!process.env.NPM_TOKEN) {
-        auto.logger.log.warn('NPM Token is needed for the NPM plugin!');
-      }
-    });
-
     auto.hooks.beforeShipIt.tap(this.name, async () => {
       if (!isCI) {
         return;


### PR DESCRIPTION
# What Changed

see title

# Why

breaks `npm version` unnecessarily 


