### PR TITLE
Add --delete to `comment` and `pr-body`

### DIFF
--- a/docs/pages/auto-comment.md
+++ b/docs/pages/auto-comment.md
@@ -1,6 +1,6 @@
 # `auto comment`
 
-Comment on a pull request with a markdown message.
+Comment on a pull request with a markdown message. Each comment has a context, and each context only has one comment.
 
 ```sh
 auto comment --pr 24 --message "You broke the build!" --context build
@@ -15,6 +15,7 @@ Options
 
   --pr number                       The pull request the command should use. Detects PR number in CI
   --context string                  A string label to differentiate this status from others
+  --delete                          Delete old comment
   -m, --message string [required]   Message to post to comment
   -d, --dry-run                     Report what command will do but do not actually do anything
 
@@ -30,5 +31,6 @@ Global Options
 
 Examples
 
+  $ auto comment --delete
   $ auto comment --pr 123 --comment "# Why you're wrong..."
 ```

--- a/docs/pages/auto-pr-body.md
+++ b/docs/pages/auto-pr-body.md
@@ -1,6 +1,6 @@
 # `auto pr-check`
 
-Update the body of a PR with a message. Appends to PR and will not overwrite user content
+Update the body of a PR with a message. Appends to PR and will not overwrite user content. Each comment has a context, and each context only has one comment.
 
 ```sh
 auto pr-body --pr 24 --message "Canary Version: 1.2.3"
@@ -15,6 +15,7 @@ Options
 
   --pr number                       The pull request the command should use. Detects PR number in CI
   --context string                  A string label to differentiate this status from others
+  --delete                          Delete old PR body update
   -m, --message string [required]   Message to post to PR body
   -d, --dry-run                     Report what command will do but do not actually do anything
 
@@ -32,5 +33,6 @@ Global Options
 
 Examples
 
+  $ auto pr-body --delete
   $ auto pr-body --pr 123 --comment "The new version is: 1.2.3"
 ```

--- a/src/__tests__/auto.test.ts
+++ b/src/__tests__/auto.test.ts
@@ -559,6 +559,33 @@ describe('Auto', () => {
       await auto.comment({ pr: 10, message: 'foo' });
       expect(createComment).toHaveBeenCalled();
     });
+
+    test('should delete a comment', async () => {
+      const auto = new Auto({ command: 'comment', ...defaults });
+      auto.logger = dummyLog();
+      await auto.loadConfig();
+
+      const deleteComment = jest.fn();
+      auto.git!.deleteComment = deleteComment;
+
+      await auto.comment({ pr: 10, delete: true });
+      expect(deleteComment).toHaveBeenCalled();
+    });
+
+    test('should not delete a comment in dry run mode', async () => {
+      const auto = new Auto({ command: 'comment', ...defaults });
+      auto.logger = dummyLog();
+      await auto.loadConfig();
+
+      const deleteComment = jest.fn();
+      auto.git!.deleteComment = deleteComment;
+
+      await auto.comment({ pr: 10, message: 'foo bar', dryRun: true });
+      expect(deleteComment).not.toHaveBeenCalled();
+
+      await auto.comment({ pr: 10, delete: true, dryRun: true });
+      expect(deleteComment).not.toHaveBeenCalled();
+    });
   });
 
   describe('prBody', () => {
@@ -581,6 +608,33 @@ describe('Auto', () => {
 
       await auto.prBody({ pr: 10, message: 'foo' });
       expect(addToPrBody).toHaveBeenCalled();
+    });
+
+    test('should delete old pr body update', async () => {
+      const auto = new Auto({ command: 'comment', ...defaults });
+      auto.logger = dummyLog();
+      await auto.loadConfig();
+
+      const addToPrBody = jest.fn();
+      auto.git!.addToPrBody = addToPrBody;
+
+      await auto.prBody({ pr: 10, delete: true });
+      expect(addToPrBody).toHaveBeenCalledWith('', 10, 'default');
+    });
+
+    test('should not update pr body a dry run mode', async () => {
+      const auto = new Auto({ command: 'comment', ...defaults });
+      auto.logger = dummyLog();
+      await auto.loadConfig();
+
+      const addToPrBody = jest.fn();
+      auto.git!.addToPrBody = addToPrBody;
+
+      await auto.prBody({ pr: 10, message: 'foo bar', dryRun: true });
+      expect(addToPrBody).not.toHaveBeenCalled();
+
+      await auto.prBody({ pr: 10, delete: true, dryRun: true });
+      expect(addToPrBody).not.toHaveBeenCalled();
     });
   });
 

--- a/src/__tests__/git.test.ts
+++ b/src/__tests__/git.test.ts
@@ -315,6 +315,18 @@ describe('github', () => {
       );
     });
 
+    test('should add to PR body if none exists', async () => {
+      const gh = new Git(options);
+
+      get.mockReturnValueOnce({ data: { body: '# My Content' } });
+      await gh.addToPrBody('', 22);
+      expect(update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: '# My Content'
+        })
+      );
+    });
+
     test('should overwrite old context', async () => {
       const gh = new Git(options);
 
@@ -349,6 +361,26 @@ describe('github', () => {
         expect.objectContaining({
           body:
             '# My Content\n<!-- GITHUB_RELEASE PR BODY: default -->\nSomething else\n<!-- GITHUB_RELEASE PR BODY: default -->\n\n<!-- GITHUB_RELEASE PR BODY: PERF -->\nSome long thing\n<!-- GITHUB_RELEASE PR BODY: PERF -->\n'
+        })
+      );
+    });
+
+    test('should clear pr body section if message blank', async () => {
+      const gh = new Git(options);
+
+      get.mockReturnValueOnce({ data: { body: '# My Content' } });
+      get.mockReturnValueOnce({
+        data: {
+          body:
+            '# My Content\n<!-- GITHUB_RELEASE PR BODY: default -->\nSomething else\n<!-- GITHUB_RELEASE PR BODY: default -->'
+        }
+      });
+      await gh.addToPrBody('Some long thing', 22);
+      update.mockClear();
+      await gh.addToPrBody('', 22);
+      expect(update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: '# My Content\n'
         })
       );
     });

--- a/src/auto.ts
+++ b/src/auto.ts
@@ -384,26 +384,40 @@ export default class Auto {
    *
    * @param options Options for the comment functionality
    */
-  async comment({
-    message,
-    pr,
-    context = 'default',
-    dryRun
-  }: ICommentCommandOptions) {
+  async comment(options: ICommentCommandOptions) {
+    const {
+      message,
+      pr,
+      context = 'default',
+      dryRun,
+      delete: deleteFlag
+    } = options;
     if (!this.git) {
       throw this.createErrorMessage();
     }
 
     this.logger.verbose.info("Using command: 'comment'");
-    if (dryRun) {
-      this.logger.log.info(
-        `Would have commented on ${pr} under "${context}" context:\n\n${message}`
-      );
-    } else {
-      const prNumber = this.getPrNumber('comment', pr);
+    const prNumber = this.getPrNumber('comment', pr);
 
-      await this.git.createComment(message, prNumber, context);
-      this.logger.log.success(`Commented on PR #${pr}`);
+    if (dryRun) {
+      if (deleteFlag) {
+        this.logger.log.info(
+          `Would have deleted comment on ${prNumber} under "${context}" context`
+        );
+      } else {
+        this.logger.log.info(
+          `Would have commented on ${prNumber} under "${context}" context:\n\n${message}`
+        );
+      }
+    } else {
+      if (deleteFlag) {
+        await this.git.deleteComment(prNumber, context);
+      }
+
+      if (message) {
+        await this.git.createComment(message, prNumber, context);
+        this.logger.log.success(`Commented on PR #${pr}`);
+      }
     }
   }
 
@@ -414,25 +428,41 @@ export default class Auto {
    *
    * @param options Options
    */
-  async prBody({
-    message,
-    pr,
-    context = 'default',
-    dryRun
-  }: ICommentCommandOptions) {
+  async prBody(options: ICommentCommandOptions) {
+    const {
+      message,
+      pr,
+      context = 'default',
+      dryRun,
+      delete: deleteFlag
+    } = options;
+
     if (!this.git) {
       throw this.createErrorMessage();
     }
 
     this.logger.verbose.info("Using command: 'pr-body'");
+    const prNumber = this.getPrNumber('pr-body', pr);
 
     if (dryRun) {
-      this.logger.log.info(
-        `Would have appended to PR body on ${pr} under "${context}" context:\n\n${message}`
-      );
+      if (deleteFlag) {
+        this.logger.log.info(
+          `Would have deleted PR body on ${prNumber} under "${context}" context`
+        );
+      } else {
+        this.logger.log.info(
+          `Would have appended to PR body on ${prNumber} under "${context}" context:\n\n${message}`
+        );
+      }
     } else {
-      const prNumber = this.getPrNumber('pr-body', pr);
-      await this.git.addToPrBody(message, prNumber, context);
+      if (deleteFlag) {
+        await this.git.addToPrBody('', prNumber, context);
+      }
+
+      if (message) {
+        await this.git.addToPrBody(message, prNumber, context);
+      }
+
       this.logger.log.success(`Updated body on PR #${prNumber}`);
     }
   }

--- a/src/cli/__tests__/args.test.ts
+++ b/src/cli/__tests__/args.test.ts
@@ -60,4 +60,17 @@ describe('root parser', () => {
       dryRun: true
     });
   });
+
+  test('error when on in array of options to is not present', () => {
+    process.exit = jest.fn() as any;
+    parseArgs(['comment']);
+    expect(process.exit).toHaveBeenCalled();
+  });
+
+  test('allow array of options to or', () => {
+    expect(parseArgs(['comment', '--message', 'foo'])).toEqual({
+      command: 'comment',
+      message: 'foo'
+    });
+  });
 });

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -382,7 +382,8 @@ const commands: ICommand[] = [
   },
   {
     name: 'comment',
-    summary: 'Comment on a pull request with a markdown message',
+    summary:
+      'Comment on a pull request with a markdown message. Each comment has a context, and each context only has one comment.',
     require: [['message', 'delete']],
     options: [
       pr,
@@ -393,13 +394,14 @@ const commands: ICommand[] = [
       ...defaultOptions
     ],
     examples: [
+      '{green $} auto comment --delete',
       '{green $} auto comment --pr 123 --comment "# Why you\'re wrong..."'
     ]
   },
   {
     name: 'pr-body',
     summary:
-      'Update the body of a PR with a message. Appends to PR and will not overwrite user content',
+      'Update the body of a PR with a message. Appends to PR and will not overwrite user content. Each comment has a context, and each context only has one comment.',
     require: [['message', 'delete']],
     options: [
       pr,
@@ -410,6 +412,7 @@ const commands: ICommand[] = [
       ...defaultOptions
     ],
     examples: [
+      '{green $} auto pr-body --delete',
       '{green $} auto pr-body --pr 123 --comment "The new version is: 1.2.3"'
     ]
   },

--- a/src/plugins/released/__tests__/released-label.test.ts
+++ b/src/plugins/released/__tests__/released-label.test.ts
@@ -10,9 +10,7 @@ import { makeHooks } from '../../../utils/make-hooks';
 const git = new Git({ owner: '1', repo: '2' });
 const log = new LogParse();
 
-const createComment = jest.fn();
-git.createComment = createComment;
-
+const comment = jest.fn();
 const addLabelToPr = jest.fn();
 git.addLabelToPr = addLabelToPr;
 
@@ -34,7 +32,7 @@ lockIssue.mockReturnValue([]);
 
 describe('release label plugin', () => {
   beforeEach(() => {
-    createComment.mockClear();
+    comment.mockClear();
     addLabelToPr.mockClear();
     commits.mockClear();
     lockIssue.mockClear();
@@ -43,57 +41,60 @@ describe('release label plugin', () => {
   test('should so nothing without PRs', async () => {
     const releasedLabel = new ReleasedLabelPlugin();
     const autoHooks = makeHooks();
-    releasedLabel.apply({
+    releasedLabel.apply(({
       hooks: autoHooks,
       labels: defaultLabelDefinition,
       logger: dummyLog(),
       args: {},
+      comment,
       git
-    } as Auto);
+    } as unknown) as Auto);
 
     const commit = makeCommitFromMsg('normal commit with no bump');
     await autoHooks.afterRelease.promise('1.0.0', [commit]);
 
-    expect(createComment).not.toHaveBeenCalled();
+    expect(comment).not.toHaveBeenCalled();
   });
 
   test('should do nothing without new version', async () => {
     const releasedLabel = new ReleasedLabelPlugin();
     const autoHooks = makeHooks();
-    releasedLabel.apply({
+    releasedLabel.apply(({
       hooks: autoHooks,
       labels: defaultLabelDefinition,
       logger: dummyLog(),
       args: {},
+      comment,
       git
-    } as Auto);
+    } as unknown) as Auto);
 
     const commit = makeCommitFromMsg('normal commit with no bump');
     await autoHooks.afterRelease.promise(undefined, [commit]);
 
-    expect(createComment).not.toHaveBeenCalled();
+    expect(comment).not.toHaveBeenCalled();
   });
 
   test('should do nothing without commits', async () => {
     const releasedLabel = new ReleasedLabelPlugin();
     const autoHooks = makeHooks();
-    releasedLabel.apply({
+    releasedLabel.apply(({
       hooks: autoHooks,
       labels: defaultLabelDefinition,
       logger: dummyLog(),
       args: {},
+      comment,
       git
-    } as Auto);
+    } as unknown) as Auto);
 
     await autoHooks.afterRelease.promise('1.0.0', []);
 
-    expect(createComment).not.toHaveBeenCalled();
+    expect(comment).not.toHaveBeenCalled();
   });
 
   test('should do nothing with skip release label', async () => {
     const releasedLabel = new ReleasedLabelPlugin();
     const autoHooks = makeHooks();
-    releasedLabel.apply({
+    releasedLabel.apply(({
       hooks: autoHooks,
       labels: defaultLabelDefinition,
       release: {
@@ -101,8 +102,9 @@ describe('release label plugin', () => {
       },
       logger: dummyLog(),
       args: {},
+      comment,
       git
-    } as Auto);
+    } as unknown) as Auto);
 
     const commit = makeCommitFromMsg('normal commit with no bump (#123)', {
       labels: ['skip-release']
@@ -112,19 +114,20 @@ describe('release label plugin', () => {
       await log.normalizeCommits([commit])
     );
 
-    expect(createComment).not.toHaveBeenCalled();
+    expect(comment).not.toHaveBeenCalled();
   });
 
   test('should comment and label PRs', async () => {
     const releasedLabel = new ReleasedLabelPlugin();
     const autoHooks = makeHooks();
-    releasedLabel.apply({
+    releasedLabel.apply(({
       hooks: autoHooks,
       labels: defaultLabelDefinition,
       logger: dummyLog(),
       args: {},
+      comment,
       git
-    } as Auto);
+    } as unknown) as Auto);
 
     const commit = makeCommitFromMsg('normal commit with no bump (#123)');
     await autoHooks.afterRelease.promise(
@@ -132,10 +135,10 @@ describe('release label plugin', () => {
       await log.normalizeCommits([commit])
     );
 
-    expect(createComment).toHaveBeenCalledWith(
-      ':rocket: PR was released in 1.0.0 :rocket:',
-      123,
-      'released'
+    expect(comment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: ':rocket: PR was released in 1.0.0 :rocket:'
+      })
     );
   });
 
@@ -143,13 +146,14 @@ describe('release label plugin', () => {
     const releasedLabel = new ReleasedLabelPlugin();
     const autoHooks = makeHooks();
 
-    releasedLabel.apply({
+    releasedLabel.apply(({
       hooks: autoHooks,
       labels: defaultLabelDefinition,
       logger: dummyLog(),
       args: { dryRun: true },
+      comment,
       git
-    } as Auto);
+    } as unknown) as Auto);
 
     await autoHooks.afterRelease.promise(
       '1.0.0',
@@ -158,20 +162,21 @@ describe('release label plugin', () => {
       ])
     );
 
-    expect(createComment).not.toHaveBeenCalled();
+    expect(comment).not.toHaveBeenCalled();
   });
 
   test('should do nothing when label is already present', async () => {
     const releasedLabel = new ReleasedLabelPlugin();
     const autoHooks = makeHooks();
 
-    releasedLabel.apply({
+    releasedLabel.apply(({
       hooks: autoHooks,
       labels: defaultLabelDefinition,
       logger: dummyLog(),
       args: {},
+      comment,
       git
-    } as Auto);
+    } as unknown) as Auto);
 
     getLabels.mockReturnValueOnce(['released']);
 
@@ -189,13 +194,14 @@ describe('release label plugin', () => {
     const releasedLabel = new ReleasedLabelPlugin();
     const autoHooks = makeHooks();
 
-    releasedLabel.apply({
+    releasedLabel.apply(({
       hooks: autoHooks,
       labels: defaultLabelDefinition,
       logger: dummyLog(),
       args: {},
+      comment,
       git
-    } as Auto);
+    } as unknown) as Auto);
 
     await autoHooks.afterRelease.promise(
       '1.0.0-canary',
@@ -210,13 +216,14 @@ describe('release label plugin', () => {
   test('should comment and lined Issues', async () => {
     const releasedLabel = new ReleasedLabelPlugin();
     const autoHooks = makeHooks();
-    releasedLabel.apply({
+    releasedLabel.apply(({
       hooks: autoHooks,
       labels: defaultLabelDefinition,
       logger: dummyLog(),
       args: {},
+      comment,
       git
-    } as Auto);
+    } as unknown) as Auto);
 
     commits.mockReturnValueOnce(
       Promise.resolve([{ commit: { message: 'fixes #420' } }])
@@ -230,23 +237,27 @@ describe('release label plugin', () => {
       await log.normalizeCommits([commit])
     );
 
-    expect(createComment).toHaveBeenCalledWith(
-      ':rocket: Issue was released in 1.0.0 :rocket:',
-      420,
-      'released'
+    expect(comment).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        message: ':rocket: Issue was released in 1.0.0 :rocket:',
+        pr: 420,
+        context: 'released'
+      })
     );
   });
 
   test('should lock Issues', async () => {
     const releasedLabel = new ReleasedLabelPlugin({ lockIssues: true });
     const autoHooks = makeHooks();
-    releasedLabel.apply({
+    releasedLabel.apply(({
       hooks: autoHooks,
       labels: defaultLabelDefinition,
       logger: dummyLog(),
       args: {},
+      comment,
       git
-    } as Auto);
+    } as unknown) as Auto);
 
     const commit = makeCommitFromMsg(
       'normal commit with no bump (#123) closes #100'
@@ -262,13 +273,14 @@ describe('release label plugin', () => {
   test('should not lock Issues for canaries', async () => {
     const releasedLabel = new ReleasedLabelPlugin();
     const autoHooks = makeHooks();
-    releasedLabel.apply({
+    releasedLabel.apply(({
       hooks: autoHooks,
       labels: defaultLabelDefinition,
       logger: dummyLog(),
       args: {},
+      comment,
       git
-    } as Auto);
+    } as unknown) as Auto);
 
     const commit = makeCommitFromMsg(
       'normal commit with no bump (#123) closes #100'

--- a/src/plugins/released/index.ts
+++ b/src/plugins/released/index.ts
@@ -122,8 +122,8 @@ export default class ReleasedLabelPlugin implements IPlugin {
     isIssue = false
   ) {
     // leave a comment with the new version
-    const comment = this.createReleasedComment(isIssue, newVersion);
-    await auto.git!.createComment(comment, prOrIssue, 'released');
+    const message = this.createReleasedComment(isIssue, newVersion);
+    await auto.comment({ message, pr: prOrIssue, context: 'released' });
 
     // Do not add released to issue/label for canary versions
     if (isCanary(newVersion)) {


### PR DESCRIPTION
# What Changed

Add a new flag to delete the old comment.

# Why

closes #308

Todo:

- [x] Add tests
- [x] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `6.5.0-canary.403.5080`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
