### PR TITLE
Add a little extra error handling around plugin loading

### DIFF
--- a/packages/core/src/utils/load-plugins.ts
+++ b/packages/core/src/utils/load-plugins.ts
@@ -49,9 +49,16 @@ export default function loadPlugin(
     return;
   }
 
-  if ('default' in plugin && plugin.default) {
-    return new plugin.default(options);
-  }
+  try {
+    if ('default' in plugin && plugin.default) {
+      return new plugin.default(options);
+    }
 
-  return new (plugin as IPluginConstructor)(options);
+    return new (plugin as IPluginConstructor)(options);
+  } catch (error) {
+    logger.log.error(
+      `Plugin at the following path encountered an error: ${pluginPath}`
+    );
+    throw error;
+  }
 }


### PR DESCRIPTION
# What Changed

Adds some extra error handling around plugin loading

# Why

With both npx (#440) and the auto bin (#471) are failing on artsy's setup with an error related to plugin is not a constructor. 

This adds a debug message to indicate _which_ plugin is failing.
