### PR TITLE
fall back to normal require for npx and global usage

### DIFF
--- a/packages/core/src/utils/__tests__/try-require.test.ts
+++ b/packages/core/src/utils/__tests__/try-require.test.ts
@@ -1,0 +1,23 @@
+import tryRequire from '../try-require';
+
+jest.mock('test', () => 'success', {
+  virtual: true
+});
+
+jest.mock('npm', () => 'success', {
+  virtual: true
+});
+
+describe('try require', () => {
+  test('should fall back to normal require', async () => {
+    expect(tryRequire('test')).toBe('success');
+  });
+
+  test('should not fall back to normal require for npm', async () => {
+    expect(tryRequire('npm')).not.toBe('success');
+  });
+
+  test('should return nothing if not found', async () => {
+    expect(tryRequire('foobar')).toBeUndefined();
+  });
+});

--- a/packages/core/src/utils/load-plugins.ts
+++ b/packages/core/src/utils/load-plugins.ts
@@ -18,12 +18,14 @@ export default function loadPlugin(
     | IPluginConstructor
     | { default: IPluginConstructor });
 
+  // Try importing plugin as a path in CWD
   if (!plugin) {
     plugin = tryRequire(
       path.join(process.cwd(), pluginPath)
     ) as IPluginConstructor;
   }
 
+  // Try importing official plugin
   if (!plugin) {
     plugin = tryRequire(
       path.join('@auto-it', pluginPath)

--- a/packages/core/src/utils/try-require.ts
+++ b/packages/core/src/utils/try-require.ts
@@ -2,8 +2,20 @@ import importCwd from 'import-cwd';
 
 export default function tryRequire(tryPath: string) {
   try {
+    // Require from CWD
     return importCwd(tryPath);
   } catch (error) {
-    return;
+    // if we try to actually require npm we will import something that is the actual npm API
+    // not the plugin that we want
+    if (tryPath === 'npm') {
+      return;
+    }
+
+    try {
+      // Require from __dirname. Needed for npx and global installs
+      return require(tryPath);
+    } catch (error) {
+      return;
+    }
   }
 }


### PR DESCRIPTION
# What Changed

Previously when `auto` wasn't a monorepo included plugins were resolved easily and it masked this bug. We were only ever trying to require plugins from the CWD, for global and npx installs this caused issues finding npm packages because they might not be in the require path.

This changes falls back to a normal require, which will find the appropriate global/npx node_modules

# Why

close #442

Todo:

- [x] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.0.3-canary.444.5828.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
