### PR TITLE
Adjust rate limiting retries from 3 to 5

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -67,8 +67,7 @@ export default class Git {
             `Request quota exhausted for request ${opts.method} ${opts.url}`
           );
 
-          // retry three times
-          if (opts.request.retryCount < 3) {
+          if (opts.request.retryCount < 5) {
             this.logger.verbose.log(`Retrying after ${retryAfter} seconds!`);
             return true;
           }


### PR DESCRIPTION
# What Changed

Ups the retry count of throttling to 5. 

# Why

I'm continuing to run up against rate limiting issues on the search end points so this _might_ help. Also, generally it won't hurt, so there's that. 
