### PR TITLE
Fix issue with warning wrapping section

### DIFF
--- a/docs/pages/autorc.md
+++ b/docs/pages/autorc.md
@@ -47,7 +47,9 @@ Will use the package `@YOUR_SCOPE/auto-config`
 
 Will use the package `auto-config-joe`
 
-::: message is-warning If extending from a config package make sure it's a dependency of your project :::
+::: message is-warning
+If extending from a config package make sure it's a dependency of your project
+:::
 
 ### Labels
 


### PR DESCRIPTION
# What Changed

Small formatting fix that caused the docs to render weird

# Why

<img width="993" alt="image" src="https://user-images.githubusercontent.com/3087225/55374013-0dee5080-54d5-11e9-9fe5-7fdc5a0103ef.png">
