### PR TITLE
add `auto pr-body` to add info to pr bodies + canary posts to body instead of comment

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,7 @@
   - [auto label](pages/auto-label.md)
   - [auto pr](pages/auto-pr.md)
   - [auto pr-check](pages/auto-pr-check.md)
+  - [auto pr-body](pages/auto-pr-body.md)
   - [auto comment](pages/auto-comment.md)
 
 ---

--- a/docs/pages/auto-pr-body.md
+++ b/docs/pages/auto-pr-body.md
@@ -1,0 +1,36 @@
+# `auto pr-check`
+
+Update the body of a PR with a message. Appends to PR and will not overwrite user content
+
+```sh
+auto pr-body --pr 24 --message "Canary Version: 1.2.3"
+```
+
+## Options
+
+```bash
+>  auto pr-body -h
+
+Options
+
+  --pr number                       The pull request the command should use. Detects PR number in CI
+  --context string                  A string label to differentiate this status from others
+  -m, --message string [required]   Message to post to PR body
+  -d, --dry-run                     Report what command will do but do not actually do anything
+
+Global Options
+
+  -h, --help            Display the help output for the command
+  -v, --verbose         Show some more logs
+  -w, --very-verbose    Show a lot more logs
+  --repo string         The repo to set the status on. Defaults to looking in the package definition
+                        for the platform
+  --owner string        The owner of the GitHub repo. Defaults to reading from the package definition
+                        for the platform
+  --github-api string   GitHub API to use
+  --plugins string[]    Plugins to load auto with. (defaults to just npm)
+
+Examples
+
+  $ auto pr-body --pr 123 --comment "The new version is: 1.2.3"
+```

--- a/src/__tests__/auto-canary-in-pr-ci.test.ts
+++ b/src/__tests__/auto-canary-in-pr-ci.test.ts
@@ -26,8 +26,8 @@ describe('canary in ci', () => {
       Promise.resolve([makeCommitFromMsg('Test Commit')]);
     const canary = jest.fn();
     auto.hooks.canary.tap('test', canary);
-    const createComment = jest.fn();
-    auto.git!.createComment = createComment;
+    const addToPrBody = jest.fn();
+    auto.git!.addToPrBody = addToPrBody;
     auto.release!.getCommits = jest.fn();
 
     await auto.canary();
@@ -41,13 +41,13 @@ describe('canary in ci', () => {
     auto.git!.getLatestRelease = () => Promise.resolve('1.2.3');
     auto.release!.getCommitsInRelease = () =>
       Promise.resolve([makeCommitFromMsg('Test Commit')]);
-    const createComment = jest.fn();
-    auto.git!.createComment = createComment;
+    const addToPrBody = jest.fn();
+    auto.git!.addToPrBody = addToPrBody;
     auto.release!.getCommits = jest.fn();
     auto.hooks.canary.tap('test', () => '1.2.4-canary.123.1');
 
     const version = await auto.canary({ pr: 123, build: 1 });
-    expect(createComment).toHaveBeenCalled();
+    expect(addToPrBody).toHaveBeenCalled();
     expect(version.newVersion).toBe('1.2.4-canary.123.1');
   });
 
@@ -58,12 +58,12 @@ describe('canary in ci', () => {
     auto.git!.getLatestRelease = () => Promise.resolve('1.2.3');
     auto.release!.getCommitsInRelease = () =>
       Promise.resolve([makeCommitFromMsg('Test Commit')]);
-    const createComment = jest.fn();
-    auto.git!.createComment = createComment;
+    const addToPrBody = jest.fn();
+    auto.git!.addToPrBody = addToPrBody;
     auto.release!.getCommits = jest.fn();
 
     await auto.canary({ pr: 123, build: 1, message: 'false' });
-    expect(createComment).not.toHaveBeenCalled();
+    expect(addToPrBody).not.toHaveBeenCalled();
   });
 
   test('can override pr and build', async () => {
@@ -72,8 +72,8 @@ describe('canary in ci', () => {
     await auto.loadConfig();
     auto.release!.getCommitsInRelease = () =>
       Promise.resolve([makeCommitFromMsg('Test Commit')]);
-    const createComment = jest.fn();
-    auto.git!.createComment = createComment;
+    const addToPrBody = jest.fn();
+    auto.git!.addToPrBody = addToPrBody;
     auto.release!.getCommits = jest.fn();
     auto.hooks.canary.tap('test', (bump, post) => `1.2.4-canary${post}`);
 
@@ -89,7 +89,7 @@ describe('shipit in ci', () => {
     await auto.loadConfig();
 
     auto.git!.getLatestRelease = () => Promise.resolve('1.2.3');
-    auto.git!.createComment = jest.fn();
+    auto.git!.addToPrBody = jest.fn();
     auto.release!.getCommitsInRelease = () => Promise.resolve([]);
     auto.release!.getCommits = () => Promise.resolve([]);
     const canary = jest.fn();

--- a/src/__tests__/auto.test.ts
+++ b/src/__tests__/auto.test.ts
@@ -536,7 +536,9 @@ describe('Auto', () => {
       const auto = new Auto({ command: 'comment', ...defaults });
       auto.logger = dummyLog();
 
-      expect(auto.comment({ pr: 10, message: 'foo' })).rejects.toBeTruthy();
+      await expect(
+        auto.comment({ pr: 10, message: 'foo' })
+      ).rejects.toBeTruthy();
     });
 
     test('should make a comment', async () => {
@@ -549,6 +551,29 @@ describe('Auto', () => {
 
       await auto.comment({ pr: 10, message: 'foo' });
       expect(createComment).toHaveBeenCalled();
+    });
+  });
+
+  describe('prBody', () => {
+    test('should throw when not initialized', async () => {
+      const auto = new Auto({ command: 'comment', ...defaults });
+      auto.logger = dummyLog();
+
+      await expect(
+        auto.prBody({ pr: 10, message: 'foo' })
+      ).rejects.toBeTruthy();
+    });
+
+    test('should make a pr body update', async () => {
+      const auto = new Auto({ command: 'comment', ...defaults });
+      auto.logger = dummyLog();
+      await auto.loadConfig();
+
+      const addToPrBody = jest.fn();
+      auto.git!.addToPrBody = addToPrBody;
+
+      await auto.prBody({ pr: 10, message: 'foo' });
+      expect(addToPrBody).toHaveBeenCalled();
     });
   });
 

--- a/src/__tests__/git.test.ts
+++ b/src/__tests__/git.test.ts
@@ -301,7 +301,7 @@ describe('github', () => {
     });
   });
 
-  describe.only('addToPrBody', () => {
+  describe('addToPrBody', () => {
     test('should add to PR body if none exists', async () => {
       const gh = new Git(options);
 

--- a/src/__tests__/git.test.ts
+++ b/src/__tests__/git.test.ts
@@ -21,6 +21,8 @@ const addLabels = jest.fn();
 const list = jest.fn();
 const lock = jest.fn();
 const errorHook = jest.fn();
+const get = jest.fn();
+const update = jest.fn();
 
 jest.mock('@octokit/rest', () => {
   const instance = () => ({
@@ -39,7 +41,9 @@ jest.mock('@octokit/rest', () => {
       createLabel,
       updateLabel,
       addLabels,
-      lock
+      lock,
+      get,
+      update
     },
     repos: {
       createStatus,
@@ -294,6 +298,59 @@ describe('github', () => {
 
       expect(deleteComment).toHaveBeenCalled();
       expect(deleteComment.mock.calls[0][0].comment_id).toBe(1000);
+    });
+  });
+
+  describe.only('addToPrBody', () => {
+    test('should add to PR body if none exists', async () => {
+      const gh = new Git(options);
+
+      get.mockReturnValueOnce({ data: { body: '# My Content' } });
+      await gh.addToPrBody('Some long thing', 22);
+      expect(update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body:
+            '# My Content\n<!-- GITHUB_RELEASE PR BODY: default -->\nSome long thing\n<!-- GITHUB_RELEASE PR BODY: default -->\n'
+        })
+      );
+    });
+
+    test('should overwrite old context', async () => {
+      const gh = new Git(options);
+
+      get.mockReturnValueOnce({
+        data: {
+          body:
+            '# My Content\n<!-- GITHUB_RELEASE PR BODY: default -->\nSome long thing\n<!-- GITHUB_RELEASE PR BODY: default -->\n'
+        }
+      });
+
+      await gh.addToPrBody('Something else', 22);
+      expect(update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body:
+            '# My Content\n<!-- GITHUB_RELEASE PR BODY: default -->\nSomething else\n<!-- GITHUB_RELEASE PR BODY: default -->\n'
+        })
+      );
+    });
+
+    test('should be able to add to body in different contexts', async () => {
+      const gh = new Git(options);
+
+      get.mockReturnValueOnce({
+        data: {
+          body:
+            '# My Content\n<!-- GITHUB_RELEASE PR BODY: default -->\nSomething else\n<!-- GITHUB_RELEASE PR BODY: default -->\n'
+        }
+      });
+
+      await gh.addToPrBody('Some long thing', 22, 'PERF');
+      expect(update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body:
+            '# My Content\n<!-- GITHUB_RELEASE PR BODY: default -->\nSomething else\n<!-- GITHUB_RELEASE PR BODY: default -->\n\n<!-- GITHUB_RELEASE PR BODY: PERF -->\nSome long thing\n<!-- GITHUB_RELEASE PR BODY: PERF -->\n'
+        })
+      );
     });
   });
 

--- a/src/auto.ts
+++ b/src/auto.ts
@@ -403,6 +403,36 @@ export default class Auto {
   }
 
   /**
+   * Update the body of a PR with a message. Only one message will be present in the PR,
+   * Older messages are removed. You can use the "context" option to multiple message
+   * in a PR body.
+   *
+   * @param options Options
+   */
+  async prBody({
+    message,
+    pr,
+    context = 'default',
+    dryRun
+  }: ICommentCommandOptions) {
+    if (!this.git) {
+      throw this.createErrorMessage();
+    }
+
+    this.logger.verbose.info("Using command: 'pr-body'");
+
+    if (dryRun) {
+      this.logger.log.info(
+        `Would have appended to PR body on ${pr} under "${context}" context:\n\n${message}`
+      );
+    } else {
+      const prNumber = this.getPrNumber('pr-body', pr);
+      await this.git.addToPrBody(message, prNumber, context);
+      this.logger.log.success(`Updated body on PR #${pr}`);
+    }
+  }
+
+  /**
    * Calculate the version bump for the current state of the repository.
    */
   async version() {

--- a/src/auto.ts
+++ b/src/auto.ts
@@ -508,7 +508,7 @@ export default class Auto {
         options.message || 'Published PR with canary version: `%v`';
 
       if (message !== 'false' && env.isCi) {
-        this.comment({
+        this.prBody({
           message: message.replace('%v', canaryVersion),
           context: 'canary-version'
         });

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -390,6 +390,22 @@ const commands: ICommand[] = [
     ]
   },
   {
+    name: 'pr-body',
+    summary:
+      'Update the body of a PR with a message. Appends to PR and will not overwrite user content',
+    require: ['message'],
+    options: [
+      pr,
+      context,
+      { ...message, description: 'Message to post to PR body' },
+      dryRun,
+      ...defaultOptions
+    ],
+    examples: [
+      '{green $} auto pr-body --pr 123 --comment "The new version is: 1.2.3"'
+    ]
+  },
+  {
     name: 'shipit',
     summary: dedent`
       Run the full \`auto\` release pipeline. Detects if in a lerna project.
@@ -487,7 +503,13 @@ function printRootHelp() {
     },
     {
       header: 'Pull Request Interaction Commands',
-      content: filterCommands(commands, ['label', 'pr-check', 'pr', 'comment'])
+      content: filterCommands(commands, [
+        'label',
+        'pr-check',
+        'pr',
+        'pr-body',
+        'comment'
+      ])
     },
     {
       header: 'Global Options',

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,6 +42,10 @@ export async function run(args: ArgsType) {
       await auto.loadConfig();
       await auto.comment(args as ICommentCommandOptions);
       break;
+    case 'pr-body':
+      await auto.loadConfig();
+      await auto.prBody(args as ICommentCommandOptions);
+      break;
     case 'version':
       await auto.loadConfig();
       await auto.version();


### PR DESCRIPTION
# What Changed

1. create `pr-body` command - it's just like comment but in the pr-body
2. make canary use pr-body

# Why

closes #376 

Also it seems like another useful tool for PR interaction

Todo:

- [x] Add tests
- [x] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `6.1.0-canary.379.4692`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
