### PR TITLE
Throw an error if extended config fails to load

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -7,9 +7,9 @@ const importMock = jest.fn();
 jest.mock('import-cwd', () => (path: string) => importMock(path));
 
 describe('loadExtendConfig', () => {
-  test('should work when no config found', async () => {
+  test('should throw when no config found', async () => {
     const config = new Config(log);
-    expect(config.loadExtendConfig('nothing')).toEqual({});
+    expect(() => config.loadExtendConfig('nothing')).toThrow();
   });
 
   test('should load file path', async () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -113,6 +113,10 @@ export default class Config {
       config = tryRequire(path.join(process.cwd(), extend));
     }
 
+    if (!config) {
+      throw new Error(`Unable to load extended config ${extend}`);
+    }
+
     if (typeof config === 'function') {
       return (config as ConfigLoader)();
     }


### PR DESCRIPTION
# What Changed

Adds an exception when the extended config fails to load in

# Why

Sometimes I'd mess up when configuring a project and the extended config wouldn't load in properly. Instead of failing the release would continue with the default config (which is definitely undesirable). 
