### PR TITLE
label creation is case insensitive

### DIFF
--- a/packages/core/src/__tests__/release.test.ts
+++ b/packages/core/src/__tests__/release.test.ts
@@ -969,6 +969,26 @@ describe('Release', () => {
       });
     });
 
+    test('should not add old labels - case sensitive', async () => {
+      const gh = new Release(git);
+      const labels = {
+        [SEMVER.major]: [{ name: 'major', description: '' }],
+        [SEMVER.minor]: [{ name: 'Minor', description: '' }]
+      };
+
+      getProjectLabels.mockReturnValueOnce(['Major', 'minor']);
+      await gh.addLabelsToProject(labels);
+
+      expect(updateLabel).toHaveBeenCalledWith(SEMVER.major, {
+        name: 'major',
+        description: ''
+      });
+      expect(updateLabel).toHaveBeenCalledWith(SEMVER.minor, {
+        description: '',
+        name: 'Minor'
+      });
+    });
+
     test('should add release label in onlyPublishWithReleaseLabel mode', async () => {
       let gh = new Release(git, {
         skipReleaseLabels: [],

--- a/packages/core/src/release.ts
+++ b/packages/core/src/release.ts
@@ -462,7 +462,9 @@ export default class Release {
     labels: Partial<ILabelDefinitionMap>,
     options: ICreateLabelsOptions = {}
   ) {
-    const oldLabels = (await this.git.getProjectLabels()) || [];
+    const oldLabels = ((await this.git.getProjectLabels()) || []).map(l =>
+      l.toLowerCase()
+    );
     const labelsToCreate = Object.entries(labels).filter(
       ([versionLabel, labelDef]) => {
         if (!labelDef) {

--- a/packages/core/src/release.ts
+++ b/packages/core/src/release.ts
@@ -498,7 +498,7 @@ export default class Release {
 
           return Promise.all(
             labelDefs.map(async labelDef => {
-              if (oldLabels.some(o => labelDef.name === o)) {
+              if (oldLabels.some(o => labelDef.name.toLowerCase() === o)) {
                 return this.git.updateLabel(label, labelDef);
               }
 


### PR DESCRIPTION
# What Changed

When deciding to update or create a label during `create-labels` make all current labels lowercase since label creation is case insensitive

# Why

Previously would error if you tried to create a lowercase version of a label

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.4.2-canary.548.7126.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
