### PR TITLE
ensure major minor and patch get to changelog in that order

### DIFF
--- a/src/__tests__/__snapshots__/changelog.test.ts.snap
+++ b/src/__tests__/__snapshots__/changelog.test.ts.snap
@@ -175,6 +175,14 @@ exports[`generateReleaseNotes should order the section major, minor, patch, then
 
 - I was a push to master  (adam@dierkens.com)
 
+#### 📝  Documentation
+
+- docs  (adam@dierkens.com)
+
+#### 🏠  Internal
+
+- something  (adam@dierkens.com)
+
 #### Authors: 1
 
 - Adam Dierkens (adam@dierkens.com)"

--- a/src/__tests__/__snapshots__/changelog.test.ts.snap
+++ b/src/__tests__/__snapshots__/changelog.test.ts.snap
@@ -162,6 +162,24 @@ exports[`generateReleaseNotes should omit authors with invalid email addresses 1
 - Some Feature [#1234](https://github.custom.com/foobar/auto/pull/1234)"
 `;
 
+exports[`generateReleaseNotes should order the section major, minor, patch, then the rest 1`] = `
+"#### 💥  Breaking Change
+
+- First Feature [#1235](https://github.custom.com/foobar/auto/pull/1235) (adam@dierkens.com)
+
+#### 🚀  Enhancement
+
+- First Feature [#1235](https://github.custom.com/foobar/auto/pull/1235) (adam@dierkens.com)
+
+#### 🐛  Bug Fix
+
+- I was a push to master  (adam@dierkens.com)
+
+#### Authors: 1
+
+- Adam Dierkens (adam@dierkens.com)"
+`;
+
 exports[`generateReleaseNotes should use only email if author name doesn't exist 1`] = `
 "#### 🐛  Bug Fix
 

--- a/src/__tests__/changelog.test.ts
+++ b/src/__tests__/changelog.test.ts
@@ -255,6 +255,45 @@ describe('generateReleaseNotes', () => {
     expect(await changelog.generateReleaseNotes(commits)).toMatchSnapshot();
   });
 
+  test('should order the section major, minor, patch, then the rest', async () => {
+    const options = testOptions();
+    options.labels = {
+      patch: options.labels.patch,
+      minor: options.labels.minor,
+      major: options.labels.major,
+      internal: options.labels.internal
+    };
+
+    const changelog = new Changelog(dummyLog(), options);
+    changelog.loadDefaultHooks();
+
+    const commits = await logParse.normalizeCommits([
+      {
+        hash: '1',
+        authorName: 'Adam Dierkens',
+        authorEmail: 'adam@dierkens.com',
+        subject: 'I was a push to master\n\n',
+        labels: ['patch']
+      },
+      {
+        hash: '2',
+        authorName: 'Adam Dierkens',
+        authorEmail: 'adam@dierkens.com',
+        subject: 'First Feature (#1235)',
+        labels: ['minor']
+      },
+      {
+        hash: '2',
+        authorName: 'Adam Dierkens',
+        authorEmail: 'adam@dierkens.com',
+        subject: 'First Feature (#1235)',
+        labels: ['major']
+      }
+    ]);
+
+    expect(await changelog.generateReleaseNotes(commits)).toMatchSnapshot();
+  });
+
   test('should be able to customize pushToBaseBranch title', async () => {
     const options = testOptions();
     options.labels = {

--- a/src/__tests__/changelog.test.ts
+++ b/src/__tests__/changelog.test.ts
@@ -258,16 +258,32 @@ describe('generateReleaseNotes', () => {
   test('should order the section major, minor, patch, then the rest', async () => {
     const options = testOptions();
     options.labels = {
+      documentation: options.labels.documentation,
+      internal: options.labels.internal,
       patch: options.labels.patch,
       minor: options.labels.minor,
-      major: options.labels.major,
-      internal: options.labels.internal
+      major: options.labels.major
     };
 
     const changelog = new Changelog(dummyLog(), options);
     changelog.loadDefaultHooks();
 
     const commits = await logParse.normalizeCommits([
+      {
+        hash: '0a',
+        authorName: 'Adam Dierkens',
+        authorEmail: 'adam@dierkens.com',
+        subject: 'something\n\n',
+        labels: ['internal']
+      },
+      {
+        hash: '0',
+        authorName: 'Adam Dierkens',
+        authorEmail: 'adam@dierkens.com',
+        subject: 'docs\n\n',
+        labels: ['documentation']
+      },
+
       {
         hash: '1',
         authorName: 'Adam Dierkens',

--- a/src/__tests__/git.test.ts
+++ b/src/__tests__/git.test.ts
@@ -479,6 +479,20 @@ describe('github', () => {
     });
   });
 
+  describe('getPr ', () => {
+    test('return pr', async () => {
+      const gh = new Git(options);
+      get.mockReturnValueOnce({ success: true });
+      expect(await gh.getPr(123)).toEqual({ success: true });
+    });
+
+    test('throw for errors', async () => {
+      const gh = new Git(options);
+      get.mockRejectedValueOnce(Error);
+      await expect(gh.getPr(120)).rejects.toBeTruthy();
+    });
+  });
+
   test('updateLabel', async () => {
     const gh = new Git(options);
 

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -133,9 +133,17 @@ export default class Changelog {
       .filter(commit => commit.labels.length === 0)
       .map(commit => commit.labels.push('patch'));
 
-    const sections = Object.values(this.options.labels).filter(
-      label => label.title
+    const ordered: ILabelDefinitionMap = Object.assign(
+      {
+        major: this.options.labels.major,
+        minor: this.options.labels.minor,
+        patch: this.options.labels.patch
+      },
+      ...Object.entries(this.options.labels)
+        .filter(([key]) => !['major', 'minor', 'patch'].includes(key))
+        .map(([key, value]) => ({ [key]: value }))
     );
+    const sections = Object.values(ordered).filter(label => label.title);
 
     return Object.assign(
       {},

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -128,39 +128,30 @@ export default class Changelog {
    */
   private splitCommits(commits: IExtendedCommit[]): ICommitSplit {
     let currentCommits = [...commits];
+    const order = ['major', 'minor', 'patch'];
+    const sections = Object.values(this.options.labels)
+      .filter(label => label.title)
+      .sort((a, b) => {
+        const bIndex = order.indexOf(b.name) + 1 || order.length + 1;
+        const aIndex = order.indexOf(a.name) + 1 || order.length + 1;
+        return aIndex - bIndex;
+      });
 
     commits
-      .filter(commit => commit.labels.length === 0)
-      .map(commit => commit.labels.push('patch'));
-
-    const ordered: ILabelDefinitionMap = Object.assign(
-      {
-        major: this.options.labels.major,
-        minor: this.options.labels.minor,
-        patch: this.options.labels.patch
-      },
-      ...Object.entries(this.options.labels)
-        .filter(([key]) => !['major', 'minor', 'patch'].includes(key))
-        .map(([key, value]) => ({ [key]: value }))
-    );
-    const sections = Object.values(ordered).filter(label => label.title);
+      .filter(({ labels }) => labels.length === 0)
+      .map(({ labels }) => labels.push('patch'));
 
     return Object.assign(
       {},
       ...sections.map(label => {
         const matchedCommits = filterLabel(currentCommits, label.name);
-
-        if (matchedCommits.length === 0) {
-          return {};
-        }
-
         currentCommits = currentCommits.filter(
           commit => !matchedCommits.includes(commit)
         );
 
-        return {
-          [label.name]: matchedCommits
-        };
+        return matchedCommits.length === 0
+          ? {}
+          : { [label.name]: matchedCommits };
       })
     );
   }

--- a/src/git.ts
+++ b/src/git.ts
@@ -202,7 +202,7 @@ export default class Git {
       this.logger.veryVerbose.info('Got response for "issues.get":\n', info);
       return info;
     } catch (e) {
-      throw new GitAPIError('listLabelsOnIssue', args, e);
+      throw new GitAPIError('getPr', args, e);
     }
   }
 


### PR DESCRIPTION
# What Changed

see title

# Why

a user could specify the labels out of order and get the changelog out of order

Todo:

- [x] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `6.3.1-canary.392.4936`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
