### PR TITLE
switch auto.args to auto.options on core

### DIFF
--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -8,8 +8,8 @@ import dedent from 'dedent';
 import signale from 'signale';
 
 import {
-  ApiArgs,
-  GlobalArgs,
+  ApiOptions,
+  GlobalOptions,
   ICanaryOptions,
   IChangelogOptions,
   ICommentOptions,
@@ -25,7 +25,7 @@ import {
 } from '@auto-it/core';
 
 export type Flags =
-  | keyof GlobalArgs
+  | keyof GlobalOptions
   | keyof IInitOptions
   | keyof ICreateLabelsOptions
   | keyof ILabelOptions
@@ -650,7 +650,7 @@ export default function parseArgs(testArgs?: string[]) {
     return [];
   }
 
-  const autoOptions: ApiArgs = commandLineArgs(options, {
+  const autoOptions: ApiOptions = commandLineArgs(options, {
     argv,
     camelCase: true
   })._all;
@@ -662,7 +662,7 @@ export default function parseArgs(testArgs?: string[]) {
           (typeof option === 'string' && !(option in autoOptions)) ||
           (typeof option === 'object' && !option.find(o => o in autoOptions)) ||
           // tslint:disable-next-line strict-type-predicates
-          autoOptions[option as keyof ApiArgs] === null
+          autoOptions[option as keyof ApiOptions] === null
       )
       .map(option =>
         typeof option === 'string'

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import Auto, {
-  ApiArgs,
+  ApiOptions,
   ICanaryOptions,
   IChangelogOptions,
   ICommentOptions,
@@ -15,7 +15,7 @@ import Auto, {
   IShipItOptions
 } from '@auto-it/core';
 
-export async function run(command: string, args: ApiArgs) {
+export async function run(command: string, args: ApiOptions) {
   const auto = new Auto(args);
 
   switch (command) {
@@ -71,7 +71,7 @@ export async function run(command: string, args: ApiArgs) {
   }
 }
 
-export default async function main(command: string, args: ApiArgs) {
+export default async function main(command: string, args: ApiOptions) {
   try {
     await run(command, args);
   } catch (error) {

--- a/packages/core/src/auto-args.ts
+++ b/packages/core/src/auto-args.ts
@@ -1,14 +1,14 @@
-interface IAuthorArgs {
+interface IAuthorOptions {
   name?: string;
   email?: string;
 }
 
-export interface IRepoArgs {
+export interface IRepoOptions {
   owner?: string;
   repo?: string;
 }
 
-export interface ILogArgs {
+export interface ILogOptions {
   verbose?: boolean;
   veryVerbose?: boolean;
 }
@@ -49,7 +49,7 @@ export interface IVersionOptions {
   onlyPublishWithReleaseLabel?: boolean;
 }
 
-export interface IChangelogOptions extends IAuthorArgs {
+export interface IChangelogOptions extends IAuthorOptions {
   noVersionPrefix?: boolean;
   dryRun?: boolean;
   from?: string;
@@ -57,7 +57,7 @@ export interface IChangelogOptions extends IAuthorArgs {
   message?: string;
 }
 
-export interface IReleaseOptions extends IAuthorArgs {
+export interface IReleaseOptions extends IAuthorOptions {
   noVersionPrefix?: boolean;
   dryRun?: boolean;
   useVersion?: string;
@@ -84,15 +84,15 @@ export interface ICanaryOptions {
   message?: string | 'false';
 }
 
-export type GlobalArgs = {
+export type GlobalOptions = {
   githubApi?: string;
   baseBranch?: string;
   githubGraphqlApi?: string;
   plugins?: string[];
-} & IRepoArgs &
-  ILogArgs;
+} & IRepoOptions &
+  ILogOptions;
 
-export type ApiArgs = GlobalArgs &
+export type ApiOptions = GlobalOptions &
   (
     | IInitOptions
     | ICreateLabelsOptions

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -12,7 +12,7 @@ import {
 } from 'tapable';
 
 import {
-  ApiArgs,
+  ApiOptions,
   ICanaryOptions,
   IChangelogOptions,
   ICommentOptions,
@@ -104,7 +104,7 @@ const loadEnv = () => {
 export default class Auto {
   hooks: IAutoHooks;
   logger: ILogger;
-  args: ApiArgs;
+  options: ApiOptions;
   baseBranch: string;
   config?: IAutoConfig;
 
@@ -113,11 +113,15 @@ export default class Auto {
   labels?: ILabelDefinitionMap;
   semVerLabels?: Map<VersionLabel, string>;
 
-  constructor(args: ApiArgs = {}) {
-    this.args = args;
-    this.baseBranch = args.baseBranch || 'master';
+  constructor(options: ApiOptions = {}) {
+    this.options = options;
+    this.baseBranch = options.baseBranch || 'master';
     this.logger = createLog(
-      args.veryVerbose ? 'veryVerbose' : args.verbose ? 'verbose' : undefined
+      options.veryVerbose
+        ? 'veryVerbose'
+        : options.verbose
+        ? 'verbose'
+        : undefined
     );
     this.hooks = makeHooks();
 
@@ -145,7 +149,7 @@ export default class Auto {
   async loadConfig() {
     const configLoader = new Config(this.logger);
     const config = this.hooks.modifyConfig.call({
-      ...(await configLoader.loadConfig(this.args)),
+      ...(await configLoader.loadConfig(this.options)),
       baseBranch: this.baseBranch
     });
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -3,7 +3,7 @@ import merge from 'deepmerge';
 import fetch from 'node-fetch';
 import * as path from 'path';
 
-import { ApiArgs } from './auto-args';
+import { ApiOptions } from './auto-args';
 import {
   defaultLabelDefinition,
   getVersionMap,
@@ -48,7 +48,7 @@ export default class Config {
    * Load the .autorc from the file system, set up defaults, combine with CLI args
    * load the extends property, load the plugins and start the git remote interface.
    */
-  async loadConfig(args: ApiArgs) {
+  async loadConfig(args: ApiOptions) {
     const explorer = cosmiconfig('auto', {
       searchPlaces: [
         `.autorc`,

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -222,7 +222,7 @@ export default class NPMPlugin implements IPlugin {
 
         if (monorepoVersion === 'independent') {
           previousVersion =
-            'dryRun' in auto.args && auto.args.dryRun
+            'dryRun' in auto.options && auto.options.dryRun
               ? await getIndependentPackageList()
               : '';
         } else {
@@ -433,7 +433,7 @@ export default class NPMPlugin implements IPlugin {
       if (isMonorepo()) {
         auto.logger.verbose.info('Detected monorepo, using lerna');
 
-        if (auto.args && auto.args.verbose) {
+        if (auto.options && auto.options.verbose) {
           await execPromise('git', ['status', '--short']);
         }
 

--- a/plugins/omit-commits/src/index.ts
+++ b/plugins/omit-commits/src/index.ts
@@ -1,6 +1,6 @@
 import { Auto, IPlugin } from '@auto-it/core';
 
-interface IOmitCommitsPluginOptions {
+export interface IOmitCommitsPluginOptions {
   username?: string | string[];
   email?: string | string[];
   name?: string | string[];
@@ -8,8 +8,7 @@ interface IOmitCommitsPluginOptions {
   labels?: string | string[];
 }
 
-const arrayify = <T>(arr: T | T[]): T[] =>
-  Array.isArray(arr) || arr === undefined ? arr : [arr];
+const arrayify = <T>(arr: T | T[]): T[] => (Array.isArray(arr) ? arr : [arr]);
 
 export default class OmitCommitsPlugin implements IPlugin {
   name = 'Omit Commits';

--- a/plugins/omit-release-notes/__tests__/omit-release-notes.test.ts
+++ b/plugins/omit-release-notes/__tests__/omit-release-notes.test.ts
@@ -1,57 +1,51 @@
 import Auto from '@auto-it/core';
 import makeCommitFromMsg from '@auto-it/core/dist/__tests__/make-commit-from-msg';
-import LogParse from '@auto-it/core/dist/log-parse';
+import Changelog from '@auto-it/core/dist/changelog';
 import {
-  makeHooks,
-  makeLogParseHooks
+  makeChangelogHooks,
+  makeHooks
 } from '@auto-it/core/dist/utils/make-hooks';
-import OmitCommits, { IOmitCommitsPluginOptions } from '../src';
+import OmitReleaseNotesPlugin, { IReleaseNotesPluginOptions } from '../src';
 
-const setup = (options: IOmitCommitsPluginOptions) => {
-  const plugin = new OmitCommits(options);
+const setup = (options: IReleaseNotesPluginOptions) => {
+  const plugin = new OmitReleaseNotesPlugin(options);
   const hooks = makeHooks();
-  const logParseHooks = makeLogParseHooks();
+  const changelogHooks = makeChangelogHooks();
 
   plugin.apply({ hooks } as Auto);
-  hooks.onCreateLogParse.call({ hooks: logParseHooks } as LogParse);
+  hooks.onCreateChangelog.call({ hooks: changelogHooks } as Changelog);
 
-  return logParseHooks;
+  return changelogHooks;
 };
 
-describe('Omit Commits Plugin', () => {
+describe('Omit Release Notes Plugin', () => {
   test('should not filter the commit', async () => {
     const hooks = setup({ name: ['pdbf'] });
     const commit = makeCommitFromMsg('foo');
-    expect(await hooks.omitCommit.promise(commit)).toBeUndefined();
+    expect(await hooks.omitReleaseNotes.promise(commit)).toBeUndefined();
   });
 
   test('should filter the commit by name', async () => {
     const hooks = setup({ name: ['pdbf'] });
     const commit = makeCommitFromMsg('foo', { name: 'pdbf' });
-    expect(await hooks.omitCommit.promise(commit)).toBe(true);
+    expect(await hooks.omitReleaseNotes.promise(commit)).toBe(true);
   });
 
   test('should filter the commit by username', async () => {
     const hooks = setup({ username: ['pdbf'] });
     const commit = makeCommitFromMsg('foo', { username: 'pdbf' });
-    expect(await hooks.omitCommit.promise(commit)).toBe(true);
+    expect(await hooks.omitReleaseNotes.promise(commit)).toBe(true);
   });
 
   test('should filter the commit by email', async () => {
     const hooks = setup({ email: ['foo@bar.com'] });
     const commit = makeCommitFromMsg('foo', { email: 'foo@bar.com' });
-    expect(await hooks.omitCommit.promise(commit)).toBe(true);
+    expect(await hooks.omitReleaseNotes.promise(commit)).toBe(true);
   });
 
   test('should filter the commit by label', async () => {
     const hooks = setup({ labels: ['me'] });
     const commit = makeCommitFromMsg('foo', { labels: ['me'] });
-    expect(await hooks.omitCommit.promise(commit)).toBe(true);
-  });
-
-  test('should filter the commit by subject', async () => {
-    const hooks = setup({ subject: 'WIP' });
-    const commit = makeCommitFromMsg('[WIP] foo');
-    expect(await hooks.omitCommit.promise(commit)).toBe(true);
+    expect(await hooks.omitReleaseNotes.promise(commit)).toBe(true);
   });
 });

--- a/plugins/omit-release-notes/src/index.ts
+++ b/plugins/omit-release-notes/src/index.ts
@@ -1,14 +1,13 @@
 import { Auto, IPlugin } from '@auto-it/core';
 
-interface IReleaseNotesPluginOptions {
+export interface IReleaseNotesPluginOptions {
   username?: string | string[];
   email?: string | string[];
   name?: string | string[];
   labels?: string | string[];
 }
 
-const arrayify = <T>(arr: T | T[]): T[] =>
-  Array.isArray(arr) || arr === undefined ? arr : [arr];
+const arrayify = <T>(arr: T | T[]): T[] => (Array.isArray(arr) ? arr : [arr]);
 
 export default class ReleaseNotesPlugin implements IPlugin {
   name = 'Omit Release Notes';

--- a/plugins/released/__tests__/released-label.test.ts
+++ b/plugins/released/__tests__/released-label.test.ts
@@ -63,7 +63,7 @@ describe('release label plugin', () => {
       hooks: autoHooks,
       labels: defaultLabelDefinition,
       logger: dummyLog(),
-      args: {},
+      options: {},
       comment,
       git
     } as unknown) as Auto);
@@ -86,7 +86,7 @@ describe('release label plugin', () => {
       hooks: autoHooks,
       labels: defaultLabelDefinition,
       logger: dummyLog(),
-      args: {},
+      options: {},
       comment,
       git
     } as unknown) as Auto);
@@ -108,7 +108,7 @@ describe('release label plugin', () => {
       hooks: autoHooks,
       labels: defaultLabelDefinition,
       logger: dummyLog(),
-      args: {},
+      options: {},
       comment,
       git
     } as unknown) as Auto);
@@ -133,7 +133,7 @@ describe('release label plugin', () => {
         options: { skipReleaseLabels: ['skip-release'] }
       },
       logger: dummyLog(),
-      args: {},
+      options: {},
       comment,
       git
     } as unknown) as Auto);
@@ -158,7 +158,7 @@ describe('release label plugin', () => {
       hooks: autoHooks,
       labels: defaultLabelDefinition,
       logger: dummyLog(),
-      args: {},
+      options: {},
       comment,
       git
     } as unknown) as Auto);
@@ -186,7 +186,7 @@ describe('release label plugin', () => {
       hooks: autoHooks,
       labels: defaultLabelDefinition,
       logger: dummyLog(),
-      args: { dryRun: true },
+      options: { dryRun: true },
       comment,
       git
     } as unknown) as Auto);
@@ -211,7 +211,7 @@ describe('release label plugin', () => {
       hooks: autoHooks,
       labels: defaultLabelDefinition,
       logger: dummyLog(),
-      args: {},
+      options: {},
       comment,
       git
     } as unknown) as Auto);
@@ -238,7 +238,7 @@ describe('release label plugin', () => {
       hooks: autoHooks,
       labels: defaultLabelDefinition,
       logger: dummyLog(),
-      args: {},
+      options: {},
       comment,
       git
     } as unknown) as Auto);
@@ -262,7 +262,7 @@ describe('release label plugin', () => {
       hooks: autoHooks,
       labels: defaultLabelDefinition,
       logger: dummyLog(),
-      args: {},
+      options: {},
       comment,
       git
     } as unknown) as Auto);
@@ -298,7 +298,7 @@ describe('release label plugin', () => {
       hooks: autoHooks,
       labels: defaultLabelDefinition,
       logger: dummyLog(),
-      args: {},
+      options: {},
       comment,
       git
     } as unknown) as Auto);
@@ -323,7 +323,7 @@ describe('release label plugin', () => {
       hooks: autoHooks,
       labels: defaultLabelDefinition,
       logger: dummyLog(),
-      args: {},
+      options: {},
       comment,
       git
     } as unknown) as Auto);

--- a/plugins/released/src/index.ts
+++ b/plugins/released/src/index.ts
@@ -45,7 +45,7 @@ export default class ReleasedLabelPlugin implements IPlugin {
           return;
         }
 
-        if ('dryRun' in auto.args && auto.args.dryRun) {
+        if ('dryRun' in auto.options && auto.options.dryRun) {
           return;
         }
 

--- a/plugins/slack/__tests__/slack.test.ts
+++ b/plugins/slack/__tests__/slack.test.ts
@@ -52,7 +52,7 @@ describe('postToSlack', () => {
 
     plugin.postToSlack = jest.fn();
     // @ts-ignore
-    plugin.apply({ hooks, args: { dryRun: true } } as Auto);
+    plugin.apply({ hooks, options: { dryRun: true } } as Auto);
 
     await hooks.afterRelease.promise({
       newVersion: '1.0.0',
@@ -70,7 +70,7 @@ describe('postToSlack', () => {
 
     plugin.postToSlack = jest.fn();
     // @ts-ignore
-    plugin.apply({ hooks, args: {} } as Auto);
+    plugin.apply({ hooks, options: {} } as Auto);
 
     await hooks.afterRelease.promise({
       newVersion: '1.0.0',
@@ -90,7 +90,7 @@ describe('postToSlack', () => {
     // @ts-ignore
     plugin.apply({
       hooks,
-      args: {},
+      options: {},
       release: { options: { skipReleaseLabels: ['skip-release'] } }
     } as Auto);
 
@@ -111,7 +111,7 @@ describe('postToSlack', () => {
 
     plugin.postToSlack = jest.fn();
     // @ts-ignore
-    plugin.apply({ hooks, args: {} } as Auto);
+    plugin.apply({ hooks, options: {} } as Auto);
 
     await expect(
       hooks.afterRelease.promise({
@@ -159,7 +159,7 @@ describe('postToSlack', () => {
     const plugin = new SlackPlugin({ url: 'https://custom-slack-url' });
     const hooks = makeHooks();
     process.env.SLACK_TOKEN = 'MY_TOKEN';
-    plugin.apply({ hooks, args: {}, ...mockAuto } as Auto);
+    plugin.apply({ hooks, options: {}, ...mockAuto } as Auto);
 
     await hooks.afterRelease.promise({
       newVersion: '1.0.0',

--- a/plugins/slack/src/index.ts
+++ b/plugins/slack/src/index.ts
@@ -37,7 +37,7 @@ export default class SlackPlugin implements IPlugin {
           return;
         }
 
-        if ('dryRun' in auto.args && auto.args.dryRun) {
+        if ('dryRun' in auto.options && auto.options.dryRun) {
           return;
         }
 


### PR DESCRIPTION
# What Changed

see title

# Why

A comment from @zephraph on the main v7 PR. IT breaking because components can depend on `args`.

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.0.0-canary.432.5698.26`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
