### PR TITLE
Rework plugin importing logic

### DIFF
--- a/docs/pages/plugins.md
+++ b/docs/pages/plugins.md
@@ -32,10 +32,12 @@ auto shipit --plugins npm
 
 ### 2. `npm` package
 
-If you are using a plugin distributed on `npm` simply supply the name. Ensure that the plugin is added as a dependency of your project.
+Unofficial plugins pulled from NPM should be named in the format `auto-plugin-PLUGIN_NAME` where `PLUGIN_NAME` is the name of the plugin.
+
+That name is provided to auto to use that particular plugin.
 
 ```sh
-auto shipit --plugins NPM_PACKAGE_NAME
+auto shipit --plugins PLUGIN_NAME
 ```
 
 ### 3. Path

--- a/packages/core/src/utils/load-plugins.ts
+++ b/packages/core/src/utils/load-plugins.ts
@@ -21,12 +21,12 @@ export default function loadPlugin(
     | undefined = undefined;
 
   // Try requiring a path
-  if (pluginPath.startsWith('.')) {
+  if (pluginPath.startsWith('.') || pluginPath.startsWith('/')) {
     plugin = tryRequire(pluginPath);
   }
 
   // Try requiring a path from cwd
-  if (!plugin && pluginPath.startsWith('.')) {
+  if (!plugin && (pluginPath.startsWith('.') || pluginPath.startsWith('/'))) {
     plugin = tryRequire(path.join(process.cwd(), pluginPath));
     logger.log.warn(`Could not find plugin from path: ${pluginPath}`);
     return;

--- a/packages/core/src/utils/load-plugins.ts
+++ b/packages/core/src/utils/load-plugins.ts
@@ -21,12 +21,12 @@ export default function loadPlugin(
     | undefined = undefined;
 
   // Try requiring a path
-  if (pluginPath.startsWith('.') || pluginPath.startsWith('/')) {
+  if (pluginPath.startsWith('.')) {
     plugin = tryRequire(pluginPath);
   }
 
   // Try requiring a path from cwd
-  if (!plugin && (pluginPath.startsWith('.') || pluginPath.startsWith('/'))) {
+  if (!plugin && pluginPath.startsWith('.')) {
     plugin = tryRequire(path.join(process.cwd(), pluginPath));
   }
 

--- a/packages/core/src/utils/load-plugins.ts
+++ b/packages/core/src/utils/load-plugins.ts
@@ -14,22 +14,20 @@ export default function loadPlugin(
   [pluginPath, options]: [string, any],
   logger: ILogger
 ): IPlugin | undefined {
-  let plugin = tryRequire(pluginPath) as (
+  // tslint:disable-next-line:no-unnecessary-initializer
+  let plugin:
     | IPluginConstructor
-    | { default: IPluginConstructor });
+    | { default: IPluginConstructor }
+    | undefined = undefined;
 
-  // Try importing plugin as a path in CWD
-  if (!plugin) {
-    plugin = tryRequire(
-      path.join(process.cwd(), pluginPath)
-    ) as IPluginConstructor;
+  // Try requiring a path
+  if (pluginPath.startsWith('.') || pluginPath.startsWith('/')) {
+    plugin = tryRequire(pluginPath);
   }
 
-  // Try importing official plugin
-  if (!plugin) {
-    plugin = tryRequire(
-      path.join('@auto-it', pluginPath)
-    ) as IPluginConstructor;
+  // Try requiring a path from cwd
+  if (!plugin && (pluginPath.startsWith('.') || pluginPath.startsWith('/'))) {
+    plugin = tryRequire(path.join(process.cwd(), pluginPath));
   }
 
   // For pkg bundle
@@ -42,6 +40,18 @@ export default function loadPlugin(
         'dist/index.js'
       )
     ) as IPluginConstructor;
+  }
+
+  // For a user created plugin
+  if (!plugin) {
+    plugin = tryRequire(`auto-plugin-${pluginPath}`) as IPluginConstructor;
+  }
+
+  // Try importing official plugin
+  if (!plugin) {
+    plugin = tryRequire(path.join('@auto-it', pluginPath)) as
+      | IPluginConstructor
+      | { default: IPluginConstructor };
   }
 
   if (!plugin) {

--- a/packages/core/src/utils/load-plugins.ts
+++ b/packages/core/src/utils/load-plugins.ts
@@ -28,6 +28,8 @@ export default function loadPlugin(
   // Try requiring a path from cwd
   if (!plugin && pluginPath.startsWith('.')) {
     plugin = tryRequire(path.join(process.cwd(), pluginPath));
+    logger.log.warn(`Could not find plugin from path: ${pluginPath}`);
+    return;
   }
 
   // For pkg bundle


### PR DESCRIPTION
# What Changed

Reorganized/changed plugin importing logic

# Why

Artsy hasn't upgraded to v7 yet because we've ran into pretty continuous errors with plugin initialization. At first, I thought this was due to npx (#440) so I started trying to move us away from that and to the binaries. Unfortunately, the binaries also failed from the same error (#471). I created a pr (#474) to give a little more debugging around what was failing. Turns out, it was failing on the `npm` plugin. 

After looking into how the plugin imports and SSHing into our CI environment I figured out the issue. 

The first thing the `loadPlugins` method did was to try to require the `pluginPath` string. As `npm` is a default plugin, it tries to require npm... which in our CI environment fails because npm is installed as a dependency of npm. Generally though, this means that plugins could fail for any number of package name collisions. Yikes.

I preserved that require, but _only_ if it's a path. So if there's something like `../package` or `./package` it'll try to import the package first, and then using cwd if that path isn't found. If it misses both (and it's a path) it bails.

If it's _not_ a path, first it tries the pkg bundle logic, then it tries a _namespaced plugin_ like `auto-plugin-foo`, and lastly it tries the official package at `@auto-it/foo`. 

## Notes

- This is technically a breaking change, but I suspect v7 potentially hasn't been working for many consumers. Should we release a v8 or just do a v7 assuming that since this hasn't been reported it's unlikely that anyone is writing custom plugins for auto at this point?
- There could potentially be a security issue here. If we push the official plugins down (like I have in this PR), then someone could add an innocuous PR that adds a plugin that overrides an official one (like `npm`) without changing any other configuration and potentially cause security issues. I wonder if would be worth have the official packages be reserved plugin names to avoid nefarious overrides. If someone had a plugin `auto-plugin-npm` that they wanted to use instead of ours they could just use a path to it instead (i.e. `./node_modules/auto-plugin-npm/index.js`) in their config.
