### PR TITLE
Respect author in config

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -890,8 +890,8 @@ If a command fails manually run:
         `Got author: ${JSON.stringify(packageAuthor, undefined, 2)}`
       );
 
-      email = packageAuthor ? packageAuthor.email : email;
-      name = packageAuthor ? packageAuthor.name : name;
+      email = !email && packageAuthor ? packageAuthor.email : email;
+      name = !name && packageAuthor ? packageAuthor.name : name;
 
       if (email) {
         await execPromise('git', ['config', 'user.email', `"${email}"`]);


### PR DESCRIPTION
# What Changed

if a user sets name and email in the config those values override any thing returned from getAuthor hook

# Why

should respect config values

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.0.5-canary.450.5926.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
