### PR TITLE
afterRelease returns an object so future updates will be easier

### DIFF
--- a/docs/pages/writing-plugins.md
+++ b/docs/pages/writing-plugins.md
@@ -97,11 +97,16 @@ Ran after the `release` command has run. This hooks gets the following arguments
 
 - version - version that was just released
 - commits - the commits in the release
+- releaseNotes - generated release notes for the release
+- response - the response returned from making the release
 
 ```ts
-auto.hooks.afterRelease.tap('MyPlugin', async (version, commits) => {
-  // do something
-});
+auto.hooks.afterRelease.tap(
+  'MyPlugin',
+  async ({ version, commits, releaseNotes, response }) => {
+    // do something
+  }
+);
 ```
 
 #### afterShipIt

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -50,11 +50,11 @@ const makePrBodyIdentifier = (context: string) =>
 // A class to interact with the local git instance and the git remote.
 // currently it only interfaces with GitHub.
 export default class Git {
+  readonly ghub: Octokit;
   readonly options: IGitOptions;
 
   private readonly baseUrl: string;
   private readonly graphqlBaseUrl: string;
-  private readonly ghub: Octokit;
   private readonly logger: ILogger;
 
   constructor(options: IGitOptions, logger: ILogger = dummyLog()) {

--- a/packages/core/src/utils/make-hooks.ts
+++ b/packages/core/src/utils/make-hooks.ts
@@ -15,7 +15,7 @@ export const makeHooks = (): IAutoHooks => ({
   modifyConfig: new SyncWaterfallHook(['config']),
   beforeShipIt: new SyncHook([]),
   afterShipIt: new AsyncParallelHook(['version', 'commits']),
-  afterRelease: new AsyncParallelHook(['version', 'commits', 'releaseNotes']),
+  afterRelease: new AsyncParallelHook(['releaseInfo']),
   onCreateRelease: new SyncHook(['options']),
   onCreateChangelog: new SyncHook(['changelog']),
   onCreateLogParse: new SyncHook(['logParse']),

--- a/plugins/released/__tests__/released-label.test.ts
+++ b/plugins/released/__tests__/released-label.test.ts
@@ -69,7 +69,11 @@ describe('release label plugin', () => {
     } as unknown) as Auto);
 
     const commit = makeCommitFromMsg('normal commit with no bump');
-    await autoHooks.afterRelease.promise('1.0.0', [commit], '');
+    await autoHooks.afterRelease.promise({
+      newVersion: '1.0.0',
+      commits: [commit],
+      releaseNotes: ''
+    });
 
     expect(comment).not.toHaveBeenCalled();
   });
@@ -87,7 +91,10 @@ describe('release label plugin', () => {
     } as unknown) as Auto);
 
     const commit = makeCommitFromMsg('normal commit with no bump');
-    await autoHooks.afterRelease.promise(undefined, [commit], '');
+    await autoHooks.afterRelease.promise({
+      commits: [commit],
+      releaseNotes: ''
+    });
 
     expect(comment).not.toHaveBeenCalled();
   });
@@ -104,7 +111,11 @@ describe('release label plugin', () => {
       git
     } as unknown) as Auto);
 
-    await autoHooks.afterRelease.promise('1.0.0', [], '');
+    await autoHooks.afterRelease.promise({
+      newVersion: '1.0.0',
+      commits: [],
+      releaseNotes: ''
+    });
 
     expect(comment).not.toHaveBeenCalled();
   });
@@ -127,11 +138,11 @@ describe('release label plugin', () => {
     const commit = makeCommitFromMsg('normal commit with no bump (#123)', {
       labels: ['skip-release']
     });
-    await autoHooks.afterRelease.promise(
-      '1.0.0',
-      await log.normalizeCommits([commit]),
-      ''
-    );
+    await autoHooks.afterRelease.promise({
+      newVersion: '1.0.0',
+      commits: await log.normalizeCommits([commit]),
+      releaseNotes: ''
+    });
 
     expect(comment).not.toHaveBeenCalled();
   });
@@ -149,11 +160,11 @@ describe('release label plugin', () => {
     } as unknown) as Auto);
 
     const commit = makeCommitFromMsg('normal commit with no bump (#123)');
-    await autoHooks.afterRelease.promise(
-      '1.0.0',
-      await log.normalizeCommits([commit]),
-      ''
-    );
+    await autoHooks.afterRelease.promise({
+      newVersion: '1.0.0',
+      commits: await log.normalizeCommits([commit]),
+      releaseNotes: ''
+    });
 
     expect(comment).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -175,13 +186,13 @@ describe('release label plugin', () => {
       git
     } as unknown) as Auto);
 
-    await autoHooks.afterRelease.promise(
-      '1.0.0',
-      await log.normalizeCommits([
+    await autoHooks.afterRelease.promise({
+      newVersion: '1.0.0',
+      commits: await log.normalizeCommits([
         makeCommitFromMsg('normal commit with no bump (#123)')
       ]),
-      ''
-    );
+      releaseNotes: ''
+    });
 
     expect(comment).not.toHaveBeenCalled();
   });
@@ -201,13 +212,13 @@ describe('release label plugin', () => {
 
     getLabels.mockReturnValueOnce(['released']);
 
-    await autoHooks.afterRelease.promise(
-      '1.0.0',
-      await log.normalizeCommits([
+    await autoHooks.afterRelease.promise({
+      newVersion: '1.0.0',
+      commits: await log.normalizeCommits([
         makeCommitFromMsg('normal commit with no bump (#123)')
       ]),
-      ''
-    );
+      releaseNotes: ''
+    });
 
     expect(addLabelToPr).not.toHaveBeenCalled();
   });
@@ -225,13 +236,13 @@ describe('release label plugin', () => {
       git
     } as unknown) as Auto);
 
-    await autoHooks.afterRelease.promise(
-      '1.0.0-canary',
-      await log.normalizeCommits([
+    await autoHooks.afterRelease.promise({
+      newVersion: '1.0.0-canary',
+      commits: await log.normalizeCommits([
         makeCommitFromMsg('normal commit with no bump (#123)')
       ]),
-      ''
-    );
+      releaseNotes: ''
+    });
 
     expect(addLabelToPr).not.toHaveBeenCalled();
   });
@@ -255,11 +266,11 @@ describe('release label plugin', () => {
     const commit = makeCommitFromMsg(
       'normal commit with no bump closes (#123)'
     );
-    await autoHooks.afterRelease.promise(
-      '1.0.0',
-      await log.normalizeCommits([commit]),
-      ''
-    );
+    await autoHooks.afterRelease.promise({
+      newVersion: '1.0.0',
+      commits: await log.normalizeCommits([commit]),
+      releaseNotes: ''
+    });
 
     expect(comment).toHaveBeenNthCalledWith(
       2,
@@ -286,11 +297,11 @@ describe('release label plugin', () => {
     const commit = makeCommitFromMsg(
       'normal commit with no bump (#123) closes #100'
     );
-    await autoHooks.afterRelease.promise(
-      '1.0.0',
-      await log.normalizeCommits([commit]),
-      ''
-    );
+    await autoHooks.afterRelease.promise({
+      newVersion: '1.0.0',
+      commits: await log.normalizeCommits([commit]),
+      releaseNotes: ''
+    });
 
     expect(lockIssue).toHaveBeenCalled();
   });
@@ -310,11 +321,11 @@ describe('release label plugin', () => {
     const commit = makeCommitFromMsg(
       'normal commit with no bump (#123) closes #100'
     );
-    await autoHooks.afterRelease.promise(
-      '1.0.0-canary',
-      await log.normalizeCommits([commit]),
-      ''
-    );
+    await autoHooks.afterRelease.promise({
+      newVersion: '1.0.0-canary',
+      commits: await log.normalizeCommits([commit]),
+      releaseNotes: ''
+    });
 
     expect(lockIssue).not.toHaveBeenCalled();
   });

--- a/plugins/released/src/index.ts
+++ b/plugins/released/src/index.ts
@@ -40,7 +40,7 @@ export default class ReleasedLabelPlugin implements IPlugin {
 
     auto.hooks.afterRelease.tapPromise(
       this.name,
-      async (newVersion, commits) => {
+      async ({ newVersion, commits }) => {
         if (!newVersion) {
           return;
         }

--- a/plugins/slack/__tests__/slack.test.ts
+++ b/plugins/slack/__tests__/slack.test.ts
@@ -37,7 +37,10 @@ describe('postToSlack', () => {
     // @ts-ignore
     plugin.apply({ hooks } as Auto);
 
-    await hooks.afterRelease.promise(undefined, [], '# My Notes');
+    await hooks.afterRelease.promise({
+      commits: [],
+      releaseNotes: '# My Notes'
+    });
 
     expect(plugin.postToSlack).not.toHaveBeenCalled();
   });
@@ -50,7 +53,11 @@ describe('postToSlack', () => {
     // @ts-ignore
     plugin.apply({ hooks, args: { dryRun: true } } as Auto);
 
-    await hooks.afterRelease.promise('1.0.0', [], '# My Notes');
+    await hooks.afterRelease.promise({
+      newVersion: '1.0.0',
+      commits: [],
+      releaseNotes: '# My Notes'
+    });
 
     expect(plugin.postToSlack).not.toHaveBeenCalled();
   });
@@ -63,7 +70,11 @@ describe('postToSlack', () => {
     // @ts-ignore
     plugin.apply({ hooks, args: {} } as Auto);
 
-    await hooks.afterRelease.promise('1.0.0', [], '# My Notes');
+    await hooks.afterRelease.promise({
+      newVersion: '1.0.0',
+      commits: [],
+      releaseNotes: '# My Notes'
+    });
 
     expect(plugin.postToSlack).not.toHaveBeenCalled();
   });
@@ -80,11 +91,11 @@ describe('postToSlack', () => {
       release: { options: { skipReleaseLabels: ['skip-release'] } }
     } as Auto);
 
-    await hooks.afterRelease.promise(
-      '1.0.0',
-      [makeCommitFromMsg('skipped', { labels: ['skip-release'] })],
-      '# My Notes'
-    );
+    await hooks.afterRelease.promise({
+      newVersion: '1.0.0',
+      commits: [makeCommitFromMsg('skipped', { labels: ['skip-release'] })],
+      releaseNotes: '# My Notes'
+    });
 
     expect(plugin.postToSlack).not.toHaveBeenCalled();
   });
@@ -99,11 +110,11 @@ describe('postToSlack', () => {
     plugin.apply({ hooks, args: {} } as Auto);
 
     await expect(
-      hooks.afterRelease.promise(
-        '1.0.0',
-        [makeCommitFromMsg('a patch')],
-        '# My Notes'
-      )
+      hooks.afterRelease.promise({
+        newVersion: '1.0.0',
+        commits: [makeCommitFromMsg('a patch')],
+        releaseNotes: '# My Notes'
+      })
     ).rejects.toBeInstanceOf(Error);
   });
 
@@ -145,11 +156,11 @@ describe('postToSlack', () => {
     process.env.SLACK_TOKEN = 'MY_TOKEN';
     plugin.apply({ hooks, args: {}, ...mockAuto } as Auto);
 
-    await hooks.afterRelease.promise(
-      '1.0.0',
-      [makeCommitFromMsg('a patch')],
-      '# My Notes\n- PR [some link](google.com)'
-    );
+    await hooks.afterRelease.promise({
+      newVersion: '1.0.0',
+      commits: [makeCommitFromMsg('a patch')],
+      releaseNotes: '# My Notes\n- PR [some link](google.com)'
+    });
 
     expect(fetchSpy).toHaveBeenCalled();
     expect(fetchSpy.mock.calls[0][0]).toBe(

--- a/plugins/slack/src/index.ts
+++ b/plugins/slack/src/index.ts
@@ -32,7 +32,7 @@ export default class SlackPlugin implements IPlugin {
   apply(auto: Auto) {
     auto.hooks.afterRelease.tapPromise(
       this.name,
-      async (newVersion, commits, releaseNotes) => {
+      async ({ newVersion, commits, releaseNotes }) => {
         if (!newVersion) {
           return;
         }


### PR DESCRIPTION
# Release Notes

old `afterRelease`

```js
auto.hooks.afterRelease.tap('MyPlugin', async (version, commits, releaseNotes) => {
  // do something
});
```

new  `afterRelease`

```js
auto.hooks.afterRelease.tap( 'MyPlugin', async ({ version, commits, releaseNotes, response }) => {
    // do something
);
```

# Why

Todo:

- [x] Add tests
- [x] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.0.0-canary.420.5424.9`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
