### PR TITLE
proxy support in auto

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -108,6 +108,15 @@
       "contributions": [
         "code"
       ]
+    },
+   {
+      "login": "yogikhan",
+      "name": "Yogesh Khandlewal",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/16071601?v=4",
+      "profile": "https://github.com/yogikhan",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -176,11 +176,13 @@ Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds
     <td align="center"><a href="https://github.com/hello-woof"><img src="https://avatars2.githubusercontent.com/u/48960849?v=4" width="100px;" alt="Zachary Sherwin"/><br /><sub><b>Zachary Sherwin</b></sub></a><br /><a href="https://github.com/intuit/auto/commits?author=hello-woof" title="Code">💻</a> <a href="https://github.com/intuit/auto/commits?author=hello-woof" title="Documentation">📖</a> <a href="https://github.com/intuit/auto/commits?author=hello-woof" title="Tests">⚠️</a></td>
     <td align="center"><a href="https://github.com/bnigh"><img src="https://avatars3.githubusercontent.com/u/8219313?v=4" width="100px;" alt="bnigh"/><br /><sub><b>bnigh</b></sub></a><br /><a href="https://github.com/intuit/auto/commits?author=bnigh" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/su7edja"><img src="https://avatars0.githubusercontent.com/u/2717065?v=4" width="100px;" alt="su7edja"/><br /><sub><b>su7edja</b></sub></a><br /><a href="https://github.com/intuit/auto/commits?author=su7edja" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/yogikhan"><img src="https://avatars3.githubusercontent.com/u/16071601?v=4" width="100px;" alt="Yogesh Khandlewal"/><br /><sub><b>Yogesh Khandlewal</b></sub></a><br /><a href="https://github.com/intuit/auto/commits?author=yogikhan" title="Code">💻</a></td>
   </tr>
 </table>
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/kentcdodds/all-contributors) specification. Contributions of any kind welcome!

--- a/docs/pages/getting-started.md
+++ b/docs/pages/getting-started.md
@@ -62,9 +62,12 @@ You must configure some environment variables for publishing and releasing to wo
 
 You can also store these values in a local file at the root of your project named `.env`. You should make sure to add this file to your `.gitignore` so you don't commit any keys! These env vars will override these any variable already set on the process. This enables you to have a per project configuration that isn't effected by your global setup.
 
+If call require to use the http or https proxy, add http_proxy or https_proxy command or add these to .env file.
+
 ```bash
 GH_TOKEN=YOUR_TOKEN
 NPM_TOKEN=PUBLISH_TOKEN
+https_proxy=<PROXYHOST>:<PROXYPORT>
 ```
 
 ### 4. Script

--- a/package.json
+++ b/package.json
@@ -146,5 +146,8 @@
       "dependencies",
       "blog-post"
     ]
+  },
+  "dependencies": {
+    "https-proxy-agent": "^2.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -146,8 +146,5 @@
       "dependencies",
       "blog-post"
     ]
-  },
-  "dependencies": {
-    "https-proxy-agent": "^2.2.2"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,6 +50,7 @@
     "enquirer": "^2.3.0",
     "env-ci": "^4.1.1",
     "gitlog": "^3.1.2",
+    "https-proxy-agent": "^2.2.2",
     "import-cwd": "^3.0.0",
     "lodash.chunk": "^4.2.0",
     "node-fetch": "2.6.0",

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -43,7 +43,7 @@ import loadPlugin, { IPlugin } from './utils/load-plugins';
 import createLog, { ILogger } from './utils/logger';
 import { makeHooks } from './utils/make-hooks';
 
-const proxyUrl = process.env.https_proxy;
+const proxyUrl = process.env.https_proxy || process.env.http_proxy;
 const env = envCi();
 
 interface IAuthor {

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -26,6 +26,7 @@ import {
   IVersionOptions
 } from './auto-args';
 
+import HttpsProxyAgent from 'https-proxy-agent';
 import Changelog from './changelog';
 import Config from './config';
 import Git, { IGitOptions, IPRInfo } from './git';
@@ -43,6 +44,7 @@ import loadPlugin, { IPlugin } from './utils/load-plugins';
 import createLog, { ILogger } from './utils/logger';
 import { makeHooks } from './utils/make-hooks';
 
+const proxyUrl = process.env.https_proxy;
 const env = envCi();
 
 interface IAuthor {
@@ -182,6 +184,7 @@ export default class Auto {
       repo: config.repo,
       ...repository,
       token,
+      agent: proxyUrl ? new HttpsProxyAgent(proxyUrl) : undefined,
       baseUrl: config.githubApi || 'https://api.github.com',
       graphqlBaseUrl:
         config.githubGraphqlApi || config.githubApi || 'https://api.github.com'
@@ -425,7 +428,7 @@ export default class Auto {
         );
       } else if (editFlag) {
         this.logger.log.info(
-            `Would have edited the comment on ${prNumber} under "${context}" context.\n\nNew message: ${message}`
+          `Would have edited the comment on ${prNumber} under "${context}" context.\n\nNew message: ${message}`
         );
       } else {
         this.logger.log.info(
@@ -434,11 +437,15 @@ export default class Auto {
       }
     } else if (editFlag && message) {
       await this.git.editComment(message, prNumber, context);
-      this.logger.log.success(`Edited comment on PR #${prNumber} under context "${context}"`);
+      this.logger.log.success(
+        `Edited comment on PR #${prNumber} under context "${context}"`
+      );
     } else {
       if (deleteFlag) {
         await this.git.deleteComment(prNumber, context);
-        this.logger.log.success(`Deleted comment on PR #${prNumber} under context "${context}"`);
+        this.logger.log.success(
+          `Deleted comment on PR #${prNumber} under context "${context}"`
+        );
       }
 
       if (message) {

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -11,6 +11,7 @@ import {
   SyncWaterfallHook
 } from 'tapable';
 
+import HttpsProxyAgent from 'https-proxy-agent';
 import {
   ApiOptions,
   ICanaryOptions,
@@ -25,8 +26,6 @@ import {
   IShipItOptions,
   IVersionOptions
 } from './auto-args';
-
-import HttpsProxyAgent from 'https-proxy-agent';
 import Changelog from './changelog';
 import Config from './config';
 import Git, { IGitOptions, IPRInfo } from './git';
@@ -754,7 +753,8 @@ export default class Auto {
         repo: gitOptions.repo,
         token: gitOptions.token,
         baseUrl: gitOptions.baseUrl,
-        graphqlBaseUrl: gitOptions.graphqlBaseUrl
+        graphqlBaseUrl: gitOptions.graphqlBaseUrl,
+        agent: gitOptions.agent
       },
       this.logger
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,7 +8,7 @@
   integrity sha512-m2OzlTDbhvzK4hgswH9Lx0cdpq1AntXu53Klz5RGkFfuoDvKsnlU7tmtVfNWtUiP0zZbGtrb/BZYH7aB6TRnMA==
 
 "@auto-it/core@link:packages/core":
-  version "7.6.2"
+  version "7.7.0"
   dependencies:
     "@atomist/slack-messages" "~1.1.0"
     "@octokit/graphql" "^4.0.0"
@@ -35,7 +35,7 @@
     url-join "^4.0.0"
 
 "@auto-it/npm@link:plugins/npm":
-  version "7.6.2"
+  version "7.7.0"
   dependencies:
     "@auto-it/core" "link:packages/core"
     env-ci "^4.1.1"
@@ -49,7 +49,7 @@
     user-home "^2.0.0"
 
 "@auto-it/released@link:plugins/released":
-  version "7.6.2"
+  version "7.7.0"
   dependencies:
     "@auto-it/core" "link:packages/core"
     deepmerge "^4.0.0"
@@ -2819,6 +2819,13 @@ agent-base@4, agent-base@^4.1.0, agent-base@~4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.1.tgz#d89e5999f797875674c07d87f260fc41e83e8ca9"
   integrity sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==
+  dependencies:
+    es6-promisify "^5.0.0"
+
+agent-base@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.3.0.tgz#8165f01c436009bccad0b1d122f05ed770efc6ee"
+  integrity sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==
   dependencies:
     es6-promisify "^5.0.0"
 
@@ -7411,6 +7418,14 @@ https-proxy-agent@^2.2.1:
   integrity sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==
   dependencies:
     agent-base "^4.1.0"
+    debug "^3.1.0"
+
+https-proxy-agent@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz#271ea8e90f836ac9f119daccd39c19ff7dfb0793"
+  integrity sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==
+  dependencies:
+    agent-base "^4.3.0"
     debug "^3.1.0"
 
 humanize-ms@^1.2.1:


### PR DESCRIPTION
# What Changed
added the proxy support in auto.

# Why
Github enterprise server which is behind firewall cannot be access directly.In order to make the call, we will have to use the proxies(http or https). 

Documentation for the same is added.
Todo:

- [ ] Add tests
- [x] Add yourself to contributors (run `yarn contributors:add`)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.8.0-canary.584.7545.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
