### PR TITLE
when canary is run locally it uses the commits SHA instead of PR + Build

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -138,8 +138,15 @@ export default class Git {
     return list.split('\n').pop() as string;
   }
 
-  async getSha(): Promise<string> {
-    const result = await execPromise('git', ['rev-parse', 'HEAD']);
+  /**
+   * Get the SHA of the latest commit
+   */
+  async getSha(short?: boolean): Promise<string> {
+    const result = await execPromise('git', [
+      'rev-parse',
+      short && '--short',
+      'HEAD'
+    ]);
 
     this.logger.verbose.info(`Got commit SHA from HEAD: ${result}`);
 

--- a/src/plugins/npm/__tests__/npm.test.ts
+++ b/src/plugins/npm/__tests__/npm.test.ts
@@ -354,6 +354,7 @@ describe('publish', () => {
       'lerna',
       'version',
       'patch',
+      false,
       '--no-commit-hooks',
       '--yes',
       '-m',

--- a/src/plugins/npm/index.ts
+++ b/src/plugins/npm/index.ts
@@ -298,7 +298,8 @@ export default class NPMPlugin implements IPlugin {
       if (isMonorepo()) {
         auto.logger.verbose.info('Detected monorepo, using lerna');
         const monorepoBump = await bumpLatest(getMonorepoPackage(), version);
-        const command = [
+
+        await execPromise('npx', [
           'lerna',
           'version',
           monorepoBump || version,
@@ -308,9 +309,7 @@ export default class NPMPlugin implements IPlugin {
           '-m',
           "'Bump version to: %v [skip ci]'",
           ...verboseArgs
-        ].filter((item): item is string => Boolean(item));
-
-        await execPromise('npx', command);
+        ]);
         auto.logger.verbose.info('Successfully versioned repo');
         return;
       }

--- a/src/utils/__tests__/exec-promise.test.ts
+++ b/src/utils/__tests__/exec-promise.test.ts
@@ -4,6 +4,10 @@ test('resolves stdout', async () => {
   expect(await exec('echo', ['foo'])).toBe('foo');
 });
 
+test('filters out anything but strings', async () => {
+  expect(await exec('echo', ['foo', false, undefined, 'baz'])).toBe('foo baz');
+});
+
 test('fails correctly', async () => {
   expect.assertions(1);
   return expect(exec('false')).rejects.toMatchInlineSnapshot(

--- a/src/utils/exec-promise.ts
+++ b/src/utils/exec-promise.ts
@@ -7,9 +7,16 @@ import { spawn } from 'child_process';
  *
  * @param cmd the command as a string to pass in
  */
-export default async function execPromise(cmd: string, args?: string[]) {
+export default async function execPromise(
+  cmd: string,
+  args: (string | undefined | false)[] = []
+) {
+  const filteredArgs = args.filter(
+    (arg): arg is string => typeof arg === 'string'
+  );
+
   return new Promise<string>((completed, reject) => {
-    const child = spawn(cmd, args || [], {
+    const child = spawn(cmd, filteredArgs, {
       cwd: process.cwd(),
       env: process.env,
       shell: true


### PR DESCRIPTION
# What Changed

see title

# Why

`auto canary` can make a unique version locally so it should!

Todo:

- [x] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
