### PR TITLE
 new hook: omit prs from release notes + add omit-release-notes plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ Auto has an extensive plugin system and wide variety of official plugins. Make a
 
 - [chrome](./plugins/chrome) - publish code to Chrome Web Store
 - [conventional-commits]](./plugins/conventional-commits) - parse conventional commit messages for version bumps
-- [omit-commits](./plugins/omit-commits) - Ignore commits base on name, email, subject, labels, and username
 - [jira](./plugins/jira) - Include jira story links in the changelog
 - [npm](./plugins/npm) - publish code to npm (DEFAULT)
+- [omit-commits](./plugins/omit-commits) - Ignore commits base on name, email, subject, labels, and username
+- [omit-release-notes](./plugins/omit-release-notes) - Ignore release notes in PRs made by certain accounts
 - [released](./plugins/released) - Add a `released` label to published PRs, comment with the version it's included in and comment on the issues the PR closes
 - [slack](./plugins/slack) - post release notes to slack
 - [twitter](./plugins/twitter) - post release notes to twitter

--- a/docs/pages/plugins.md
+++ b/docs/pages/plugins.md
@@ -6,9 +6,10 @@ Current official plugins:
 
 - chrome - publish code to Chrome Web Store
 - conventional-commits - parse conventional commit messages for version bumps
-- omit-commits - Ignore commits made by certain accounts
 - jira - Include jira story links in the changelog
 - npm - publish code to npm (DEFAULT)
+- omit-commits - Ignore commits made by certain accounts
+- omit-release-notes - Ignore release notes in PRs made by certain accounts
 - released - Add a `released` label to published PRs, comment with the version it's included in and comment on the issues the PR closes
 - slack - post release notes to slack
 - twitter - post release notes to twitter

--- a/packages/core/src/__tests__/__snapshots__/changelog.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/changelog.test.ts.snap
@@ -41,6 +41,26 @@ Bam!?
 - Adam Dierkens (adam@dierkens.com)"
 `;
 
+exports[`generateReleaseNotes additional release notes should have tappable omit 1`] = `
+"#### 🚀  Enhancement
+
+- First Feature [#1235](https://github.custom.com/foobar/auto/pull/1235) (adam@dierkens.com)
+
+#### Authors: 1
+
+- Adam Dierkens (adam@dierkens.com)"
+`;
+
+exports[`generateReleaseNotes additional release notes should omit renovate prs 1`] = `
+"#### 🚀  Enhancement
+
+- First Feature [#1235](https://github.custom.com/foobar/auto/pull/1235) ([@renovate-bot](https://github.custom.com/renovate-bot))
+
+#### Authors: 1
+
+- Adam Dierkens ([@renovate-bot](https://github.custom.com/renovate-bot))"
+`;
+
 exports[`generateReleaseNotes doesn't add additional release notes when there are none 1`] = `
 "#### 🚀  Enhancement
 

--- a/packages/core/src/changelog.ts
+++ b/packages/core/src/changelog.ts
@@ -35,6 +35,7 @@ export interface IChangelogHooks {
     [ICommitAuthor, string],
     string | void
   >;
+  omitReleaseNotes: AsyncSeriesBailHook<[IExtendedCommit], boolean | void>;
 }
 
 const getHeaderDepth = (line: string) =>
@@ -77,6 +78,17 @@ export default class Changelog {
       'Default',
       (label, changelogTitles) => `#### ${changelogTitles[label]}\n`
     );
+    this.hooks.omitReleaseNotes.tap('Renovate', commit => {
+      const usernames = ['renovate-pro[bot]', 'renovate-bot'];
+
+      if (
+        commit.authors.find(author =>
+          Boolean(author.username && usernames.includes(author.username))
+        )
+      ) {
+        return true;
+      }
+    });
   }
 
   async generateReleaseNotes(commits: IExtendedCommit[]): Promise<string> {
@@ -90,8 +102,8 @@ export default class Changelog {
     this.logger.veryVerbose.info('\n', split);
     const sections: string[] = [];
 
-    this.createReleaseNotesSection(commits, sections);
-    this.logger.verbose.info('Added relase notes to changelog');
+    await this.createReleaseNotesSection(commits, sections);
+    this.logger.verbose.info('Added release notes to changelog');
 
     await this.createLabelSection(split, sections);
     this.logger.verbose.info('Added groups to changelog');
@@ -279,7 +291,7 @@ export default class Changelog {
     );
   }
 
-  private createReleaseNotesSection(
+  private async createReleaseNotesSection(
     commits: IExtendedCommit[],
     sections: string[]
   ) {
@@ -287,10 +299,23 @@ export default class Changelog {
       return;
     }
 
-    const visited = new Set<number>();
     let section = '';
+    const visited = new Set<number>();
+    const included = await Promise.all(
+      commits.map(async commit => {
+        const omit = await this.hooks.omitReleaseNotes.promise(commit);
 
-    commits.map(commit => {
+        if (!omit) {
+          return commit;
+        }
+      })
+    );
+
+    included.map(commit => {
+      if (!commit) {
+        return;
+      }
+
       const pr = commit.pullRequest;
 
       if (!pr || !pr.body) {

--- a/packages/core/src/changelog.ts
+++ b/packages/core/src/changelog.ts
@@ -79,11 +79,14 @@ export default class Changelog {
       (label, changelogTitles) => `#### ${changelogTitles[label]}\n`
     );
     this.hooks.omitReleaseNotes.tap('Renovate', commit => {
-      const usernames = ['renovate-pro[bot]', 'renovate-bot'];
+      const names = ['renovate-pro[bot]', 'renovate-bot'];
 
       if (
         commit.authors.find(author =>
-          Boolean(author.username && usernames.includes(author.username))
+          Boolean(
+            (author.name && names.includes(author.name)) ||
+              (author.username && names.includes(author.username))
+          )
         )
       ) {
         return true;

--- a/packages/core/src/utils/make-hooks.ts
+++ b/packages/core/src/utils/make-hooks.ts
@@ -48,5 +48,6 @@ export const makeChangelogHooks = (): IChangelogHooks => ({
     'commit',
     'options'
   ]),
-  renderChangelogAuthorLine: new AsyncSeriesBailHook(['author', 'user'])
+  renderChangelogAuthorLine: new AsyncSeriesBailHook(['author', 'user']),
+  omitReleaseNotes: new AsyncSeriesBailHook(['commit'])
 });

--- a/plugins/omit-commits/README.md
+++ b/plugins/omit-commits/README.md
@@ -24,6 +24,8 @@ Yarn can omit by most any field available on a commit. Each options accepts eith
       {
         // By usernames
         "username": ["pdbf", "ghost"],
+        // By name
+        "name": "Adam",
         // By emails
         "email": ["foo@gmail.com", "doesnt-exits@yahoo.com"],
         // By presence of string in subject

--- a/plugins/omit-release-notes/README.md
+++ b/plugins/omit-release-notes/README.md
@@ -1,0 +1,37 @@
+# Omit Release Notes Plugin
+
+Filter PRs with release notes that shouldn't make it into a release. By default `auto` will not include and `Release Notes` from [renovate](https://renovatebot.com/) PRs. This plugin allows you to omit more PRs from effecting you releases.
+
+## Installation
+
+This plugin is not included with the `auto` CLI. To install:
+
+```sh
+npm i --save-dev @intuit-auto/omit-release-notes
+# or
+yarn add -D @intuit-auto/omit-release-notes
+```
+
+## Usage
+
+Yarn can omit by most any field available on a PR. Each options accepts either a string or an array of strings.
+
+```json
+{
+  "plugins": [
+    [
+      "omit-release-notes",
+      {
+        // By usernames
+        "username": ["pdbf", "ghost"],
+        // By name
+        "name": "Adam",
+        // By emails
+        "email": ["foo@gmail.com", "doesnt-exits@yahoo.com"],
+        // By labels
+        "labels": "grunt-work"
+      }
+    ]
+  ]
+}
+```

--- a/plugins/omit-release-notes/package.json
+++ b/plugins/omit-release-notes/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@intuit-auto/omit-release-notes",
+  "version": "6.5.0",
+  "main": "dist/index.js",
+  "description": "Omit release notes plugin for auto",
+  "author": {
+    "name": "Andrew Lisowski",
+    "email": "lisowski54@gmail.com"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/intuit/auto"
+  },
+  "files": [
+    "dist"
+  ],
+  "keywords": [
+    "automation",
+    "semantic",
+    "release",
+    "github",
+    "labels",
+    "automated",
+    "continuos integration",
+    "changelog",
+    "filter",
+    "omit"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "build:watch": "npm run build -- -w",
+    "lint": "tslint -p . --format stylish",
+    "test": "jest --maxWorkers=2 --config ../../package.json"
+  },
+  "dependencies": {
+    "@intuit-auto/core": "6.5.0"
+  }
+}

--- a/plugins/omit-release-notes/src/index.ts
+++ b/plugins/omit-release-notes/src/index.ts
@@ -1,0 +1,56 @@
+import { Auto, IPlugin } from '@intuit-auto/core';
+
+interface IReleaseNotesPluginOptions {
+  username?: string | string[];
+  email?: string | string[];
+  name?: string | string[];
+  labels?: string | string[];
+}
+
+const arrayify = <T>(arr: T | T[]): T[] =>
+  Array.isArray(arr) || arr === undefined ? arr : [arr];
+
+export default class ReleaseNotesPlugin implements IPlugin {
+  name = 'Omit Release Notes';
+
+  readonly options: {
+    username: string[];
+    email: string[];
+    name: string[];
+    labels: string[];
+  };
+
+  constructor(options: IReleaseNotesPluginOptions) {
+    this.options = {
+      username: options.username ? arrayify(options.username) : [],
+      email: options.email ? arrayify(options.email) : [],
+      name: options.name ? arrayify(options.name) : [],
+      labels: options.labels ? arrayify(options.labels) : []
+    };
+  }
+
+  apply(auto: Auto) {
+    auto.hooks.onCreateChangelog.tap(this.name, changelog => {
+      changelog.hooks.omitReleaseNotes.tap(this.name, commit => {
+        if (
+          commit.authors.find(author =>
+            Boolean(author.name && this.options.name.includes(author.name))
+          ) ||
+          commit.authors.find(author =>
+            Boolean(author.email && this.options.email.includes(author.email))
+          ) ||
+          commit.authors.find(author =>
+            Boolean(
+              author.username && this.options.username.includes(author.username)
+            )
+          ) ||
+          commit.labels.find(label =>
+            Boolean(this.options.labels.includes(label))
+          )
+        ) {
+          return true;
+        }
+      });
+    });
+  }
+}

--- a/plugins/omit-release-notes/tsconfig.json
+++ b/plugins/omit-release-notes/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*", "../../typings/**/*"]
+}


### PR DESCRIPTION
# What Changed

1. Ignore release notes for PRs from renovate accounts
2. make a plugin for the experience

# Why

Some automated tools add a `Release Notes` sections to PRs. this was interfering with the `auto changelog`'s additional changelog section.

Todo:

- [x] Add tests
- [x] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `6.6.0-canary.427.5596.15`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
