### PR TITLE
fix bug when tying to publish canary for PR with skip-release label

### DIFF
--- a/src/__tests__/auto.test.ts
+++ b/src/__tests__/auto.test.ts
@@ -690,6 +690,26 @@ describe('Auto', () => {
       await auto.canary();
       expect(canary).toHaveBeenCalledWith('1.2.4-canary.abcd');
     });
+
+    test.only('works when PR has "skip-release" label', async () => {
+      const auto = new Auto({ command: 'comment', ...defaults, plugins: [] });
+      auto.logger = dummyLog();
+      await auto.loadConfig();
+
+      auto.git!.getSha = () => Promise.resolve('abcd');
+      auto.git!.getLatestRelease = () => Promise.resolve('1.2.3');
+      auto.release!.getCommitsInRelease = () =>
+        Promise.resolve([
+          makeCommitFromMsg('Test Commit', {
+            labels: ['skip-release']
+          })
+        ]);
+      const canary = jest.fn();
+      auto.hooks.canary.tap('test', canary);
+
+      await auto.canary();
+      expect(canary).toHaveBeenCalledWith('1.2.4-canary.abcd');
+    });
   });
 });
 

--- a/src/auto.ts
+++ b/src/auto.ts
@@ -455,7 +455,7 @@ export default class Auto {
       this.semVerLabels!,
       this.config
     );
-    const nextVersion = inc(current, version as ReleaseType);
+    const nextVersion = inc(current, (version || 'patch') as ReleaseType);
     let canaryVersion = `${nextVersion}-canary.${preId}`;
 
     if (build) {


### PR DESCRIPTION
# What Changed

see title

# Why

canary for #366 failed so I fixed the problem

Todo:

- [x] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
