### PR TITLE
Parse monorepo packages outside of `packages` directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "clean": "lerna clean --yes && rm -rf node_modules && rm -rf packages/*/dist && rm -rf plugins/*/dist",
     "semver:check": "./scripts/post-install.sh",
     "build": "lerna run build --stream",
-    "build:watch": "npm run build -- -- -w",
+    "build:watch": "lerna run build --parallel -- --watch --preserveWatchOutput",
     "lint": "tslint -p . --format stylish",
     "precommit": "lint-staged",
     "test": "jest --maxWorkers=2",

--- a/plugins/npm/__tests__/monorepo-log.test.ts
+++ b/plugins/npm/__tests__/monorepo-log.test.ts
@@ -50,7 +50,7 @@ test('should create sections for packages', async () => {
   exec.mockImplementation(async command => {
     if (command === 'npx') {
       return Promise.resolve(
-        'packages/@foobar/release/README.md\npackages/@foobar/party/package.json'
+        'packages/@foobar/release:@foobar/release:1.0.0\npackages/@foobar/party:@foobar/party:1.0.0'
       );
     }
 

--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -66,10 +66,25 @@ describe('changedPackages ', () => {
       `packages/foo/README.md\npackages/bar/package.json`
     );
 
-    expect(await changedPackages('sha', [], {}, dummyLog())).toEqual([
-      'foo',
-      'bar'
-    ]);
+    expect(
+      await changedPackages(
+        'sha',
+        [
+          {
+            name: 'foo',
+            path: 'packages/foo',
+            version: '1.0.0'
+          },
+          {
+            name: 'bar',
+            path: 'packages/bar',
+            version: '1.0.0'
+          }
+        ],
+        {},
+        dummyLog()
+      )
+    ).toEqual(['foo', 'bar']);
   });
 
   test('should match files in package directory with @scope/ names', async () => {
@@ -77,10 +92,25 @@ describe('changedPackages ', () => {
       `packages/@scope/foo/README.md\npackages/@scope/bar/package.json`
     );
 
-    expect(await changedPackages('sha', [], {}, dummyLog())).toEqual([
-      '@scope/foo',
-      '@scope/bar'
-    ]);
+    expect(
+      await changedPackages(
+        'sha',
+        [
+          {
+            name: '@scope/foo',
+            path: 'packages/@scope/foo',
+            version: '1.0.0'
+          },
+          {
+            name: '@scope/bar',
+            path: 'packages/@scope/bar',
+            version: '1.0.0'
+          }
+        ],
+        {},
+        dummyLog()
+      )
+    ).toEqual(['@scope/foo', '@scope/bar']);
   });
 });
 

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -49,8 +49,8 @@ interface IMonorepoPackage {
   version: string;
 }
 
-const inFolder = (parent: string, dir: string) => {
-  const relative = path.relative(parent, dir);
+const inFolder = (parent: string, child: string) => {
+  const relative = path.relative(parent, child);
 
   return Boolean(
     relative && !relative.startsWith('..') && !path.isAbsolute(relative)
@@ -82,7 +82,7 @@ export async function changedPackages(
     }
 
     changed.add(
-      monorepoPackage && lernaJson.version === 'independent'
+      lernaJson.version === 'independent'
         ? `${monorepoPackage.name}@${monorepoPackage.version}`
         : monorepoPackage.name
     );

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -1,6 +1,7 @@
 import envCi from 'env-ci';
 import * as fs from 'fs';
 import parseAuthor from 'parse-author';
+import path from 'path';
 
 import { Auto, execPromise, ILogger, IPlugin, SEMVER } from '@intuit-auto/core';
 import getPackages from 'get-monorepo-packages';
@@ -48,6 +49,14 @@ interface IMonorepoPackage {
   version: string;
 }
 
+const inFolder = (parent: string, dir: string) => {
+  const relative = path.relative(parent, dir);
+
+  return Boolean(
+    relative && !relative.startsWith('..') && !path.isAbsolute(relative)
+  );
+};
+
 export async function changedPackages(
   sha: string,
   packages: IMonorepoPackage[],
@@ -64,25 +73,18 @@ export async function changedPackages(
   ]);
 
   changedFiles.split('\n').forEach(filePath => {
-    const parts = filePath.split('/');
+    const monorepoPackage = packages.find(subPackage =>
+      inFolder(subPackage.path, filePath)
+    );
 
-    // TODO: fix monorpo pacakge parsing to support more that just packages repo
-    if (parts[0] !== 'packages' || parts.length < 3) {
+    if (!monorepoPackage) {
       return;
     }
 
-    const packageName =
-      parts.length > 3 && parts[1][0] === '@'
-        ? `${parts[1]}/${parts[2]}`
-        : parts[1];
-    const version = packages.find(monorepoPackage =>
-      monorepoPackage.path.includes(parts.slice(0, -1).join('/'))
-    );
-
     changed.add(
-      version && lernaJson.version === 'independent'
-        ? `${packageName}@${version.version}`
-        : packageName
+      monorepoPackage && lernaJson.version === 'independent'
+        ? `${monorepoPackage.name}@${monorepoPackage.version}`
+        : monorepoPackage.name
     );
   });
 
@@ -135,8 +137,8 @@ interface INpmConfig {
 const getLernaPackages = async () =>
   execPromise('npx', ['lerna', 'ls', '-pl']).then(res =>
     res.split('\n').map(packageInfo => {
-      const [path, name, version] = packageInfo.split(':');
-      return { path, name, version };
+      const [packagePath, name, version] = packageInfo.split(':');
+      return { path: packagePath, name, version };
     })
   );
 


### PR DESCRIPTION
# What Changed

see title

# Why

it's common in monorepo projects to have multiple directories that contain packages. our implementation only look in the `packages` directory,  now it will correctly find all packages

closes #172 

Todo:

- [x] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `6.5.1-canary.411.5306.7`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
