### PR TITLE
Independant Canary version reporting + Whitespace in pr-body

### DIFF
--- a/packages/core/src/__tests__/git.test.ts
+++ b/packages/core/src/__tests__/git.test.ts
@@ -335,7 +335,7 @@ describe('github', () => {
       get.mockReturnValueOnce({
         data: {
           body:
-            '# My Content\n<!-- GITHUB_RELEASE PR BODY: default -->\n\n\nSome long thing\n<!-- GITHUB_RELEASE PR BODY: default -->\n'
+            '# My Content\n<!-- GITHUB_RELEASE PR BODY: default -->\n\n\nSome long thing\nand more\n<!-- GITHUB_RELEASE PR BODY: default -->\n'
         }
       });
 

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -528,7 +528,7 @@ export default class Git {
     });
 
     this.logger.veryVerbose.info('Got PR description\n', issue.data.body);
-    const regex = new RegExp(`(${id})\\s*(.*)\\s*(${id})`);
+    const regex = new RegExp(`(${id})\\s*([\\S\\s]*)\\s*(${id})`);
     let body = issue.data.body;
 
     if (body.match(regex)) {

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -180,7 +180,9 @@ export default class NPMPlugin implements IPlugin {
   @Memoize()
   async getIndependentPackageList() {
     return this.getLernaPackages().then(packages =>
-      packages.map(p => `\n - ${p.name}@${p.version.split('+')[0]}`).join('')
+      packages
+        .map(p => `\n - \`${p.name}@${p.version.split('+')[0]}\``)
+        .join('')
     );
   }
 
@@ -392,7 +394,7 @@ export default class NPMPlugin implements IPlugin {
             return { error: 'No packages were changed. No canary published.' };
           }
 
-          return independentPackages;
+          return `<details><summary>Canary Versions</summary>${independentPackages}</details>`;
         }
 
         const versioned = packages.find(p => p.version.includes('canary'));


### PR DESCRIPTION
# What Changed

1. put all version in details tag cause there can be a lot
2. ensure scoped package names displace correctly in markdown
3. update addToPrBody regex to include whitespace

# Why

b.u.g

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.0.8-canary.455.b9d0c95.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
