### PR TITLE
fix jira PR titles without additional subject

### DIFF
--- a/src/__tests__/__snapshots__/changelog.test.ts.snap
+++ b/src/__tests__/__snapshots__/changelog.test.ts.snap
@@ -142,6 +142,16 @@ exports[`generateReleaseNotes should create note for PR commits without labels 1
 - Adam Dierkens (adam@dierkens.com)"
 `;
 
+exports[`generateReleaseNotes should create note for jira commits without PR title 1`] = `
+"#### 🐛  Bug Fix
+
+- [PLAYA-5052](https://jira.custom.com/browse/PLAYA-5052)  (adam@dierkens.com)
+
+#### Authors: 1
+
+- Adam Dierkens (adam@dierkens.com)"
+`;
+
 exports[`generateReleaseNotes should create note for jira commits without labels 1`] = `
 "#### 🐛  Bug Fix
 

--- a/src/__tests__/changelog.test.ts
+++ b/src/__tests__/changelog.test.ts
@@ -170,6 +170,16 @@ describe('generateReleaseNotes', () => {
     expect(await changelog.generateReleaseNotes(normalized)).toMatchSnapshot();
   });
 
+  test('should create note for jira commits without PR title', async () => {
+    const changelog = new Changelog(dummyLog(), testOptions());
+    changelog.loadDefaultHooks();
+    const normalized = await logParse.normalizeCommits([
+      makeCommitFromMsg('[PLAYA-5052]')
+    ]);
+
+    expect(await changelog.generateReleaseNotes(normalized)).toMatchSnapshot();
+  });
+
   test('should use username if present', async () => {
     const changelog = new Changelog(dummyLog(), testOptions());
     changelog.loadDefaultHooks();

--- a/src/__tests__/log-parse.test.ts
+++ b/src/__tests__/log-parse.test.ts
@@ -90,6 +90,17 @@ describe('jira', () => {
     );
   });
 
+  test('story found, pr no title', () => {
+    const commit = {
+      ...makeCommitFromMsg(''),
+      jira: {
+        number: ['PLAYA-5052']
+      }
+    };
+
+    expect(parseJira(makeCommitFromMsg('[PLAYA-5052]'))).toEqual(commit);
+  });
+
   test('story found', () => {
     const commit = {
       ...makeCommitFromMsg('Add log'),

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -176,12 +176,13 @@ export default class Changelog {
   }
 
   private async generateCommitNote(commit: IExtendedCommit) {
+    const subject = commit.subject ? commit.subject.trim() : '';
     let jira = '';
     let pr = '';
 
     if (commit.jira && this.options.jira) {
       const link = join(this.options.jira, ...commit.jira.number);
-      jira = `[${commit.jira.number}](${link}): `;
+      jira = `[${commit.jira.number}](${link})${subject ? ': ' : ''}`;
     }
 
     if (commit.pullRequest && commit.pullRequest.number) {
@@ -194,7 +195,7 @@ export default class Changelog {
     }
 
     const user = await this.createUserLinkList(commit);
-    return `- ${jira}${commit.subject.trim()} ${pr}${user ? ` (${user})` : ''}`;
+    return `- ${jira}${subject} ${pr}${user ? ` (${user})` : ''}`;
   }
 
   private async createAuthorSection(split: ICommitSplit, sections: string[]) {

--- a/src/log-parse.ts
+++ b/src/log-parse.ts
@@ -80,19 +80,27 @@ export function parseJira(commit: IExtendedCommit): IExtendedCommit {
 
   while (currentMatch) {
     matches.push(currentMatch);
-    currentMatch = currentMatch[2].match(jira);
+    const rest = currentMatch[2];
+
+    if (!rest) {
+      break;
+    }
+
+    currentMatch = rest.match(jira);
   }
 
   if (!matches.length) {
     return commit;
   }
 
+  const newSubject = matches[matches.length - 1][2];
+
   return {
     ...commit,
     jira: {
       number: matches.map(match => match[1])
     },
-    subject: matches[matches.length - 1][2].trim()
+    subject: newSubject ? newSubject.trim() : ''
   };
 }
 


### PR DESCRIPTION
# What Changed

see title

# Why

If a user merged a PR with a title like `[JIRA-123]`, since there was no extra subject to the title changelog generation broke

Todo:

- [x] Add tests
- [x] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `6.4.1-canary.404.5085`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
