### PR TITLE
Remove pr semver check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,20 +35,11 @@ aliases:
   - &build
     name: Build
     command: yarn build
-  - &semver
-    name: Check PR for semVer label
-    command: yarn semver:check
   - &bundle
     name: Bundle the code into binaries for multiple platforms
     command: yarn lerna run bundle --scope=auto
 
 jobs:
-  semver:
-    <<: *defaults
-    steps:
-      - checkout
-      - run: *semver
-
   install:
     <<: *defaults
     steps:
@@ -118,10 +109,6 @@ workflows:
       - build:
           requires:
             - install
-
-      - semver: 
-          requires:
-            - build
 
       - lint:
           requires:


### PR DESCRIPTION
# What Changed

The PR check script isn't currently working (at least on the PRs that I've seen) and prevents contributors from merging PRs. 

We should be able to use autobot to fill this need. Let's disable the CI check.

TODO:

- [ ] Disable pr-check from being a required status check (cc @hipstersmoothie)
