### PR TITLE
Lerna independent mode bugs

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -571,7 +571,9 @@ export default class Auto {
           pr: Number(pr),
           message: message.replace(
             '%v',
-            newVersion.includes('\n') ? newVersion : `\`${newVersion}\``
+            !newVersion || newVersion.includes('\n')
+              ? newVersion
+              : `\`${newVersion}\``
           ),
           context: 'canary-version'
         });

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -79,7 +79,7 @@ export interface IAutoHooks {
   getRepository: AsyncSeriesBailHook<[], IRepository | void>;
   onCreateRelease: SyncHook<[Release]>;
   onCreateLogParse: SyncHook<[LogParse]>;
-  onCreateChangelog: SyncHook<[Changelog]>;
+  onCreateChangelog: SyncHook<[Changelog, SEMVER | undefined]>;
   version: AsyncParallelHook<[SEMVER]>;
   afterVersion: AsyncParallelHook<[]>;
   publish: AsyncParallelHook<[SEMVER]>;
@@ -113,6 +113,8 @@ export default class Auto {
   labels?: ILabelDefinitionMap;
   semVerLabels?: Map<VersionLabel, string>;
 
+  private versionBump?: SEMVER;
+
   constructor(options: ApiOptions = {}) {
     this.options = options;
     this.baseBranch = options.baseBranch || 'master';
@@ -128,8 +130,8 @@ export default class Auto {
     this.hooks.onCreateRelease.tap('Link onCreateChangelog', release => {
       release.hooks.onCreateChangelog.tap(
         'Link onCreateChangelog',
-        changelog => {
-          this.hooks.onCreateChangelog.call(changelog);
+        (changelog, version) => {
+          this.hooks.onCreateChangelog.call(changelog, version);
         }
       );
     });
@@ -734,7 +736,10 @@ export default class Auto {
     }
 
     const lastRelease = await this.git.getLatestRelease();
-    return this.release.getSemverBump(lastRelease);
+    const bump = await this.release.getSemverBump(lastRelease);
+    this.versionBump = bump;
+
+    return bump;
   }
 
   private async makeChangelog({
@@ -752,7 +757,8 @@ export default class Auto {
     const lastRelease = from || (await this.git.getLatestRelease());
     const releaseNotes = await this.release.generateReleaseNotes(
       lastRelease,
-      to || undefined
+      to || undefined,
+      this.versionBump
     );
 
     this.logger.log.info('New Release Notes\n', releaseNotes);
@@ -791,7 +797,11 @@ export default class Auto {
     const commitsInRelease = await this.release.getCommitsInRelease(
       lastRelease
     );
-    const releaseNotes = await this.release.generateReleaseNotes(lastRelease);
+    const releaseNotes = await this.release.generateReleaseNotes(
+      lastRelease,
+      undefined,
+      this.versionBump
+    );
 
     this.logger.log.info(`Using release notes:\n${releaseNotes}`);
 

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -809,7 +809,12 @@ export default class Auto {
       ? this.prefixRelease(rawVersion)
       : rawVersion;
 
-    if (!dryRun && eq(newVersion, lastRelease)) {
+    if (
+      !dryRun &&
+      parse(newVersion) &&
+      parse(lastRelease) &&
+      eq(newVersion, lastRelease)
+    ) {
       this.logger.log.warn(
         `Nothing released to Github. Version to be released is the same as the latest release on Github: ${newVersion}`
       );

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -564,13 +564,15 @@ export default class Auto {
       }
 
       newVersion = result;
-      const message =
-        options.message || 'Published PR with canary version: `%v`';
+      const message = options.message || 'Published PR with canary version: %v';
 
       if (message !== 'false' && pr) {
         await this.prBody({
           pr: Number(pr),
-          message: message.replace('%v', newVersion),
+          message: message.replace(
+            '%v',
+            newVersion.includes('\n') ? newVersion : `\`${newVersion}\``
+          ),
           context: 'canary-version'
         });
       }

--- a/packages/core/src/release.ts
+++ b/packages/core/src/release.ts
@@ -138,7 +138,7 @@ const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
 
 export interface IReleaseHooks {
-  onCreateChangelog: SyncHook<[Changelog]>;
+  onCreateChangelog: SyncHook<[Changelog, SEMVER | undefined]>;
   createChangelogTitle: AsyncSeriesBailHook<[], string | void>;
   onCreateLogParse: SyncHook<[LogParse]>;
 }
@@ -260,7 +260,11 @@ export default class Release {
    * @param from sha or tag to start changelog from
    * @param to sha or tag to end changelog at (defaults to HEAD)
    */
-  async generateReleaseNotes(from: string, to = 'HEAD'): Promise<string> {
+  async generateReleaseNotes(
+    from: string,
+    to = 'HEAD',
+    version?: SEMVER
+  ): Promise<string> {
     const commits = await this.getCommitsInRelease(from, to);
     const project = await this.git.getProject();
     const changelog = new Changelog(this.logger, {
@@ -271,7 +275,7 @@ export default class Release {
       baseBranch: this.options.baseBranch
     });
 
-    this.hooks.onCreateChangelog.call(changelog);
+    this.hooks.onCreateChangelog.call(changelog, version);
     changelog.loadDefaultHooks();
 
     return changelog.generateReleaseNotes(commits);

--- a/packages/core/src/utils/make-hooks.ts
+++ b/packages/core/src/utils/make-hooks.ts
@@ -17,7 +17,7 @@ export const makeHooks = (): IAutoHooks => ({
   afterShipIt: new AsyncParallelHook(['version', 'commits']),
   afterRelease: new AsyncParallelHook(['releaseInfo']),
   onCreateRelease: new SyncHook(['options']),
-  onCreateChangelog: new SyncHook(['changelog']),
+  onCreateChangelog: new SyncHook(['changelog', 'version']),
   onCreateLogParse: new SyncHook(['logParse']),
   getAuthor: new AsyncSeriesBailHook([]),
   getPreviousVersion: new AsyncSeriesBailHook(['prefixRelease']),
@@ -30,7 +30,7 @@ export const makeHooks = (): IAutoHooks => ({
 });
 
 export const makeReleaseHooks = (): IReleaseHooks => ({
-  onCreateChangelog: new SyncHook(['changelog']),
+  onCreateChangelog: new SyncHook(['changelog', 'version']),
   createChangelogTitle: new AsyncSeriesBailHook([]),
   onCreateLogParse: new SyncHook(['logParse'])
 });

--- a/plugins/jira/__tests__/jira.test.ts
+++ b/plugins/jira/__tests__/jira.test.ts
@@ -1,4 +1,4 @@
-import Auto from '@auto-it/core';
+import Auto, { SEMVER } from '@auto-it/core';
 import makeCommitFromMsg from '@auto-it/core/dist/__tests__/make-commit-from-msg';
 import Changelog, {
   IGenerateReleaseNotesOptions
@@ -73,7 +73,10 @@ describe('render jira', () => {
     const commit = makeCommitFromMsg('Add log');
 
     plugin.apply({ hooks, logger: dummyLog() } as Auto);
-    hooks.onCreateChangelog.promise({ hooks: changelogHooks } as Changelog);
+    hooks.onCreateChangelog.promise(
+      { hooks: changelogHooks } as Changelog,
+      SEMVER.patch
+    );
 
     expect(
       (await changelogHooks.renderChangelogLine.promise([commit, 'Add log']))[1]
@@ -86,7 +89,10 @@ describe('render jira', () => {
     const changelogHooks = makeChangelogHooks();
 
     plugin.apply({ hooks, logger: dummyLog() } as Auto);
-    hooks.onCreateChangelog.promise({ hooks: changelogHooks } as Changelog);
+    hooks.onCreateChangelog.promise(
+      { hooks: changelogHooks } as Changelog,
+      SEMVER.patch
+    );
 
     const [, line] = await changelogHooks.renderChangelogLine.promise([
       makeCommitFromMsg('[PLAYA-5052] Add log'),
@@ -114,7 +120,7 @@ test('should create note for jira commits without PR title', async () => {
   const autoHooks = makeHooks();
 
   plugin.apply({ hooks: autoHooks } as Auto);
-  autoHooks.onCreateChangelog.promise(changelog);
+  autoHooks.onCreateChangelog.promise(changelog, SEMVER.patch);
   changelog.loadDefaultHooks();
 
   const normalized = await logParse.normalizeCommits([
@@ -130,7 +136,7 @@ test('should create note for JIRA commits', async () => {
   const autoHooks = makeHooks();
 
   plugin.apply({ hooks: autoHooks } as Auto);
-  autoHooks.onCreateChangelog.promise(changelog);
+  autoHooks.onCreateChangelog.promise(changelog, SEMVER.patch);
   changelog.loadDefaultHooks();
 
   const normalized = await logParse.normalizeCommits([

--- a/plugins/npm/__tests__/__snapshots__/monorepo-log.test.ts.snap
+++ b/plugins/npm/__tests__/__snapshots__/monorepo-log.test.ts.snap
@@ -4,14 +4,14 @@ exports[`should add versions for independent packages 1`] = `
 "#### 💥  Breaking Change
 
 - woot [#12343](https://github.custom.com/pull/12343) (adam@dierkens.com)
-- \`@foobar/release@1.0.0\`, \`@foobar/party@1.0.2\`
+- \`@foobar/release@1.0.1\`, \`@foobar/party@1.0.3\`
   - [PLAYA-5052] - Some Feature [#12345](https://github.custom.com/pull/12345) (adam@dierkens.com)
-- \`@foobar/release@1.0.0\`, \`@foobar/party@1.0.2\`
+- \`@foobar/release@1.0.1\`, \`@foobar/party@1.0.3\`
   - [PLAYA-5052] - Some Feature - Revert [#12345](https://github.custom.com/pull/12345) (adam@dierkens.com)
 
 #### 🏠  Internal
 
-- \`@foobar/release@1.0.0\`
+- \`@foobar/release@1.0.1\`
   - Another Feature [#1234](https://github.custom.com/pull/1234) (adam@dierkens.com)
 
 #### Authors: 1

--- a/plugins/npm/__tests__/monorepo-log.test.ts
+++ b/plugins/npm/__tests__/monorepo-log.test.ts
@@ -82,7 +82,7 @@ test('should create sections for packages', async () => {
   });
 
   plugin.apply({ hooks, logger: dummyLog() } as Auto.Auto);
-  hooks.onCreateChangelog.call(changelog);
+  hooks.onCreateChangelog.call(changelog, Auto.SEMVER.patch);
   changelog.loadDefaultHooks();
 
   const commits = await commitsPromise;
@@ -126,7 +126,7 @@ test('should add versions for independent packages', async () => {
   });
 
   plugin.apply({ hooks, logger: dummyLog() } as Auto.Auto);
-  hooks.onCreateChangelog.call(changelog);
+  hooks.onCreateChangelog.call(changelog, Auto.SEMVER.patch);
   changelog.loadDefaultHooks();
 
   const commits = await commitsPromise;

--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -664,7 +664,7 @@ describe('canary', () => {
     });
   });
 
-  test('use lerna for independent monorepo', async () => {
+  test("doesn't force publish in independent mode", async () => {
     const plugin = new NPMPlugin();
     const hooks = makeHooks();
 
@@ -684,10 +684,17 @@ describe('canary', () => {
       )
     );
 
-    const value = await hooks.canary.promise(Auto.SEMVER.patch, '');
-    expect(value).toBe(
-      '\n - @foo/app@1.2.4-canary.0\n - @foo/lib@1.1.0-canary.0'
-    );
+    await hooks.version.promise(Auto.SEMVER.patch);
+    expect(exec).toHaveBeenNthCalledWith(2, 'npx', [
+      'lerna',
+      'version',
+      'patch',
+      false,
+      '--no-commit-hooks',
+      '--yes',
+      '-m',
+      "'Bump version to: %v [skip ci]'"
+    ]);
   });
 
   test('error when no canary release found - independent', async () => {

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -62,7 +62,8 @@ export async function changedPackages(
   sha: string,
   packages: IMonorepoPackage[],
   lernaJson: { version?: string },
-  logger: ILogger
+  logger: ILogger,
+  version?: SEMVER
 ) {
   const changed = new Set<string>();
   const changedFiles = await execPromise('git', [
@@ -84,7 +85,10 @@ export async function changedPackages(
 
     changed.add(
       lernaJson.version === 'independent'
-        ? `${monorepoPackage.name}@${monorepoPackage.version}`
+        ? `${monorepoPackage.name}@${inc(
+            monorepoPackage.version,
+            version as ReleaseType
+          )}`
         : monorepoPackage.name
     );
   });
@@ -281,7 +285,7 @@ export default class NPMPlugin implements IPlugin {
       );
     });
 
-    auto.hooks.onCreateChangelog.tap(this.name, changelog => {
+    auto.hooks.onCreateChangelog.tap(this.name, (changelog, version) => {
       changelog.hooks.renderChangelogLine.tapPromise(
         'NPM - Monorepo',
         async ([commit, line]) => {
@@ -296,7 +300,8 @@ export default class NPMPlugin implements IPlugin {
             commit.hash,
             lernaPackages,
             lernaJson,
-            auto.logger
+            auto.logger,
+            version
           );
 
           const section =

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -318,13 +318,16 @@ export default class NPMPlugin implements IPlugin {
 
       if (isMonorepo()) {
         auto.logger.verbose.info('Detected monorepo, using lerna');
-        const monorepoBump = await bumpLatest(getMonorepoPackage(), version);
+        const isIndependent = getLernaJson().version !== 'independent';
+        const monorepoBump = isIndependent
+          ? await bumpLatest(getMonorepoPackage(), version)
+          : undefined;
 
         await execPromise('npx', [
           'lerna',
           'version',
           monorepoBump || version,
-          this.forcePublish && '--force-publish',
+          !isIndependent && this.forcePublish && '--force-publish',
           '--no-commit-hooks',
           '--yes',
           '-m',

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -318,8 +318,8 @@ export default class NPMPlugin implements IPlugin {
 
       if (isMonorepo()) {
         auto.logger.verbose.info('Detected monorepo, using lerna');
-        const isIndependent = getLernaJson().version !== 'independent';
-        const monorepoBump = isIndependent
+        const isIndependent = getLernaJson().version === 'independent';
+        const monorepoBump = !isIndependent
           ? await bumpLatest(getMonorepoPackage(), version)
           : undefined;
 

--- a/plugins/omit-release-notes/__tests__/omit-release-notes.test.ts
+++ b/plugins/omit-release-notes/__tests__/omit-release-notes.test.ts
@@ -1,4 +1,4 @@
-import Auto from '@auto-it/core';
+import Auto, { SEMVER } from '@auto-it/core';
 import makeCommitFromMsg from '@auto-it/core/dist/__tests__/make-commit-from-msg';
 import Changelog from '@auto-it/core/dist/changelog';
 import {
@@ -13,7 +13,10 @@ const setup = (options: IReleaseNotesPluginOptions) => {
   const changelogHooks = makeChangelogHooks();
 
   plugin.apply({ hooks } as Auto);
-  hooks.onCreateChangelog.call({ hooks: changelogHooks } as Changelog);
+  hooks.onCreateChangelog.call(
+    { hooks: changelogHooks } as Changelog,
+    SEMVER.patch
+  );
 
   return changelogHooks;
 };


### PR DESCRIPTION
# What Changed

1. fix semver parsing bug
2. don't force publish packages in independent mode
3. fix changelog versions

# Why

bugs are bad, m'kay

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.0.6-canary.451.5951.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
