### PR TITLE
shipit will publish a canary locally when not on master

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Release Features:
 
 - Calculate semantic version bumps from PRs
 - Skip a release with the `skip-release` label
-- Publish canary releases from PRs
+- Publish canary releases from PRs or locally
 - Generate changelogs with fancy headers, authors, and monorepo package association
 - Use labels to create new changelog section
 - Generate a GitHub release

--- a/docs/pages/auto-shipit.md
+++ b/docs/pages/auto-shipit.md
@@ -1,6 +1,6 @@
 # `auto shipit`
 
-Run the full `auto` release pipeline. Will detect if in a lerna project and publish accordingly. If ran from a PR build, `shipit` publish a canary release using [`auto canary`](./auto-canary.md).
+Run the full `auto` release pipeline. Will detect if in a lerna project and publish accordingly. If ran from a PR build or locally from any branch other than the `baseBranch`, `shipit` will publish a canary release using [`auto canary`](./auto-canary.md).
 
 ```sh
 auto shipit

--- a/docs/pages/getting-started.md
+++ b/docs/pages/getting-started.md
@@ -75,8 +75,8 @@ To version, changelog, publish and release your code all at the same time, we've
 
 It will:
 
-1. Publish canary releases when run from a PR
-2. Generate a changelog and publish a "latest" release to a package manager when run from the base branch
+1. Publish canary releases when run from a PR or locally on any branch other than the `baseBranch`
+2. Generate a changelog and publish a "latest" release to a package manager when run from the `baseBranch`
 
 ```json
 {

--- a/docs/pages/introduction.md
+++ b/docs/pages/introduction.md
@@ -8,7 +8,7 @@ Release Features:
 
 - Calculate semantic version bumps from PRs
 - Skip a release with the `skip-release` label
-- Publish canary releases from PRs
+- Publish canary releases from PRs or locally
 - Generate changelogs with fancy headers, authors, and monorepo package association
 - Use labels to create new changelog section
 - Generate a GitHub release

--- a/src/__tests__/auto-canary-local.test.ts
+++ b/src/__tests__/auto-canary-local.test.ts
@@ -1,0 +1,29 @@
+import Auto from '../auto';
+import { dummyLog } from '../utils/logger';
+
+jest.mock('env-ci', () => () => ({
+  branch: 'local-test'
+}));
+
+const defaults = {
+  owner: 'foo',
+  repo: 'bar',
+  token: 'XXXX'
+};
+
+test('shipit should publish canary in locally when not on master', async () => {
+  const auto = new Auto({ command: 'comment', ...defaults, plugins: [] });
+  auto.logger = dummyLog();
+  await auto.loadConfig();
+
+  auto.git!.getLatestRelease = () => Promise.resolve('1.2.3');
+  auto.git!.getSha = () => Promise.resolve('abc');
+  auto.git!.createComment = jest.fn();
+  auto.release!.getCommitsInRelease = () => Promise.resolve([]);
+  auto.release!.getCommits = () => Promise.resolve([]);
+  const canary = jest.fn();
+  auto.hooks.canary.tap('test', canary);
+
+  await auto.shipit();
+  expect(canary).toHaveBeenCalledWith('1.2.4-canary.abc');
+});

--- a/src/auto.ts
+++ b/src/auto.ts
@@ -506,7 +506,9 @@ export default class Auto {
 
     // env-ci sets branch to target branch (ex: master) in some CI services.
     // so we should make sure we aren't in a PR just to be safe
-    const isBaseBranch = 'branch' in env && env.branch === this.baseBranch;
+    const isPR = 'isPr' in env && env.isPr;
+    const isBaseBranch =
+      !isPR && 'branch' in env && env.branch === this.baseBranch;
     const publishInfo = isBaseBranch
       ? await this.publishLatest(options)
       : await this.canary(options);

--- a/src/auto.ts
+++ b/src/auto.ts
@@ -504,24 +504,12 @@ export default class Auto {
     this.logger.verbose.info("Using command: 'shipit'");
     this.hooks.beforeShipIt.call();
 
-    const isPR = 'isPr' in env && env.isPr;
     // env-ci sets branch to target branch (ex: master) in some CI services.
     // so we should make sure we aren't in a PR just to be safe
-    const isBaseBranch =
-      !isPR && 'branch' in env && env.branch === this.baseBranch;
-    const publishInfo = isPR
-      ? await this.canary(options)
-      : isBaseBranch
+    const isBaseBranch = 'branch' in env && env.branch === this.baseBranch;
+    const publishInfo = isBaseBranch
       ? await this.publishLatest(options)
-      : undefined;
-
-    if (!isPR && !isBaseBranch) {
-      this.logger.log.info(
-        `No version published. Could not detect if in PR or on ${
-          this.baseBranch
-        }.`
-      );
-    }
+      : await this.canary(options);
 
     if (!publishInfo) {
       return;

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -395,7 +395,8 @@ const commands: ICommand[] = [
       Run the full \`auto\` release pipeline. Detects if in a lerna project.
 
       1. call from base branch -> latest version released
-      2. call from PR in CI -> canary version released #351
+      2. call from PR in CI -> canary version released
+      3. call locally when not on base branch -> canary version released
     `,
     examples: ['{green $} auto shipit'],
     options: [...defaultOptions, baseBranch, dryRun]


### PR DESCRIPTION
# What Changed

see title

# Why

This is what was intended (look at the docs). Was overlooked before merging #351 

Todo:

- [x] Add tests
- [x] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
