### PR TITLE
increase buffer for situations when user has a LOT of unpublished work

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -202,7 +202,8 @@ export default class Git {
       repo: process.cwd(),
       number: Number.MAX_SAFE_INTEGER,
       fields: ['hash', 'authorName', 'authorEmail', 'rawBody'],
-      branch: `${start.trim()}..${end.trim()}`
+      branch: `${start.trim()}..${end.trim()}`,
+      execOptions: { maxBuffer: 1000 * 1024 }
     });
 
     return log.map(commit => ({

--- a/src/types/gitlog.d.ts
+++ b/src/types/gitlog.d.ts
@@ -13,6 +13,9 @@ declare module 'gitlog' {
     fields: string[];
     branch: string;
     number: number;
+    execOptions: {
+      maxBuffer: number;
+    };
   }
 
   export default function gitlog(


### PR DESCRIPTION
# What Changed

increase gitlog buffer

# Why

Repo i was adding auto to had > 200 commits since last tag. caused a maxBuffer exception

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
