### PR TITLE
Ability to edit comments

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -99,6 +99,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "su7edja",
+      "name": "su7edja",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/2717065?v=4",
+      "profile": "https://github.com/su7edja",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -175,12 +175,12 @@ Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds
   <tr>
     <td align="center"><a href="https://github.com/hello-woof"><img src="https://avatars2.githubusercontent.com/u/48960849?v=4" width="100px;" alt="Zachary Sherwin"/><br /><sub><b>Zachary Sherwin</b></sub></a><br /><a href="https://github.com/intuit/auto/commits?author=hello-woof" title="Code">💻</a> <a href="https://github.com/intuit/auto/commits?author=hello-woof" title="Documentation">📖</a> <a href="https://github.com/intuit/auto/commits?author=hello-woof" title="Tests">⚠️</a></td>
     <td align="center"><a href="https://github.com/bnigh"><img src="https://avatars3.githubusercontent.com/u/8219313?v=4" width="100px;" alt="bnigh"/><br /><sub><b>bnigh</b></sub></a><br /><a href="https://github.com/intuit/auto/commits?author=bnigh" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/su7edja"><img src="https://avatars0.githubusercontent.com/u/2717065?v=4" width="100px;" alt="su7edja"/><br /><sub><b>su7edja</b></sub></a><br /><a href="https://github.com/intuit/auto/commits?author=su7edja" title="Code">💻</a></td>
   </tr>
 </table>
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
-
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/kentcdodds/all-contributors) specification. Contributions of any kind welcome!

--- a/packages/cli/__tests__/args.test.ts
+++ b/packages/cli/__tests__/args.test.ts
@@ -79,4 +79,14 @@ describe('root parser', () => {
       }
     ]);
   });
+
+  test('allow edit in comment', () => {
+    expect(parseArgs(['comment', '--edit', '--message', 'foo'])).toEqual([
+      'comment',
+      {
+        edit: true,
+        message: 'foo'
+      }
+    ]);
+  });
 });

--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -211,6 +211,13 @@ const deleteFlag: commandLineUsage.OptionDefinition = {
   group: 'main'
 };
 
+const editFlag: commandLineUsage.OptionDefinition = {
+  name: 'edit',
+  type: Boolean,
+  alias: 'e',
+  group: 'main'
+};
+
 interface ICommand {
   name: string;
   summary: string;
@@ -260,6 +267,7 @@ const commands: ICommand[] = [
       pr,
       context,
       { ...deleteFlag, description: 'Delete old comment' },
+      { ...editFlag, description: 'Edit old comment' },
       { ...message, description: 'Message to post to comment' },
       dryRun,
       ...defaultOptions

--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -274,7 +274,8 @@ const commands: ICommand[] = [
     ],
     examples: [
       '{green $} auto comment --delete',
-      '{green $} auto comment --pr 123 --comment "# Why you\'re wrong..."'
+      '{green $} auto comment --pr 123 --message "# Why you\'re wrong..."',
+      '{green $} auto comment --pr 123 --edit --message "This smells..." --context code-smell'
     ]
   },
   {

--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -211,13 +211,6 @@ const deleteFlag: commandLineUsage.OptionDefinition = {
   group: 'main'
 };
 
-const editFlag: commandLineUsage.OptionDefinition = {
-  name: 'edit',
-  type: Boolean,
-  alias: 'e',
-  group: 'main'
-};
-
 interface ICommand {
   name: string;
   summary: string;
@@ -266,8 +259,14 @@ const commands: ICommand[] = [
     options: [
       pr,
       context,
+      {
+        name: 'edit',
+        type: Boolean,
+        alias: 'e',
+        group: 'main',
+        description: 'Edit old comment'
+      },
       { ...deleteFlag, description: 'Delete old comment' },
-      { ...editFlag, description: 'Edit old comment' },
       { ...message, description: 'Message to post to comment' },
       dryRun,
       ...defaultOptions

--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -578,6 +578,18 @@ describe('Auto', () => {
       expect(deleteComment).toHaveBeenCalled();
     });
 
+    test('should edit a comment', async () => {
+      const auto = new Auto(defaults);
+      auto.logger = dummyLog();
+      await auto.loadConfig();
+
+      const editComment = jest.fn();
+      auto.git!.editComment = editComment;
+
+      await auto.comment({ pr: 10, message: 'foo', edit: true });
+      expect(editComment).toHaveBeenCalled();
+    });
+
     test('should not delete a comment in dry run mode', async () => {
       const auto = new Auto(defaults);
       auto.logger = dummyLog();
@@ -585,12 +597,18 @@ describe('Auto', () => {
 
       const deleteComment = jest.fn();
       auto.git!.deleteComment = deleteComment;
+      const editComment = jest.fn();
+      auto.git!.editComment = editComment;
 
       await auto.comment({ pr: 10, message: 'foo bar', dryRun: true });
       expect(deleteComment).not.toHaveBeenCalled();
 
       await auto.comment({ pr: 10, delete: true, dryRun: true });
       expect(deleteComment).not.toHaveBeenCalled();
+
+      await auto.comment({ pr: 10, message: 'foo bar', edit: true, dryRun: true });
+      expect(deleteComment).not.toHaveBeenCalled();
+      expect(editComment).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/auto-args.ts
+++ b/packages/core/src/auto-args.ts
@@ -71,6 +71,7 @@ export interface ICommentOptions {
   context?: string;
   dryRun?: boolean;
   delete?: boolean;
+  edit?: boolean;
 }
 
 export type IPRBodyOptions = ICommentOptions;

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -408,7 +408,8 @@ export default class Auto {
       pr,
       context = 'default',
       dryRun,
-      delete: deleteFlag
+      delete: deleteFlag,
+      edit: editFlag
     } = options;
     if (!this.git) {
       throw this.createErrorMessage();
@@ -422,19 +423,26 @@ export default class Auto {
         this.logger.log.info(
           `Would have deleted comment on ${prNumber} under "${context}" context`
         );
+      } else if (editFlag) {
+        this.logger.log.info(
+            `Would have edited the comment on ${prNumber} under "${context}" context.\n\nNew message: ${message}`
+        );
       } else {
         this.logger.log.info(
           `Would have commented on ${prNumber} under "${context}" context:\n\n${message}`
         );
       }
     } else {
-      if (deleteFlag) {
-        await this.git.deleteComment(prNumber, context);
-      }
-
-      if (message) {
-        await this.git.createComment(message, prNumber, context);
-        this.logger.log.success(`Commented on PR #${pr}`);
+      if (editFlag && message) {
+        await this.git.editComment(message, prNumber, context);
+        this.logger.log.success(`Edited comment on PR #${pr} under context "${context}"`);
+      } else {
+        if (deleteFlag) {
+          await this.git.deleteComment(prNumber, context);
+        } else if (message) {
+          await this.git.createComment(message, prNumber, context);
+          this.logger.log.success(`Commented on PR #${pr}`);
+        }
       }
     }
   }

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -439,8 +439,8 @@ export default class Auto {
       if (deleteFlag) {
         await this.git.deleteComment(prNumber, context);
         this.logger.log.success(`Deleted comment on PR #${prNumber} under context "${context}"`);
-      } 
-      
+      }
+
       if (message) {
         await this.git.createComment(message, prNumber, context);
         this.logger.log.success(`Commented on PR #${prNumber}`);

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -435,12 +435,16 @@ export default class Auto {
     } else if (editFlag && message) {
       await this.git.editComment(message, prNumber, context);
       this.logger.log.success(`Edited comment on PR #${prNumber} under context "${context}"`);
-    } else if (deleteFlag) {
-      await this.git.deleteComment(prNumber, context);
-      this.logger.log.success(`Deleted comment on PR #${prNumber} under context "${context}"`);
-    } else if (message) {
-      await this.git.createComment(message, prNumber, context);
-      this.logger.log.success(`Commented on PR #${prNumber}`);
+    } else {
+      if (deleteFlag) {
+        await this.git.deleteComment(prNumber, context);
+        this.logger.log.success(`Deleted comment on PR #${prNumber} under context "${context}"`);
+      } 
+      
+      if (message) {
+        await this.git.createComment(message, prNumber, context);
+        this.logger.log.success(`Commented on PR #${prNumber}`);
+      }
     }
   }
 

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -432,18 +432,15 @@ export default class Auto {
           `Would have commented on ${prNumber} under "${context}" context:\n\n${message}`
         );
       }
-    } else {
-      if (editFlag && message) {
-        await this.git.editComment(message, prNumber, context);
-        this.logger.log.success(`Edited comment on PR #${pr} under context "${context}"`);
-      } else {
-        if (deleteFlag) {
-          await this.git.deleteComment(prNumber, context);
-        } else if (message) {
-          await this.git.createComment(message, prNumber, context);
-          this.logger.log.success(`Commented on PR #${pr}`);
-        }
-      }
+    } else if (editFlag && message) {
+      await this.git.editComment(message, prNumber, context);
+      this.logger.log.success(`Edited comment on PR #${prNumber} under context "${context}"`);
+    } else if (deleteFlag) {
+      await this.git.deleteComment(prNumber, context);
+      this.logger.log.success(`Deleted comment on PR #${prNumber} under context "${context}"`);
+    } else if (message) {
+      await this.git.createComment(message, prNumber, context);
+      this.logger.log.success(`Commented on PR #${prNumber}`);
     }
   }
 

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -475,7 +475,7 @@ export default class Git {
     this.logger.veryVerbose.info('Got PR comments\n', comments);
 
     const oldMessage = comments.data.find(comment =>
-        comment.body.includes(commentIdentifier)
+      comment.body.includes(commentIdentifier)
     );
 
     if (!oldMessage) {
@@ -545,6 +545,8 @@ export default class Git {
       this.logger.verbose.info('Successfully edited comment on PR');
 
       return result;
+    } else {
+      await this.createComment(message, pr, context);
     }
   }
 

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -489,17 +489,16 @@ export default class Git {
   async deleteComment(pr: number, context = 'default') {
     const commentId = await this.getCommentId(pr, context);
 
-    if (commentId != -1) {
-      this.logger.verbose.info(`Deleting comment: ${commentId}`);
-
-      await this.github.issues.deleteComment({
-        owner: this.options.owner,
-        repo: this.options.repo,
-        comment_id: commentId
-      });
-
-      this.logger.verbose.info(`Successfully deleted comment: ${commentId}`);
+    if (commentId === -1) {
+      return;
     }
+    this.logger.verbose.info(`Deleting comment: ${commentId}`);
+    await this.github.issues.deleteComment({
+      owner: this.options.owner,
+      repo: this.options.repo,
+      comment_id: commentId
+    });
+    this.logger.verbose.info(`Successfully deleted comment: ${commentId}`);
   }
 
   async createComment(message: string, pr: number, context = 'default') {
@@ -529,25 +528,24 @@ export default class Git {
 
     this.logger.verbose.info('Using comment identifier:', commentIdentifier);
     const commentId = await this.getCommentId(pr, context);
-    if (commentId != -1) {
-      this.logger.verbose.info('Editing comment');
-      const result = await this.github.issues.updateComment({
-        owner: this.options.owner,
-        repo: this.options.repo,
-        comment_id: commentId,
-        body: `${commentIdentifier}\n${message}`
-      });
-
-      this.logger.veryVerbose.info(
-          'Got response from editing comment\n',
-          result
-      );
-      this.logger.verbose.info('Successfully edited comment on PR');
-
-      return result;
-    } else {
-      await this.createComment(message, pr, context);
+    if (commentId === -1) {
+      return this.createComment(message, pr, context);
     }
+    this.logger.verbose.info('Editing comment');
+    const result = await this.github.issues.updateComment({
+      owner: this.options.owner,
+      repo: this.options.repo,
+      comment_id: commentId,
+      body: `${commentIdentifier}\n${message}`
+    });
+
+    this.logger.veryVerbose.info(
+        'Got response from editing comment\n',
+        result
+    );
+    this.logger.verbose.info('Successfully edited comment on PR');
+
+    return result;
   }
 
   async addToPrBody(message: string, pr: number, context = 'default') {


### PR DESCRIPTION
# What Changed
When making comment, --edit / -e would allow editing of existing comment. If no comment exists for a given context, a new comment is created.

# Why
fixes #516

Todo:

- [x] Add tests
- [x] Add docs
- [x] Add yourself to contributors (run `yarn contributors:add`)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.7.0-canary.583.7506.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
