### PR TITLE
stop using --canary flag in npm package

### DIFF
--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -369,6 +369,7 @@ export default class NPMPlugin implements IPlugin {
           '--force-publish', // you always want a canary version to publish
           '--yes', // skip prompts,
           '--no-git-reset', // so we can get the version that just published
+          '--no-git-tag-version', // no need to tag and commit
           ...verboseArgs
         ]);
 

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -361,12 +361,9 @@ export default class NPMPlugin implements IPlugin {
         await execPromise('npx', [
           'lerna',
           'publish',
-          version,
-          '--canary',
+          `pre${version}`,
           '--dist-tag',
           'canary',
-          // Locally we use sha for canary version's postFix, but the --canary flag
-          // already attaches the SHA so we only attach postFix in PRs for context
           '--preid',
           `canary${postFix}`,
           '--force-publish', // you always want a canary version to publish


### PR DESCRIPTION
# What Changed

see title

# Why

some npm package repositories (articatory) have trouble with + signs in the version. By not using the --canary flag we can get around this

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.0.4-canary.446.5861.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
