### PR TITLE
Remove bin entry from core

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,9 +7,6 @@
     "name": "Andrew Lisowski",
     "email": "lisowski54@gmail.com"
   },
-  "bin": {
-    "auto": "dist/bin/auto.js"
-  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"


### PR DESCRIPTION
Fixes #440 

# What Changed

Removed the `bin` entry from `@auto-it/core`. 

# Why

The `core` package doesn't generate a bin and it's causing npx and npm installs to fail. 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.0.2-canary.441.5808.1`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
