### PR TITLE
Add 'from' option for release command

### DIFF
--- a/docs/pages/auto-release.md
+++ b/docs/pages/auto-release.md
@@ -30,6 +30,7 @@ Options
 
   -d, --dry-run          Report what command will do but do not actually do anything
   --no-version-prefix    Use the version as the tag without the 'v' prefix
+  --from string          Git revision (tag, commit sha, ...) to start release notes from. Defaults to latest tag.
   --use-version string   Version number to publish as. Defaults to reading from the package definition for the platform.
 
 Global Options
@@ -46,4 +47,5 @@ Global Options
 Examples
 
   $ auto release
+  $ auto release --from v0.20.1 --use-version v0.21.0
 ```

--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -420,6 +420,13 @@ const commands: ICommand[] = [
       name,
       email,
       {
+        name: 'from',
+        type: String,
+        group: 'main',
+        description:
+          'Git revision (tag, commit sha, ...) to start release notes from. Defaults to latest tag.'
+      },
+      {
         name: 'use-version',
         type: String,
         group: 'main',
@@ -429,7 +436,10 @@ const commands: ICommand[] = [
       baseBranch,
       ...defaultOptions
     ],
-    examples: ['{green $} auto release']
+    examples: [
+      '{green $} auto release',
+      '{green $} auto release --from v0.20.1 --use-version v0.21.0'
+    ]
   },
   {
     name: 'shipit',

--- a/packages/core/src/auto-args.ts
+++ b/packages/core/src/auto-args.ts
@@ -60,6 +60,7 @@ export interface IChangelogOptions extends IAuthorOptions {
 export interface IReleaseOptions extends IAuthorOptions {
   noVersionPrefix?: boolean;
   dryRun?: boolean;
+  from?: string;
   useVersion?: string;
 }
 

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -784,12 +784,16 @@ export default class Auto {
     );
   }
 
-  private async makeRelease({ dryRun, useVersion }: IReleaseOptions = {}) {
+  private async makeRelease({
+    dryRun,
+    from,
+    useVersion
+  }: IReleaseOptions = {}) {
     if (!this.release || !this.git) {
       throw this.createErrorMessage();
     }
 
-    let lastRelease = await this.git.getLatestRelease();
+    let lastRelease = from || (await this.git.getLatestRelease());
 
     // Find base commit or latest release to generate the changelog to HEAD (new tag)
     this.logger.veryVerbose.info(`Using ${lastRelease} as previous release.`);


### PR DESCRIPTION
# What Changed
- Added `from` option to `auto release` command

# Why
- See #534

Todo:
- [ ] Add tests
- [x] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
