### PR TITLE
split off useless hash from version

### DIFF
--- a/src/plugins/npm/__tests__/npm.test.ts
+++ b/src/plugins/npm/__tests__/npm.test.ts
@@ -601,7 +601,7 @@ describe('canary', () => {
     exec.mockReturnValueOnce('');
     exec.mockReturnValue(
       Promise.resolve(
-        `path/to/package:@foo/app:1.2.3-canary.0\npath/to/package:@foo/lib:1.2.3-canary.0`
+        `path/to/package:@foo/app:1.2.3-canary.0+abcd\npath/to/package:@foo/lib:1.2.3-canary.0+abcd`
       )
     );
 

--- a/src/plugins/npm/index.ts
+++ b/src/plugins/npm/index.ts
@@ -200,7 +200,6 @@ const checkClean = async (auto: Auto) => {
   }
 
   auto.logger.log.error('Changed Files:\n', status);
-
   throw new Error(
     'Working direction is not clean, make sure all files are commited'
   );
@@ -449,7 +448,7 @@ export default class NPMPlugin implements IPlugin {
           return { error: 'No packages were changed. No canary published.' };
         }
 
-        return versioned.version;
+        return versioned.version.split('+')[0];
       }
 
       auto.logger.verbose.info('Detected single npm package');


### PR DESCRIPTION
# What Changed

lerna adds a weird hash to the version. independent code will remove it but it should also be removed here

Todo:

- [x] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
