### PR TITLE
add forcePublish config option to npm plugin

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,7 @@
 - [.autorc](pages/autorc.md)
 - [Plugins](pages/plugins.md)
   - [Writing Plugins](pages/writing-plugins.md)
+  - [NPM](pages/npm.md)
   - [Chrome Web Store](pages/chrome.md)
   - [Released](pages/released.md)
 - [Troubleshooting](pages/troubleshooting.md)

--- a/docs/pages/npm.md
+++ b/docs/pages/npm.md
@@ -1,0 +1,48 @@
+# NPM
+
+Publish to NPM. Works in both a monorepo setting and for a single package. This plugin is loaded by default. If you configure `auto` to use any other plugin this will be lost. So you must add the `npm` plugin to your plugins array if you still want NPM functionality.
+
+```json
+{
+  "plugins": [
+    "npm"
+    // other plugins
+  ]
+}
+```
+
+## Options
+
+### setRcToken
+
+When running the `shipit` command auto will try to set your `.npmrc` token while publishing. To disable this feature you must set the `setRcToken` to false.
+
+```json
+{
+  "plugins": [
+    [
+      "npm",
+      {
+        "setRcToken": false
+      }
+    ]
+  ]
+}
+```
+
+### forcePublish
+
+By default `auto` will force publish all packages for monorepos. To disable this behavior you must set the `setRcToken` to false.
+
+```json
+{
+  "plugins": [
+    [
+      "npm",
+      {
+        "forcePublish": false
+      }
+    ]
+  ]
+}
+```

--- a/src/plugins/npm/__tests__/npm.test.ts
+++ b/src/plugins/npm/__tests__/npm.test.ts
@@ -247,6 +247,7 @@ test('should use string semver if no published package', async () => {
   const plugin = new NPMPlugin({ setRcToken: false });
 
   expect(plugin).toEqual({
+    forcePublish: true,
     name: 'NPM',
     setRcToken: false
   });
@@ -305,6 +306,34 @@ describe('publish', () => {
       "'Bump version to: %v [skip ci]'"
     ]);
   });
+
+  test('monorepo - should be able to not force publish all packages', async () => {
+    const plugin = new NPMPlugin({ forcePublish: false });
+    const hooks = makeHooks();
+
+    plugin.apply({ hooks, logger: dummyLog() } as Auto);
+
+    existsSync.mockReturnValueOnce(true);
+    monorepoPackages.mockReturnValueOnce([]);
+
+    readResult = `
+      {
+        "name": "test"
+      }
+    `;
+
+    await hooks.version.promise(SEMVER.patch);
+    expect(exec).toHaveBeenCalledWith('npx', [
+      'lerna',
+      'version',
+      'patch',
+      '--no-commit-hooks',
+      '--yes',
+      '-m',
+      "'Bump version to: %v [skip ci]'"
+    ]);
+  });
+
   test('monorepo - should publish', async () => {
     const plugin = new NPMPlugin();
     const hooks = makeHooks();

--- a/src/utils/__tests__/load-plugin.test.ts
+++ b/src/utils/__tests__/load-plugin.test.ts
@@ -10,6 +10,7 @@ describe('loadPlugins', () => {
 
   test('should use supported plugin', async () => {
     expect(loadPlugin(['npm', {}], logger)).toEqual({
+      forcePublish: true,
       name: 'NPM',
       setRcToken: true
     });


### PR DESCRIPTION
# What Changed

see title

# Why

a monorepo user may not want every package published if there are no changes 

Todo:

- [x] Add tests
- [x] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
