### PR TITLE
Override any env var set in the .env

### DIFF
--- a/docs/pages/getting-started.md
+++ b/docs/pages/getting-started.md
@@ -58,7 +58,7 @@ You must configure some environment variables for publishing and releasing to wo
 - `GH_TOKEN` - Used for updating the changelog and publishing the GitHub release
 - `NPM_TOKEN` - Used to publish to npm. (only with NPM plugin)
 
-You can also store these values in a local file at the root of your project named `.env`. You should make sure to add this file to your `.gitignore` so you don't commit any keys!
+You can also store these values in a local file at the root of your project named `.env`. You should make sure to add this file to your `.gitignore` so you don't commit any keys! These env vars will override these any variable already set on the process. This enables you to have a per project configuration that isn't effected by your global setup.
 
 ```bash
 GH_TOKEN=YOUR_TOKEN

--- a/src/__tests__/auto-env.test.ts
+++ b/src/__tests__/auto-env.test.ts
@@ -3,7 +3,7 @@ import Auto from '../auto';
 jest.mock('fs', () => ({
   readFileSync: () => 'FOO="test value"',
   closeSync: () => undefined,
-  existsSync: () => undefined,
+  existsSync: () => true,
   readFile: () => undefined,
   ReadStream: () => undefined,
   WriteStream: () => undefined,

--- a/src/__tests__/auto-env.test.ts
+++ b/src/__tests__/auto-env.test.ts
@@ -10,7 +10,9 @@ jest.mock('fs', () => ({
   writeFile: () => undefined
 }));
 
-test('should load .env file', async () => {
+test('should load .env file and override and env vars that are already set', async () => {
+  process.env.FOO = 'old value';
+
   const auto = new Auto({
     command: 'init',
     owner: 'foo',

--- a/src/auto.ts
+++ b/src/auto.ts
@@ -1,5 +1,7 @@
 import dotenv from 'dotenv';
 import envCi from 'env-ci';
+import fs from 'fs';
+import path from 'path';
 import { gt, inc, ReleaseType } from 'semver';
 import {
   AsyncParallelHook,
@@ -75,6 +77,20 @@ export interface IAutoHooks {
   afterPublish: AsyncParallelHook<[]>;
 }
 
+const loadEnv = () => {
+  const envFile = path.resolve(process.cwd(), '.env');
+
+  if (!fs.existsSync(envFile)) {
+    return;
+  }
+
+  const envConfig = dotenv.parse(fs.readFileSync(envFile));
+
+  Object.entries(envConfig).forEach(([key, value]) => {
+    process.env[key] = value;
+  });
+};
+
 export default class Auto {
   hooks: IAutoHooks;
   logger: ILogger;
@@ -108,7 +124,7 @@ export default class Auto {
       });
     });
 
-    dotenv.config();
+    loadEnv();
   }
 
   /**


### PR DESCRIPTION
# What Changed

see title

# Why

This is how I actually thought it worked so just matching that. This allows for a user to have some tokens set in their bashrc file but override them with the .env file that is project specifc. Makes working with an enterprise npm/github easier

Todo:

- [x] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
