### PR TITLE
Fix create-labels bug

### DIFF
--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -367,6 +367,7 @@ export default class Git {
       : tinyColor.random().toString('hex6');
     const result = await this.github.issues.updateLabel({
       current_name: label.name,
+      name: label.name,
       owner: this.options.owner,
       repo: this.options.repo,
       color: color.replace('#', ''),


### PR DESCRIPTION
# What Changed

`name` seem to be required now. getting 422 error if not

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.4.1-canary.542.7084.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
