### PR TITLE
released plugin respects dry run flag

### DIFF
--- a/src/plugins/released/index.ts
+++ b/src/plugins/released/index.ts
@@ -1,4 +1,5 @@
 import merge from 'deepmerge';
+import { IReleaseCommandOptions } from '../../cli/args';
 import { IExtendedCommit } from '../../log-parse';
 import { Auto, IPlugin } from '../../main';
 
@@ -41,6 +42,10 @@ export default class ReleasedLabelPlugin implements IPlugin {
       this.name,
       async (newVersion, commits) => {
         if (!newVersion) {
+          return;
+        }
+
+        if ((auto.args as IReleaseCommandOptions).dryRun) {
           return;
         }
 


### PR DESCRIPTION
# What Changed

check args in released plugin for dryRun flag

# Why

the released plugin would run even when the dry run flag was present. Lots of unwanted comments!

Todo:

- [x] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
