### PR TITLE
typo

### DIFF
--- a/docs/pages/autorc.md
+++ b/docs/pages/autorc.md
@@ -69,7 +69,7 @@ If you're extending from a local file it can be any file in JSON format or a `pa
 
 ### Labels
 
-To override any of the default labels use the `labels` seciton in the `.autorc`.
+To override any of the default labels use the `labels` section in the `.autorc`.
 
 ```json
 {


### PR DESCRIPTION
# What Changed

Fixed a typo

# Why

Because typo

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `6.5.1-canary.405.5111`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
