### PR TITLE
Remove auth in error responses if it's present

### DIFF
--- a/src/__tests__/auto.test.ts
+++ b/src/__tests__/auto.test.ts
@@ -309,11 +309,11 @@ describe('Auto', () => {
       auto.logger = dummyLog();
       await auto.loadConfig();
       auto.git!.createStatus = createStatus;
-      createStatus.mockRejectedValueOnce(new Error());
+      createStatus.mockRejectedValueOnce({ status: 400 });
 
       await expect(
         auto.pr({ ...required, sha: '1234' })
-      ).resolves.toBeUndefined();
+      ).rejects.toBeInstanceOf(Error);
       expect(createStatus).toHaveBeenCalled();
     });
 
@@ -428,11 +428,11 @@ describe('Auto', () => {
       auto.logger = dummyLog();
       await auto.loadConfig();
       auto.git!.createStatus = createStatus;
-      createStatus.mockRejectedValueOnce(new Error());
+      createStatus.mockRejectedValueOnce({ status: 123 });
 
       await expect(
         auto.prCheck({ ...required, pr: 13 })
-      ).resolves.toBeUndefined();
+      ).rejects.toBeInstanceOf(Error);
       expect(createStatus).toHaveBeenCalled();
     });
 

--- a/src/__tests__/auto.test.ts
+++ b/src/__tests__/auto.test.ts
@@ -304,6 +304,19 @@ describe('Auto', () => {
       expect(auto.pr(required)).rejects.toBeTruthy();
     });
 
+    test('should catch exceptions when status fails to post', async () => {
+      const auto = new Auto({ command: 'pr', ...defaults });
+      auto.logger = dummyLog();
+      await auto.loadConfig();
+      auto.git!.createStatus = createStatus;
+      createStatus.mockRejectedValueOnce(new Error());
+
+      await expect(
+        auto.pr({ ...required, sha: '1234' })
+      ).resolves.toBeUndefined();
+      expect(createStatus).toHaveBeenCalled();
+    });
+
     test('should do nothing ', async () => {
       const auto = new Auto({ command: 'pr', ...defaults });
       auto.logger = dummyLog();
@@ -408,6 +421,19 @@ describe('Auto', () => {
           state: 'error'
         })
       );
+    });
+
+    test('should catch status errors', async () => {
+      const auto = new Auto({ command: 'pr', ...defaults });
+      auto.logger = dummyLog();
+      await auto.loadConfig();
+      auto.git!.createStatus = createStatus;
+      createStatus.mockRejectedValueOnce(new Error());
+
+      await expect(
+        auto.prCheck({ ...required, pr: 13 })
+      ).resolves.toBeUndefined();
+      expect(createStatus).toHaveBeenCalled();
     });
 
     test('should error with no label', async () => {

--- a/src/__tests__/auto.test.ts
+++ b/src/__tests__/auto.test.ts
@@ -28,6 +28,9 @@ jest.mock('@octokit/rest', () => {
     authenticate: () => undefined,
     search: {
       issuesAndPullRequests: () => ({ data: { items: [] } })
+    },
+    hook: {
+      error: () => undefined
     }
   });
 

--- a/src/__tests__/git.test.ts
+++ b/src/__tests__/git.test.ts
@@ -52,6 +52,9 @@ jest.mock('@octokit/rest', () => {
     },
     users: {
       getByUsername
+    },
+    hook: {
+      error: () => undefined
     }
   });
 

--- a/src/auto.ts
+++ b/src/auto.ts
@@ -227,11 +227,15 @@ export default class Auto {
     const target_url = url;
 
     if (!dryRun) {
-      await this.git.createStatus({
-        ...options,
-        sha,
-        target_url
-      });
+      try {
+        await this.git.createStatus({
+          ...options,
+          sha,
+          target_url
+        });
+      } catch {
+        this.logger.log.error('Failed to post status to Pull Request.');
+      }
 
       this.logger.log.success('Posted status to Pull Request.');
     } else {

--- a/src/auto.ts
+++ b/src/auto.ts
@@ -322,7 +322,7 @@ export default class Auto {
 
         this.logger.log.success('Posted status to Pull Request.');
       } catch (error) {
-        this.logger.verbose.error('Failed to post status to github');
+        this.logger.log.error('Failed to post status to github');
       }
     } else {
       this.logger.verbose.info('`pr-check` dry run complete.');

--- a/src/auto.ts
+++ b/src/auto.ts
@@ -308,14 +308,18 @@ export default class Auto {
     this.logger.verbose.info('Posting comment to GitHub\n', msg);
 
     if (!dryRun) {
-      await this.git.createStatus({
-        ...options,
-        ...msg,
-        target_url,
-        sha
-      } as IPRInfo);
+      try {
+        await this.git.createStatus({
+          ...options,
+          ...msg,
+          target_url,
+          sha
+        } as IPRInfo);
 
-      this.logger.log.success('Posted status to Pull Request.');
+        this.logger.log.success('Posted status to Pull Request.');
+      } catch (error) {
+        this.logger.verbose.error('Failed to post status to github');
+      }
     } else {
       this.logger.verbose.info('`pr-check` dry run complete.');
     }

--- a/src/auto.ts
+++ b/src/auto.ts
@@ -233,8 +233,12 @@ export default class Auto {
           sha,
           target_url
         });
-      } catch {
-        this.logger.log.error('Failed to post status to Pull Request.');
+      } catch (error) {
+        throw new Error(
+          `Failed to post status to Pull Request with error code ${
+            error.status
+          }`
+        );
       }
 
       this.logger.log.success('Posted status to Pull Request.');
@@ -322,7 +326,11 @@ export default class Auto {
 
         this.logger.log.success('Posted status to Pull Request.');
       } catch (error) {
-        this.logger.log.error('Failed to post status to github');
+        throw new Error(
+          `Failed to post status to Pull Request with error code ${
+            error.status
+          }`
+        );
       }
     } else {
       this.logger.verbose.info('`pr-check` dry run complete.');

--- a/src/git.ts
+++ b/src/git.ts
@@ -58,6 +58,10 @@ export default class Git {
       auth: `token ${this.options.token}`,
       previews: ['symmetra-preview']
     });
+    this.ghub.hook.error('request', (error, opts) => {
+      delete error.headers.authorization;
+      throw error;
+    });
   }
 
   @Memoize()

--- a/src/git.ts
+++ b/src/git.ts
@@ -59,7 +59,9 @@ export default class Git {
       previews: ['symmetra-preview']
     });
     this.ghub.hook.error('request', (error, opts) => {
-      delete error.headers.authorization;
+      if (error && error.headers && error.headers.authorization) {
+        delete error.headers.authorization;
+      }
       throw error;
     });
   }

--- a/src/git.ts
+++ b/src/git.ts
@@ -58,7 +58,7 @@ export default class Git {
       auth: `token ${this.options.token}`,
       previews: ['symmetra-preview']
     });
-    this.ghub.hook.error('request', (error, opts) => {
+    this.ghub.hook.error('request', error => {
       if (error && error.headers && error.headers.authorization) {
         delete error.headers.authorization;
       }


### PR DESCRIPTION
Fixes #296 

Adds exception handling and a sanitizing hook to octokit to try to prevent the leaking of auth tokens. 

# What Changed

Adds a hook to octokit that deletes the `authorization` header on all error objects before passing it throwing it again. This should ensure the token is never accidentally exposed, regardless of whether an exception is caught or not. 

# Why

If an octokit exception isn't caught then it likely will print out the authorization header in the error response which leads to leaking credentials in CI. 

Todo:

- [x] Add tests
- [x] Add docs
- [x] Add yourself to contributors (run `yarn contributors:add`)
