### PR TITLE
make logLevel available on the logger

### DIFF
--- a/src/auto.ts
+++ b/src/auto.ts
@@ -37,7 +37,7 @@ import Release, {
 import SEMVER, { calculateSemVerBump } from './semver';
 import getGitHubToken from './utils/github-token';
 import loadPlugin, { IPlugin } from './utils/load-plugins';
-import createLog, { ILogger, LogLevel } from './utils/logger';
+import createLog, { ILogger } from './utils/logger';
 import { makeHooks } from './utils/make-hooks';
 
 const env = envCi();
@@ -79,7 +79,6 @@ export default class Auto {
   hooks: IAutoHooks;
   logger: ILogger;
   args: ArgsType;
-  logLevel: LogLevel;
   config?: IReleaseOptions;
 
   release?: Release;

--- a/src/plugins/npm/__tests__/npm.test.ts
+++ b/src/plugins/npm/__tests__/npm.test.ts
@@ -261,12 +261,10 @@ describe('publish', () => {
   test('should use silly logging in verbose mode', async () => {
     const plugin = new NPMPlugin();
     const hooks = makeHooks();
+    const logger = dummyLog();
+    logger.logLevel = 'veryVerbose';
 
-    plugin.apply({
-      hooks,
-      logger: dummyLog(),
-      logLevel: 'veryVerbose'
-    } as Auto);
+    plugin.apply({ hooks, logger } as Auto);
 
     readResult = `
       {

--- a/src/plugins/npm/index.ts
+++ b/src/plugins/npm/index.ts
@@ -174,7 +174,8 @@ export default class NPMPlugin implements IPlugin {
 
   apply(auto: Auto) {
     const isVerbose =
-      auto.logLevel === 'verbose' || auto.logLevel === 'veryVerbose';
+      auto.logger.logLevel === 'verbose' ||
+      auto.logger.logLevel === 'veryVerbose';
     const verboseArgs = isVerbose ? verbose : [];
 
     auto.hooks.beforeShipIt.tap(this.name, async () => {
@@ -334,6 +335,8 @@ export default class NPMPlugin implements IPlugin {
 
       if (isMonorepo()) {
         auto.logger.verbose.info('Detected monorepo, using lerna');
+
+        console.log(verboseArgs);
 
         await execPromise('npx', [
           'lerna',

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,6 +1,7 @@
 import signale, { Signale } from 'signale';
 
 export interface ILogger {
+  logLevel: LogLevel;
   log: signale.Signale<signale.DefaultMethods>;
   verbose: signale.Signale<signale.DefaultMethods>;
   veryVerbose: signale.Signale<signale.DefaultMethods>;
@@ -8,6 +9,7 @@ export interface ILogger {
 
 export function dummyLog(): ILogger {
   return {
+    logLevel: undefined,
     log: new Signale({ disabled: true }),
     verbose: new Signale({ disabled: true }),
     veryVerbose: new Signale({ disabled: true })
@@ -18,6 +20,7 @@ export type LogLevel = 'verbose' | 'veryVerbose' | undefined;
 
 export default function createLog(mode: LogLevel): ILogger {
   return {
+    logLevel: mode,
     log: new Signale(),
     verbose: new Signale({
       disabled: mode !== 'verbose' && mode !== 'veryVerbose'


### PR DESCRIPTION
# What Changed

see title

# Why

it wasn't exposed at all so the feature wasn't working. putting it on the logger made the most sense

Todo:

- [x] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
