### PR TITLE
Slack Plugin: fix tag link

### DIFF
--- a/plugins/slack/__tests__/__snapshots__/slack.test.ts.snap
+++ b/plugins/slack/__tests__/__snapshots__/slack.test.ts.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`postToSlack should call slack api 1`] = `"{\\"text\\":\\"@channel: New release *<https://github.custom.com/Adam Dierkens/test/releases/tag/1.0.0|1.0.0>*\\\\n* My Notes*\\\\n• PR <google.com|some link>\\",\\"link_names\\":1}"`;
+exports[`postToSlack should call slack api 1`] = `"{\\"text\\":\\"@channel: New release *<https://github.custom.com/adierkens/test/releases/tag/1.0.0|1.0.0>*\\\\n* My Notes*\\\\n• PR <google.com|some link>\\",\\"link_names\\":1}"`;
 
-exports[`postToSlack should call slack api with minimal config 1`] = `"{\\"text\\":\\"@channel: New release *<https://github.custom.com/Adam Dierkens/test/releases/tag/1.0.0|1.0.0>*\\\\n* My Notes*\\\\n• PR <google.com|some link>\\",\\"link_names\\":1}"`;
+exports[`postToSlack should call slack api with minimal config 1`] = `"{\\"text\\":\\"@channel: New release *<https://github.custom.com/adierkens/test/releases/tag/1.0.0|1.0.0>*\\\\n* My Notes*\\\\n• PR <google.com|some link>\\",\\"link_names\\":1}"`;

--- a/plugins/slack/__tests__/slack.test.ts
+++ b/plugins/slack/__tests__/slack.test.ts
@@ -16,11 +16,11 @@ beforeEach(() => {
 
 const mockGit = {
   options: {
-    owner: 'Adam Dierkens',
+    owner: 'adierkens',
     repo: 'test'
   },
   getProject: () => ({
-    html_url: 'https://github.custom.com'
+    html_url: 'https://github.custom.com/adierkens/test'
   })
 };
 const mockAuto = ({

--- a/plugins/slack/src/index.ts
+++ b/plugins/slack/src/index.ts
@@ -74,13 +74,7 @@ export default class SlackPlugin implements IPlugin {
     const project = await auto.git.getProject();
     const body = sanitizeMarkdown(releaseNotes);
     const token = process.env.SLACK_TOKEN;
-    const releaseUrl = join(
-      project.html_url,
-      auto.git.options.owner,
-      auto.git.options.repo,
-      'releases/tag',
-      newVersion
-    );
+    const releaseUrl = join(project.html_url, 'releases/tag', newVersion);
 
     if (!token) {
       auto.logger.verbose.warn('Slack may need a token to send a message');


### PR DESCRIPTION
# What Changed

see title

# Why

slack tag links were broken

closes #463

Todo:

- [x] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
