### PR TITLE
Configure base-branch + pushToMaster => pushToBaseBranch

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,15 @@
 
 <br />
 
-CI/CD helpers for github releases. Generate releases based on semantic version labels on pull requests.
+Automated releases powered by pull request labels. Streamline you release workflow and publish constantly!
 
 Release Features:
 
-- Release every merge to master based on a PR labels
+- Calculate semantic version bumps from PRs
 - Skip a release with the `skip-release` label
-- Generate a changelog with fancy headers, authors, and monorepo package association
+- Publish canary releases from PRs
+- Generate changelogs with fancy headers, authors, and monorepo package association
+- Use labels to create new changelog section
 - Generate a GitHub release
 
 Pull Request Interaction Features:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <br />
 
-Automated releases powered by pull request labels. Streamline you release workflow and publish constantly!
+Automated releases powered by pull request labels. Streamline you release workflow and publish constantly! `auto` is meant to be run in a continuos integration (CI) environment, but all the commands work locally as well.
 
 Release Features:
 

--- a/docs/pages/auto-canary.md
+++ b/docs/pages/auto-canary.md
@@ -23,6 +23,7 @@ Global Options
   --owner string        The owner of the GitHub repo. Defaults to reading from the package definition
                         for the platform
   --github-api string   GitHub API to use
+  --base-branch string  Branch to treat as the "master" branch
   --plugins string[]    Plugins to load auto with. (defaults to just npm)
 
 Examples

--- a/docs/pages/auto-canary.md
+++ b/docs/pages/auto-canary.md
@@ -23,7 +23,6 @@ Global Options
   --owner string        The owner of the GitHub repo. Defaults to reading from the package definition
                         for the platform
   --github-api string   GitHub API to use
-  --base-branch string  Branch to treat as the "master" branch
   --plugins string[]    Plugins to load auto with. (defaults to just npm)
 
 Examples

--- a/docs/pages/auto-changelog.md
+++ b/docs/pages/auto-changelog.md
@@ -39,7 +39,7 @@ Examples
 
 ## Jira
 
-To include Jira story information you must include a URL to your hosted JIRA instance as a CLI flag or [.autorc`](./autorc.md) config option.
+To include Jira story information you must include a URL to your hosted JIRA instance as a CLI flag or [.autorc](./autorc.md) config option.
 
 ## Changelog Titles
 

--- a/docs/pages/auto-changelog.md
+++ b/docs/pages/auto-changelog.md
@@ -26,6 +26,7 @@ Global Options
   --repo string         The repo to set the status on. Defaults to looking in the package definition for the platform
   --owner string        The owner of the GitHub repo. Defaults to reading from the package definition for the platform
   --github-api string   GitHub API to use
+  --base-branch string  Branch to treat as the "master" branch
   --plugins string[]    Plugins to load auto with. (defaults to just npm)
 
 Examples

--- a/docs/pages/auto-label.md
+++ b/docs/pages/auto-label.md
@@ -2,6 +2,17 @@
 
 Get the labels for a pull request. Doesn't do much, but the return value lets you write you own scripts based off of the PR labels!
 
+The following will only run the `test:visual` script when the PR has has the `Visual` label.
+
+```sh
+export PATH=$(npm bin):$PATH
+
+if [ `auto label --pr $PR_NUMBER | grep -c '^Visual'` -ne 0 ];
+then
+    npm run test:visual
+fi
+```
+
 ```bash
 >  auto label -h
 

--- a/docs/pages/auto-release.md
+++ b/docs/pages/auto-release.md
@@ -44,6 +44,7 @@ Global Options
   --repo string         The repo to set the status on. Defaults to looking in the package definition for the platform
   --owner string        The owner of the GitHub repo. Defaults to reading from the package definition for the platform
   --github-api string   GitHub API to use
+  --base-branch string  Branch to treat as the "master" branch
   --plugins string[]    Plugins to load auto with. (defaults to just npm)
 
 Examples

--- a/docs/pages/auto-shipit.md
+++ b/docs/pages/auto-shipit.md
@@ -24,6 +24,7 @@ Global Options
   --repo string         The repo to set the status on. Defaults to looking in the package definition for the platform
   --owner string        The owner of the GitHub repo. Defaults to reading from the package definition for the platform
   --github-api string   GitHub API to use
+  --base-branch string  Branch to treat as the "master" branch
   --plugins string[]    Plugins to load auto with. (defaults to just npm)
 
 Examples

--- a/docs/pages/auto-shipit.md
+++ b/docs/pages/auto-shipit.md
@@ -1,6 +1,6 @@
 # `auto shipit`
 
-Run the full `auto` release pipeline. Will detect if in a lerna project and publish accordingly.
+Run the full `auto` release pipeline. Will detect if in a lerna project and publish accordingly. If ran from a PR build, `shipit` publish a canary release using [`auto canary`](./auto-canary.md).
 
 ```sh
 auto shipit

--- a/docs/pages/auto-version.md
+++ b/docs/pages/auto-version.md
@@ -18,6 +18,7 @@ Global Options
   --repo string         The repo to set the status on. Defaults to looking in the package definition for the platform
   --owner string        The owner of the GitHub repo. Defaults to reading from the package definition for the platform
   --github-api string   GitHub API to use
+  --base-branch string  Branch to treat as the "master" branch
   --plugins string[]    Plugins to load auto with. (defaults to just npm)
 
 Examples

--- a/docs/pages/auto-version.md
+++ b/docs/pages/auto-version.md
@@ -35,7 +35,7 @@ Useful in conjunction with `npm version` to auto-version releases.
 
 To create a prerelease add the `prerelease` label to your pull request.
 
-## No Release
+## Skip Release
 
 To not create a release for a pull request add the `skip-release` label. Any pull request with this tag will make `auto version` return `''`.
 

--- a/docs/pages/auto-version.md
+++ b/docs/pages/auto-version.md
@@ -18,7 +18,6 @@ Global Options
   --repo string         The repo to set the status on. Defaults to looking in the package definition for the platform
   --owner string        The owner of the GitHub repo. Defaults to reading from the package definition for the platform
   --github-api string   GitHub API to use
-  --base-branch string  Branch to treat as the "master" branch
   --plugins string[]    Plugins to load auto with. (defaults to just npm)
 
 Examples

--- a/docs/pages/autorc.md
+++ b/docs/pages/autorc.md
@@ -175,6 +175,16 @@ You can set any CLI option in the `.autorc` these options will get overridden by
 
 The following are options that might be more useful to set in the `.autorc` rather than with a flag.
 
+### Base Branch
+
+Configure what your repo considers the "master" branch.
+
+```json
+{
+  "baseBranch": "trunk"
+}
+```
+
 ### Plugins
 
 It is useful to specify your plugins in the rc file rather than in all the commands.

--- a/docs/pages/getting-started.md
+++ b/docs/pages/getting-started.md
@@ -73,6 +73,11 @@ NPM_TOKEN=PUBLISH_TOKEN
 
 To version, changelog, publish and release your code all at the same time, we've included the `shipit` tool. This tool takes the default `auto` workflow and puts it into one command.
 
+It will:
+
+1. Publish canary releases when run from a PR
+2. Generate a changelog and publish a "latest" release to a package manager when run from the base branch
+
 ```json
 {
   "scripts": {
@@ -138,7 +143,7 @@ VERSION=`auto version`
 
 if [ ! -z "$VERSION" ]; then
   auto changelog
-  lerna publish --yes --force-publish=* $VERSION -m '%v [skip ci]'
+  lerna publish --yes $VERSION -m '%v [skip ci]'
   auto release
 fi
 ```

--- a/docs/pages/introduction.md
+++ b/docs/pages/introduction.md
@@ -2,13 +2,15 @@
 
 # :rocket: auto :rocket:/.has-text-centered\
 
-CI/CD helpers for github releases. Generate releases based on semantic version labels on pull requests.
+Automated releases powered by pull request labels. Streamline you release workflow and publish constantly!
 
 Release Features:
 
-- Release every merge to master based on a PR labels
+- Calculate semantic version bumps from PRs
 - Skip a release with the `skip-release` label
-- Generate a changelog with fancy headers, authors, and monorepo package association
+- Publish canary releases from PRs
+- Generate changelogs with fancy headers, authors, and monorepo package association
+- Use labels to create new changelog section
 - Generate a GitHub release
 
 Pull Request Interaction Features:

--- a/docs/pages/introduction.md
+++ b/docs/pages/introduction.md
@@ -2,7 +2,7 @@
 
 # :rocket: auto :rocket:/.has-text-centered\
 
-Automated releases powered by pull request labels. Streamline you release workflow and publish constantly!
+Automated releases powered by pull request labels. Streamline you release workflow and publish constantly! `auto` is meant to be run in a continuos integration (CI) environment, but all the commands work locally as well.
 
 Release Features:
 

--- a/docs/pages/publishing.md
+++ b/docs/pages/publishing.md
@@ -11,3 +11,38 @@ pre: (optional) Check if new version
 ```
 
 `auto` makes no assumptions about your publishing process. Each tool is a function that can be run in isolation and only does one thing really well. For instance, you could just use `auto changelog` to generate the changelog and nothing else or use `auto version` to calculate just the semver bump.
+
+## Base Branch
+
+By default `auto` assumes that your repo's base branch is `master`. You can configure this behavior through the [.autorc](./autorc.md#base-branch) or via a CLI to any relevant command.
+
+```sh
+auto shipit --base-branch trunk
+```
+
+## Push to base branch
+
+If you push commits to the base branch they will count as patches. This is a good way to get a release out without having to make a PR.
+
+The changelog entry will contain the first line of the commit message. These commits will fall under a special section in the changelog.
+
+ex:
+
+```md
+⚠️ Pushed to master
+
+- fix docs publishing ([@lisowski54@gmail.com](https://github.com/lisowski54@gmail.com))
+```
+
+You can configure the title of this changelog entry by adding the `pushToBaseBranch` label in your config.
+
+```json
+{
+  "labels": {
+    "pushToBaseBranch": {
+      "name": "pushToBaseBranch",
+      "title": "Emergency!!"
+    }
+  }
+}
+```

--- a/src/__tests__/__snapshots__/auto.test.ts.snap
+++ b/src/__tests__/__snapshots__/auto.test.ts.snap
@@ -58,6 +58,7 @@ exports[`Auto createLabels should create the labels 1`] = `
 
 exports[`Auto should extend config 1`] = `
 Object {
+  "baseBranch": "master",
   "command": "init",
   "extends": "@artsy",
   "labels": Object {
@@ -112,6 +113,7 @@ Object {
 
 exports[`Auto should extend local config 1`] = `
 Object {
+  "baseBranch": "master",
   "command": "init",
   "extends": "./fake.json",
   "labels": Object {

--- a/src/__tests__/__snapshots__/changelog.test.ts.snap
+++ b/src/__tests__/__snapshots__/changelog.test.ts.snap
@@ -19,7 +19,7 @@ exports[`Hooks title 1`] = `
 - Adam Dierkens (adam@dierkens.com)"
 `;
 
-exports[`generateReleaseNotes should be able to customize "Push To Master" title 1`] = `
+exports[`generateReleaseNotes should be able to customize pushToBaseBranch title 1`] = `
 "#### 🚀  Enhancement
 
 - First Feature [#1235](https://github.custom.com/foobar/auto/pull/1235) (adam@dierkens.com)

--- a/src/__tests__/auto.test.ts
+++ b/src/__tests__/auto.test.ts
@@ -6,7 +6,7 @@ import makeCommitFromMsg from './make-commit-from-msg';
 
 const importMock = jest.fn();
 jest.mock('import-cwd', () => (path: string) => importMock(path));
-jest.mock('env-ci', () => () => ({ isCi: false }));
+jest.mock('env-ci', () => () => ({ isCi: false, branch: 'master' }));
 
 const defaults = {
   owner: 'foo',
@@ -693,6 +693,63 @@ describe('Auto', () => {
 
       await auto.canary({ pr: 123, build: 1 });
       expect(canary).toHaveBeenCalledWith('1.2.4-canary.123.1');
+    });
+  });
+
+  describe('shipit', () => {
+    test('should throw when not initialized', async () => {
+      const auto = new Auto({ command: 'comment', ...defaults });
+      auto.logger = dummyLog();
+
+      expect(auto.shipit()).rejects.toBeTruthy();
+    });
+
+    test('should not publish when no latest version found', async () => {
+      const auto = new Auto({ command: 'comment', ...defaults, plugins: [] });
+      auto.logger = dummyLog();
+      await auto.loadConfig();
+
+      auto.git!.getLatestRelease = () => Promise.resolve('');
+      auto.release!.getSemverBump = () => Promise.resolve(SEMVER.noVersion);
+      const afterShipIt = jest.fn();
+      auto.hooks.afterShipIt.tap('test', afterShipIt);
+
+      await auto.shipit();
+      expect(afterShipIt).not.toHaveBeenCalled();
+    });
+
+    test('should publish to latest on base branch', async () => {
+      const auto = new Auto({ command: 'comment', ...defaults, plugins: [] });
+      auto.logger = dummyLog();
+      await auto.loadConfig();
+
+      auto.git!.getLatestRelease = () => Promise.resolve('1.2.3');
+      auto.git!.publish = jest.fn();
+      auto.release!.getCommitsInRelease = jest.fn();
+      auto.release!.generateReleaseNotes = jest.fn();
+      auto.release!.addToChangelog = jest.fn();
+      const afterShipIt = jest.fn();
+      auto.hooks.afterShipIt.tap('test', afterShipIt);
+
+      await auto.shipit();
+      expect(afterShipIt).toHaveBeenCalled();
+    });
+
+    test('should skip publish in dry run', async () => {
+      const auto = new Auto({ command: 'comment', ...defaults, plugins: [] });
+      auto.logger = dummyLog();
+      await auto.loadConfig();
+
+      auto.git!.getLatestRelease = () => Promise.resolve('1.2.3');
+      auto.git!.publish = jest.fn();
+      auto.release!.getCommitsInRelease = jest.fn();
+      auto.release!.generateReleaseNotes = jest.fn();
+      auto.release!.addToChangelog = jest.fn();
+      const version = jest.fn();
+      auto.hooks.version.tap('test', version);
+
+      await auto.shipit({ dryRun: true });
+      expect(version).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/__tests__/changelog.test.ts
+++ b/src/__tests__/changelog.test.ts
@@ -9,7 +9,8 @@ const testOptions = (): IGenerateReleaseNotesOptions => ({
   repo: 'auto',
   baseUrl: 'https://github.custom.com/foobar/auto',
   jira: 'https://jira.custom.com/browse',
-  labels: defaultLabelDefinition
+  labels: defaultLabelDefinition,
+  baseBranch: 'master'
 });
 
 const logParse = new LogParse();
@@ -20,7 +21,8 @@ describe('createUserLink', () => {
       owner: '',
       repo: '',
       baseUrl: 'https://github.custom.com/',
-      labels: defaultLabelDefinition
+      labels: defaultLabelDefinition,
+      baseBranch: 'master'
     });
     changelog.loadDefaultHooks();
 
@@ -56,7 +58,8 @@ describe('createUserLink', () => {
       owner: '',
       repo: '',
       baseUrl: 'https://github.custom.com/',
-      labels: defaultLabelDefinition
+      labels: defaultLabelDefinition,
+      baseBranch: 'master'
     });
     changelog.loadDefaultHooks();
 
@@ -237,7 +240,7 @@ describe('generateReleaseNotes', () => {
         authorName: 'Adam Dierkens',
         authorEmail: 'adam@dierkens.com',
         subject: 'I was a push to master\n\n',
-        labels: ['pushToMaster']
+        labels: ['pushToBaseBranch']
       },
       {
         hash: '2',
@@ -251,10 +254,10 @@ describe('generateReleaseNotes', () => {
     expect(await changelog.generateReleaseNotes(commits)).toMatchSnapshot();
   });
 
-  test('should be able to customize "Push To Master" title', async () => {
+  test('should be able to customize pushToBaseBranch title', async () => {
     const options = testOptions();
-    options.labels.pushToMaster = {
-      name: 'pushToMaster',
+    options.labels.pushToBaseBranch = {
+      name: 'pushToBaseBranch',
       title: 'Custom Title',
       description: 'N/A'
     };
@@ -268,7 +271,7 @@ describe('generateReleaseNotes', () => {
         authorName: 'Adam Dierkens',
         authorEmail: 'adam@dierkens.com',
         subject: 'I was a push to master\n\n',
-        labels: ['pushToMaster']
+        labels: ['pushToBaseBranch']
       },
       {
         hash: '2',

--- a/src/__tests__/release.test.ts
+++ b/src/__tests__/release.test.ts
@@ -278,7 +278,8 @@ describe('Release', () => {
       const gh = new Release(git, {
         noVersionPrefix: true,
         skipReleaseLabels: ['skip-release'],
-        labels: defaultLabelDefinition
+        labels: defaultLabelDefinition,
+        baseBranch: 'master'
       });
       await gh.addToChangelog('# My new Notes', '1.0.0', '1.0.0');
 
@@ -320,7 +321,8 @@ describe('Release', () => {
     test('throws without slack url', async () => {
       const gh = new Release(git, {
         skipReleaseLabels: [],
-        labels: defaultLabelDefinition
+        labels: defaultLabelDefinition,
+        baseBranch: 'master'
       });
       expect(gh.postToSlack('# My Notes', 'v1.0.0')).rejects.toBeTruthy();
     });
@@ -329,7 +331,8 @@ describe('Release', () => {
       const gh = new Release(git, {
         slack: 'https://custom-slack-url',
         skipReleaseLabels: [],
-        labels: defaultLabelDefinition
+        labels: defaultLabelDefinition,
+        baseBranch: 'master'
       });
       await gh.postToSlack('# My Notes', 'v1.0.0');
       expect(slackSpy).toHaveBeenCalled();
@@ -429,7 +432,7 @@ describe('Release', () => {
         published_at: '2019-01-16'
       });
       getCommitsForPR.mockReturnValueOnce(undefined);
-      // Rebased PR will have different commit SHAs than the commits in master
+      // Rebased PR will have different commit SHAs than the commits in base branch
       getCommitsForPR.mockReturnValueOnce([{ sha: '1a1a' }]);
 
       searchRepo.mockReturnValueOnce({ items: [{ number: 123 }] });
@@ -469,7 +472,7 @@ describe('Release', () => {
         published_at: '2019-01-16'
       });
       getCommitsForPR.mockReturnValueOnce(undefined);
-      // Rebased PR will have different commit SHAs than the commits in master
+      // Rebased PR will have different commit SHAs than the commits in base branch
       getCommitsForPR.mockReturnValueOnce([{ sha: '1a1a' }]);
 
       searchRepo.mockReturnValueOnce({ items: [{ number: 123 }] });
@@ -628,7 +631,8 @@ describe('Release', () => {
       const gh = new Release(git, {
         onlyPublishWithReleaseLabel: true,
         skipReleaseLabels: [],
-        labels: defaultLabelDefinition
+        labels: defaultLabelDefinition,
+        baseBranch: 'master'
       });
       const commits = [
         makeCommitFromMsg('First (#1234)'),
@@ -648,7 +652,8 @@ describe('Release', () => {
       const gh = new Release(git, {
         onlyPublishWithReleaseLabel: true,
         skipReleaseLabels: [],
-        labels: defaultLabelDefinition
+        labels: defaultLabelDefinition,
+        baseBranch: 'master'
       });
       const commits = [
         makeCommitFromMsg('First (#1234)'),
@@ -675,7 +680,8 @@ describe('Release', () => {
       const gh = new Release(git, {
         onlyPublishWithReleaseLabel: true,
         skipReleaseLabels: [],
-        labels: customLabels
+        labels: customLabels,
+        baseBranch: 'master'
       });
       const commits = [
         makeCommitFromMsg('First (#1234)'),
@@ -733,7 +739,8 @@ describe('Release', () => {
         git,
         {
           skipReleaseLabels: [],
-          labels: defaultLabelDefinition
+          labels: defaultLabelDefinition,
+          baseBranch: 'master'
         },
         mockLogger
       );
@@ -773,7 +780,8 @@ describe('Release', () => {
     test('should add release label in onlyPublishWithReleaseLabel mode', async () => {
       let gh = new Release(git, {
         skipReleaseLabels: [],
-        labels: defaultLabelDefinition
+        labels: defaultLabelDefinition,
+        baseBranch: 'master'
       });
       const labels = {
         release: { name: 'deploy', description: 'release the code' }
@@ -788,7 +796,8 @@ describe('Release', () => {
       gh = new Release(git, {
         onlyPublishWithReleaseLabel: true,
         skipReleaseLabels: [],
-        labels: defaultLabelDefinition
+        labels: defaultLabelDefinition,
+        baseBranch: 'master'
       });
       await gh.addLabelsToProject(labels);
       expect(createLabel).toHaveBeenCalledWith('release', {
@@ -801,7 +810,8 @@ describe('Release', () => {
       let gh = new Release(git, {
         onlyPublishWithReleaseLabel: true,
         skipReleaseLabels: [],
-        labels: defaultLabelDefinition
+        labels: defaultLabelDefinition,
+        baseBranch: 'master'
       });
       const labels = {
         'skip-release': { name: 'no!', description: 'Do not create a release' }
@@ -815,7 +825,8 @@ describe('Release', () => {
 
       gh = new Release(git, {
         skipReleaseLabels: [],
-        labels: defaultLabelDefinition
+        labels: defaultLabelDefinition,
+        baseBranch: 'master'
       });
       await gh.addLabelsToProject(labels);
       expect(createLabel).toHaveBeenCalledWith('skip-release', {

--- a/src/auto.ts
+++ b/src/auto.ts
@@ -79,6 +79,7 @@ export default class Auto {
   hooks: IAutoHooks;
   logger: ILogger;
   args: ArgsType;
+  baseBranch: string;
   config?: IReleaseOptions;
 
   release?: Release;
@@ -88,6 +89,7 @@ export default class Auto {
 
   constructor(args: ArgsType) {
     this.args = args;
+    this.baseBranch = args.baseBranch || 'master';
     this.logger = createLog(
       args.veryVerbose ? 'veryVerbose' : args.verbose ? 'verbose' : undefined
     );
@@ -116,9 +118,10 @@ export default class Auto {
    */
   async loadConfig() {
     const configLoader = new Config(this.logger);
-    const config = this.hooks.modifyConfig.call(
-      await configLoader.loadConfig(this.args)
-    );
+    const config = this.hooks.modifyConfig.call({
+      ...(await configLoader.loadConfig(this.args)),
+      baseBranch: this.baseBranch
+    });
 
     this.logger.verbose.success('Loaded `auto` with config:', config);
 
@@ -487,7 +490,7 @@ export default class Auto {
    * 3. Publish code
    * 4. Create a release
    */
-  async shipit(options: IShipItCommandOptions) {
+  async shipit(options: IShipItCommandOptions = {}) {
     if (!this.git || !this.release) {
       throw this.createErrorMessage();
     }
@@ -498,16 +501,19 @@ export default class Auto {
     const isPR = 'isPr' in env && env.isPr;
     // env-ci sets branch to target branch (ex: master) in some CI services.
     // so we should make sure we aren't in a PR just to be safe
-    const isMaster = !isPR && 'branch' in env && env.branch === 'master';
+    const isBaseBranch =
+      !isPR && 'branch' in env && env.branch === this.baseBranch;
     const publishInfo = isPR
       ? await this.canary(options)
-      : isMaster
+      : isBaseBranch
       ? await this.publishLatest(options)
       : undefined;
 
-    if (!isPR && !isMaster) {
+    if (!isPR && !isBaseBranch) {
       this.logger.log.info(
-        'No version published. Could not detect if in PR or on master branch.'
+        `No version published. Could not detect if in PR or on ${
+          this.baseBranch
+        }.`
       );
     }
 

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -14,6 +14,7 @@ export interface IGenerateReleaseNotesOptions {
   baseUrl: string;
   jira?: string;
   labels: ILabelDefinitionMap;
+  baseBranch: string;
 }
 
 export interface IChangelogHooks {
@@ -47,11 +48,11 @@ export default class Changelog {
     this.logger = logger;
     this.options = options;
     this.hooks = makeChangelogHooks();
-    this.options.labels.pushToMaster = {
-      name: 'pushToMaster',
-      title: '⚠️  Pushed to master',
+    this.options.labels.pushToBaseBranch = {
+      name: 'pushToBaseBranch',
+      title: `⚠️  Pushed to ${options.baseBranch}`,
       description: 'N/A',
-      ...(this.options.labels.pushToMaster || {})
+      ...(this.options.labels.pushToBaseBranch || {})
     };
   }
 
@@ -75,7 +76,7 @@ export default class Changelog {
     );
   }
 
-  // Every Commit will either be a PR, jira story, or push to master (patch)
+  // Every Commit will either be a PR, jira story, or push to base branch (patch)
   async generateReleaseNotes(commits: IExtendedCommit[]): Promise<string> {
     if (commits.length === 0) {
       return '';

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -291,7 +291,6 @@ const commands: ICommand[] = [
         group: 'main'
       },
       skipReleaseLabels,
-      baseBranch,
       ...defaultOptions
     ],
     examples: [
@@ -411,7 +410,6 @@ const commands: ICommand[] = [
       '{green $} auto canary --message false'
     ],
     options: [
-      baseBranch,
       ...defaultOptions,
       dryRun,
       {

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -97,6 +97,13 @@ const defaultOptions = [
   }
 ];
 
+const baseBranch: commandLineUsage.OptionDefinition = {
+  name: 'base-branch',
+  type: String,
+  description: 'Branch to treat as the "master" branch',
+  group: 'misc'
+};
+
 const pr: commandLineUsage.OptionDefinition = {
   name: 'pr',
   type: Number,
@@ -284,6 +291,7 @@ const commands: ICommand[] = [
         group: 'main'
       },
       skipReleaseLabels,
+      baseBranch,
       ...defaultOptions
     ],
     examples: [
@@ -324,6 +332,7 @@ const commands: ICommand[] = [
         description:
           "Message to commit the changelog with. Defaults to 'Update CHANGELOG.md [skip ci]'"
       },
+      baseBranch,
       ...defaultOptions
     ],
     examples: [
@@ -361,6 +370,7 @@ const commands: ICommand[] = [
         description:
           'Url to post a slack message to about the release. Make sure the SLACK_TOKEN environment variable is set.'
       },
+      baseBranch,
       ...defaultOptions
     ],
     examples: ['{green $} auto release']
@@ -385,11 +395,11 @@ const commands: ICommand[] = [
     summary: dedent`
       Run the full \`auto\` release pipeline. Detects if in a lerna project.
 
-      1. call from master -> latest version released
+      1. call from base branch -> latest version released
       2. call from PR in CI -> canary version released #351
     `,
     examples: ['{green $} auto shipit'],
-    options: [...defaultOptions, dryRun]
+    options: [...defaultOptions, baseBranch, dryRun]
   },
   {
     name: 'canary',
@@ -401,6 +411,7 @@ const commands: ICommand[] = [
       '{green $} auto canary --message false'
     ],
     options: [
+      baseBranch,
       ...defaultOptions,
       dryRun,
       {
@@ -704,6 +715,7 @@ export interface ICanaryCommandOptions {
 type GlobalFlags = {
   command: string;
   githubApi?: string;
+  baseBranch?: string;
   githubGraphqlApi?: string;
   plugins?: string[];
 } & IRepoArgs &

--- a/src/init.ts
+++ b/src/init.ts
@@ -49,6 +49,12 @@ async function getFlags() {
         'GitHub Graphql API base path to use (press enter to use githubApi)'
     },
     {
+      type: 'input',
+      name: 'baseBranch',
+      message:
+        'Branch to treat as the "master" branch (press enter to use "master")'
+    },
+    {
       type: 'confirm',
       name: 'onlyPublishWithReleaseLabel',
       message: 'Only bump version if `release` label is on pull request',

--- a/src/plugins/npm/__tests__/monorepo-log.test.ts
+++ b/src/plugins/npm/__tests__/monorepo-log.test.ts
@@ -59,7 +59,8 @@ test('should create sections for packages', async () => {
     repo: 'test',
     jira: 'jira.com',
     baseUrl: 'https://github.custom.com/',
-    labels: defaultLabelDefinition
+    labels: defaultLabelDefinition,
+    baseBranch: 'master'
   });
 
   plugin.apply({ hooks, logger: dummyLog() } as Auto);

--- a/src/release.ts
+++ b/src/release.ts
@@ -40,6 +40,7 @@ export interface IReleaseOptions {
   jira?: string;
   slack?: string;
   githubApi?: string;
+  baseBranch: string;
   githubGraphqlApi?: string;
   name?: string;
   email?: string;
@@ -156,6 +157,7 @@ export default class Release {
   constructor(
     git: Git,
     options: IReleaseOptions = {
+      baseBranch: 'master',
       skipReleaseLabels: [],
       labels: defaultLabelDefinition
     },
@@ -182,7 +184,8 @@ export default class Release {
       repo: this.git.options.repo,
       baseUrl: project.html_url,
       jira: this.options.jira,
-      labels: this.options.labels
+      labels: this.options.labels,
+      baseBranch: this.options.baseBranch
     });
 
     this.hooks.onCreateChangelog.call(changelog);
@@ -299,7 +302,7 @@ export default class Release {
             ...commit.labels
           ];
         } else {
-          commit.labels = ['pushToMaster', ...commit.labels];
+          commit.labels = ['pushToBaseBranch', ...commit.labels];
         }
 
         commit.subject = commit.subject.split('\n')[0];


### PR DESCRIPTION
# What Changed

Now that `shipit` only publishes to latest when on master we give the ability to the user to configure which branch is master.

This PR also changes the `pushToMaster` to `pushToBaseBranch. If you were configuring it in your autorc you should change pushToMaster => pushToBaseBranch

# Why

#355 

Todo:

- [x] Add tests
- [x] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
