### PR TITLE
update canary to update pr body when there is a pr

### DIFF
--- a/src/__tests__/auto.test.ts
+++ b/src/__tests__/auto.test.ts
@@ -720,6 +720,7 @@ describe('Auto', () => {
       await auto.loadConfig();
       auto.git!.getLatestRelease = () => Promise.resolve('1.2.3');
       auto.git!.getSha = () => Promise.resolve('abc');
+      auto.git!.addToPrBody = jest.fn();
       auto.release!.getCommitsInRelease = () =>
         Promise.resolve([makeCommitFromMsg('Test Commit')]);
       const canary = jest.fn();
@@ -728,6 +729,7 @@ describe('Auto', () => {
 
       await auto.canary({ pr: 123, build: 1 });
       expect(canary).toHaveBeenCalledWith(SEMVER.patch, '.123.1.abc');
+      expect(auto.git!.addToPrBody).toHaveBeenCalled();
     });
 
     test("doesn't comment if there is an error", async () => {

--- a/src/auto.ts
+++ b/src/auto.ts
@@ -468,18 +468,18 @@ export default class Auto {
     }
 
     // SailEnv falls back to commit SHA
-    let preId: string | undefined;
+    let pr: string | undefined;
     let build: string | undefined;
 
     if ('pr' in env && 'build' in env) {
-      preId = env.pr;
+      ({ pr } = env);
       ({ build } = env);
     } else if ('pr' in env && 'commit' in env) {
-      preId = env.pr;
+      ({ pr } = env);
       build = env.commit;
     }
 
-    preId = options.pr ? String(options.pr) : preId;
+    pr = options.pr ? String(options.pr) : pr;
     build = options.build ? String(options.build) : build;
 
     const head = await this.release.getCommitsInRelease('HEAD^');
@@ -489,8 +489,8 @@ export default class Auto {
       SEMVER.patch;
     let canaryVersion = '';
 
-    if (preId) {
-      canaryVersion = `${canaryVersion}.${preId}`;
+    if (pr) {
+      canaryVersion = `${canaryVersion}.${pr}`;
     }
 
     if (build) {
@@ -520,8 +520,9 @@ export default class Auto {
       const message =
         options.message || 'Published PR with canary version: `%v`';
 
-      if (message !== 'false' && env.isCi) {
+      if (message !== 'false' && pr) {
         await this.prBody({
+          pr: Number(pr),
           message: message.replace('%v', newVersion),
           context: 'canary-version'
         });


### PR DESCRIPTION
# What Changed

see title

# Why

Used to only call prBody if in the CI because we knew there would be a pr number. But if the user supplies a pr number we should just use that. This is also the reasoning that this is a `minor`.
 
closes #397

Todo:

- [x] Add tests
- [x] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
