### PR TITLE
fix bundle step, must gzip correct folder

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,7 +38,7 @@
     "lint": "tslint -p . --format stylish",
     "test": "jest --maxWorkers=2",
     "bundle": "rimraf binary && pkg . --out-path binary && yarn gzip",
-    "gzip": "ls dist/auto* | xargs gzip"
+    "gzip": "ls binary/auto* | xargs gzip"
   },
   "dependencies": {
     "@auto-it/core": "^7.0.0",


### PR DESCRIPTION
# What Changed

was targeting the wrong folder

# Why

i didn't ever check if the gzip happened after i moved the files

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
