### PR TITLE
omit commit+prs that: aren't found in repo, are issues, or have the "released" label

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/log-parse.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/log-parse.test.ts.snap
@@ -14,6 +14,7 @@ Array [
     "hash": "foo",
     "labels": Array [],
     "packages": undefined,
+    "pullRequest": undefined,
     "subject": "First",
   },
   Object {
@@ -28,6 +29,7 @@ Array [
     "hash": "foo",
     "labels": Array [],
     "packages": undefined,
+    "pullRequest": undefined,
     "subject": "Second",
   },
   Object {
@@ -42,6 +44,7 @@ Array [
     "hash": "foo",
     "labels": Array [],
     "packages": undefined,
+    "pullRequest": undefined,
     "subject": "Third",
   },
 ]

--- a/packages/core/src/__tests__/__snapshots__/release.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/release.test.ts.snap
@@ -304,6 +304,7 @@ Array [
     "hash": "foo",
     "labels": Array [],
     "packages": undefined,
+    "pullRequest": undefined,
     "subject": "First",
   },
   Object {
@@ -355,6 +356,7 @@ Array [
     "hash": "foo",
     "labels": Array [],
     "packages": undefined,
+    "pullRequest": undefined,
     "subject": "Third",
   },
 ]

--- a/packages/core/src/__tests__/make-commit-from-msg.ts
+++ b/packages/core/src/__tests__/make-commit-from-msg.ts
@@ -9,6 +9,9 @@ const makeCommitFromMsg = (
     labels?: string[];
     username?: string;
     packages?: string[];
+    pullRequest?: {
+      number: number;
+    };
   } = {}
 ): IExtendedCommit => ({
   hash: options.hash || 'foo',
@@ -23,7 +26,8 @@ const makeCommitFromMsg = (
     }
   ],
   subject,
-  packages: options.packages
+  packages: options.packages,
+  pullRequest: options.pullRequest
 });
 
 export default makeCommitFromMsg;

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -941,7 +941,7 @@ If a command fails manually run:
    */
   private loadPlugins(config: IAutoConfig) {
     const pluginsPaths = [
-      path.join(__dirname, './plugins/filter-non-pull-request'),
+     require.resolve('./plugins/filter-non-pull-request')
       ...(config.plugins || ['npm'])
     ];
 

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -292,9 +292,7 @@ export default class Auto {
         });
       } catch (error) {
         throw new Error(
-          `Failed to post status to Pull Request with error code ${
-            error.status
-          }`
+          `Failed to post status to Pull Request with error code ${error.status}`
         );
       }
 
@@ -387,9 +385,7 @@ export default class Auto {
         this.logger.log.success('Posted status to Pull Request.');
       } catch (error) {
         throw new Error(
-          `Failed to post status to Pull Request with error code ${
-            error.status
-          }`
+          `Failed to post status to Pull Request with error code ${error.status}`
         );
       }
     } else {
@@ -944,7 +940,10 @@ If a command fails manually run:
    * Apply all of the plugins in the config.
    */
   private loadPlugins(config: IAutoConfig) {
-    const pluginsPaths = config.plugins || ['npm'];
+    const pluginsPaths = [
+      path.join(__dirname, './plugins/filter-non-pull-request'),
+      ...(config.plugins || ['npm'])
+    ];
 
     pluginsPaths
       .map(plugin =>

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -941,7 +941,7 @@ If a command fails manually run:
    */
   private loadPlugins(config: IAutoConfig) {
     const pluginsPaths = [
-     require.resolve('./plugins/filter-non-pull-request')
+      require.resolve('./plugins/filter-non-pull-request'),
       ...(config.plugins || ['npm'])
     ];
 

--- a/packages/core/src/plugins/__tests__/filter-non-pull-request.test.ts
+++ b/packages/core/src/plugins/__tests__/filter-non-pull-request.test.ts
@@ -1,0 +1,74 @@
+import makeCommitFromMsg from '../../__tests__/make-commit-from-msg';
+import Auto from '../../auto';
+import Git from '../../git';
+import LogParse from '../../log-parse';
+import { makeHooks, makeLogParseHooks } from '../../utils/make-hooks';
+
+import FilterNonPullRequestPlugin from '../filter-non-pull-request';
+
+const getPr = jest.fn();
+
+const setup = () => {
+  const plugin = new FilterNonPullRequestPlugin();
+  const hooks = makeHooks();
+  const logParseHooks = makeLogParseHooks();
+
+  plugin.apply({ hooks, git: ({ getPr } as unknown) as Git } as Auto);
+  hooks.onCreateLogParse.call({ hooks: logParseHooks } as LogParse);
+
+  return logParseHooks;
+};
+
+describe('Filter Non Pull Request Plugin', () => {
+  test('should do nothing for non-prs', async () => {
+    const hooks = setup();
+    const commit = makeCommitFromMsg('foo');
+    expect(await hooks.omitCommit.promise(commit)).toBeUndefined();
+  });
+
+  test('should not filter bad PR numbers', async () => {
+    const hooks = setup();
+    const commit = makeCommitFromMsg('foo', { pullRequest: { number: 404 } });
+
+    getPr.mockRejectedValueOnce(new Error('Not Found'));
+    expect(await hooks.omitCommit.promise(commit)).toBe(true);
+  });
+
+  test('should throw unknown errors', async () => {
+    const hooks = setup();
+    const commit = makeCommitFromMsg('foo', { pullRequest: { number: 123 } });
+
+    getPr.mockRejectedValueOnce(new Error('Some error'));
+    await expect(hooks.omitCommit.promise(commit)).rejects.toBeInstanceOf(
+      Error
+    );
+  });
+
+  test('should with no PR return value', async () => {
+    const hooks = setup();
+    const commit = makeCommitFromMsg('foo', { pullRequest: { number: 123 } });
+
+    getPr.mockReturnValueOnce(Promise.resolve());
+    await expect(hooks.omitCommit.promise(commit)).rejects.toBeInstanceOf(
+      Error
+    );
+  });
+
+  test('should filter issues', async () => {
+    const hooks = setup();
+    const commit = makeCommitFromMsg('foo', { pullRequest: { number: 123 } });
+
+    getPr.mockReturnValueOnce(Promise.resolve({ data: {} }));
+    expect(await hooks.omitCommit.promise(commit)).toBe(true);
+  });
+
+  test('should not filter PRs', async () => {
+    const hooks = setup();
+    const commit = makeCommitFromMsg('foo', { pullRequest: { number: 123 } });
+
+    getPr.mockReturnValueOnce(
+      Promise.resolve({ data: { pull_request: true } })
+    );
+    expect(await hooks.omitCommit.promise(commit)).toBeUndefined();
+  });
+});

--- a/packages/core/src/plugins/filter-non-pull-request.ts
+++ b/packages/core/src/plugins/filter-non-pull-request.ts
@@ -1,0 +1,37 @@
+import on from 'await-to-js';
+
+import { Auto, IPlugin } from '../auto';
+
+export default class FilterNonPullRequestPlugin implements IPlugin {
+  name = 'Filter Non Pull Request';
+
+  apply(auto: Auto) {
+    auto.hooks.onCreateLogParse.tap(this.name, logParse => {
+      logParse.hooks.omitCommit.tapPromise(this.name, async commit => {
+        // tslint:disable-next-line early-exit
+        if (commit.pullRequest && commit.pullRequest.number) {
+          const { number: prNumber } = commit.pullRequest;
+          const [err, info] = await on(auto.git!.getPr(prNumber));
+
+          // Omit PRs that don't exist on the repo
+          if (err && err.message.includes('Not Found')) {
+            return true;
+          }
+
+          if (err) {
+            throw err;
+          }
+
+          if (!info) {
+            throw new Error(`Could not find PR: ${prNumber}`);
+          }
+
+          // Omit issues
+          if (!info.data.pull_request) {
+            return true;
+          }
+        }
+      });
+    });
+  }
+}

--- a/plugins/released/src/index.ts
+++ b/plugins/released/src/index.ts
@@ -38,6 +38,14 @@ export default class ReleasedLabelPlugin implements IPlugin {
       return config;
     });
 
+    auto.hooks.onCreateLogParse.tap(this.name, logParse => {
+      logParse.hooks.omitCommit.tapPromise(this.name, async commit => {
+        if (commit.labels.includes(this.options.label)) {
+          return true;
+        }
+      });
+    });
+
     auto.hooks.afterRelease.tapPromise(
       this.name,
       async ({ newVersion, commits }) => {


### PR DESCRIPTION
# What Changed

Better handling of situations where the parsed commit message might have a PR number that shouldn't be included. Situations covered:

1. PR number that doesn't exist in the repo yet (ex: 4000, but max PR number is 30)
2. Number is an issue and not a pr
3. Pr already has the "released" label attached

# Why

more fixes for #536 

this should also close #465

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.3.6-canary.538.7039.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
