### PR TITLE
skip releases for greenkeeper + make special changelog section

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,6 +165,15 @@
     "plugins": [
       "npm",
       "released"
+    ],
+    "labels": {
+      "greenkeeper": {
+        "name": "greenkeeper",
+        "title": "Dependency Updates"
+      }
+    },
+    "skipReleaseLabels": [
+      "greenkeeper"
     ]
   }
 }

--- a/src/__tests__/auto.test.ts
+++ b/src/__tests__/auto.test.ts
@@ -691,7 +691,7 @@ describe('Auto', () => {
       expect(canary).toHaveBeenCalledWith('1.2.4-canary.abcd');
     });
 
-    test.only('works when PR has "skip-release" label', async () => {
+    test('works when PR has "skip-release" label', async () => {
       const auto = new Auto({ command: 'comment', ...defaults, plugins: [] });
       auto.logger = dummyLog();
       await auto.loadConfig();


### PR DESCRIPTION
# What Changed

edit auto config

# Why

I'm tired of adding skip release to greenkeeper PRs

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
