### PR TITLE
Fix conventional commits link

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Visit [the docs](https://intuit.github.io/auto/) for more information.
 Auto has an extensive plugin system and wide variety of official plugins. Make a PR to add yours!
 
 - [chrome](./plugins/chrome) - publish code to Chrome Web Store
-- [conventional-commits]](./plugins/conventional-commits) - parse conventional commit messages for version bumps
+- [conventional-commits](./plugins/conventional-commits) - parse conventional commit messages for version bumps
 - [jira](./plugins/jira) - Include jira story links in the changelog
 - [npm](./plugins/npm) - publish code to npm (DEFAULT)
 - [omit-commits](./plugins/omit-commits) - Ignore commits base on name, email, subject, labels, and username


### PR DESCRIPTION
# What Changed

Fixed a broken link. 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.0.2-canary.439.5795.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
