### PR TITLE
Better get by username/email error handling

### DIFF
--- a/src/__tests__/git.test.ts
+++ b/src/__tests__/git.test.ts
@@ -319,15 +319,25 @@ describe('github', () => {
     expect(listCommits).toHaveBeenCalled();
   });
 
-  test('getUserByUsername', async () => {
-    const gh = new Git(options);
+  describe('getUserByUsername', () => {
+    test('exists', async () => {
+      const gh = new Git(options);
 
-    getByUsername.mockReturnValueOnce({
-      data: { name: 'Andrew Lisowski' }
+      getByUsername.mockReturnValueOnce({
+        data: { name: 'Andrew Lisowski' }
+      });
+
+      expect(await gh.getUserByUsername('andrew')).toEqual({
+        name: 'Andrew Lisowski'
+      });
     });
 
-    expect(await gh.getUserByUsername('andrew')).toEqual({
-      name: 'Andrew Lisowski'
+    test('not found', async () => {
+      const gh = new Git(options);
+
+      getByUsername.mockRejectedValueOnce(Error);
+
+      expect(await gh.getUserByUsername('andrew')).toBeUndefined();
     });
   });
 

--- a/src/__tests__/git.test.ts
+++ b/src/__tests__/git.test.ts
@@ -355,6 +355,14 @@ describe('github', () => {
         login: 'lisowski54@gmail.com'
       });
     });
+
+    test('errors', async () => {
+      const gh = new Git(options);
+
+      getByUsername.mockRejectedValueOnce(Error);
+
+      expect(await gh.getUserByEmail('lisowski54@gmail.com')).toBeUndefined();
+    });
   });
 
   describe('getLatestRelease', () => {

--- a/src/git.ts
+++ b/src/git.ts
@@ -238,9 +238,15 @@ export default class Git {
 
   @Memoize()
   async getUserByUsername(username: string) {
-    return (await this.ghub.users.getByUsername({
-      username
-    })).data;
+    try {
+      const user = await this.ghub.users.getByUsername({
+        username
+      });
+
+      return user.data;
+    } catch (error) {
+      this.logger.verbose.warn(`Could not find user by username: ${username}`);
+    }
   }
 
   @Memoize()

--- a/src/git.ts
+++ b/src/git.ts
@@ -223,13 +223,17 @@ export default class Git {
 
   @Memoize()
   async getUserByEmail(email: string) {
-    const search = (await this.ghub.search.users({
-      q: `in:email ${email}`
-    })).data;
+    try {
+      const search = (await this.ghub.search.users({
+        q: `in:email ${email}`
+      })).data;
 
-    return search && search.items.length > 0
-      ? search.items[0]
-      : { login: email };
+      return search && search.items.length > 0
+        ? search.items[0]
+        : { login: email };
+    } catch (error) {
+      this.logger.verbose.warn(`Could not find user by email: ${email}`);
+    }
   }
 
   @Memoize()


### PR DESCRIPTION
# What Changed

see title

# Why

seeing requests to 'https://github.com/api/v3/search/users?q=in%3Aemail%20nobody%40nowhere' which would fail the publish

Todo:

- [x] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
