### PR TITLE
Greenkeeper/@octokit/plugin throttling 2.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@octokit/graphql": "^2.1.1",
     "@octokit/plugin-enterprise-compatibility": "^1.1.0",
     "@octokit/plugin-retry": "^2.2.0",
-    "@octokit/plugin-throttling": "^2.4.0",
+    "@octokit/plugin-throttling": "^2.5.0",
     "@octokit/rest": "^16.24.1",
     "arr-flatten": "^1.1.0",
     "chalk": "^2.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1272,10 +1272,10 @@
   dependencies:
     bottleneck "^2.15.3"
 
-"@octokit/plugin-throttling@^2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-throttling/-/plugin-throttling-2.4.0.tgz#add1bd6a797aa210ce860e8bbe7f7505ba5e4d99"
-  integrity sha512-0bYfgQdqAtWiqXvS6oKMiousTno+e3pFoaYS57LpAp8p56Far49/vpGvbEvBUuNyoUFgOcTGm5WTpO1IPptHuQ==
+"@octokit/plugin-throttling@^2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-throttling/-/plugin-throttling-2.5.0.tgz#220128b9b234e9d737be4eab446df8c1f9b5cbab"
+  integrity sha512-/At81g5SRkzYcdajozmZkHYhTSltXhUs5C6rDx3uHTD7skXVx/+0DOdAn2kx6agm+BjZSLYMdDsnrRij8jRiTg==
   dependencies:
     bottleneck "^2.15.3"
 


### PR DESCRIPTION
# What Changed

# Why

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `6.3.6-canary.400.5040`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
