### PR TITLE
Fix typo in introduction documentation

### DIFF
--- a/docs/pages/introduction.md
+++ b/docs/pages/introduction.md
@@ -2,7 +2,7 @@
 
 # :rocket: auto :rocket:/.has-text-centered\
 
-Automated releases powered by pull request labels. Streamline you release workflow and publish constantly! `auto` is meant to be run in a continuos integration (CI) environment, but all the commands work locally as well.
+Automated releases powered by pull request labels. Streamline you release workflow and publish constantly! `auto` is meant to be run in a continuous integration (CI) environment, but all the commands work locally as well.
 
 Release Features:
 


### PR DESCRIPTION
# What Changed
Spelling of one word in "Introduction" documentation
<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `6.2.5-canary.391.4884`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
