### PR TITLE
Graphql url config

### DIFF
--- a/docs/pages/autorc.md
+++ b/docs/pages/autorc.md
@@ -201,7 +201,19 @@ If you are using enterprise github, `auto` lets you configure the github API URL
 
 ```json
 {
-  "jira": "https://url-to-jira.com"
+  "githubApi": "https://github.mine.com/api/v3"
+}
+```
+
+### githubGraphqlApi
+
+This is used for doing some searches in `auto`.
+
+If you are using enterprise github and your company hosts the graphql at some other URL than the `githubApi`, you can use `githubGraphqlApi` to set the base path for `auto`. The `githubGraphqlApi` get merged with `/graphql` to build the final URL.
+
+```json
+{
+  "githubGraphqlApi": "https://github.mine.com/api/"
 }
 ```
 

--- a/src/auto.ts
+++ b/src/auto.ts
@@ -136,7 +136,9 @@ export default class Auto {
       repo: config.repo,
       ...repository,
       token,
-      baseUrl: config.githubApi || 'https://api.github.com'
+      baseUrl: config.githubApi || 'https://api.github.com',
+      graphqlBaseUrl:
+        config.githubGraphqlApi || config.githubApi || 'https://api.github.com'
     };
 
     this.git = this.startGit(githubOptions as IGitOptions);
@@ -492,7 +494,8 @@ export default class Auto {
         owner: gitOptions.owner,
         repo: gitOptions.repo,
         token: gitOptions.token,
-        baseUrl: gitOptions.baseUrl
+        baseUrl: gitOptions.baseUrl,
+        graphqlBaseUrl: gitOptions.graphqlBaseUrl
       },
       this.logger
     );

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -660,6 +660,7 @@ export interface IShipItCommandOptions {
 type GlobalFlags = {
   command: string;
   githubApi?: string;
+  githubGraphqlApi?: string;
   plugins?: string[];
 } & IRepoArgs &
   ILogArgs;

--- a/src/git.ts
+++ b/src/git.ts
@@ -24,6 +24,7 @@ export interface IGitOptions {
   owner: string;
   repo: string;
   baseUrl?: string;
+  graphqlBaseUrl?: string;
   token?: string;
 }
 
@@ -46,6 +47,7 @@ export default class Git {
   readonly options: IGitOptions;
 
   private readonly baseUrl: string;
+  private readonly graphqlBaseUrl: string;
   private readonly ghub: Octokit;
   private readonly logger: ILogger;
 
@@ -53,6 +55,7 @@ export default class Git {
     this.logger = logger;
     this.options = options;
     this.baseUrl = this.options.baseUrl || 'https://api.github.com';
+    this.graphqlBaseUrl = this.options.graphqlBaseUrl || this.baseUrl;
 
     this.logger.veryVerbose.info(`Initializing GitHub with: ${this.baseUrl}`);
     const gitHub = Octokit.plugin(enterpriseCompat)
@@ -266,7 +269,7 @@ export default class Git {
     this.logger.verbose.info('Querying Github using GraphQL:\n', query);
 
     const data = await graphql(query, {
-      baseUrl: this.baseUrl,
+      baseUrl: this.graphqlBaseUrl,
       headers: {
         authorization: `token ${this.options.token}`
       }

--- a/src/init.ts
+++ b/src/init.ts
@@ -43,6 +43,12 @@ async function getFlags() {
       message: 'GitHub API to use (press enter to use public)'
     },
     {
+      type: 'input',
+      name: 'githubGraphqlApi',
+      message:
+        'GitHub Graphql API base path to use (press enter to use githubApi)'
+    },
+    {
       type: 'confirm',
       name: 'onlyPublishWithReleaseLabel',
       message: 'Only bump version if `release` label is on pull request',

--- a/src/release.ts
+++ b/src/release.ts
@@ -40,6 +40,7 @@ export interface IReleaseOptions {
   jira?: string;
   slack?: string;
   githubApi?: string;
+  githubGraphqlApi?: string;
   name?: string;
   email?: string;
   owner?: string;


### PR DESCRIPTION
# What Changed

allow user to configure where the graphql api lives.

# Why

 necassary for enterprise

Todo:

- [ ] Add tests
- [x] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
