### PR TITLE
set-token: handle when no name in root package.json

### DIFF
--- a/plugins/npm/__tests__/set-npm-token.test.ts
+++ b/plugins/npm/__tests__/set-npm-token.test.ts
@@ -31,6 +31,15 @@ describe('set npm token', () => {
     );
   });
 
+  test('should write a new npmrc w/o name', async () => {
+    loadPackageJson.mockReturnValueOnce({});
+    await setNpmToken(dummyLog());
+    expect(writeFile).toHaveBeenCalledWith(
+      '/User/name/.npmrc',
+      'npm.registry.com:_authToken=${NPM_TOKEN}'
+    );
+  });
+
   test('should use registry from packageJson', async () => {
     loadPackageJson.mockReturnValueOnce({
       name: 'test',

--- a/plugins/npm/src/set-npm-token.ts
+++ b/plugins/npm/src/set-npm-token.ts
@@ -27,7 +27,7 @@ export default async function setTokenOnCI(logger: ILogger) {
 
   if (publishConfig.registry) {
     registry = publishConfig.registry;
-  } else if (name.startsWith('@')) {
+  } else if (name && name.startsWith('@')) {
     const scope = name.split(`/`)[0];
     registry = registryUrl(scope);
   } else {


### PR DESCRIPTION
# What Changed

see title

# Why

it was causing a bug in a monorepo with no name

Todo:

- [x] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.4.2-canary.549.7138.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
