### PR TITLE
fix logging error in pr-check

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -346,7 +346,9 @@ export default class Auto {
         throw new Error('No semver label!');
       }
 
-      this.logger.log.success(`PR is using label: ${semverTag}`);
+      this.logger.log.success(
+        `PR is using label: ${semverTag || skipReleaseTag}`
+      );
 
       let description;
 


### PR DESCRIPTION
# What Changed

log `skipReleaseTag` if it exists.

# Why

pr-check passes for any `skipReleaseTag` but was only logging `semverTag`
