### PR TITLE
fix install names in readmes

### DIFF
--- a/plugins/crates/README.md
+++ b/plugins/crates/README.md
@@ -7,9 +7,9 @@ Deploy Rust crates to [crates.io](https://crates.io/).
 This plugin is not included with the `auto` CLI installed via NPM. To install:
 
 ```sh
-npm i --save-dev @auto-cli/crates
+npm i --save-dev @auto-it/crates
 # or
-yarn add -D @auto-cli/crates
+yarn add -D @auto-it/crates
 ```
 
 ## Usage

--- a/plugins/maven/README.md
+++ b/plugins/maven/README.md
@@ -7,9 +7,9 @@ Release a Java project to a [maven](https://maven.apache.org/) instance.
 This plugin is not included with the `auto` CLI installed via NPM. To install:
 
 ```sh
-npm i --save-dev @auto-cli/maven
+npm i --save-dev @auto-it/maven
 # or
-yarn add -D @auto-cli/maven
+yarn add -D @auto-it/maven
 ```
 
 ## Usage


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.8.1-canary.608.7840.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
