### PR TITLE
fix problem where pr-body would only match after two were rendered

### DIFF
--- a/packages/core/src/__tests__/git.test.ts
+++ b/packages/core/src/__tests__/git.test.ts
@@ -333,7 +333,7 @@ describe('github', () => {
       get.mockReturnValueOnce({
         data: {
           body:
-            '# My Content\n<!-- GITHUB_RELEASE PR BODY: default -->\nSome long thing\n<!-- GITHUB_RELEASE PR BODY: default -->\n'
+            '# My Content\n<!-- GITHUB_RELEASE PR BODY: default -->\n\n\nSome long thing\n<!-- GITHUB_RELEASE PR BODY: default -->\n'
         }
       });
 

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -528,7 +528,7 @@ export default class Git {
     });
 
     this.logger.veryVerbose.info('Got PR description\n', issue.data.body);
-    const regex = new RegExp(`(${id})\\s(.+)\\s(${id})`);
+    const regex = new RegExp(`(${id})\\s*(.*)\\s*(${id})`);
     let body = issue.data.body;
 
     if (body.match(regex)) {


### PR DESCRIPTION
# What Changed

unlimited white space matched now

# Why

sometime two pr-body notes would be attached

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `6.5.1-canary.431.5657.18`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
