### PR TITLE
check if released label has already been added

### DIFF
--- a/src/plugins/released/__tests__/released-label.test.ts
+++ b/src/plugins/released/__tests__/released-label.test.ts
@@ -9,19 +9,29 @@ import { makeHooks } from '../../../utils/make-hooks';
 
 const git = new Git({ owner: '1', repo: '2' });
 const log = new LogParse();
+
 const createComment = jest.fn();
 git.createComment = createComment;
-git.addLabelToPr = jest.fn();
+
+const addLabelToPr = jest.fn();
+git.addLabelToPr = addLabelToPr;
+
 const getPr = jest.fn();
 git.getPullRequest = getPr;
 getPr.mockReturnValue({ data: { body: '' } });
+
 const commits = jest.fn();
 git.getCommitsForPR = commits;
 commits.mockReturnValue([]);
 
+const getLabels = jest.fn();
+git.getLabels = getLabels;
+getLabels.mockReturnValue([]);
+
 describe('release label plugin', () => {
   beforeEach(() => {
     createComment.mockClear();
+    addLabelToPr.mockClear();
     commits.mockClear();
   });
 
@@ -144,6 +154,30 @@ describe('release label plugin', () => {
     );
 
     expect(createComment).not.toHaveBeenCalled();
+  });
+
+  test('should do nothing when label is already present', async () => {
+    const releasedLabel = new ReleasedLabelPlugin();
+    const autoHooks = makeHooks();
+
+    releasedLabel.apply({
+      hooks: autoHooks,
+      labels: defaultLabelDefinition,
+      logger: dummyLog(),
+      args: {},
+      git
+    } as Auto);
+
+    getLabels.mockReturnValueOnce(['released']);
+
+    await autoHooks.afterRelease.promise(
+      '1.0.0',
+      await log.normalizeCommits([
+        makeCommitFromMsg('normal commit with no bump (#123)')
+      ])
+    );
+
+    expect(addLabelToPr).not.toHaveBeenCalled();
   });
 
   test('should comment and lined Issues', async () => {

--- a/src/plugins/released/index.ts
+++ b/src/plugins/released/index.ts
@@ -125,7 +125,11 @@ export default class ReleasedLabelPlugin implements IPlugin {
     await auto.git!.createComment(comment, prOrIssue, 'released');
 
     // add a `released` label to a PR
-    await auto.git!.addLabelToPr(prOrIssue, this.options.label);
+    const labels = await auto.git!.getLabels(prOrIssue);
+
+    if (!labels.includes(this.options.label)) {
+      await auto.git!.addLabelToPr(prOrIssue, this.options.label);
+    }
   }
 
   private createReleasedComment(isIssue: boolean, version: string) {


### PR DESCRIPTION
# What Changed

ensure released label only added once

# Why

closes #281

Todo:

- [x] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
