### PR TITLE
use correct variable in pr-body success message

### DIFF
--- a/src/auto.ts
+++ b/src/auto.ts
@@ -428,7 +428,7 @@ export default class Auto {
     } else {
       const prNumber = this.getPrNumber('pr-body', pr);
       await this.git.addToPrBody(message, prNumber, context);
-      this.logger.log.success(`Updated body on PR #${pr}`);
+      this.logger.log.success(`Updated body on PR #${prNumber}`);
     }
   }
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `6.2.3-canary.389.4824`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
