### PR TITLE
fix typo in docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,6 @@
 
 ---
 
-:bathtub: Continuos Integration
+:bathtub: Continuous Integration
 
 - [CircleCI](pages/circleci.md)


### PR DESCRIPTION
# What Changed

Fixed a small typo in the documentation.

# Why

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
