### PR TITLE
Restrict config type

### DIFF
--- a/docs/pages/autorc.md
+++ b/docs/pages/autorc.md
@@ -2,12 +2,13 @@
 
 All options for the CLI tools can also be configured via the `.autorc`. As CLI options you supply them in snake-case (`--foo-bar`), but as `.autorc` options you supply them in camelCase (`fooBar`),
 
-We use [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) to find your config, so that means you can define this file a variety of ways. By default, Cosmiconfig will start at the root of your project and start to search up the directory tree for the following:
+We use [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) to find your config, so that means you can define this file a variety of ways. Our Cosmiconfig setup is a little custom and will start at the root of your project and start to search up the directory tree for the following:
 
-- a package.json property
 - a JSON or YAML, extension-less "rc file"
-- an "rc file" with the extensions .json, .yaml, .yml, or .js.
-- a .config.js CommonJS module
+- an "rc file" with the extensions .json, .yaml, or .yml
+- a package.json property
+
+We do not support writing configuration files in JavaScript.
 
 ## Initialization
 
@@ -23,13 +24,14 @@ These options can be set exclusively in the `.autorc` and do not exist as CLI fl
 
 ### Extending
 
-If you want to share your auto configuration between projects you can use the `extends` property. This property will load an autorc object or a function that returns an autorc object and merge it with your project's `.autorc`.
+If you want to share your auto configuration between projects you can use the `extends` property. This property will load from a module's package.json or from a custom path. It's expected that the extended configuration be under the `auto` key in the package.json file.
 
 Auto can load `extends` configs in the following ways:
 
-- from a path `path/to/config`
-- from a scoped package `@YOUR_SCOPE/auto-config`
+- from a path `./path/to/config` (this file must be in JSON format)
+- from a scoped package `@YOUR_SCOPE/auto-config` (under the `auto` key in the package.json)
 - from a package `auto-config-YOUR_NAME`
+- from a url `https://yourdomain.com/auto-config.json` (must return the content type `application/json`)
 
 ```json
 {
@@ -50,6 +52,20 @@ Will use the package `auto-config-joe`
 ::: message is-warning
 If extending from a config package make sure it's a dependency of your project
 :::
+
+If you're extending from a local file it can be any file in JSON format or a `package.json` file.
+
+```json
+{
+  "extends": "./path/to/config.json"
+}
+```
+
+```json
+{
+  "extends": "./path/to/other/package.json"
+}
+```
 
 ### Labels
 

--- a/src/__tests__/auto.test.ts
+++ b/src/__tests__/auto.test.ts
@@ -72,8 +72,8 @@ describe('Auto', () => {
   test('should extend config', async () => {
     search.mockReturnValueOnce({ config: { ...defaults, extends: '@artsy' } });
     importMock.mockImplementation(path =>
-      path === '@artsy/auto-config'
-        ? { onlyPublishWithReleaseLabel: true }
+      path === '@artsy/auto-config/package.json'
+        ? { auto: { onlyPublishWithReleaseLabel: true } }
         : undefined
     );
 

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -18,7 +18,7 @@ jest.mock('import-cwd', () => (path: string) => importMock(path));
 describe('loadExtendConfig', () => {
   test('should reject when no config found', async () => {
     const config = new Config(log);
-    return expect(config.loadExtendConfig('nothing')).rejects.toBeInstanceOf(
+    await expect(config.loadExtendConfig('nothing')).rejects.toBeInstanceOf(
       Error
     );
   });
@@ -50,7 +50,7 @@ describe('loadExtendConfig', () => {
     importMock.mockImplementation(path =>
       path === '../fake/path.js' ? { jira: 'url' } : undefined
     );
-    return expect(
+    await expect(
       config.loadExtendConfig('../fake/path.js')
     ).rejects.toBeInstanceOf(Error);
   });
@@ -74,7 +74,7 @@ describe('loadExtendConfig', () => {
     const config = new Config(log);
 
     fetchSpy.mockRejectedValueOnce(new Error());
-    return expect(
+    await expect(
       // tslint:disable-next-line:no-http-string
       config.loadExtendConfig('http://www.test.com/config.json')
     ).rejects.toBeInstanceOf(Error);

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -34,6 +34,17 @@ describe('loadExtendConfig', () => {
     });
   });
 
+  test('should load package.json file from path', async () => {
+    const config = new Config(log);
+
+    importMock.mockImplementation(path =>
+      path === './package.json' ? { auto: { jira: 'url' } } : undefined
+    );
+    expect(await config.loadExtendConfig('./package.json')).toEqual({
+      jira: 'url'
+    });
+  });
+
   test('should fail if file path points to js file', async () => {
     const config = new Config(log);
     importMock.mockImplementation(path =>

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,15 +1,26 @@
 import Config from '../config';
 import { dummyLog } from '../utils/logger';
 
+const fetchSpy = jest.fn();
+
+// @ts-ignore
+jest.mock('node-fetch', () => (...args) => fetchSpy(...args));
+
+beforeEach(() => {
+  fetchSpy.mockClear();
+});
+
 const log = dummyLog();
 
 const importMock = jest.fn();
 jest.mock('import-cwd', () => (path: string) => importMock(path));
 
 describe('loadExtendConfig', () => {
-  test('should throw when no config found', async () => {
+  test('should reject when no config found', async () => {
     const config = new Config(log);
-    expect(() => config.loadExtendConfig('nothing')).toThrow();
+    return expect(config.loadExtendConfig('nothing')).rejects.toBeInstanceOf(
+      Error
+    );
   });
 
   test('should load file path', async () => {
@@ -18,21 +29,56 @@ describe('loadExtendConfig', () => {
     importMock.mockImplementation(path =>
       path === '../fake/path.json' ? { jira: 'url' } : undefined
     );
-    expect(config.loadExtendConfig('../fake/path.json')).toEqual({
+    expect(await config.loadExtendConfig('../fake/path.json')).toEqual({
       jira: 'url'
     });
+  });
+
+  test('should fail if file path points to js file', async () => {
+    const config = new Config(log);
+    importMock.mockImplementation(path =>
+      path === '../fake/path.js' ? { jira: 'url' } : undefined
+    );
+    return expect(
+      config.loadExtendConfig('../fake/path.js')
+    ).rejects.toBeInstanceOf(Error);
+  });
+
+  test('should call fetch on URL with config', async () => {
+    const config = new Config(log);
+    const mockFetchJson = jest.fn();
+    mockFetchJson.mockReturnValue({});
+
+    fetchSpy.mockResolvedValueOnce({
+      json: mockFetchJson
+    });
+
+    // tslint:disable-next-line:no-http-string
+    await config.loadExtendConfig('http://www.test.com/config.json');
+    expect(fetchSpy).toHaveBeenCalled();
+    expect(mockFetchJson).toHaveBeenCalled();
+  });
+
+  test('should reject if extends URL fails to fetch', async () => {
+    const config = new Config(log);
+
+    fetchSpy.mockRejectedValueOnce(new Error());
+    return expect(
+      // tslint:disable-next-line:no-http-string
+      config.loadExtendConfig('http://www.test.com/config.json')
+    ).rejects.toBeInstanceOf(Error);
   });
 
   test('should load @NAME/auto-config', async () => {
     const config = new Config(log);
 
     importMock.mockImplementation(path =>
-      path === '@artsy/auto-config'
-        ? { onlyPublishWithReleaseLabel: true }
+      path === '@artsy/auto-config/package.json'
+        ? { auto: { onlyPublishWithReleaseLabel: true } }
         : undefined
     );
 
-    expect(config.loadExtendConfig('@artsy')).toEqual({
+    expect(await config.loadExtendConfig('@artsy')).toEqual({
       onlyPublishWithReleaseLabel: true
     });
   });
@@ -41,22 +87,13 @@ describe('loadExtendConfig', () => {
     const config = new Config(log);
 
     importMock.mockImplementation(path =>
-      path === 'auto-config-fuego' ? { noVersionPrefix: true } : undefined
+      path === 'auto-config-fuego/package.json'
+        ? { auto: { noVersionPrefix: true } }
+        : undefined
     );
 
-    expect(config.loadExtendConfig('fuego')).toEqual({
+    expect(await config.loadExtendConfig('fuego')).toEqual({
       noVersionPrefix: true
-    });
-  });
-  test('should load extend config from function', async () => {
-    const config = new Config(log);
-
-    importMock.mockImplementation(path =>
-      path === '../fake/path.js' ? () => ({ slack: 'url' }) : undefined
-    );
-
-    expect(config.loadExtendConfig('../fake/path.js')).toEqual({
-      slack: 'url'
     });
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -122,6 +122,9 @@ export default class Config {
       }
     } else if (extend.startsWith('.')) {
       config = tryRequire(extend);
+      if (extend.endsWith('package.json')) {
+        config = config && config.auto;
+      }
       this.logger.verbose.note(`${extend} found: ${config}`);
     } else {
       config = tryRequire(`${extend}/package.json`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,8 +13,6 @@ import {
 import { ILogger } from './utils/logger';
 import tryRequire from './utils/try-require';
 
-type ConfigLoader = () => cosmiconfig.Config;
-
 function normalizeLabels(config: cosmiconfig.Config) {
   let labels = defaultLabelDefinition;
 
@@ -72,7 +70,10 @@ export default class Config {
     }
 
     if (rawConfig.extends) {
-      rawConfig = merge(rawConfig, this.loadExtendConfig(rawConfig.extends));
+      rawConfig = merge(
+        rawConfig,
+        await this.loadExtendConfig(rawConfig.extends)
+      );
     }
 
     const labels = normalizeLabels(rawConfig);
@@ -103,31 +104,42 @@ export default class Config {
    * @param extend Path or name of config to find
    */
   async loadExtendConfig(extend: string) {
-    let config: cosmiconfig.Config | ConfigLoader;
+    let config: cosmiconfig.Config | { auto: cosmiconfig.Config };
+
+    if (extend.endsWith('.js') || extend.endsWith('.mjs')) {
+      throw new Error('Extended config cannot be a JavaScript file');
+    }
 
     if (extend.startsWith('http')) {
       try {
-        return (await fetch(extend)).json();
+        config = (await fetch(extend)).json();
+        this.logger.verbose.note(`${extend} found: ${config}`);
       } catch (error) {
         error.message = `Failed to get extended config from ${extend} -- ${
           error.message
         }`;
         throw error;
       }
+    } else if (extend.startsWith('.')) {
+      config = tryRequire(extend);
+      this.logger.verbose.note(`${extend} found: ${config}`);
+    } else {
+      config = tryRequire(`${extend}/package.json`);
+      config = config && config.auto;
+      this.logger.verbose.note(`${extend} found: ${config}`);
     }
-
-    config = tryRequire(`${extend}/package.json`);
-    this.logger.verbose.note(`${extend} found: ${config}`);
 
     if (!config) {
       const scope = `${extend}/auto-config/package.json`;
       config = tryRequire(scope);
+      config = config && config.auto;
       this.logger.verbose.note(`${scope} found: ${config}`);
     }
 
     if (!config) {
       const scope = `auto-config-${extend}/package.json`;
       config = tryRequire(scope);
+      config = config && config.auto;
       this.logger.verbose.note(`${scope} found: ${config}`);
     }
 
@@ -139,10 +151,6 @@ export default class Config {
       throw new Error(`Unable to load extended config ${extend}`);
     }
 
-    if (typeof config === 'function') {
-      return (config as ConfigLoader)();
-    }
-
-    return config || {};
+    return config;
   }
 }


### PR DESCRIPTION
Resolves #369

# What Changed

- Adds support for using a URL for extended configs
- Extended config from npm packages _must_ be in the package.json under the `auto` property
- Extended configs can _only_ be json (even if they're local to your repo)
- Project auto configs can no longer be JS files
- Changes the search order for configs to look in the package.json _last_ so that we can support extended config repos that share their config but have a local auto config for deployments. 

# Why

In order to build better automation tooling around auto (like a GitHub app) we can't allow the configuration files to be javascript. If they are this would mean any automation app would ultimately be running untrusted JS which is a rather hard problem to solve for. 

# Todo

- [x] Add tests
- [x] Add docs
- [x] Add yourself to contributors (run `yarn contributors:add`)
