### PR TITLE
lerna no-force-publish release conflict

### DIFF
--- a/src/__tests__/__snapshots__/changelog.test.ts.snap
+++ b/src/__tests__/__snapshots__/changelog.test.ts.snap
@@ -41,6 +41,16 @@ Bam!?
 - Adam Dierkens (adam@dierkens.com)"
 `;
 
+exports[`generateReleaseNotes doesn't add additional release notes when there are none 1`] = `
+"#### 🚀  Enhancement
+
+- First Feature [#1235](https://github.custom.com/foobar/auto/pull/1235) (adam@dierkens.com)
+
+#### Authors: 1
+
+- Adam Dierkens (adam@dierkens.com)"
+`;
+
 exports[`generateReleaseNotes should add additional release notes 1`] = `
 "### Release Notes
 

--- a/src/__tests__/auto.test.ts
+++ b/src/__tests__/auto.test.ts
@@ -671,6 +671,26 @@ describe('Auto', () => {
     });
   });
 
+  describe('release', () => {
+    test("doesn't try to overwrite releases", async () => {
+      const auto = new Auto({ command: 'release', ...defaults, plugins: [] });
+      auto.logger = dummyLog();
+      await auto.loadConfig();
+      auto.git!.getLatestRelease = () => Promise.resolve('1.2.3');
+      auto.release!.generateReleaseNotes = jest.fn();
+      auto.release!.getCommitsInRelease = () =>
+        Promise.resolve([makeCommitFromMsg('Test Commit')]);
+
+      auto.hooks.getPreviousVersion.tap('test', () => '1.2.3');
+      const afterRelease = jest.fn();
+      auto.hooks.afterRelease.tap('test', afterRelease);
+      auto.release!.getCommits = jest.fn();
+
+      await auto.runRelease();
+      expect(afterRelease).not.toHaveBeenCalled();
+    });
+  });
+
   describe('canary', () => {
     test('should throw when not initialized', async () => {
       const auto = new Auto({ command: 'comment', ...defaults });

--- a/src/__tests__/changelog.test.ts
+++ b/src/__tests__/changelog.test.ts
@@ -455,7 +455,6 @@ describe('generateReleaseNotes', () => {
     `;
 
     const res = await changelog.generateReleaseNotes(commits);
-    console.log(res);
-    // expect(res).toMatchSnapshot();
+    expect(res).toMatchSnapshot();
   });
 });

--- a/src/auto.ts
+++ b/src/auto.ts
@@ -768,7 +768,7 @@ export default class Auto {
       : rawVersion;
 
     if (!dryRun && eq(newVersion, lastRelease)) {
-      this.logger.log.error(
+      this.logger.log.warn(
         `Nothing released to Github. Version to be released is the same as the latest release on Github: ${newVersion}`
       );
       return;

--- a/src/auto.ts
+++ b/src/auto.ts
@@ -457,7 +457,7 @@ export default class Auto {
   /**
    * Make a release to the git remote with the changes.
    */
-  async runRelease(options: IReleaseCommandOptions) {
+  async runRelease(options: IReleaseCommandOptions = {}) {
     this.logger.verbose.info("Using command: 'release'");
     await this.makeRelease(options);
   }


### PR DESCRIPTION


# What Changed

do not continue with release if the "new" version is the same as the last release, this results in build failures. 

this issue can arise when using lerna repos with force publish off. in that setup sometimes no version increment happens and no release is published to NPM. Since the version is not bumped auto used to try to publish to an existing tag that was already released.

# Why

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `6.3.5-canary.399.5028`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
