### PR TITLE
Conventional Commits Plugin: fix looping issue

### DIFF
--- a/plugins/conventional-commits/__tests__/conventional-commits.test.ts
+++ b/plugins/conventional-commits/__tests__/conventional-commits.test.ts
@@ -92,7 +92,7 @@ test('should not include label-less head commit if any other commit in PR has co
     getFirstCommit: jest.fn(),
     getPr: jest.fn(),
     getCommitsForPR: () =>
-      Promise.resolve([{ sha: '1', subject: 'fix: child commit' }])
+      Promise.resolve([{ sha: '1', commit: { message: 'fix: child commit' } }])
   } as unknown) as Git;
   conventionalCommitsPlugin.apply({
     hooks: autoHooks,

--- a/plugins/conventional-commits/__tests__/conventional-commits.test.ts
+++ b/plugins/conventional-commits/__tests__/conventional-commits.test.ts
@@ -91,14 +91,8 @@ test('should not include label-less head commit if any other commit in PR has co
     getCommitDate: jest.fn(),
     getFirstCommit: jest.fn(),
     getPr: jest.fn(),
-    getLatestRelease: () => Promise.resolve('1.2.3'),
-    getGitLog: () =>
-      Promise.resolve([
-        commit,
-        makeCommitFromMsg('fix: child commit', { hash: '1' }),
-        makeCommitFromMsg('unrelated', { hash: '2' })
-      ]),
-    getCommitsForPR: () => Promise.resolve([{ sha: '1' }])
+    getCommitsForPR: () =>
+      Promise.resolve([{ sha: '1', subject: 'fix: child commit' }])
   } as unknown) as Git;
   conventionalCommitsPlugin.apply({
     hooks: autoHooks,

--- a/plugins/conventional-commits/src/index.ts
+++ b/plugins/conventional-commits/src/index.ts
@@ -42,21 +42,13 @@ export default class ConventionalCommitsPlugin implements IPlugin {
           commit.pullRequest &&
           commit.labels.length === 0
         ) {
-          const lastRelease = await auto.git.getLatestRelease();
-          const allCommits = await auto.release.getCommits(lastRelease);
           const prCommits = await auto.git.getCommitsForPR(
             commit.pullRequest.number
           );
-          const allPrCommitHashes = prCommits.reduce(
-            (all, pr) => [...all, pr.sha],
-            [] as string[]
-          );
-          const extendedCommitsInPr = allCommits.filter(c =>
-            allPrCommitHashes.includes(c.hash)
-          );
 
+          // Omit the commit if one of the commits in the PR contains a CC message since it will already be counted
           return Boolean(
-            extendedCommitsInPr.find(c => Boolean(parse(c.subject)[0].header))
+            prCommits.find(c => Boolean(parse(c.subject)[0].header))
           );
         }
       });

--- a/plugins/conventional-commits/src/index.ts
+++ b/plugins/conventional-commits/src/index.ts
@@ -48,7 +48,13 @@ export default class ConventionalCommitsPlugin implements IPlugin {
 
           // Omit the commit if one of the commits in the PR contains a CC message since it will already be counted
           return Boolean(
-            prCommits.find(c => Boolean(parse(c.subject)[0].header))
+            prCommits.find(c => {
+              try {
+                return Boolean(parse(c.commit.message)[0].header);
+              } catch (error) {
+                return false;
+              }
+            })
           );
         }
       });


### PR DESCRIPTION
# What Changed

if using this plugins most commands stalled and looped forever!

# Why

during `omitCommit` we were calling `getCommits` which would kick of log parsing and eventually get back to `omitCommit`, creating an infinite loop

Todo:

- [x] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
