### PR TITLE
Canary: fallback to first commit if now tags exist

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -586,7 +586,14 @@ export default class Auto {
       );
     }
 
-    const latestTag = await this.git.getLatestTagInBranch();
+    let latestTag: string;
+
+    try {
+      latestTag = await this.git.getLatestTagInBranch();
+    } catch (error) {
+      latestTag = await this.git.getFirstCommit();
+    }
+
     const commitsInRelease = await this.release.getCommits(latestTag);
     return { newVersion, commitsInRelease };
   }


### PR DESCRIPTION
# What Changed

When trying to make the very first canary release auto would error out.

# Why

closes #554

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.4.5-canary.560.7245.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
