### PR TITLE
conventional-commit plugin: should omit PR merge commits when a commit in the PR has CC commit message

### DIFF
--- a/docs/pages/conventional-commits.md
+++ b/docs/pages/conventional-commits.md
@@ -1,6 +1,6 @@
 # Conventional Commits Plugin
 
-Parse [conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.4/) and use them to calculate the version.
+Parse [conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.4/) and use them to calculate the version. This plugin will omit the PR HEAD if it isn't labeled and has a commit with a conventional-commit commit message.
 
 ```json
 {

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "logo": "logo.gif",
     "bulmaTheme": "materia",
     "githubURL": "https://github.com/intuit/auto",
-    "customHead": "<style>.content p > .header-image { max-width: 200px !important; } .navbar { box-shadow: none !important; border-bottom: 1px solid lightgrey; } .list { font-size: 1.2rem; } .is-purple { background: #870048 !important;  } .has-text-purple { color: #870048 !important;  } .is-red { background: #C5000B !important;  } .is-yellow { background: #F1A60E !important;  } a.navbar-item.is-active, a.navbar-item:hover, a.navbar-link.is-active, a.navbar-link:hover { background-color: #f5f5f5;color: #870048; } .button.is-link.is-inverted.is-outlined:hover { background-color: #fff;color: #870048; } p .image { max-width: 100% !important; }.menu .menu-list a.is-active {background-color: transparent;color: #870048;}</style>",
+    "customHead": "<style>.content p > .header-image { max-width: 200px !important; } .navbar { box-shadow: none !important; border-bottom: 1px solid lightgrey; } .list { font-size: 1.2rem; } .is-purple { background: #870048 !important;  } .has-text-purple { color: #870048 !important;  } .is-red { background: #C5000B !important;  } .is-yellow { background: #F1A60E !important;  } a.navbar-item.is-active, a.navbar-item:hover, a.navbar-link.is-active, a.navbar-link:hover { background-color: #f5f5f5;color: #870048; } .button.is-link.is-inverted.is-outlined:hover { background-color: #fff;color: #870048; } p .image { max-width: 100% !important; }.menu .menu-list a.is-active {background-color: transparent;color: #870048;} .blogPost .mediumImage .image { max-width: 400px !important; }</style>",
     "favicon": "favicon.png"
   },
   "auto": {


### PR DESCRIPTION
# What Changed

see title

# Why

it seem like this is the right behavior.

Todo:

- [x] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `6.3.3-canary.395.4969`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
