### PR TITLE
add ability for configured labels to be an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,17 +120,21 @@ Make sure to read our [code of conduct](./CODE_OF_CONDUCT.md).
 
 ## :rocket: Projects Using `auto` :rocket:
 
-:star: [webpack-inject-plugin](https://github.com/adierkens/webpack-inject-plugin) - A webpack plugin to dynamically inject code into the bundle.
+:star: [Storybookjs design-system](https://github.com/storybookjs/design-system) - Storybook's official design system
 
-:star: [storybook-addon-notes-github-markdown-css](https://github.com/hipstersmoothie/github-markdown-css) - Make your notes addon look like github markdown.
-
-:star: [html-webpack-insert-text-plugin](https://github.com/hipstersmoothie/html-webpack-insert-text-plugin) - Insert text into the head or body of your HTML
+:star: [space-kit](https://github.com/apollographql/space-kit) - Home base for Apollo's design system
 
 :star: [react-glider](https://github.com/hipstersmoothie/react-glider) - A react wrapper for glider.js
 
 :star: [Ignite](https://github.com/intuit/Ignite) - Modern markdown documentation generator
 
 :star: [reaction](https://github.com/artsy/reaction) - Artsy’s React Components
+
+:star: [emission](https://github.com/artsy/emission) - Artsy’s React Native Components
+
+:star: [webpack-inject-plugin](https://github.com/adierkens/webpack-inject-plugin) - A webpack plugin to dynamically inject code into the bundle.
+
+:star: [html-webpack-insert-text-plugin](https://github.com/hipstersmoothie/html-webpack-insert-text-plugin) - Insert text into the head or body of your HTML
 
 ## :nail_care: `auto` Badge :nail_care:
 

--- a/docs/pages/autorc.md
+++ b/docs/pages/autorc.md
@@ -109,7 +109,7 @@ You can customize everything about a label
 
 #### Multiple Labels
 
-You have multiple labels for each of the default labels.
+You have can multiple labels for each of the default labels.
 
 ```json
 {
@@ -131,7 +131,7 @@ You have multiple labels for each of the default labels.
 ```
 
 ::: message is-warning
-:warning: If you override any of the semantic versioning labels the default values are lost! Make sure to include that label if you still want it to be used during version calculation.
+:warning: If you override any of the semantic versioning labels the default values are overridden too! Make sure to include that label if you still want it to be used during version calculation.
 :::
 
 ```json

--- a/docs/pages/autorc.md
+++ b/docs/pages/autorc.md
@@ -107,6 +107,49 @@ You can customize everything about a label
 }
 ```
 
+#### Multiple Labels
+
+You have multiple labels for each of the default labels.
+
+```json
+{
+  "labels": {
+    "major": [
+      {
+        "name": "BREAKING",
+        "title": "SUPER BREAKING CHANGED",
+      },
+      {
+        "name": "Version: Major",
+        "title": "The API has changed:",
+        "description": "Add this label to a PR to create a major release",
+      }
+    ],
+    ...
+  }
+}
+```
+
+::: message is-warning
+:warning: If you override any of the semantic versioning labels the default values are lost! Make sure to include that label if you still want it to be used during version calculation.
+:::
+
+```json
+{
+  "labels": {
+    "minor": [
+      "minor",
+      {
+        "name": "New Component",
+        "title": "🧩 New Component",
+        "description": "A new component has been added to the design-system",
+      }
+    ],
+    ...
+  }
+}
+```
+
 #### Changelog Titles
 
 By default auto will create sections in the changelog for the following labels.

--- a/packages/core/src/__tests__/__snapshots__/auto.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/auto.test.ts.snap
@@ -5,44 +5,60 @@ exports[`Auto createLabels should create the labels 1`] = `
   "calls": Array [
     Array [
       Object {
-        "documentation": Object {
-          "description": "Changes only affect the documentation",
-          "name": "documentation",
-          "title": "📝  Documentation",
-        },
-        "internal": Object {
-          "description": "Changes only affect the internal API",
-          "name": "internal",
-          "title": "🏠  Internal",
-        },
-        "major": Object {
-          "description": "Increment the major version when merged",
-          "name": "Version: Major",
-          "title": "💥  Breaking Change",
-        },
-        "minor": Object {
-          "description": "Increment the minor version when merged",
-          "name": "Version: Minor",
-          "title": "🚀  Enhancement",
-        },
-        "patch": Object {
-          "description": "Increment the patch version when merged",
-          "name": "Version: Patch",
-          "title": "🐛  Bug Fix",
-        },
-        "prerelease": Object {
-          "description": "Create a pre-release version when merged",
-          "name": "prerelease",
-          "title": "🚧 Prerelease",
-        },
-        "release": Object {
-          "description": "Create a release when this pr is merged",
-          "name": "release",
-        },
-        "skip-release": Object {
-          "description": "Preserve the current version when merged",
-          "name": "skip-release",
-        },
+        "documentation": Array [
+          Object {
+            "description": "Changes only affect the documentation",
+            "name": "documentation",
+            "title": "📝  Documentation",
+          },
+        ],
+        "internal": Array [
+          Object {
+            "description": "Changes only affect the internal API",
+            "name": "internal",
+            "title": "🏠  Internal",
+          },
+        ],
+        "major": Array [
+          Object {
+            "description": "Increment the major version when merged",
+            "name": "Version: Major",
+            "title": "💥  Breaking Change",
+          },
+        ],
+        "minor": Array [
+          Object {
+            "description": "Increment the minor version when merged",
+            "name": "Version: Minor",
+            "title": "🚀  Enhancement",
+          },
+        ],
+        "patch": Array [
+          Object {
+            "description": "Increment the patch version when merged",
+            "name": "Version: Patch",
+            "title": "🐛  Bug Fix",
+          },
+        ],
+        "prerelease": Array [
+          Object {
+            "description": "Create a pre-release version when merged",
+            "name": "prerelease",
+            "title": "🚧 Prerelease",
+          },
+        ],
+        "release": Array [
+          Object {
+            "description": "Create a release when this pr is merged",
+            "name": "release",
+          },
+        ],
+        "skip-release": Array [
+          Object {
+            "description": "Preserve the current version when merged",
+            "name": "skip-release",
+          },
+        ],
       },
       Object {},
     ],
@@ -61,44 +77,60 @@ Object {
   "baseBranch": "master",
   "extends": "@artsy",
   "labels": Object {
-    "documentation": Object {
-      "description": "Changes only affect the documentation",
-      "name": "documentation",
-      "title": "📝  Documentation",
-    },
-    "internal": Object {
-      "description": "Changes only affect the internal API",
-      "name": "internal",
-      "title": "🏠  Internal",
-    },
-    "major": Object {
-      "description": "Increment the major version when merged",
-      "name": "major",
-      "title": "💥  Breaking Change",
-    },
-    "minor": Object {
-      "description": "Increment the minor version when merged",
-      "name": "minor",
-      "title": "🚀  Enhancement",
-    },
-    "patch": Object {
-      "description": "Increment the patch version when merged",
-      "name": "patch",
-      "title": "🐛  Bug Fix",
-    },
-    "prerelease": Object {
-      "description": "Create a pre-release version when merged",
-      "name": "prerelease",
-      "title": "🚧 Prerelease",
-    },
-    "release": Object {
-      "description": "Create a release when this pr is merged",
-      "name": "release",
-    },
-    "skip-release": Object {
-      "description": "Preserve the current version when merged",
-      "name": "skip-release",
-    },
+    "documentation": Array [
+      Object {
+        "description": "Changes only affect the documentation",
+        "name": "documentation",
+        "title": "📝  Documentation",
+      },
+    ],
+    "internal": Array [
+      Object {
+        "description": "Changes only affect the internal API",
+        "name": "internal",
+        "title": "🏠  Internal",
+      },
+    ],
+    "major": Array [
+      Object {
+        "description": "Increment the major version when merged",
+        "name": "major",
+        "title": "💥  Breaking Change",
+      },
+    ],
+    "minor": Array [
+      Object {
+        "description": "Increment the minor version when merged",
+        "name": "minor",
+        "title": "🚀  Enhancement",
+      },
+    ],
+    "patch": Array [
+      Object {
+        "description": "Increment the patch version when merged",
+        "name": "patch",
+        "title": "🐛  Bug Fix",
+      },
+    ],
+    "prerelease": Array [
+      Object {
+        "description": "Create a pre-release version when merged",
+        "name": "prerelease",
+        "title": "🚧 Prerelease",
+      },
+    ],
+    "release": Array [
+      Object {
+        "description": "Create a release when this pr is merged",
+        "name": "release",
+      },
+    ],
+    "skip-release": Array [
+      Object {
+        "description": "Preserve the current version when merged",
+        "name": "skip-release",
+      },
+    ],
   },
   "onlyPublishWithReleaseLabel": true,
   "owner": "foo",
@@ -116,44 +148,60 @@ Object {
   "baseBranch": "master",
   "extends": "./fake.json",
   "labels": Object {
-    "documentation": Object {
-      "description": "Changes only affect the documentation",
-      "name": "documentation",
-      "title": "📝  Documentation",
-    },
-    "internal": Object {
-      "description": "Changes only affect the internal API",
-      "name": "internal",
-      "title": "🏠  Internal",
-    },
-    "major": Object {
-      "description": "Increment the major version when merged",
-      "name": "major",
-      "title": "💥  Breaking Change",
-    },
-    "minor": Object {
-      "description": "Increment the minor version when merged",
-      "name": "minor",
-      "title": "🚀  Enhancement",
-    },
-    "patch": Object {
-      "description": "Increment the patch version when merged",
-      "name": "patch",
-      "title": "🐛  Bug Fix",
-    },
-    "prerelease": Object {
-      "description": "Create a pre-release version when merged",
-      "name": "prerelease",
-      "title": "🚧 Prerelease",
-    },
-    "release": Object {
-      "description": "Create a release when this pr is merged",
-      "name": "release",
-    },
-    "skip-release": Object {
-      "description": "Preserve the current version when merged",
-      "name": "skip-release",
-    },
+    "documentation": Array [
+      Object {
+        "description": "Changes only affect the documentation",
+        "name": "documentation",
+        "title": "📝  Documentation",
+      },
+    ],
+    "internal": Array [
+      Object {
+        "description": "Changes only affect the internal API",
+        "name": "internal",
+        "title": "🏠  Internal",
+      },
+    ],
+    "major": Array [
+      Object {
+        "description": "Increment the major version when merged",
+        "name": "major",
+        "title": "💥  Breaking Change",
+      },
+    ],
+    "minor": Array [
+      Object {
+        "description": "Increment the minor version when merged",
+        "name": "minor",
+        "title": "🚀  Enhancement",
+      },
+    ],
+    "patch": Array [
+      Object {
+        "description": "Increment the patch version when merged",
+        "name": "patch",
+        "title": "🐛  Bug Fix",
+      },
+    ],
+    "prerelease": Array [
+      Object {
+        "description": "Create a pre-release version when merged",
+        "name": "prerelease",
+        "title": "🚧 Prerelease",
+      },
+    ],
+    "release": Array [
+      Object {
+        "description": "Create a release when this pr is merged",
+        "name": "release",
+      },
+    ],
+    "skip-release": Array [
+      Object {
+        "description": "Preserve the current version when merged",
+        "name": "skip-release",
+      },
+    ],
   },
   "owner": "foo",
   "repo": "bar",

--- a/packages/core/src/__tests__/__snapshots__/changelog.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/changelog.test.ts.snap
@@ -134,7 +134,7 @@ exports[`generateReleaseNotes should create note for PR commits 1`] = `
 - Adam Dierkens (adam@dierkens.com)"
 `;
 
-exports[`generateReleaseNotes should create note for PR commits without labels 1`] = `
+exports[`generateReleaseNotes should create note for PR commits with only non config labels 1`] = `
 "#### 🐛  Bug Fix
 
 - Some Feature [#1234](https://github.custom.com/foobar/auto/pull/1234) (adam@dierkens.com)
@@ -144,7 +144,7 @@ exports[`generateReleaseNotes should create note for PR commits without labels 1
 - Adam Dierkens (adam@dierkens.com)"
 `;
 
-exports[`generateReleaseNotes should create note for PR commits with only non config labels 1`] = `
+exports[`generateReleaseNotes should create note for PR commits without labels 1`] = `
 "#### 🐛  Bug Fix
 
 - Some Feature [#1234](https://github.custom.com/foobar/auto/pull/1234) (adam@dierkens.com)
@@ -173,6 +173,17 @@ exports[`generateReleaseNotes should include prs with released label 1`] = `
 
 - Some Feature [#1234](https://github.custom.com/foobar/auto/pull/1234) (adam@dierkens.com)
 - Third  (adam@dierkens.com)
+
+#### Authors: 1
+
+- Adam Dierkens (adam@dierkens.com)"
+`;
+
+exports[`generateReleaseNotes should merge sections with same changelog title 1`] = `
+"#### Enhancement
+
+- Second Feature [#1236](https://github.custom.com/foobar/auto/pull/1236) (adam@dierkens.com)
+- First Feature [#1235](https://github.custom.com/foobar/auto/pull/1235) (adam@dierkens.com)
 
 #### Authors: 1
 

--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -116,12 +116,12 @@ describe('Auto', () => {
     await auto.loadConfig();
 
     expect([...auto.semVerLabels!.values()]).toEqual([
-      'Version: Major',
-      'Version: Minor',
-      'Version: Patch',
-      'skip-release',
-      'release',
-      'prerelease'
+      ['Version: Major'],
+      ['Version: Minor'],
+      ['Version: Patch'],
+      ['skip-release'],
+      ['release'],
+      ['prerelease']
     ]);
   });
 
@@ -154,11 +154,13 @@ describe('Auto', () => {
     auto.logger = dummyLog();
     await auto.loadConfig();
 
-    expect(auto.release!.options.labels.minor).toEqual({
-      description: 'Increment the minor version when merged',
-      name: 'feature',
-      title: '🚀  Enhancement'
-    });
+    expect(auto.release!.options.labels.minor).toEqual([
+      {
+        description: 'Increment the minor version when merged',
+        name: 'feature',
+        title: '🚀  Enhancement'
+      }
+    ]);
   });
 
   test('should be able to omit properties from label definition', async () => {
@@ -176,11 +178,13 @@ describe('Auto', () => {
     auto.logger = dummyLog();
     await auto.loadConfig();
 
-    expect(auto.release!.options.labels.minor).toEqual({
-      description: 'This is a test',
-      name: 'minor',
-      title: '🚀  Enhancement'
-    });
+    expect(auto.release!.options.labels.minor).toEqual([
+      {
+        description: 'This is a test',
+        name: 'minor',
+        title: '🚀  Enhancement'
+      }
+    ]);
   });
 
   test('arbitrary labels should be able to omit name', async () => {
@@ -198,10 +202,12 @@ describe('Auto', () => {
     auto.logger = dummyLog();
     await auto.loadConfig();
 
-    expect(auto.release!.options.labels.fooBar).toEqual({
-      description: 'This is a test',
-      name: 'fooBar'
-    });
+    expect(auto.release!.options.labels.fooBar).toEqual([
+      {
+        description: 'This is a test',
+        name: 'fooBar'
+      }
+    ]);
   });
 
   describe('createLabels', () => {
@@ -921,20 +927,24 @@ describe('hooks', () => {
     auto.logger = dummyLog();
 
     auto.hooks.modifyConfig.tap('test', testConfig => {
-      testConfig.labels.released = {
-        name: 'released',
-        description: 'This issue/pull request has been released'
-      };
+      testConfig.labels.released = [
+        {
+          name: 'released',
+          description: 'This issue/pull request has been released'
+        }
+      ];
 
       return testConfig;
     });
 
     await auto.loadConfig();
 
-    expect(auto.labels!.released).toEqual({
-      description: 'This issue/pull request has been released',
-      name: 'released'
-    });
+    expect(auto.labels!.released).toEqual([
+      {
+        description: 'This issue/pull request has been released',
+        name: 'released'
+      }
+    ]);
   });
 
   describe('logParse', () => {
@@ -944,7 +954,7 @@ describe('hooks', () => {
 
       auto.hooks.onCreateLogParse.tap('test', logParse => {
         logParse.hooks.parseCommit.tap('test parse', commit => {
-          commit.labels = [auto.semVerLabels!.get(SEMVER.major)!];
+          commit.labels = [...auto.semVerLabels!.get(SEMVER.major)!];
           return commit;
         });
       });
@@ -964,7 +974,7 @@ describe('hooks', () => {
 
       auto.hooks.onCreateLogParse.tap('test', logParse => {
         logParse.hooks.parseCommit.tap('test parse', commit => {
-          commit.labels = [auto.semVerLabels!.get(SEMVER.major)!];
+          commit.labels = [...auto.semVerLabels!.get(SEMVER.major)!];
           return commit;
         });
       });

--- a/packages/core/src/__tests__/changelog.test.ts
+++ b/packages/core/src/__tests__/changelog.test.ts
@@ -312,11 +312,13 @@ describe('generateReleaseNotes', () => {
     const options = testOptions();
     options.labels = {
       ...options.labels,
-      pushToBaseBranch: {
-        name: 'pushToBaseBranch',
-        title: 'Custom Title',
-        description: 'N/A'
-      }
+      pushToBaseBranch: [
+        {
+          name: 'pushToBaseBranch',
+          title: 'Custom Title',
+          description: 'N/A'
+        }
+      ]
     };
 
     const changelog = new Changelog(dummyLog(), options);
@@ -346,11 +348,13 @@ describe('generateReleaseNotes', () => {
     const options = testOptions();
     options.labels = {
       ...options.labels,
-      minor: {
-        name: 'Version: Minor',
-        title: 'Woo Woo New Features',
-        description: 'N/A'
-      }
+      minor: [
+        {
+          name: 'Version: Minor',
+          title: 'Woo Woo New Features',
+          description: 'N/A'
+        }
+      ]
     };
 
     const changelog = new Changelog(dummyLog(), options);

--- a/packages/core/src/__tests__/changelog.test.ts
+++ b/packages/core/src/__tests__/changelog.test.ts
@@ -373,6 +373,43 @@ describe('generateReleaseNotes', () => {
     expect(await changelog.generateReleaseNotes(commits)).toMatchSnapshot();
   });
 
+  test('should merge sections with same changelog title', async () => {
+    const options = testOptions();
+    options.labels = {
+      ...options.labels,
+      minor: [
+        { name: 'new-component', title: 'Enhancement' },
+        {
+          name: 'Version: Minor',
+          title: 'Enhancement',
+          description: 'N/A'
+        }
+      ]
+    };
+
+    const changelog = new Changelog(dummyLog(), options);
+    changelog.loadDefaultHooks();
+
+    const commits = await logParse.normalizeCommits([
+      {
+        hash: '3',
+        authorName: 'Adam Dierkens',
+        authorEmail: 'adam@dierkens.com',
+        subject: 'Second Feature (#1236)',
+        labels: ['new-component']
+      },
+      {
+        hash: '2',
+        authorName: 'Adam Dierkens',
+        authorEmail: 'adam@dierkens.com',
+        subject: 'First Feature (#1235)',
+        labels: ['Version: Minor']
+      }
+    ]);
+
+    expect(await changelog.generateReleaseNotes(commits)).toMatchSnapshot();
+  });
+
   test('should add additional release notes', async () => {
     const changelog = new Changelog(dummyLog(), testOptions());
     changelog.loadDefaultHooks();

--- a/packages/core/src/__tests__/config.test.ts
+++ b/packages/core/src/__tests__/config.test.ts
@@ -1,4 +1,4 @@
-import Config from '../config';
+import Config, { normalizeLabel } from '../config';
 import { dummyLog } from '../utils/logger';
 
 const fetchSpy = jest.fn();
@@ -14,6 +14,36 @@ const log = dummyLog();
 
 const importMock = jest.fn();
 jest.mock('import-cwd', () => (path: string) => importMock(path));
+
+describe('normalizeLabel', () => {
+  test('should handle string', () => {
+    expect(normalizeLabel('foo', 'foo')).toEqual([{ name: 'foo' }]);
+  });
+
+  test('should handle object', () => {
+    const label = { name: 'foo', description: 'something' };
+    expect(normalizeLabel('foo', label)).toEqual([label]);
+  });
+
+  test('should attach name', () => {
+    const label = { description: 'something' };
+    expect(normalizeLabel('foo', label)).toEqual([
+      { name: 'foo', description: 'something' }
+    ]);
+  });
+
+  test('should handle arrays', () => {
+    const label = { name: 'foo', description: 'something' };
+    expect(normalizeLabel('major', ['major', label])).toEqual([
+      {
+        description: 'Increment the major version when merged',
+        name: 'major',
+        title: '💥  Breaking Change'
+      },
+      label
+    ]);
+  });
+});
 
 describe('loadExtendConfig', () => {
   test('should reject when no config found', async () => {

--- a/packages/core/src/__tests__/config.test.ts
+++ b/packages/core/src/__tests__/config.test.ts
@@ -1,4 +1,4 @@
-import Config, { normalizeLabel } from '../config';
+import Config, { normalizeLabel, normalizeLabels } from '../config';
 import { dummyLog } from '../utils/logger';
 
 const fetchSpy = jest.fn();
@@ -41,6 +41,26 @@ describe('normalizeLabel', () => {
         title: '💥  Breaking Change'
       },
       { ...label, title: '💥  Breaking Change' }
+    ]);
+  });
+});
+
+describe('normalizeLabels', () => {
+  test('user labels should override defaults', () => {
+    expect(normalizeLabels({}).minor).toEqual([
+      {
+        description: 'Increment the minor version when merged',
+        name: 'minor',
+        title: '🚀  Enhancement'
+      }
+    ]);
+
+    expect(normalizeLabels({ labels: { minor: ['foo'] } }).minor).toEqual([
+      {
+        description: 'Increment the minor version when merged',
+        name: 'foo',
+        title: '🚀  Enhancement'
+      }
     ]);
   });
 });

--- a/packages/core/src/__tests__/config.test.ts
+++ b/packages/core/src/__tests__/config.test.ts
@@ -40,7 +40,7 @@ describe('normalizeLabel', () => {
         name: 'major',
         title: '💥  Breaking Change'
       },
-      label
+      { ...label, title: '💥  Breaking Change' }
     ]);
   });
 });

--- a/packages/core/src/__tests__/release.test.ts
+++ b/packages/core/src/__tests__/release.test.ts
@@ -2,7 +2,11 @@ import merge from 'deepmerge';
 import { parse } from 'graphql';
 import Git from '../git';
 import LogParse from '../log-parse';
-import Release, { buildSearchQuery, defaultLabelDefinition } from '../release';
+import Release, {
+  buildSearchQuery,
+  defaultLabelDefinition,
+  getVersionMap
+} from '../release';
 import SEMVER from '../semver';
 import { dummyLog } from '../utils/logger';
 import makeCommitFromMsg from './make-commit-from-msg';
@@ -102,6 +106,27 @@ const git = new Git({
   owner: 'Andrew',
   repo: 'test',
   token: 'MY_TOKEN'
+});
+
+describe('getVersionMap', () => {
+  test('should return the default map', () => {
+    expect(getVersionMap()).toEqual(
+      new Map([
+        ['major', ['major']],
+        ['minor', ['minor']],
+        ['patch', ['patch']],
+        ['skip-release', ['skip-release']],
+        ['release', ['release']],
+        ['prerelease', ['prerelease']]
+      ])
+    );
+  });
+
+  test('should add custom labels', () => {
+    expect(
+      getVersionMap({ major: [{ name: 'major' }, { name: 'BREAKING' }] })
+    ).toEqual(new Map([['major', ['major', 'BREAKING']]]));
+  });
 });
 
 describe('Release', () => {

--- a/packages/core/src/__tests__/release.test.ts
+++ b/packages/core/src/__tests__/release.test.ts
@@ -943,7 +943,7 @@ describe('Release', () => {
 
       await gh.addLabelsToProject(labels);
 
-      expect(mockLogger.log.log).toHaveBeenCalledWith('Created labels: patch');
+      expect(mockLogger.log.log).toHaveBeenCalledWith('Created labels: 3');
       expect(mockLogger.log.log).toHaveBeenCalledWith(
         '\nYou can see these, and more at https://github.com/web/site/labels'
       );

--- a/packages/core/src/__tests__/release.test.ts
+++ b/packages/core/src/__tests__/release.test.ts
@@ -838,10 +838,10 @@ describe('Release', () => {
 
     test('should be able to configure labels', async () => {
       const customLabels = merge(defaultLabelDefinition, {
-        [SEMVER.major]: { name: 'Version: Major' },
-        [SEMVER.minor]: { name: 'Version: Minor' },
-        [SEMVER.patch]: { name: 'Version: Patch' },
-        release: { name: 'Deploy' }
+        [SEMVER.major]: [{ name: 'Version: Major' }],
+        [SEMVER.minor]: [{ name: 'Version: Minor' }],
+        [SEMVER.patch]: [{ name: 'Version: Patch' }],
+        release: [{ name: 'Deploy' }]
       });
 
       const gh = new Release(git, {
@@ -877,9 +877,9 @@ describe('Release', () => {
     test('should add labels', async () => {
       const gh = new Release(git);
       const customLabels = {
-        [SEMVER.major]: { name: '1', description: 'major' },
-        [SEMVER.minor]: { name: '2', description: 'minor' },
-        [SEMVER.patch]: { name: '3', description: 'patch' }
+        [SEMVER.major]: [{ name: '1', description: 'major' }],
+        [SEMVER.minor]: [{ name: '2', description: 'minor' }],
+        [SEMVER.patch]: [{ name: '3', description: 'patch' }]
       };
 
       await gh.addLabelsToProject(customLabels);
@@ -913,7 +913,7 @@ describe('Release', () => {
       );
 
       const labels = {
-        [SEMVER.patch]: { name: '3', description: 'three' }
+        [SEMVER.patch]: [{ name: '3', description: 'three' }]
       };
 
       await gh.addLabelsToProject(labels);
@@ -927,8 +927,8 @@ describe('Release', () => {
     test('should not add old labels', async () => {
       const gh = new Release(git);
       const labels = {
-        [SEMVER.major]: { name: '1', description: 'major' },
-        [SEMVER.minor]: { name: '2', description: 'minor' }
+        [SEMVER.major]: [{ name: '1', description: 'major' }],
+        [SEMVER.minor]: [{ name: '2', description: 'minor' }]
       };
 
       getProjectLabels.mockReturnValueOnce(['1']);
@@ -951,7 +951,7 @@ describe('Release', () => {
         baseBranch: 'master'
       });
       const labels = {
-        release: { name: 'deploy', description: 'release the code' }
+        release: [{ name: 'deploy', description: 'release the code' }]
       };
 
       await gh.addLabelsToProject(labels);
@@ -981,7 +981,9 @@ describe('Release', () => {
         baseBranch: 'master'
       });
       const labels = {
-        'skip-release': { name: 'no!', description: 'Do not create a release' }
+        'skip-release': [
+          { name: 'no!', description: 'Do not create a release' }
+        ]
       };
 
       await gh.addLabelsToProject(labels);

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -36,7 +36,7 @@ import Release, {
   ILabelDefinitionMap,
   VersionLabel
 } from './release';
-import SEMVER, { calculateSemVerBump } from './semver';
+import SEMVER, { calculateSemVerBump, IVersionLabels } from './semver';
 import execPromise from './utils/exec-promise';
 import loadPlugin, { IPlugin } from './utils/load-plugins';
 import createLog, { ILogger } from './utils/logger';
@@ -111,7 +111,7 @@ export default class Auto {
   release?: Release;
   git?: Git;
   labels?: ILabelDefinitionMap;
-  semVerLabels?: Map<VersionLabel, string>;
+  semVerLabels?: IVersionLabels;
 
   private versionBump?: SEMVER;
 
@@ -327,7 +327,7 @@ export default class Auto {
       sha = res.data.head.sha;
 
       const labels = await this.git.getLabels(prNumber);
-      const labelTexts = [...this.semVerLabels.values()];
+      const labelValues = [...this.semVerLabels.values()];
       const releaseTag = labels.find(l => l === 'release');
 
       const skipReleaseTag = labels.find(
@@ -336,7 +336,7 @@ export default class Auto {
       );
       const semverTag = labels.find(
         l =>
-          labelTexts.includes(l) &&
+          labelValues.some(labelValue => labelValue.includes(l)) &&
           !!this.release &&
           !this.release.options.skipReleaseLabels.includes(l) &&
           l !== 'release'

--- a/packages/core/src/changelog.ts
+++ b/packages/core/src/changelog.ts
@@ -319,15 +319,23 @@ export default class Changelog {
         );
 
         return [
-          title,
-          ...[...lines].sort(
-            (a, b) => a.split('\n').length - b.split('\n').length
-          )
-        ].join('\n');
+          title as string,
+          [...lines].sort((a, b) => a.split('\n').length - b.split('\n').length)
+        ] as [string, string[]];
       })
     );
 
-    labelSections.map(section => sections.push(section));
+    const mergedSections = labelSections.reduce(
+      (acc, [title, commits]) => ({
+        ...acc,
+        [title]: [...(acc[title] || []), ...commits]
+      }),
+      {} as Record<string, string[]>
+    );
+
+    Object.entries(mergedSections)
+      .map(([title, lines]) => [title, ...lines].join('\n'))
+      .map(section => sections.push(section));
   }
 
   private async createReleaseNotesSection(

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -39,7 +39,7 @@ export function normalizeLabel(
   return [{ ...baseLabel, ...label }];
 }
 
-function normalizeLabels(config: cosmiconfig.Config) {
+export function normalizeLabels(config: cosmiconfig.Config) {
   let labels = defaultLabelDefinition;
 
   if (config.labels) {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -13,12 +13,16 @@ import {
 import { ILogger } from './utils/logger';
 import tryRequire from './utils/try-require';
 
-function normalizeLabel(
+export function normalizeLabel(
   name: string,
-  label: string | Partial<ILabelDefinition> | Partial<ILabelDefinition>[]
+  label:
+    | string
+    | Partial<ILabelDefinition>
+    | (Partial<ILabelDefinition> | string)[]
 ): Partial<ILabelDefinition>[] {
   if (typeof label === 'string') {
-    return [{ ...defaultLabelDefinition[name][0], name: label }];
+    const baseLabel = defaultLabelDefinition[name] || [[]];
+    return [{ ...baseLabel[0], name: label }];
   }
 
   if (Array.isArray(label)) {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -20,9 +20,10 @@ export function normalizeLabel(
     | Partial<ILabelDefinition>
     | (Partial<ILabelDefinition> | string)[]
 ): Partial<ILabelDefinition>[] {
+  const baseLabel = (defaultLabelDefinition[name] || [{}])[0];
+
   if (typeof label === 'string') {
-    const baseLabel = defaultLabelDefinition[name] || [[]];
-    return [{ ...baseLabel[0], name: label }];
+    return [{ ...baseLabel, name: label }];
   }
 
   if (Array.isArray(label)) {
@@ -35,8 +36,7 @@ export function normalizeLabel(
     label.name = name;
   }
 
-  const defaultLabel = (defaultLabelDefinition[label.name] || [])[0] || {};
-  return [{ ...defaultLabel, ...label }];
+  return [{ ...baseLabel, ...label }];
 }
 
 function normalizeLabels(config: cosmiconfig.Config) {

--- a/packages/core/src/init.ts
+++ b/packages/core/src/init.ts
@@ -110,15 +110,15 @@ async function getCustomLabels(onlyLabels = false) {
       const { name, title, description } = response.value.values;
       const newLabel: Partial<ILabelDefinition> = {};
 
-      if (name !== labelDef.name) {
+      if (!labelDef.some(l => name !== l.name)) {
         newLabel.name = name;
       }
 
-      if (title !== labelDef.title) {
+      if (!labelDef.some(l => title !== l.title)) {
         newLabel.title = title;
       }
 
-      if (description !== labelDef.description) {
+      if (!labelDef.some(l => description !== l.description)) {
         newLabel.description = description;
       }
 

--- a/packages/core/src/release.ts
+++ b/packages/core/src/release.ts
@@ -508,7 +508,10 @@ export default class Release {
     }
 
     const repoMetadata = await this.git.getProject();
-    const justLabelNames = labelsToCreate.map(([name]) => name);
+    const justLabelNames = labelsToCreate.reduce<string[]>(
+      (acc, [, cLabel]) => [...acc, ...(cLabel || []).map(l => l.name)],
+      []
+    );
 
     if (justLabelNames.length > 0) {
       const state = options.dryRun ? 'Would have created' : 'Created';

--- a/packages/core/src/release.ts
+++ b/packages/core/src/release.ts
@@ -13,7 +13,7 @@ import { ICreateLabelsOptions } from './auto-args';
 import Changelog from './changelog';
 import Git from './git';
 import LogParse, { IExtendedCommit } from './log-parse';
-import SEMVER, { calculateSemVerBump } from './semver';
+import SEMVER, { calculateSemVerBump, IVersionLabels } from './semver';
 import execPromise from './utils/exec-promise';
 import { dummyLog, ILogger } from './utils/logger';
 import { makeReleaseHooks } from './utils/make-hooks';
@@ -82,59 +82,78 @@ export interface ILabelDefinition {
 }
 
 export interface ILabelDefinitionMap {
-  [label: string]: ILabelDefinition;
+  [label: string]: ILabelDefinition[];
 }
 
 export const defaultLabelDefinition: ILabelDefinitionMap = {
-  [SEMVER.major]: {
-    name: 'major',
-    title: '💥  Breaking Change',
-    description: 'Increment the major version when merged'
-  },
-  [SEMVER.minor]: {
-    name: 'minor',
-    title: '🚀  Enhancement',
-    description: 'Increment the minor version when merged'
-  },
-  [SEMVER.patch]: {
-    name: 'patch',
-    title: '🐛  Bug Fix',
-    description: 'Increment the patch version when merged'
-  },
-  'skip-release': {
-    name: 'skip-release',
-    description: 'Preserve the current version when merged'
-  },
-  release: {
-    name: 'release',
-    description: 'Create a release when this pr is merged'
-  },
-  prerelease: {
-    name: 'prerelease',
-    title: '🚧 Prerelease',
-    description: 'Create a pre-release version when merged'
-  },
-  internal: {
-    name: 'internal',
-    title: '🏠  Internal',
-    description: 'Changes only affect the internal API'
-  },
-  documentation: {
-    name: 'documentation',
-    title: '📝  Documentation',
-    description: 'Changes only affect the documentation'
-  }
+  [SEMVER.major]: [
+    {
+      name: 'major',
+      title: '💥  Breaking Change',
+      description: 'Increment the major version when merged'
+    }
+  ],
+  [SEMVER.minor]: [
+    {
+      name: 'minor',
+      title: '🚀  Enhancement',
+      description: 'Increment the minor version when merged'
+    }
+  ],
+  [SEMVER.patch]: [
+    {
+      name: 'patch',
+      title: '🐛  Bug Fix',
+      description: 'Increment the patch version when merged'
+    }
+  ],
+  'skip-release': [
+    {
+      name: 'skip-release',
+      description: 'Preserve the current version when merged'
+    }
+  ],
+  release: [
+    {
+      name: 'release',
+      description: 'Create a release when this pr is merged'
+    }
+  ],
+  prerelease: [
+    {
+      name: 'prerelease',
+      title: '🚧 Prerelease',
+      description: 'Create a pre-release version when merged'
+    }
+  ],
+  internal: [
+    {
+      name: 'internal',
+      title: '🏠  Internal',
+      description: 'Changes only affect the internal API'
+    }
+  ],
+  documentation: [
+    {
+      name: 'documentation',
+      title: '📝  Documentation',
+      description: 'Changes only affect the documentation'
+    }
+  ]
 };
 
 export const getVersionMap = (labels = defaultLabelDefinition) =>
-  Object.entries(labels).reduce((semVer, [label, labelDef]) => {
-    if (isVersionLabel(label)) {
-      semVer.set(label, labelDef.name);
-    }
+  Object.entries(labels).reduce(
+    (semVer, [label, labelDef]) => {
+      if (isVersionLabel(label)) {
+        semVer.set(label, labelDef.map(l => l.name));
+      }
 
-    return semVer;
-    // tslint:disable-next-line align
-  }, new Map<VersionLabel, string>());
+      return semVer;
+      // tslint:disable-next-line align
+    },
+    new Map() as IVersionLabels
+  );
 
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
@@ -238,7 +257,7 @@ export default class Release {
 
   private readonly git: Git;
   private readonly logger: ILogger;
-  private readonly versionLabels: Map<VersionLabel, string>;
+  private readonly versionLabels: IVersionLabels;
 
   constructor(
     git: Git,
@@ -443,7 +462,7 @@ export default class Release {
     labels: Partial<ILabelDefinitionMap>,
     options: ICreateLabelsOptions = {}
   ) {
-    const oldLabels = await this.git.getProjectLabels();
+    const oldLabels = (await this.git.getProjectLabels()) || [];
     const labelsToCreate = Object.entries(labels).filter(
       ([versionLabel, labelDef]) => {
         if (!labelDef) {
@@ -470,16 +489,20 @@ export default class Release {
 
     if (!options.dryRun) {
       await Promise.all(
-        labelsToCreate.map(async ([label, labelDef]) => {
-          if (!labelDef) {
+        labelsToCreate.map(async ([label, labelDefs]) => {
+          if (!labelDefs) {
             return;
           }
 
-          if (oldLabels && oldLabels.includes(labelDef.name)) {
-            await this.git.updateLabel(label, labelDef);
-          } else {
-            await this.git.createLabel(label, labelDef);
-          }
+          return Promise.all(
+            labelDefs.map(async labelDef => {
+              if (oldLabels.some(o => labelDef.name === o)) {
+                return this.git.updateLabel(label, labelDef);
+              }
+
+              return this.git.createLabel(label, labelDef);
+            })
+          );
         })
       );
     }

--- a/plugins/conventional-commits/src/index.ts
+++ b/plugins/conventional-commits/src/index.ts
@@ -22,7 +22,7 @@ export default class ConventionalCommitsPlugin implements IPlugin {
           );
 
           if (conventionalCommit.header && incrementLabel) {
-            commit.labels = [...commit.labels, incrementLabel];
+            commit.labels = [...commit.labels, ...incrementLabel];
           }
         } catch (error) {
           auto.logger.verbose.info(


### PR DESCRIPTION
# What Changed

Labels in config can now supply an array of labels.

# Why

closes #539

Todo:

- [x] Add tests
- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.4.0-canary.540.7071.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
