### PR TITLE
add page for conventional-commits plugin

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,7 @@
   - [Writing Plugins](pages/writing-plugins.md)
   - [NPM](pages/npm.md)
   - [Chrome Web Store](pages/chrome.md)
+  - [Conventional Commits](pages/conventional-commits.md)
   - [Released](pages/released.md)
 - [Troubleshooting](pages/troubleshooting.md)
 

--- a/docs/pages/conventional-commits.md
+++ b/docs/pages/conventional-commits.md
@@ -1,0 +1,12 @@
+# Conventional Commits Plugin
+
+Parse [conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.4/) and use them to calculate the version.
+
+```json
+{
+  "plugins": [
+    "conventional-commits"
+    // other plugins
+  ]
+}
+```


### PR DESCRIPTION
# What Changed

add a docs page for conventional-commits plugin

# Why

it was kinda hidden that auto even had this included

Todo:

- [ ] Add tests
- [x] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `6.3.1-canary.393.4942`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
