### PR TITLE
only add hash to canary version if no pr or build detected

### DIFF
--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -937,7 +937,7 @@ describe('Auto', () => {
       jest.spyOn(auto.release!, 'getCommits').mockImplementation();
 
       await auto.canary({ pr: 123, build: 1 });
-      expect(canary).toHaveBeenCalledWith(SEMVER.patch, '.123.1.abc');
+      expect(canary).toHaveBeenCalledWith(SEMVER.patch, '.123.1');
       expect(auto.git!.addToPrBody).toHaveBeenCalled();
     });
 

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -560,7 +560,7 @@ export default class Auto {
       canaryVersion = `${canaryVersion}.${build}`;
     }
 
-    if (!('isPr' in env) || !build) {
+    if (!pr || !build) {
       canaryVersion = `${canaryVersion}.${await this.git.getSha(true)}`;
     }
 


### PR DESCRIPTION
# What Changed

We were adding the commit sha to canaries when we didn't need to

# Why

Shorter canary version are easier to consume

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.9.1-canary.609.7851.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
