### PR TITLE
Improve Author Reporting

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,6 @@
     "@octokit/plugin-retry": "^2.2.0",
     "@octokit/plugin-throttling": "^2.6.0",
     "@octokit/rest": "16.28.7",
-    "arr-flatten": "^1.1.0",
     "cosmiconfig": "5.2.1",
     "dedent": "^0.7.0",
     "deepmerge": "^4.0.0",

--- a/packages/core/src/__tests__/__snapshots__/changelog.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/changelog.test.ts.snap
@@ -158,6 +158,17 @@ exports[`generateReleaseNotes should include PR-less commits as patches 1`] = `
 - Adam Dierkens (adam@dierkens.com)"
 `;
 
+exports[`generateReleaseNotes should include prs with released label 1`] = `
+"#### 🐛  Bug Fix
+
+- Some Feature [#1234](https://github.custom.com/foobar/auto/pull/1234) (adam@dierkens.com)
+- Third  (adam@dierkens.com)
+
+#### Authors: 1
+
+- Adam Dierkens (adam@dierkens.com)"
+`;
+
 exports[`generateReleaseNotes should omit authors with invalid email addresses 1`] = `
 "#### 🚀  Enhancement
 
@@ -194,7 +205,7 @@ exports[`generateReleaseNotes should use only email if author name doesn't exist
 "#### 🐛  Bug Fix
 
 - Another Feature [#1234](https://github.custom.com/foobar/auto/pull/1234) (adam@dierkens.com)
-- One Feature [#1235](https://github.custom.com/foobar/auto/pull/1235)
+- One Feature [#1235](https://github.custom.com/foobar/auto/pull/1235) (adam@dierkens.com)
 
 #### Authors: 1
 

--- a/packages/core/src/__tests__/__snapshots__/release.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/release.test.ts.snap
@@ -95,6 +95,16 @@ exports[`Release generateReleaseNotes should find matching PRs for shas through 
 - Adam Dierkens (adam@dierkens.com)"
 `;
 
+exports[`Release generateReleaseNotes should get extra user data for login 1`] = `
+"#### 🐛  Bug Fix
+
+- I have a login attached [#1235](https://github.com/web/site/pull/1235) ([@adierkens](https://github.com/adierkens))
+
+#### Authors: 1
+
+- Adam Dierkens ([@adierkens](https://github.com/adierkens))"
+`;
+
 exports[`Release generateReleaseNotes should include PR-less commits 1`] = `
 "#### 🚀  Enhancement
 
@@ -117,7 +127,7 @@ exports[`Release generateReleaseNotes should include PRs merged to other PRs 1`]
 
 #### Authors: 1
 
-- adam@dierkens.com"
+- Adam Dierkens (adam@dierkens.com)"
 `;
 
 exports[`Release generateReleaseNotes should match commits with related PRs 1`] = `

--- a/packages/core/src/__tests__/changelog.test.ts
+++ b/packages/core/src/__tests__/changelog.test.ts
@@ -186,6 +186,17 @@ describe('generateReleaseNotes', () => {
     expect(await changelog.generateReleaseNotes(normalized)).toMatchSnapshot();
   });
 
+  test('should include prs with released label', async () => {
+    const changelog = new Changelog(dummyLog(), testOptions());
+    changelog.loadDefaultHooks();
+    const normalized = await logParse.normalizeCommits([
+      makeCommitFromMsg('Some Feature (#1234)', { labels: ['released'] }),
+      makeCommitFromMsg('Third', { labels: ['patch'] })
+    ]);
+
+    expect(await changelog.generateReleaseNotes(normalized)).toMatchSnapshot();
+  });
+
   test("should use only email if author name doesn't exist", async () => {
     const changelog = new Changelog(dummyLog(), testOptions());
     changelog.loadDefaultHooks();

--- a/packages/core/src/__tests__/release.test.ts
+++ b/packages/core/src/__tests__/release.test.ts
@@ -35,7 +35,7 @@ getProject.mockResolvedValue({
 });
 
 const mockLabels = (labels: string[]) => ({
-  data: { labels: labels.map(label => ({ name: label })) }
+  data: { labels: labels.map(label => ({ name: label })), user: {} }
 });
 
 // @ts-ignore
@@ -171,10 +171,6 @@ describe('Release', () => {
           }
         }
       ]);
-      getUserByUsername.mockReturnValueOnce({
-        login: 'andrew',
-        name: 'Andrew Lisowski'
-      });
       getUserByUsername.mockReturnValueOnce({
         login: 'andrew',
         name: 'Andrew Lisowski'
@@ -431,6 +427,32 @@ describe('Release', () => {
       expect(await gh.generateReleaseNotes('1234', '123')).toMatchSnapshot();
     });
 
+    test('should get extra user data for login', async () => {
+      const gh = new Release(git);
+
+      const commits = [
+        {
+          hash: '1',
+          authors: [],
+          subject: 'I have a login attached',
+          pullRequest: {
+            number: '1235'
+          }
+        }
+      ];
+
+      getGitLog.mockReturnValueOnce(commits);
+      getPr.mockReturnValueOnce({
+        data: { labels: [], user: { login: 'adierkens' } }
+      });
+      getUserByUsername.mockReturnValueOnce({
+        login: 'adierkens',
+        name: 'Adam Dierkens'
+      });
+
+      expect(await gh.generateReleaseNotes('1234', '123')).toMatchSnapshot();
+    });
+
     test('should allow user to configure section headings', async () => {
       const gh = new Release(git);
 
@@ -604,10 +626,46 @@ describe('Release', () => {
           hash: '3'
         })
       ]);
-      getCommitsForPR.mockReturnValue([{ sha: '2' }]);
-      getCommitsForPR.mockReturnValue([{ sha: '2' }]);
-      getCommitsForPR.mockReturnValue([{ sha: '3' }]);
-      getCommitsForPR.mockReturnValue([{ sha: '3' }]);
+      getCommitsForPR.mockReturnValue([
+        {
+          sha: '2',
+          commit: {},
+          author: {
+            name: 'Adam Dierkens',
+            email: 'adam@dierkens.com'
+          }
+        }
+      ]);
+      getCommitsForPR.mockReturnValue([
+        {
+          sha: '2',
+          commit: {},
+          author: {
+            name: 'Adam Dierkens',
+            email: 'adam@dierkens.com'
+          }
+        }
+      ]);
+      getCommitsForPR.mockReturnValue([
+        {
+          sha: '3',
+          commit: {},
+          author: {
+            name: 'Adam Dierkens',
+            email: 'adam@dierkens.com'
+          }
+        }
+      ]);
+      getCommitsForPR.mockReturnValue([
+        {
+          sha: '3',
+          commit: {},
+          author: {
+            name: 'Adam Dierkens',
+            email: 'adam@dierkens.com'
+          }
+        }
+      ]);
 
       expect(await gh.generateReleaseNotes('1234', '123')).toMatchSnapshot();
     });

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -441,7 +441,9 @@ export default class Git {
   }
 
   @Memoize()
-  async getCommitsForPR(pr: number) {
+  async getCommitsForPR(
+    pr: number
+  ): Promise<Octokit.PullsListCommitsResponseItem[]> {
     this.logger.verbose.info(`Getting commits for PR #${pr}`);
 
     const result = await this.github.paginate(

--- a/packages/core/src/release.ts
+++ b/packages/core/src/release.ts
@@ -352,8 +352,8 @@ export default class Release {
       )
     );
 
-    return commitsInRelease.filter(
-      (commit): commit is IExtendedCommit => Boolean(commit)
+    return commitsInRelease.filter((commit): commit is IExtendedCommit =>
+      Boolean(commit)
     );
   }
 
@@ -610,6 +610,14 @@ export default class Release {
       const labels = info ? info.data.labels.map(l => l.name) : [];
       commit.labels = [...new Set([...labels, ...commit.labels])];
       commit.pullRequest.body = info.data.body;
+
+      if (!commit.authors.find(author => Boolean(author.username))) {
+        const user = await this.git.getUserByUsername(info.data.user.login);
+
+        if (user) {
+          commit.authors.push({ ...user, username: user.login });
+        }
+      }
     }
 
     return commit;
@@ -657,8 +665,8 @@ export default class Release {
 
       resolvedAuthors = await Promise.all(
         prCommits.map(async prCommit => {
-          if (!prCommit || !prCommit.author) {
-            return;
+          if (!prCommit.author) {
+            return prCommit.commit.author;
           }
 
           return {

--- a/typings/arr-flatten.d.ts
+++ b/typings/arr-flatten.d.ts
@@ -1,4 +1,0 @@
-declare module 'arr-flatten' {
-  function flatten<P>(arr: P[][]): P[];
-  export = flatten;
-}


### PR DESCRIPTION
# What Changed

- Favor authors with Github Information attached
- if no login found look at PR for account that oped the PR
- Use author with Github Information on changelog line

# Why

fixes #509 

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.3.3-canary.531.6903.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
