### PR TITLE
fix changelog indentation

### DIFF
--- a/packages/core/src/changelog.ts
+++ b/packages/core/src/changelog.ts
@@ -360,6 +360,6 @@ export default class Changelog {
       return;
     }
 
-    sections.push(`### Release Notes\n\n${section}---\n`);
+    sections.push(`### Release Notes\n\n${section}---`);
   }
 }

--- a/packages/core/src/changelog.ts
+++ b/packages/core/src/changelog.ts
@@ -3,7 +3,6 @@ import { AsyncSeriesBailHook, AsyncSeriesWaterfallHook } from 'tapable';
 import { URL } from 'url';
 import join from 'url-join';
 
-import dedent from 'dedent';
 import { ICommitAuthor, IExtendedCommit } from './log-parse';
 import { ILabelDefinitionMap } from './release';
 import { ILogger } from './utils/logger';
@@ -354,21 +353,13 @@ export default class Changelog {
         }
       }
 
-      section += dedent`
-        _From #${pr.number}_
-
-        ${notes.trim()}\n\n
-      `;
+      section += `_From #${pr.number}_\n\n${notes.trim()}\n\n`;
     });
 
     if (!section) {
       return;
     }
 
-    sections.push(dedent`
-      ### Release Notes
-
-      ${section}---
-    `);
+    sections.push(`### Release Notes\n\n${section}---\n`);
   }
 }


### PR DESCRIPTION
# What Changed

I thought dedent would preserve the indentation but it wasnt.

# Why

The generated changelog was pretty ugly

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.0.1-canary.438.5781.2`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
