### PR TITLE
NPM Plugin: fix canary versions

### DIFF
--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -379,7 +379,8 @@ export default class NPMPlugin implements IPlugin {
           '--force-publish', // you always want a canary version to publish
           '--yes', // skip prompts,
           '--no-git-reset', // so we can get the version that just published
-          '--no-git-tag-version', // no need to tag and commit
+          '--no-git-tag-version', // no need to tag and commit,
+          '--exact', // do not add ^ to canary versions, this can result in `npm i` resolving the wrong canary version
           ...verboseArgs
         ]);
 


### PR DESCRIPTION
# What Changed

without --exact lerna will make the range `^` which can resolve to other canary versions than the one specified, breaking build

# Why

broken build suuuuuck

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
