### PR TITLE
Fix type error with changelog hook

### DIFF
--- a/packages/core/src/utils/make-hooks.ts
+++ b/packages/core/src/utils/make-hooks.ts
@@ -41,7 +41,7 @@ export const makeLogParseHooks = (): ILogParseHooks => ({
 });
 
 export const makeChangelogHooks = (): IChangelogHooks => ({
-  renderChangelogLine: new AsyncSeriesBailHook(['lineData']),
+  renderChangelogLine: new AsyncSeriesWaterfallHook(['lineData']),
   renderChangelogTitle: new AsyncSeriesBailHook(['commits', 'lineRender']),
   renderChangelogAuthor: new AsyncSeriesBailHook([
     'author',


### PR DESCRIPTION
# What Changed

I noticed that a lot of the greenkeeper PRs was failing due to a type error. I traced it down to the type definition for the `renderChangelogLine` hook being wrong. Looks like it wasn't updated when that hook was moved to a waterfall hook. 

# Why

To fix builds!
