### PR TITLE
enable loglevel silly for npm/lerna when in verbose or veryVerbose mode

### DIFF
--- a/src/auto.ts
+++ b/src/auto.ts
@@ -37,7 +37,7 @@ import Release, {
 import SEMVER, { calculateSemVerBump } from './semver';
 import getGitHubToken from './utils/github-token';
 import loadPlugin, { IPlugin } from './utils/load-plugins';
-import createLog, { ILogger } from './utils/logger';
+import createLog, { ILogger, LogLevel } from './utils/logger';
 import { makeHooks } from './utils/make-hooks';
 
 const env = envCi();
@@ -79,6 +79,7 @@ export default class Auto {
   hooks: IAutoHooks;
   logger: ILogger;
   args: ArgsType;
+  logLevel: LogLevel;
   config?: IReleaseOptions;
 
   release?: Release;

--- a/src/plugins/npm/__tests__/npm.test.ts
+++ b/src/plugins/npm/__tests__/npm.test.ts
@@ -258,6 +258,33 @@ describe('publish', () => {
     exec.mockClear();
   });
 
+  test('should use silly logging in verbose mode', async () => {
+    const plugin = new NPMPlugin();
+    const hooks = makeHooks();
+
+    plugin.apply({
+      hooks,
+      logger: dummyLog(),
+      logLevel: 'veryVerbose'
+    } as Auto);
+
+    readResult = `
+      {
+        "name": "test"
+      }
+    `;
+
+    await hooks.version.promise(SEMVER.patch);
+    expect(exec).toHaveBeenCalledWith('npm', [
+      'version',
+      SEMVER.patch,
+      '-m',
+      '"Bump version to: %s [skip ci]"',
+      '--loglevel',
+      'silly'
+    ]);
+  });
+
   test('should use string semver if no published package', async () => {
     const plugin = new NPMPlugin();
     const hooks = makeHooks();

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -14,9 +14,9 @@ export function dummyLog(): ILogger {
   };
 }
 
-export default function createLog(
-  mode: 'verbose' | 'veryVerbose' | undefined
-): ILogger {
+export type LogLevel = 'verbose' | 'veryVerbose' | undefined;
+
+export default function createLog(mode: LogLevel): ILogger {
   return {
     log: new Signale(),
     verbose: new Signale({


### PR DESCRIPTION
# What Changed

see title

# Why

it sucks having to set all that up when you just want verbose logging

Todo:

- [x] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
