### PR TITLE
Move jira functionality to plugin

### DIFF
--- a/docs/pages/auto-changelog.md
+++ b/docs/pages/auto-changelog.md
@@ -13,7 +13,6 @@ Options
 
   -d, --dry-run          Report what command will do but do not actually do anything
   --no-version-prefix    Use the version as the tag without the 'v' prefix
-  --jira string          Jira base URL
   --from string          Tag to start changelog generation on. Defaults to latest tag.
   --to string            Tag to end changelog generation on. Defaults to HEAD.
   -m, --message string   Message to commit the changelog with. Defaults to 'Update CHANGELOG.md [skip ci]'
@@ -36,10 +35,6 @@ Examples
   Generate a changelog across specific           $ auto changelog --from v0.20.1 --to v0.21.0
   versions
 ```
-
-## Jira
-
-To include Jira story information you must include a URL to your hosted JIRA instance as a CLI flag or [.autorc](./autorc.md) config option.
 
 ## Changelog Titles
 

--- a/docs/pages/auto-release.md
+++ b/docs/pages/auto-release.md
@@ -30,7 +30,6 @@ Options
 
   -d, --dry-run          Report what command will do but do not actually do anything
   --no-version-prefix    Use the version as the tag without the 'v' prefix
-  --jira string          Jira base URL
   --use-version string   Version number to publish as. Defaults to reading from the package definition for the platform.
 
 Global Options

--- a/docs/pages/autorc.md
+++ b/docs/pages/autorc.md
@@ -201,16 +201,6 @@ It is useful to specify your plugins in the rc file rather than in all the comma
 }
 ```
 
-### Jira
-
-To include Jira story information in your changelogs you must include a URL to your hosted JIRA instance.
-
-```json
-{
-  "jira": "https://url-to-jira.com"
-}
-```
-
 ### githubApi
 
 If you are using enterprise github, `auto` lets you configure the github API URL that it uses.

--- a/docs/pages/jira.md
+++ b/docs/pages/jira.md
@@ -8,6 +8,10 @@ To use the plugin include it in your `.autorc`
 
 ```json
 {
-  "plugins": [["jira", { "url": "https://url-to-your-jira.com" }]]
+  "plugins": [
+    ["jira", { "url": "https://url-to-your-jira.com" }],
+    // or
+    ["jira", "https://url-to-your-jira.com"]
+  ]
 }
 ```

--- a/docs/pages/jira.md
+++ b/docs/pages/jira.md
@@ -1,0 +1,13 @@
+# Jira Plugin
+
+To include Jira story information in your changelogs you must include a URL to your hosted JIRA instance.
+
+## Usage
+
+To use the plugin include it in your `.autorc`
+
+```json
+{
+  "plugins": [["jira", { "url": "https://url-to-your-jira.com" }]]
+}
+```

--- a/docs/pages/writing-plugins.md
+++ b/docs/pages/writing-plugins.md
@@ -258,7 +258,7 @@ auto.hooks.canary.tapPromise(this.name, async (version, postFix) => {
 
 #### renderChangelogLine
 
-Change how the changelog renders lines. This hook provides the default line renderer so you don't have to change much.
+Change how the changelog renders lines. This hook provides the commit and the current state of the line render. You must return the commit and the line string state as a tuple ([commit, line]).
 
 The following plugin would change all the bullet points in the changelog to star emojis.
 
@@ -266,8 +266,8 @@ The following plugin would change all the bullet points in the changelog to star
 auto.hooks.onCreateChangelog.tapPromise('Stars', changelog =>
   changelog.hooks.renderChangelogLine.tapPromise(
     'Stars',
-    async (commits, renderLine) =>
-      commits.map(commit => `${renderLine(commit).replace('-', ':star:')}\n`)
+    async (commit, line) =>
+      [commit, `${line.replace('-', ':star:')}\n`]
   );
 );
 ```

--- a/src/__tests__/__snapshots__/changelog.test.ts.snap
+++ b/src/__tests__/__snapshots__/changelog.test.ts.snap
@@ -145,7 +145,7 @@ exports[`generateReleaseNotes should create note for PR commits without labels 1
 exports[`generateReleaseNotes should create note for jira commits without PR title 1`] = `
 "#### 🐛  Bug Fix
 
-- [PLAYA-5052](https://jira.custom.com/browse/PLAYA-5052)  (adam@dierkens.com)
+- [PLAYA-5052](https://jira.custom.com/browse/PLAYA-5052) (adam@dierkens.com)
 
 #### Authors: 1
 

--- a/src/__tests__/changelog.test.ts
+++ b/src/__tests__/changelog.test.ts
@@ -3,13 +3,16 @@ import Changelog, { IGenerateReleaseNotesOptions } from '../changelog';
 import LogParse from '../log-parse';
 import { defaultLabelDefinition } from '../release';
 import { dummyLog } from '../utils/logger';
+
+import Auto from '../auto';
+import JiraPlugin from '../plugins/jira';
+import { makeHooks } from '../utils/make-hooks';
 import makeCommitFromMsg from './make-commit-from-msg';
 
 const testOptions = (): IGenerateReleaseNotesOptions => ({
   owner: 'foobar',
   repo: 'auto',
   baseUrl: 'https://github.custom.com/foobar/auto',
-  jira: 'https://jira.custom.com/browse',
   labels: defaultLabelDefinition,
   baseBranch: 'master'
 });
@@ -162,7 +165,13 @@ describe('generateReleaseNotes', () => {
 
   test('should create note for jira commits without labels', async () => {
     const changelog = new Changelog(dummyLog(), testOptions());
+    const plugin = new JiraPlugin({ url: 'https://jira.custom.com/browse/' });
+    const autoHooks = makeHooks();
+
+    plugin.apply({ hooks: autoHooks } as Auto);
+    autoHooks.onCreateChangelog.promise(changelog);
     changelog.loadDefaultHooks();
+
     const normalized = await logParse.normalizeCommits([
       makeCommitFromMsg('[PLAYA-5052] - Fix P0')
     ]);
@@ -172,7 +181,13 @@ describe('generateReleaseNotes', () => {
 
   test('should create note for jira commits without PR title', async () => {
     const changelog = new Changelog(dummyLog(), testOptions());
+    const plugin = new JiraPlugin({ url: 'https://jira.custom.com/browse/' });
+    const autoHooks = makeHooks();
+
+    plugin.apply({ hooks: autoHooks } as Auto);
+    autoHooks.onCreateChangelog.promise(changelog);
     changelog.loadDefaultHooks();
+
     const normalized = await logParse.normalizeCommits([
       makeCommitFromMsg('[PLAYA-5052]')
     ]);
@@ -197,7 +212,13 @@ describe('generateReleaseNotes', () => {
 
   test('should create note for JIRA commits', async () => {
     const changelog = new Changelog(dummyLog(), testOptions());
+    const plugin = new JiraPlugin({ url: 'https://jira.custom.com/browse/' });
+    const autoHooks = makeHooks();
+
+    plugin.apply({ hooks: autoHooks } as Auto);
+    autoHooks.onCreateChangelog.promise(changelog);
     changelog.loadDefaultHooks();
+
     const normalized = await logParse.normalizeCommits([
       makeCommitFromMsg('[PLAYA-5052] - Some Feature (#12345)', {
         labels: ['major'],

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -27,10 +27,10 @@ describe('loadExtendConfig', () => {
     const config = new Config(log);
 
     importMock.mockImplementation(path =>
-      path === '../fake/path.json' ? { jira: 'url' } : undefined
+      path === '../fake/path.json' ? { someOption: 'url' } : undefined
     );
     expect(await config.loadExtendConfig('../fake/path.json')).toEqual({
-      jira: 'url'
+      someOption: 'url'
     });
   });
 
@@ -38,17 +38,17 @@ describe('loadExtendConfig', () => {
     const config = new Config(log);
 
     importMock.mockImplementation(path =>
-      path === './package.json' ? { auto: { jira: 'url' } } : undefined
+      path === './package.json' ? { auto: { someOption: 'url' } } : undefined
     );
     expect(await config.loadExtendConfig('./package.json')).toEqual({
-      jira: 'url'
+      someOption: 'url'
     });
   });
 
   test('should fail if file path points to js file', async () => {
     const config = new Config(log);
     importMock.mockImplementation(path =>
-      path === '../fake/path.js' ? { jira: 'url' } : undefined
+      path === '../fake/path.js' ? { someOption: 'url' } : undefined
     );
     await expect(
       config.loadExtendConfig('../fake/path.js')

--- a/src/__tests__/log-parse.test.ts
+++ b/src/__tests__/log-parse.test.ts
@@ -1,6 +1,5 @@
 import LogParse, {
   filterServiceAccounts,
-  parseJira,
   parsePR,
   parseSquashPR
 } from '../log-parse';
@@ -64,66 +63,6 @@ describe('filterServiceAccounts', () => {
   });
 });
 
-describe('jira', () => {
-  test('no story', () => {
-    const commit = {
-      ...makeCommitFromMsg('Add log')
-    };
-
-    expect(parseJira(commit)).toEqual(commit);
-  });
-
-  test('story found', () => {
-    const commit = {
-      ...makeCommitFromMsg('Add log'),
-      jira: {
-        number: ['PLAYA-5052']
-      }
-    };
-
-    expect(parseJira(makeCommitFromMsg('PLAYA-5052: Add log'))).toEqual(commit);
-    expect(parseJira(makeCommitFromMsg('[PLAYA-5052] - Add log'))).toEqual(
-      commit
-    );
-    expect(parseJira(makeCommitFromMsg('[PLAYA-5052] Add log'))).toEqual(
-      commit
-    );
-  });
-
-  test('story found, pr no title', () => {
-    const commit = {
-      ...makeCommitFromMsg(''),
-      jira: {
-        number: ['PLAYA-5052']
-      }
-    };
-
-    expect(parseJira(makeCommitFromMsg('[PLAYA-5052]'))).toEqual(commit);
-  });
-
-  test('story found', () => {
-    const commit = {
-      ...makeCommitFromMsg('Add log'),
-      jira: {
-        number: ['PLAYA-5052', 'PLAYA-6000']
-      }
-    };
-
-    expect(
-      parseJira(makeCommitFromMsg('PLAYA-5052 PLAYA-6000: Add log'))
-    ).toEqual(commit);
-    expect(
-      parseJira(makeCommitFromMsg('[PLAYA-5052][PLAYA-6000] - Add log'))
-    ).toEqual(commit);
-    expect(
-      parseJira(makeCommitFromMsg('[PLAYA-5052] PLAYA-6000: Add log'))
-    ).toEqual(commit);
-    expect(
-      parseJira(makeCommitFromMsg('PLAYA-5052 [PLAYA-6000] - Add log'))
-    ).toEqual(commit);
-  });
-});
-
 describe('normalizeCommits', () => {
   test('should handle undefined', async () => {
     const logParse = new LogParse();
@@ -141,31 +80,5 @@ describe('normalizeCommits', () => {
     ];
 
     expect(await logParse.normalizeCommits(commits)).toMatchSnapshot();
-  });
-
-  test('should use parsing functions to normalize', async () => {
-    const logParse = new LogParse();
-    const commits = [
-      makeCommitFromMsg('First'),
-      makeCommitFromMsg('Second'),
-      makeCommitFromMsg('[PLAYA-5052] Add log')
-    ];
-
-    expect((await logParse.normalizeCommits(commits))[2]).toEqual({
-      authorEmail: 'adam@dierkens.com',
-      authorName: 'Adam Dierkens',
-      authors: [
-        {
-          email: 'adam@dierkens.com',
-          name: 'Adam Dierkens'
-        }
-      ],
-      labels: [],
-      subject: 'Add log',
-      hash: 'foo',
-      jira: {
-        number: ['PLAYA-5052']
-      }
-    });
   });
 });

--- a/src/auto-rc.json
+++ b/src/auto-rc.json
@@ -2,11 +2,6 @@
   "title": "auto-rc",
   "type": "object",
   "properties": {
-    "jira": {
-      "type": "string",
-      "description": "Jira base URL"
-    },
-
     "labels": {
       "description": "Text used for versioning labels.",
       "type": "object",

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -134,13 +134,6 @@ const noVersionPrefix: commandLineUsage.OptionDefinition = {
   group: 'main'
 };
 
-const jira: commandLineUsage.OptionDefinition = {
-  name: 'jira',
-  type: String,
-  description: 'Jira base URL',
-  group: 'main'
-};
-
 const name: commandLineUsage.OptionDefinition = {
   name: 'name',
   type: String,
@@ -318,7 +311,6 @@ const commands: ICommand[] = [
       noVersionPrefix,
       name,
       email,
-      jira,
       {
         name: 'from',
         type: String,
@@ -359,7 +351,6 @@ const commands: ICommand[] = [
       noVersionPrefix,
       name,
       email,
-      jira,
       {
         name: 'use-version',
         type: String,
@@ -712,7 +703,6 @@ export interface IVersionCommandOptions {
 
 export interface IChangelogOptions extends IAuthorArgs {
   noVersionPrefix?: boolean;
-  jira?: string;
   dryRun?: boolean;
   from?: string;
   to?: string;
@@ -721,7 +711,6 @@ export interface IChangelogOptions extends IAuthorArgs {
 
 export interface IReleaseCommandOptions extends IAuthorArgs {
   noVersionPrefix?: boolean;
-  jira?: string;
   dryRun?: boolean;
   useVersion?: string;
 }

--- a/src/init.ts
+++ b/src/init.ts
@@ -34,11 +34,6 @@ async function getFlags() {
     },
     {
       type: 'input',
-      name: 'jira',
-      message: 'Jira base URL (press enter to skip)'
-    },
-    {
-      type: 'input',
       name: 'githubApi',
       message: 'GitHub API to use (press enter to use public)'
     },

--- a/src/plugins/jira/__tests__/jira.test.ts
+++ b/src/plugins/jira/__tests__/jira.test.ts
@@ -60,7 +60,7 @@ describe('parse jira', () => {
 
 describe('render jira', () => {
   test('no jira number', async () => {
-    const plugin = new JiraPlugin({ url: 'jira.com' });
+    const plugin = new JiraPlugin('jira.com');
     const hooks = makeHooks();
     const changelogHooks = makeChangelogHooks();
     const commit = makeCommitFromMsg('Add log');

--- a/src/plugins/jira/__tests__/jira.test.ts
+++ b/src/plugins/jira/__tests__/jira.test.ts
@@ -1,0 +1,93 @@
+import JiraPlugin, { parseJira } from '..';
+import makeCommitFromMsg from '../../../__tests__/make-commit-from-msg';
+import Auto from '../../../auto';
+import Changelog from '../../../changelog';
+import { dummyLog } from '../../../utils/logger';
+import { makeChangelogHooks, makeHooks } from '../../../utils/make-hooks';
+
+describe('parse jira', () => {
+  test('no story', () => {
+    const commit = {
+      ...makeCommitFromMsg('Add log')
+    };
+
+    expect(parseJira(commit)).toEqual(commit);
+  });
+
+  test('story found', () => {
+    const jira = {
+      number: ['PLAYA-5052']
+    };
+
+    expect(parseJira(makeCommitFromMsg('PLAYA-5052: Add log')).jira).toEqual(
+      jira
+    );
+    expect(parseJira(makeCommitFromMsg('[PLAYA-5052] - Add log')).jira).toEqual(
+      jira
+    );
+    expect(parseJira(makeCommitFromMsg('[PLAYA-5052] Add log')).jira).toEqual(
+      jira
+    );
+  });
+
+  test('story found, pr no title', () => {
+    const jira = {
+      number: ['PLAYA-5052']
+    };
+
+    expect(parseJira(makeCommitFromMsg('[PLAYA-5052]')).jira).toEqual(jira);
+  });
+
+  test('story found', () => {
+    const jira = {
+      number: ['PLAYA-5052', 'PLAYA-6000']
+    };
+
+    expect(
+      parseJira(makeCommitFromMsg('PLAYA-5052 PLAYA-6000: Add log')).jira
+    ).toEqual(jira);
+    expect(
+      parseJira(makeCommitFromMsg('[PLAYA-5052][PLAYA-6000] - Add log')).jira
+    ).toEqual(jira);
+    expect(
+      parseJira(makeCommitFromMsg('[PLAYA-5052] PLAYA-6000: Add log')).jira
+    ).toEqual(jira);
+    expect(
+      parseJira(makeCommitFromMsg('PLAYA-5052 [PLAYA-6000] - Add log')).jira
+    ).toEqual(jira);
+  });
+});
+
+describe('render jira', () => {
+  test('no jira number', async () => {
+    const plugin = new JiraPlugin({ url: 'jira.com' });
+    const hooks = makeHooks();
+    const changelogHooks = makeChangelogHooks();
+    const commit = makeCommitFromMsg('Add log');
+
+    plugin.apply({ hooks, logger: dummyLog() } as Auto);
+    hooks.onCreateChangelog.promise({ hooks: changelogHooks } as Changelog);
+
+    expect(
+      (await changelogHooks.renderChangelogLine.promise([commit, 'Add log']))[1]
+    ).toBe('Add log');
+  });
+
+  test('with jira number', async () => {
+    const plugin = new JiraPlugin({ url: 'jira.com' });
+    const hooks = makeHooks();
+    const changelogHooks = makeChangelogHooks();
+
+    plugin.apply({ hooks, logger: dummyLog() } as Auto);
+    hooks.onCreateChangelog.promise({ hooks: changelogHooks } as Changelog);
+
+    const [, line] = await changelogHooks.renderChangelogLine.promise([
+      makeCommitFromMsg('[PLAYA-5052] Add log'),
+      '[PLAYA-5052] Add log [author](link/to/author)'
+    ]);
+
+    expect(line).toBe(
+      '[PLAYA-5052](jira.com/PLAYA-5052): Add log [author](link/to/author)'
+    );
+  });
+});

--- a/src/plugins/jira/index.ts
+++ b/src/plugins/jira/index.ts
@@ -49,8 +49,8 @@ export default class JiraPlugin implements IPlugin {
 
   readonly options: IJiraPluginOptions;
 
-  constructor(options: IJiraPluginOptions) {
-    this.options = options;
+  constructor(options: IJiraPluginOptions | string) {
+    this.options = typeof options === 'string' ? { url: options } : options;
   }
 
   apply(auto: Auto) {

--- a/src/plugins/jira/index.ts
+++ b/src/plugins/jira/index.ts
@@ -1,0 +1,78 @@
+import join from 'url-join';
+
+import { IExtendedCommit } from '../../log-parse';
+import { Auto, IPlugin } from '../../main';
+
+interface IJiraPluginOptions {
+  url: string;
+}
+
+interface IJiraCommit extends IExtendedCommit {
+  jira?: {
+    number: string[];
+  };
+}
+
+const jira = /\[?([\w]{3,}-\d+)\]?:?\s?[-\s]*([\S ]+)?/;
+
+export function parseJira(commit: IExtendedCommit): IJiraCommit {
+  // Support 'JIRA-XXX:' and '[JIRA-XXX]' and '[JIRA-XXX] - '
+  const matches = [];
+
+  let currentMatch = commit.subject.match(jira);
+
+  while (currentMatch) {
+    matches.push(currentMatch);
+    const rest = currentMatch[2];
+
+    if (!rest) {
+      break;
+    }
+
+    currentMatch = rest.match(jira);
+  }
+
+  if (!matches.length) {
+    return commit;
+  }
+
+  return {
+    ...commit,
+    jira: {
+      number: matches.map(match => match[1])
+    }
+  };
+}
+
+export default class JiraPlugin implements IPlugin {
+  name = 'Jira';
+
+  readonly options: IJiraPluginOptions;
+
+  constructor(options: IJiraPluginOptions) {
+    this.options = options;
+  }
+
+  apply(auto: Auto) {
+    auto.hooks.onCreateChangelog.tap(this.name, changelog => {
+      changelog.hooks.renderChangelogLine.tap(
+        this.name,
+        ([commit, currentRender]) => {
+          let line = currentRender;
+          const jiraCommit = parseJira(commit);
+
+          if (jiraCommit.jira && this.options.url) {
+            const link = join(this.options.url, ...jiraCommit.jira.number);
+            const [, , rest] = commit.subject.match(jira);
+            line = line.replace(
+              jira,
+              `[${jiraCommit.jira.number}](${link})${rest ? ':' : ''} $2`
+            );
+          }
+
+          return [commit, line];
+        }
+      );
+    });
+  }
+}

--- a/src/plugins/npm/__tests__/__snapshots__/monorepo-log.test.ts.snap
+++ b/src/plugins/npm/__tests__/__snapshots__/monorepo-log.test.ts.snap
@@ -5,8 +5,9 @@ exports[`should add versions for independent packages 1`] = `
 
 - woot [#12343](https://github.custom.com/pull/12343) (adam@dierkens.com)
 - \`@foobar/release@1.0.0\`, \`@foobar/party@1.0.2\`
-  - [PLAYA-5052](jira.com/PLAYA-5052): Some Feature [#12345](https://github.custom.com/pull/12345) (adam@dierkens.com)
-  - [PLAYA-5052](jira.com/PLAYA-5052): Some Feature - Revert [#12345](https://github.custom.com/pull/12345) (adam@dierkens.com)
+  - [PLAYA-5052] - Some Feature [#12345](https://github.custom.com/pull/12345) (adam@dierkens.com)
+- \`@foobar/release@1.0.0\`, \`@foobar/party@1.0.2\`
+  - [PLAYA-5052] - Some Feature - Revert [#12345](https://github.custom.com/pull/12345) (adam@dierkens.com)
 
 #### 🏠  Internal
 
@@ -23,8 +24,9 @@ exports[`should create sections for packages 1`] = `
 
 - woot [#12343](https://github.custom.com/pull/12343) (adam@dierkens.com)
 - \`@foobar/release\`, \`@foobar/party\`
-  - [PLAYA-5052](jira.com/PLAYA-5052): Some Feature [#12345](https://github.custom.com/pull/12345) (adam@dierkens.com)
-  - [PLAYA-5052](jira.com/PLAYA-5052): Some Feature - Revert [#12345](https://github.custom.com/pull/12345) (adam@dierkens.com)
+  - [PLAYA-5052] - Some Feature [#12345](https://github.custom.com/pull/12345) (adam@dierkens.com)
+- \`@foobar/release\`, \`@foobar/party\`
+  - [PLAYA-5052] - Some Feature - Revert [#12345](https://github.custom.com/pull/12345) (adam@dierkens.com)
 
 #### 🏠  Internal
 

--- a/src/plugins/npm/__tests__/monorepo-log.test.ts
+++ b/src/plugins/npm/__tests__/monorepo-log.test.ts
@@ -46,33 +46,37 @@ const commitsPromise = logParse.normalizeCommits([
 ]);
 
 test('should create sections for packages', async () => {
-  exec.mockReturnValueOnce(
-    Promise.resolve(
-      'packages/@foobar/release:@foobar/release:1.0.0\npackages/@foobar/party:@foobar/party:1.0.0'
-    )
-  );
-  exec.mockReturnValueOnce(
-    Promise.resolve(
-      'packages/@foobar/release:@foobar/release:1.0.0\npackages/@foobar/party:@foobar/party:1.0.0'
-    )
-  );
-  exec.mockReturnValueOnce(
-    'packages/@foobar/release/README.md\npackages/@foobar/party/package.json'
-  );
-  exec.mockReturnValueOnce(
-    'packages/@foobar/release/README.md\npackages/@foobar/party/package.json'
-  );
-  exec.mockReturnValueOnce('');
-  exec.mockReturnValueOnce('packages/@foobar/release/README.md');
-  readFileSync.mockReturnValueOnce('{}');
-  readFileSync.mockReturnValueOnce('{}');
+  let changed = 0;
+
+  exec.mockImplementation(async command => {
+    if (command === 'npx') {
+      return Promise.resolve(
+        'packages/@foobar/release/README.md\npackages/@foobar/party/package.json'
+      );
+    }
+
+    changed++;
+
+    if (changed === 3) {
+      return Promise.resolve('');
+    }
+
+    if (changed === 4) {
+      return Promise.resolve('packages/@foobar/release/README.md');
+    }
+
+    return Promise.resolve(
+      'packages/@foobar/release/README.md\npackages/@foobar/party/package.jso'
+    );
+  });
+
+  readFileSync.mockReturnValue('{}');
 
   const plugin = new NpmPlugin();
   const hooks = makeHooks();
   const changelog = new Changelog(dummyLog(), {
     owner: 'andrew',
     repo: 'test',
-    jira: 'jira.com',
     baseUrl: 'https://github.custom.com/',
     labels: defaultLabelDefinition,
     baseBranch: 'master'
@@ -87,25 +91,29 @@ test('should create sections for packages', async () => {
 });
 
 test('should add versions for independent packages', async () => {
-  exec.mockReturnValueOnce(
-    Promise.resolve(
-      'packages/@foobar/release:@foobar/release:1.0.0\npackages/@foobar/party:@foobar/party:1.0.2'
-    )
-  );
-  exec.mockReturnValueOnce(
-    Promise.resolve(
-      'packages/@foobar/release:@foobar/release:1.0.0\npackages/@foobar/party:@foobar/party:1.0.0'
-    )
-  );
-  exec.mockReturnValueOnce(
-    'packages/@foobar/release/README.md\npackages/@foobar/party/package.json'
-  );
-  exec.mockReturnValueOnce(
-    'packages/@foobar/release/README.md\npackages/@foobar/party/package.json'
-  );
-  exec.mockReturnValueOnce('');
-  exec.mockReturnValueOnce('packages/@foobar/release/README.md');
-  readFileSync.mockReturnValue('{ "version": "independent" }');
+  let changed = 0;
+  exec.mockImplementation(async command => {
+    if (command === 'npx') {
+      return Promise.resolve(
+        'packages/@foobar/release:@foobar/release:1.0.0\npackages/@foobar/party:@foobar/party:1.0.2'
+      );
+    }
+
+    changed++;
+
+    if (changed === 3) {
+      return Promise.resolve('');
+    }
+
+    if (changed === 4) {
+      return Promise.resolve('packages/@foobar/release/README.md');
+    }
+
+    return Promise.resolve(
+      'packages/@foobar/release/README.md\npackages/@foobar/party/package.jso'
+    );
+  });
+
   readFileSync.mockReturnValue('{ "version": "independent" }');
 
   const plugin = new NpmPlugin();
@@ -113,7 +121,6 @@ test('should add versions for independent packages', async () => {
   const changelog = new Changelog(dummyLog(), {
     owner: 'andrew',
     repo: 'test',
-    jira: 'jira.com',
     baseUrl: 'https://github.custom.com/',
     labels: defaultLabelDefinition,
     baseBranch: 'master'

--- a/src/release.ts
+++ b/src/release.ts
@@ -36,7 +36,6 @@ export const isVersionLabel = (label: string): label is VersionLabel =>
   defaultLabels.includes(label as VersionLabel);
 
 export interface IReleaseOptions {
-  jira?: string;
   githubApi?: string;
   baseBranch: string;
   githubGraphqlApi?: string;
@@ -183,7 +182,6 @@ export default class Release {
       owner: this.git.options.owner,
       repo: this.git.options.repo,
       baseUrl: project.html_url,
-      jira: this.options.jira,
       labels: this.options.labels,
       baseBranch: this.options.baseBranch
     });

--- a/src/utils/make-hooks.ts
+++ b/src/utils/make-hooks.ts
@@ -41,7 +41,7 @@ export const makeLogParseHooks = (): ILogParseHooks => ({
 });
 
 export const makeChangelogHooks = (): IChangelogHooks => ({
-  renderChangelogLine: new AsyncSeriesBailHook(['commits', 'lineRender']),
+  renderChangelogLine: new AsyncSeriesBailHook(['lineData']),
   renderChangelogTitle: new AsyncSeriesBailHook(['commits', 'lineRender']),
   renderChangelogAuthor: new AsyncSeriesBailHook([
     'author',


### PR DESCRIPTION
# Release Notes

Previously a user would have the following configuration in their `.autorc`:

```json
{
  "jira": "https://url-to-jira"
}
```

this should be changed to:

```json
{
  "plugins": [
    ["jira", { "url": "https://url-to-jira" }],
    // or
    ["jira", "https://url-to-jira"]
  ]
}
```

## Plugin Authors

If you are a plugin author that uses the `renderChangelogLine` hook you must change your usage.

Before it was a bail hook. meaning on 1 plugin could effect the changelog message. The first to return would be the message.

```ts
auto.hooks.onCreateChangelog.tapPromise('Stars', changelog =>
  changelog.hooks.renderChangelogLine.tapPromise(
    'Stars',
    async (commits, renderLine) =>
      commits.map(commit => `${renderLine(commit).replace('-', ':star:')}\n`)
  );
);
```

Now it is a waterfall hook. Each plugin has the chance to change the commit message in some way, but it must return the args for the next plugin in the waterfall.

```ts
auto.hooks.onCreateChangelog.tapPromise('Stars', changelog =>
  changelog.hooks.renderChangelogLine.tapPromise(
    'Stars',
    async (commit, line) =>
      [commit, `${line.replace('-', ':star:')}\n`]
  );
);
```

# Why

Not everybody might use jira and it makes sense as a plugin

Todo:

- [x] Add tests
- [x] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.0.0-canary.408.5176`
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.0.0-canary.408.5181`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
