### PR TITLE
conventional-commits plugin blog post

### DIFF
--- a/docs/blog/both-worlds.md
+++ b/docs/blog/both-worlds.md
@@ -1,0 +1,26 @@
+---
+image: https://images.unsplash.com/photo-1554916171-0cfab61e5607?ixlib=rb-1.2.1&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1200&h=600&fit=crop&ixid=eyJhcHBfaWQiOjF9
+title: Best of Both Worlds
+author:
+  name: Andrew Lisowski
+  url: https://twitter.com/HipsterSmoothie
+  email: lisowski54@gmail.com
+---
+
+One of the main goals we had when building auto was to ease the introduction to automated releases through using pull request labels.
+
+The main alternative to auto works in a slightly different way, [semantic-release](https://github.com/semantic-release/semantic-release) uses the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0-beta.4/) to calculate the next version. This is an awesome way to accomplish automated releases, but it is very strict and can create more work when accepting outside contribution. PR labels solve this problem beautifully, but...
+
+![Why not both](https://i.giphy.com/media/cjYH0IhoWiQk8/giphy.webp) /.mediumImage\
+
+That's exactly why we made the [conventional-commits plugin](). It allows you to keep you conventional commit work flow but still get the benefits of PR labels based automation.
+
+To start using conventional commit style commit messages simply add the following to your auto config.
+
+```json
+{
+  "plugins": ["conventional-commits"]
+}
+```
+
+Now you can enjoy the best of both worlds! :tada:

--- a/docs/blog/both-worlds.md
+++ b/docs/blog/both-worlds.md
@@ -13,7 +13,7 @@ The main alternative to auto works in a slightly different way, [semantic-releas
 
 ![Why not both](https://i.giphy.com/media/cjYH0IhoWiQk8/giphy.webp) /.mediumImage\
 
-That's exactly why we made the [conventional-commits plugin](). It allows you to keep you conventional commit work flow but still get the benefits of PR labels based automation.
+That's exactly why we made the [conventional-commits plugin](). It allows you to keep your conventional commit work flow but still get the benefits of PR labels based automation.
 
 To start using conventional commit style commit messages simply add the following to your auto config.
 

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "all-contributors-cli": "^6.4.0",
     "graphql": "^14.2.1",
     "husky": "^2.0.0",
-    "ignite": "^1.8.1",
+    "ignite": "^1.8.2",
     "jest": "~24.5.0",
     "lint-staged": "^8.1.6",
     "prettier": "^1.16.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5626,10 +5626,10 @@ iferr@^0.1.5:
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
 
-ignite@^1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/ignite/-/ignite-1.8.1.tgz#26ee5814e514bd445b5a00aa7c5c7381f44579fc"
-  integrity sha512-4eHf4aZaHvQFtpkvUoTVt7Daz938OwrCzHQI0b8asEiPfusjzw2jdPNLESKJoaStOwgdC62wzkdZvI8ABb9+BQ==
+ignite@^1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/ignite/-/ignite-1.8.2.tgz#759bb575e3c836a6575ab2bf021f0da126c8e5b1"
+  integrity sha512-jvX5uGUZgWGk5YOAo3bRhVAz2pAH0APE75ZHoQUHXeq5JXXtvzSURYtTeuHFAwwsyQF3eBRgPhHPk1GbjkAlSw==
   dependencies:
     "@babel/cli" "7.2.0"
     "@babel/core" "7.2.0"


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `6.3.4-canary.394.4986`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
