### PR TITLE
Correct reported lerna independent version

### DIFF
--- a/src/__tests__/auto-canary-in-pr-ci.test.ts
+++ b/src/__tests__/auto-canary-in-pr-ci.test.ts
@@ -48,7 +48,7 @@ describe('canary in ci', () => {
 
     const version = await auto.canary({ pr: 123, build: 1 });
     expect(addToPrBody).toHaveBeenCalled();
-    expect(version.newVersion).toBe('1.2.4-canary.123.1');
+    expect(version!.newVersion).toBe('1.2.4-canary.123.1');
   });
 
   test('should not comment when passed "false"', async () => {
@@ -78,7 +78,7 @@ describe('canary in ci', () => {
     auto.hooks.canary.tap('test', (bump, post) => `1.2.4-canary${post}`);
 
     const version = await auto.canary({ pr: 456, build: 5 });
-    expect(version.newVersion).toBe('1.2.4-canary.456.5');
+    expect(version!.newVersion).toBe('1.2.4-canary.456.5');
   });
 });
 

--- a/src/__tests__/auto.test.ts
+++ b/src/__tests__/auto.test.ts
@@ -692,6 +692,7 @@ describe('Auto', () => {
       auto.logger = dummyLog();
       await auto.loadConfig();
       auto.git!.getLatestRelease = () => Promise.resolve('1.2.3');
+      auto.git!.getSha = () => Promise.resolve('abc');
       auto.release!.getCommitsInRelease = () =>
         Promise.resolve([makeCommitFromMsg('Test Commit')]);
       const canary = jest.fn();
@@ -699,7 +700,7 @@ describe('Auto', () => {
       auto.release!.getCommits = jest.fn();
 
       await auto.canary({ pr: 123, build: 1 });
-      expect(canary).toHaveBeenCalledWith(SEMVER.patch, '.123.1');
+      expect(canary).toHaveBeenCalledWith(SEMVER.patch, '.123.1.abc');
     });
 
     test('defaults to sha when run locally', async () => {

--- a/src/auto.ts
+++ b/src/auto.ts
@@ -496,6 +496,8 @@ export default class Auto {
       canaryVersion = `${canaryVersion}.${await this.git.getSha(true)}`;
     }
 
+    let newVersion = '';
+
     if (options.dryRun) {
       this.logger.log.warn(
         `Published canary identifier would be: "-canary${canaryVersion}"`
@@ -509,24 +511,25 @@ export default class Auto {
         return;
       }
 
+      newVersion = result;
       const message =
         options.message || 'Published PR with canary version: `%v`';
 
       if (message !== 'false' && env.isCi) {
         this.prBody({
-          message: message.replace('%v', result),
+          message: message.replace('%v', newVersion),
           context: 'canary-version'
         });
       }
 
       this.logger.log.success(
-        `Published canary version${result ? `: ${result}` : ''}`
+        `Published canary version${newVersion ? `: ${newVersion}` : ''}`
       );
     }
 
     const latestTag = await this.git.getLatestTagInBranch();
     const commitsInRelease = await this.release.getCommits(latestTag);
-    return { newVersion: canaryVersion, commitsInRelease };
+    return { newVersion, commitsInRelease };
   }
 
   /**

--- a/src/auto.ts
+++ b/src/auto.ts
@@ -492,8 +492,8 @@ export default class Auto {
       canaryVersion = `${canaryVersion}.${build}`;
     }
 
-    if (!canaryVersion) {
-      canaryVersion = `.${await this.git.getSha(true)}`;
+    if (!('isPr' in env)) {
+      canaryVersion = `${canaryVersion}.${await this.git.getSha(true)}`;
     }
 
     if (options.dryRun) {

--- a/src/plugins/npm/__tests__/npm.test.ts
+++ b/src/plugins/npm/__tests__/npm.test.ts
@@ -549,10 +549,9 @@ describe('canary', () => {
       }
     `;
     exec.mockReturnValue(
-      Promise.resolve(`
-        path/to/package:@foo/app:1.2.3-canary.0
-        path/to/package:@foo/lib:1.2.3-canary.0
-      `)
+      Promise.resolve(
+        `path/to/package:@foo/app:1.2.3-canary.0\npath/to/package:@foo/lib:1.2.3-canary.0`
+      )
     );
 
     const value = await hooks.canary.promise(SEMVER.patch, '');

--- a/src/plugins/npm/index.ts
+++ b/src/plugins/npm/index.ts
@@ -414,11 +414,12 @@ export default class NPMPlugin implements IPlugin {
 
         auto.logger.verbose.info('Successfully published canary version');
         const packages = await getLernaPackages();
+        const independentPackages = await getIndependentPackageList();
         // Reset after we read the packages from the system
         await execPromise('git', ['reset', '--hard', 'HEAD']);
 
         if (getLernaJson().version === 'independent') {
-          return getIndependentPackageList();
+          return independentPackages;
         }
 
         const one = packages.find(p => Boolean(p.version));

--- a/src/plugins/npm/index.ts
+++ b/src/plugins/npm/index.ts
@@ -424,17 +424,13 @@ export default class NPMPlugin implements IPlugin {
           return independentPackages;
         }
 
-        const one = packages.find(p => Boolean(p.version));
+        const versioned = packages.find(p => p.version.includes('canary'));
 
-        if (!one) {
-          return { error: 'Could not find monorepo packages' };
-        }
-
-        if (!one.version.includes('canary')) {
+        if (!versioned) {
           return { error: 'No packages were changed. No canary published.' };
         }
 
-        return one.version;
+        return versioned.version;
       }
 
       auto.logger.verbose.info('Detected single npm package');

--- a/src/plugins/npm/index.ts
+++ b/src/plugins/npm/index.ts
@@ -419,13 +419,21 @@ export default class NPMPlugin implements IPlugin {
         await execPromise('git', ['reset', '--hard', 'HEAD']);
 
         if (getLernaJson().version === 'independent') {
+          if (!independentPackages.includes('canary')) {
+            return { error: 'No packages were changed. No canary published.' };
+          }
+
           return independentPackages;
         }
 
         const one = packages.find(p => Boolean(p.version));
 
         if (!one) {
-          return '';
+          return { error: 'Could not find monorepo packages' };
+        }
+
+        if (!one.version.includes('canary')) {
+          return { error: 'No packages were changed. No canary published.' };
         }
 
         return one.version;

--- a/src/plugins/npm/index.ts
+++ b/src/plugins/npm/index.ts
@@ -13,7 +13,7 @@ import execPromise from '../../utils/exec-promise';
 import { ILogger } from '../../utils/logger';
 import getConfigFromPackageJson from './package-config';
 
-const { isCi, ...env } = envCi();
+const { isCi } = envCi();
 const readFile = promisify(fs.readFile);
 
 function isMonorepo() {
@@ -189,9 +189,8 @@ const getLernaPackages = async () =>
 const getLernaJson = () => JSON.parse(fs.readFileSync('lerna.json', 'utf8'));
 const getIndependentPackageList = async () =>
   getLernaPackages().then(packages =>
-    packages.map(p => `\n - ${p.name}@${p.version}`).join('')
+    packages.map(p => `\n - ${p.name}@${p.version.split('+')[0]}`).join('')
   );
-
 export default class NPMPlugin implements IPlugin {
   name = 'NPM';
 
@@ -394,7 +393,6 @@ export default class NPMPlugin implements IPlugin {
 
       if (isMonorepo()) {
         auto.logger.verbose.info('Detected monorepo, using lerna');
-        const isPr = 'isPr' in env && env.isPr;
 
         await execPromise('npx', [
           'lerna',
@@ -406,7 +404,7 @@ export default class NPMPlugin implements IPlugin {
           // Locally we use sha for canary version's postFix, but the --canary flag
           // already attaches the SHA so we only attach postFix in PRs for context
           '--preid',
-          isPr ? `canary${postFix}` : 'canary',
+          `canary${postFix}`,
           '--yes', // skip prompts,
           '--no-git-reset', // so we can get the version that just published
           ...verboseArgs


### PR DESCRIPTION
# What Changed

see title

# Why

canary command was not reporting the right version

closes #381

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `6.1.1-canary.383.4742`
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `6.1.1-canary.383.4747`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
