### PR TITLE
Fix setting npm token with a URL that doesn't end in /

### DIFF
--- a/plugins/npm/__tests__/set-npm-token.test.ts
+++ b/plugins/npm/__tests__/set-npm-token.test.ts
@@ -27,7 +27,7 @@ describe('set npm token', () => {
     await setNpmToken(dummyLog());
     expect(writeFile).toHaveBeenCalledWith(
       '/User/name/.npmrc',
-      'npm.registry.com:_authToken=${NPM_TOKEN}'
+      'npm.registry.com/:_authToken=${NPM_TOKEN}'
     );
   });
 
@@ -36,7 +36,7 @@ describe('set npm token', () => {
     await setNpmToken(dummyLog());
     expect(writeFile).toHaveBeenCalledWith(
       '/User/name/.npmrc',
-      'npm.registry.com:_authToken=${NPM_TOKEN}'
+      'npm.registry.com/:_authToken=${NPM_TOKEN}'
     );
   });
 
@@ -48,7 +48,7 @@ describe('set npm token', () => {
     await setNpmToken(dummyLog());
     expect(writeFile).toHaveBeenCalledWith(
       '/User/name/.npmrc',
-      '//my-registry.com:_authToken=${NPM_TOKEN}'
+      '//my-registry.com/:_authToken=${NPM_TOKEN}'
     );
   });
 
@@ -59,7 +59,7 @@ describe('set npm token', () => {
     await setNpmToken(dummyLog());
     expect(writeFile).toHaveBeenCalledWith(
       '/User/name/.npmrc',
-      'foo.registry.com:_authToken=${NPM_TOKEN}'
+      'foo.registry.com/:_authToken=${NPM_TOKEN}'
     );
   });
 
@@ -68,7 +68,7 @@ describe('set npm token', () => {
       name: 'test',
       publishConfig: { registry: 'https://my-registry.com' }
     });
-    readFile.mockReturnValueOnce('//my-registry.com:_authToken=${NPM_TOKEN}');
+    readFile.mockReturnValueOnce('//my-registry.com/:_authToken=${NPM_TOKEN}');
 
     await setNpmToken(dummyLog());
     expect(writeFile).not.toHaveBeenCalled();

--- a/plugins/npm/src/set-npm-token.ts
+++ b/plugins/npm/src/set-npm-token.ts
@@ -2,6 +2,7 @@ import { ILogger } from '@auto-it/core';
 import envCi from 'env-ci';
 import path from 'path';
 import registryUrl from 'registry-url';
+import urlJoin from 'url-join';
 import userHome from 'user-home';
 
 import { loadPackageJson, readFile, writeFile } from './utils';
@@ -37,7 +38,8 @@ export default async function setTokenOnCI(logger: ILogger) {
   logger.verbose.note(`Using ${registry} registry for package`);
 
   const url = registry.replace(/^https?:/, ``);
-  const authTokenString = `${url}:_authToken=\${NPM_TOKEN}`;
+  // tslint:disable-next-line no-invalid-template-strings
+  const authTokenString = urlJoin(url, ':_authToken=${NPM_TOKEN}');
 
   logger.verbose.info(`Will set authentication token string in ${rc}`);
 


### PR DESCRIPTION
# What Changed

registry url + auth token must have a '/' between

# Why

This works

```sh
//registry.npmjs.org/:_authToken=TOKEN
```

This does not

```sh
//registry.npmjs.org:_authToken=TOKEN
```

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.4.4-canary.551.7180.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
