### PR TITLE
New Plugin: "first-time-contributor"

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,19 @@ Visit [the docs](https://intuit.github.io/auto/) for more information.
 
 Auto has an extensive plugin system and wide variety of official plugins. Make a PR to add yours!
 
+**Package Managers:**
+
 - [chrome](./plugins/chrome) - Publish code to Chrome Web Store
-- [conventional-commits](./plugins/conventional-commits) - Parse conventional commit messages for version bumps
 - [crates](./plugins/crates) - Publish Rust crates
-- [jira](./plugins/jira) - Include Jira story links in the changelog
-- [git-tag](./plugins/git-tag) - Manage your projects version through just a git tag
 - [maven](./plugins/maven) - Publish code with maven
 - [npm](./plugins/npm) - Publish code to npm (DEFAULT)
+
+**Extra Functionality:**
+
+- [conventional-commits](./plugins/conventional-commits) - Parse conventional commit messages for version bumps
+- [jira](./plugins/jira) - Include Jira story links in the changelog
+- [first-time-contributor](./plugins/first-time-contributor) - Thanks first time contributors for their work right in your release notes.
+- [git-tag](./plugins/git-tag) - Manage your projects version through just a git tag
 - [omit-commits](./plugins/omit-commits) - Ignore commits base on name, email, subject, labels, and username
 - [omit-release-notes](./plugins/omit-release-notes) - Ignore release notes in PRs made by certain accounts
 - [released](./plugins/released) - Add a `released` label to published PRs, comment with the version it's included in and comment on the issues the PR closes

--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ To get set up, fork and clone the project then run the following command:
 yarn
 ```
 
+### Build/Typecheck
+
+You must build at least once before running the tests or lint.
+
+```sh
+yarn build
+```
+
+In watch mode:
+
+```sh
+yarn start
+```
+
 ### Cleaning
 
 ```sh
@@ -81,30 +95,10 @@ yarn lint
 yarn test
 ```
 
-### Build/Typecheck
-
-```sh
-yarn build
-```
-
-In watch mode:
-
-```sh
-yarn build:watch
-```
-
 ### Run the docs
-
-To deploy the docs you will need to add the `documentation` label to your pull request.
 
 ```sh
 yarn docs:watch
-```
-
-### Adding a contributor
-
-```sh
-yarn contributors:add
 ```
 
 ### Create a new plugin

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ Auto has an extensive plugin system and wide variety of official plugins. Make a
 **Extra Functionality:**
 
 - [conventional-commits](./plugins/conventional-commits) - Parse conventional commit messages for version bumps
-- [jira](./plugins/jira) - Include Jira story links in the changelog
-- [first-time-contributor](./plugins/first-time-contributor) - Thanks first time contributors for their work right in your release notes.
+- [first-time-contributor](./plugins/first-time-contributor) - Thank first time contributors for their work right in your release notes.
 - [git-tag](./plugins/git-tag) - Manage your projects version through just a git tag
+- [jira](./plugins/jira) - Include Jira story links in the changelog
 - [omit-commits](./plugins/omit-commits) - Ignore commits base on name, email, subject, labels, and username
 - [omit-release-notes](./plugins/omit-release-notes) - Ignore release notes in PRs made by certain accounts
 - [released](./plugins/released) - Add a `released` label to published PRs, comment with the version it's included in and comment on the issues the PR closes

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,7 @@
   - [Maven](../plugins/maven/README.md)
   - [Crates](../plugins/crates/README.md)
   - [Chrome Web Store](../plugins/chrome/README.md)
+  - [First Time Contributor](../plugins/first-time-contributor/README.md)
   - [Git Tag](../plugins/git-tag/README.md)
   - [Conventional Commits](../plugins/conventional-commits/README.md)
   - [Omit Commits](../plugins/omit-commits/README.md)

--- a/docs/pages/writing-plugins.md
+++ b/docs/pages/writing-plugins.md
@@ -261,6 +261,29 @@ auto.hooks.canary.tapPromise(this.name, async (version, postFix) => {
 
 ### Changelog Hooks
 
+#### addToBody
+
+Add extra content to your changelogs.
+This hook provide all the current "extra" notes and all of the commits for the changelog.
+You must return the notes array.
+
+The following adds a random GIF from [giphy](https://giphy.com) to each new changelog.
+
+```ts
+auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
+  changelog.hooks.renderChangelogLine.tapPromise(
+    'Giphy',
+    async (notes, commits) => {
+      const response = await fetch(`https://api.giphy.com/v1/gifs/random?api_key=${process.env.GIPHY_KEY}`);
+      const json = await response.json();
+      const { data: gif } = json;
+
+      return [...notes, `![${gif.title}](${gif.url})\n`]
+    }
+  );
+);
+```
+
 #### renderChangelogLine
 
 Change how the changelog renders lines. This hook provides the commit and the current state of the line render. You must return the commit and the line string state as a tuple ([commit, line]).

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "plugins": [
       "npm",
       "released",
+      "first-time-contributor",
       [
         "upload-assets",
         [

--- a/packages/core/src/__tests__/make-commit-from-msg.ts
+++ b/packages/core/src/__tests__/make-commit-from-msg.ts
@@ -16,11 +16,17 @@ const makeCommitFromMsg = (
 ): IExtendedCommit => ({
   hash: options.hash || 'foo',
   labels: options.labels || [],
-  authorName: options.name || 'Adam Dierkens',
+  authorName:
+    options.name !== undefined && options.name !== null
+      ? options.name
+      : 'Adam Dierkens',
   authorEmail: options.email || 'adam@dierkens.com',
   authors: [
     {
-      name: options.name || 'Adam Dierkens',
+      name:
+        options.name !== undefined && options.name !== null
+          ? options.name
+          : 'Adam Dierkens',
       email: options.email || 'adam@dierkens.com',
       ...(options.username ? { username: options.username } : {})
     }

--- a/packages/core/src/changelog.ts
+++ b/packages/core/src/changelog.ts
@@ -1,8 +1,4 @@
-import {
-  AsyncSeriesBailHook,
-  AsyncSeriesWaterfallHook,
-  SyncHook
-} from 'tapable';
+import { AsyncSeriesBailHook, AsyncSeriesWaterfallHook } from 'tapable';
 import { URL } from 'url';
 import join from 'url-join';
 

--- a/packages/core/src/changelog.ts
+++ b/packages/core/src/changelog.ts
@@ -1,4 +1,8 @@
-import { AsyncSeriesBailHook, AsyncSeriesWaterfallHook } from 'tapable';
+import {
+  AsyncSeriesBailHook,
+  AsyncSeriesWaterfallHook,
+  SyncHook
+} from 'tapable';
 import { URL } from 'url';
 import join from 'url-join';
 
@@ -33,6 +37,7 @@ export interface IChangelogHooks {
     [ICommitAuthor, string],
     string | void
   >;
+  addToBody: AsyncSeriesWaterfallHook<[string[], IExtendedCommit[]]>;
   omitReleaseNotes: AsyncSeriesBailHook<[IExtendedCommit], boolean | void>;
 }
 
@@ -44,10 +49,10 @@ const filterLabel = (commits: IExtendedCommit[], label: string) =>
 
 export default class Changelog {
   readonly hooks: IChangelogHooks;
+  readonly options: IGenerateReleaseNotesOptions;
 
   private authors?: [IExtendedCommit, ICommitAuthor][];
   private readonly logger: ILogger;
-  private readonly options: IGenerateReleaseNotesOptions;
 
   constructor(logger: ILogger, options: IGenerateReleaseNotesOptions) {
     this.logger = logger;
@@ -112,6 +117,9 @@ export default class Changelog {
     this.logger.veryVerbose.info('\n', split);
 
     const sections: string[] = [];
+
+    const extraNotes = (await this.hooks.addToBody.promise([], commits)) || [];
+    extraNotes.filter(Boolean).forEach(note => sections.push(note));
 
     await this.createReleaseNotesSection(commits, sections);
     this.logger.verbose.info('Added release notes to changelog');

--- a/packages/core/src/utils/make-hooks.ts
+++ b/packages/core/src/utils/make-hooks.ts
@@ -41,6 +41,7 @@ export const makeLogParseHooks = (): ILogParseHooks => ({
 });
 
 export const makeChangelogHooks = (): IChangelogHooks => ({
+  addToBody: new AsyncSeriesWaterfallHook(['notes', 'commits']),
   renderChangelogLine: new AsyncSeriesWaterfallHook(['lineData']),
   renderChangelogTitle: new AsyncSeriesBailHook(['commits', 'lineRender']),
   renderChangelogAuthor: new AsyncSeriesBailHook([

--- a/plugins/crates/package.json
+++ b/plugins/crates/package.json
@@ -31,9 +31,9 @@
     "crates.io"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json",
-    "build:watch": "npm run build -- -w",
-    "lint": "tslint -p . --format stylish",
+    "build": "tsc -b",
+    "start": "npm run build -- -w",
+    "lint": "eslint src --ext .ts",
     "test": "jest --maxWorkers=2 --config ../../package.json"
   },
   "dependencies": {

--- a/plugins/first-time-contributor/README.md
+++ b/plugins/first-time-contributor/README.md
@@ -1,0 +1,23 @@
+# First Time Contributor Plugin
+
+Thanks first time contributors for their work right in your release notes.
+
+## Installation
+
+This plugin is not included with the `auto` CLI installed via NPM. To install:
+
+```sh
+npm i --save-dev @auto-it/first-time-contributor
+# or
+yarn add -D @auto-it/first-time-contributor
+```
+
+## Usage
+
+Simply add the plugins to your auto configuration.
+
+```json
+{
+  "plugins": ["first-time-contributor"]
+}
+```

--- a/plugins/first-time-contributor/README.md
+++ b/plugins/first-time-contributor/README.md
@@ -1,6 +1,6 @@
 # First Time Contributor Plugin
 
-Thanks first time contributors for their work right in your release notes.
+Thank first time contributors for their work right in your release notes.
 
 ## Installation
 

--- a/plugins/first-time-contributor/__tests__/__snapshots__/first-time-contributor.test.ts.snap
+++ b/plugins/first-time-contributor/__tests__/__snapshots__/first-time-contributor.test.ts.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`First Time Contributor Plugin should exclude a past contributor 1`] = `
+Array [
+  ":tada: This release contains work from a new contributor! :tada:
+
+Thank you, Jeff, for all your work!",
+]
+`;
+
+exports[`First Time Contributor Plugin should include a username if it exists 1`] = `
+Array [
+  ":tada: This release contains work from new contributors! :tada:
+
+Thanks for all your work!
+
+:heart: Jeff ([@jeff-the-snake](https://github.com/jeff-the-snake))
+
+:heart: Andrew ([@hipstersmoothie](https://github.com/hipstersmoothie))",
+]
+`;
+
+exports[`First Time Contributor Plugin should include all authors with no past contributors 1`] = `
+Array [
+  ":tada: This release contains work from new contributors! :tada:
+
+Thanks for all your work!
+
+:heart: Jeff
+
+:heart: Andrew",
+]
+`;
+
+exports[`First Time Contributor Plugin should include only username if no name exists 1`] = `
+Array [
+  ":tada: This release contains work from a new contributor! :tada:
+
+Thank you, [@jeff-the-snake](https://github.com/jeff-the-snake), for all your work!",
+]
+`;
+
+exports[`First Time Contributor Plugin should not include past contributors - email 1`] = `Array []`;
+
+exports[`First Time Contributor Plugin should not include past contributors 1`] = `Array []`;

--- a/plugins/first-time-contributor/__tests__/first-time-contributor.test.ts
+++ b/plugins/first-time-contributor/__tests__/first-time-contributor.test.ts
@@ -1,0 +1,7 @@
+import Auto from '@auto-it/core';
+import FirstTimeContributor from '../src';
+
+describe('First Time Contributor Plugin', () => {
+  test('should do something', async () => {
+  });
+});

--- a/plugins/first-time-contributor/__tests__/first-time-contributor.test.ts
+++ b/plugins/first-time-contributor/__tests__/first-time-contributor.test.ts
@@ -1,7 +1,101 @@
-import Auto from '@auto-it/core';
+import * as Auto from '@auto-it/core';
+import makeCommitFromMsg from '@auto-it/core/dist/__tests__/make-commit-from-msg';
+import Changelog from '@auto-it/core/dist/changelog';
+import {
+  makeChangelogHooks,
+  makeHooks
+} from '@auto-it/core/dist/utils/make-hooks';
+
 import FirstTimeContributor from '../src';
 
+const exec = jest.fn();
+exec.mockReturnValue('');
+// @ts-ignore
+jest.spyOn(Auto, 'execPromise').mockImplementation(exec);
+
+const setup = () => {
+  const plugin = new FirstTimeContributor();
+  const hooks = makeHooks();
+  const changelogHooks = makeChangelogHooks();
+
+  plugin.apply({ hooks } as Auto.Auto);
+  hooks.onCreateChangelog.call(
+    {
+      hooks: changelogHooks,
+      options: { baseUrl: 'https://github.com' }
+    } as Changelog,
+    Auto.SEMVER.patch
+  );
+
+  return changelogHooks;
+};
+
 describe('First Time Contributor Plugin', () => {
-  test('should do something', async () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should include all authors with no past contributors', async () => {
+    const hooks = setup();
+    const commits = [
+      makeCommitFromMsg('foo', { name: 'Jeff' }),
+      makeCommitFromMsg('foo', { name: 'Andrew' })
+    ];
+
+    expect(await hooks.addToBody.promise([], commits)).toMatchSnapshot();
+  });
+
+  test('should exclude a past contributor', async () => {
+    const hooks = setup();
+    const commits = [
+      makeCommitFromMsg('foo', { name: 'Jeff' }),
+      makeCommitFromMsg('foo', { name: 'Andrew' })
+    ];
+    exec.mockReturnValueOnce('Andrew');
+
+    expect(await hooks.addToBody.promise([], commits)).toMatchSnapshot();
+  });
+
+  test('should not include past contributors', async () => {
+    const hooks = setup();
+    const commits = [
+      makeCommitFromMsg('foo', { name: 'Jeff' }),
+      makeCommitFromMsg('foo', { name: 'Andrew' })
+    ];
+    exec.mockReturnValueOnce('Jeff');
+    exec.mockReturnValueOnce('Andrew');
+
+    expect(await hooks.addToBody.promise([], commits)).toMatchSnapshot();
+  });
+
+  test('should not include past contributors - email', async () => {
+    const hooks = setup();
+    const commits = [
+      makeCommitFromMsg('foo', { name: 'Jeff', email: 'Jeff@email.com' })
+    ];
+    exec.mockReturnValueOnce('Jeff@email.com');
+
+    expect(await hooks.addToBody.promise([], commits)).toMatchSnapshot();
+  });
+
+  test('should include a username if it exists', async () => {
+    const hooks = setup();
+    const commits = [
+      makeCommitFromMsg('foo', { name: 'Jeff', username: 'jeff-the-snake' }),
+      makeCommitFromMsg('foo', { name: 'Andrew', username: 'hipstersmoothie' })
+    ];
+
+    expect(await hooks.addToBody.promise([], commits)).toMatchSnapshot();
+  });
+
+  test('should include only username if no name exists', async () => {
+    const hooks = setup();
+    const commits = [
+      makeCommitFromMsg('foo', { username: 'jeff-the-snake', name: '' })
+    ];
+
+    console.log(commits);
+
+    expect(await hooks.addToBody.promise([], commits)).toMatchSnapshot();
   });
 });

--- a/plugins/first-time-contributor/package.json
+++ b/plugins/first-time-contributor/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@auto-it/first-time-contributor",
+  "version": "7.9.1",
+  "main": "dist/index.js",
+  "description": "Thanks first time contributors for their work right in your release notes.",
+  "author": {
+    "name": "Andrew Lisowski",
+    "email": "lisowski54@gmail.com"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/intuit/auto"
+  },
+  "files": [
+    "dist"
+  ],
+  "keywords": [
+    "automation",
+    "semantic",
+    "release",
+    "github",
+    "labels",
+    "automated",
+    "continuos integration",
+    "changelog"
+  ],
+  "scripts": {
+    "build": "tsc -b",
+    "start": "npm run build -- -w",
+    "lint": "eslint src --ext .ts",
+    "test": "jest --maxWorkers=2 --config ../../package.json"
+  },
+  "dependencies": {
+    "@auto-it/core": "7.9.1",
+    "tslib": "1.10.0"
+  }
+}

--- a/plugins/first-time-contributor/package.json
+++ b/plugins/first-time-contributor/package.json
@@ -36,6 +36,10 @@
   },
   "dependencies": {
     "@auto-it/core": "7.9.1",
+    "array.prototype.flatmap": "^1.2.2",
     "tslib": "1.10.0"
+  },
+  "devDependencies": {
+    "@types/array.prototype.flatmap": "^1.2.0"
   }
 }

--- a/plugins/first-time-contributor/package.json
+++ b/plugins/first-time-contributor/package.json
@@ -2,7 +2,7 @@
   "name": "@auto-it/first-time-contributor",
   "version": "7.9.1",
   "main": "dist/index.js",
-  "description": "Thanks first time contributors for their work right in your release notes.",
+  "description": "Thank first time contributors for their work right in your release notes.",
   "author": {
     "name": "Andrew Lisowski",
     "email": "lisowski54@gmail.com"

--- a/plugins/first-time-contributor/src/index.ts
+++ b/plugins/first-time-contributor/src/index.ts
@@ -1,5 +1,6 @@
 import { Auto, IPlugin, execPromise } from '@auto-it/core';
 import { ICommitAuthor } from '@auto-it/core/dist/log-parse';
+import flatMap from 'array.prototype.flatmap';
 import dedent from 'dedent';
 import urlJoin from 'url-join';
 import { URL } from 'url';
@@ -32,7 +33,7 @@ export default class FirstTimeContributorPlugin implements IPlugin {
       changelog.hooks.addToBody.tapPromise(
         this.name,
         async (notes, commits) => {
-          const authors = commits.flatMap(c => c.authors);
+          const authors = flatMap(commits, c => c.authors);
 
           const contributors = await Promise.all([
             getContributors(JUST_NAME),

--- a/plugins/first-time-contributor/src/index.ts
+++ b/plugins/first-time-contributor/src/index.ts
@@ -1,0 +1,84 @@
+import { Auto, IPlugin, execPromise } from '@auto-it/core';
+import { ICommitAuthor } from '@auto-it/core/dist/log-parse';
+import dedent from 'dedent';
+import urlJoin from 'url-join';
+import { URL } from 'url';
+
+export default class FirstTimeContributorPlugin implements IPlugin {
+  name = 'First Time Contributor';
+
+  apply(auto: Auto) {
+    auto.hooks.onCreateChangelog.tap(this.name, changelog => {
+      const renderContributor = (n: ICommitAuthor) => {
+        let line = n.name || '';
+
+        if (n.username) {
+          const base = new URL(changelog.options.baseUrl).origin;
+          const link = `[@${n.username}](${urlJoin(base, n.username)})`;
+
+          line += n.name ? ` (${link})` : link;
+        }
+
+        return line;
+      };
+
+      changelog.hooks.addToBody.tapPromise(
+        this.name,
+        async (notes, commits) => {
+          if (!auto.git) {
+            return notes;
+          }
+
+          const contributors = (await Promise.all([
+            execPromise(
+              "git log --format='%aN' $(git rev-list HEAD | tail -n 1)..$(git describe --tags --abbrev=0) | sort -u"
+            ),
+            execPromise(
+              "git log --format='%cE' $(git rev-list HEAD | tail -n 1)..$(git describe --tags --abbrev=0) | sort -u"
+            )
+          ]))
+            .join('\n')
+            .split('\n');
+
+          const authors = commits
+            .map(c => c.authors)
+            .reduce<ICommitAuthor[]>((acc, i) => [...acc, ...i], []);
+
+          const newContributors = authors.filter(
+            ({ name = '', email = '', username = '' }) =>
+              !(
+                (name && contributors.includes(name)) ||
+                (email && contributors.includes(email)) ||
+                (username && contributors.includes(username))
+              )
+          );
+
+          if (!newContributors.length) {
+            return notes;
+          }
+
+          const lines = new Set(newContributors.map(renderContributor));
+          let thankYou: string;
+
+          if (lines.size > 1) {
+            thankYou = dedent`
+              :tada: This release contains work from new contributors! :tada:
+            
+              Thanks for all your work!\n\n${[...lines]
+                .map(line => `:heart: ${line}`)
+                .join('\n\n')}
+            `;
+          } else {
+            thankYou = dedent`
+              :tada: This release contains work from a new contributor! :tada:
+            
+              Thank you, ${[...lines][0]}, for all your work!
+            `;
+          }
+
+          return [...notes, thankYou];
+        }
+      );
+    });
+  }
+}

--- a/plugins/first-time-contributor/src/index.ts
+++ b/plugins/first-time-contributor/src/index.ts
@@ -25,10 +25,6 @@ export default class FirstTimeContributorPlugin implements IPlugin {
       changelog.hooks.addToBody.tapPromise(
         this.name,
         async (notes, commits) => {
-          if (!auto.git) {
-            return notes;
-          }
-
           const contributors = (await Promise.all([
             execPromise(
               "git log --format='%aN' $(git rev-list HEAD | tail -n 1)..$(git describe --tags --abbrev=0) | sort -u"

--- a/plugins/first-time-contributor/tsconfig.json
+++ b/plugins/first-time-contributor/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*", "../../typings/**/*"],
+
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+
+  "references": [
+    {
+      "path": "../../packages/core"
+    }
+  ]
+}

--- a/scripts/create-plugin.js
+++ b/scripts/create-plugin.js
@@ -13,6 +13,7 @@ const { version } = JSON.parse(
 const inDir = path.join(__dirname, './template-plugin');
 const kebab = changeCase.paramCase(name);
 const outDir = path.join(__dirname, '../plugins', kebab);
+const TSCONFIG = path.join(__dirname, '../tsconfig.dev.json');
 
 fs.mkdirSync(outDir);
 
@@ -33,4 +34,19 @@ copy(inDir, outDir, vars, (err, createdFiles) => {
     log.info(`Created ${path.relative(outDir, filePath)}`)
   );
   log.success(`Created @auto-it/${kebab} plugin!`);
+});
+
+fs.readFile(TSCONFIG, 'utf8', (err, data) => {
+  if (err) {
+    throw err;
+  }
+
+  const json = JSON.parse(data);
+
+  json.references.push({
+    path: `plugins/${kebab}`
+  });
+
+  fs.writeFileSync(TSCONFIG, JSON.stringify(json, null, 2));
+  log.success(`Updated tsconfig.dev.json!`);
 });

--- a/scripts/template-plugin/README.md
+++ b/scripts/template-plugin/README.md
@@ -1,3 +1,13 @@
 # {{title}} Plugin
 
 {{description}}
+
+## Installation
+
+This plugin is not included with the `auto` CLI installed via NPM. To install:
+
+```sh
+npm i --save-dev @auto-it/{{kebab}}
+# or
+yarn add -D @auto-it/{{kebab}}
+```

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -16,6 +16,9 @@
       "path": "plugins/conventional-commits"
     },
     {
+      "path": "plugins/first-time-contributor"
+    },
+    {
       "path": "plugins/git-tag"
     },
     {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs", // Resolve modules the node way
-    "lib": ["esnext"], // Use newest ecma script features
+    "lib": ["es2017"], // Use newest ecma script features
     /* Outputs: */
     "sourceMap": true,
     "declaration": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2229,6 +2229,11 @@
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
   integrity sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==
 
+"@types/array.prototype.flatmap@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/array.prototype.flatmap/-/array.prototype.flatmap-1.2.0.tgz#e11283ae3bf9b432173756764064f2d8a7a377b1"
+  integrity sha512-sMRMigmTCA1EVX46F0jPhSFo51uFNo83GkeYlp7r4xKkXwfjkDpTm13vB9Tba4Ey+0rUXX3QjSWHAIwSb3qzrA==
+
 "@types/babel__core@^7.1.0":
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.1.tgz#ce9a9e5d92b7031421e1d0d74ae59f572ba48be6"
@@ -3130,6 +3135,15 @@ array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
+
+array.prototype.flatmap@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/array.prototype.flatmap/-/array.prototype.flatmap-1.2.2.tgz#28d621d351c19a62b84331b01669395ef6cef4c4"
+  integrity sha512-ZZtPLE74KNE+0XcPv/vQmcivxN+8FhwOLvt2udHauO0aDEpsXDQrmd5HuJGpgPVyaV8HvkDPWnJ2iaem0oCKtA==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.15.0"
+    function-bind "^1.1.1"
 
 arrify@^1.0.1:
   version "1.0.1"
@@ -5766,6 +5780,22 @@ es-abstract@^1.11.0, es-abstract@^1.12.0, es-abstract@^1.5.0, es-abstract@^1.7.0
     is-callable "^1.1.4"
     is-regex "^1.0.4"
     object-keys "^1.0.12"
+
+es-abstract@^1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.15.0.tgz#8884928ec7e40a79e3c9bc812d37d10c8b24cc57"
+  integrity sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==
+  dependencies:
+    es-to-primitive "^1.2.0"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.0"
+    is-callable "^1.1.4"
+    is-regex "^1.0.4"
+    object-inspect "^1.6.0"
+    object-keys "^1.1.1"
+    string.prototype.trimleft "^2.1.0"
+    string.prototype.trimright "^2.1.0"
 
 es-abstract@^1.5.1:
   version "1.12.0"
@@ -11002,7 +11032,12 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-keys@^1.0.11, object-keys@^1.0.12:
+object-inspect@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.6.0.tgz#c70b6cbf72f274aab4c34c0c82f5167bf82cf15b"
+  integrity sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==
+
+object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
@@ -13959,6 +13994,22 @@ string.prototype.trim@^1.1.2:
     define-properties "^1.1.2"
     es-abstract "^1.5.0"
     function-bind "^1.0.2"
+
+string.prototype.trimleft@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz#6cc47f0d7eb8d62b0f3701611715a3954591d634"
+  integrity sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==
+  dependencies:
+    define-properties "^1.1.3"
+    function-bind "^1.1.1"
+
+string.prototype.trimright@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz#669d164be9df9b6f7559fa8e89945b168a5a6c58"
+  integrity sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==
+  dependencies:
+    define-properties "^1.1.3"
+    function-bind "^1.1.1"
 
 string_decoder@^1.0.0, string_decoder@^1.1.1:
   version "1.2.0"


### PR DESCRIPTION
# What Changed

Thank first time contributors for their work right in your release notes.

## Release Notes

This PR also introduces the `changelog.addToBody` hook. This can be used to add whatever extra content you want to a changelog.

The following adds a random GIF from [giphy](https://giphy.com) to each new changelog.

```ts
auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
  changelog.hooks.renderChangelogLine.tapPromise(
    'Giphy',
    async (notes, commits) => {
      const response = await fetch(`https://api.giphy.com/v1/gifs/random?api_key=${process.env.GIPHY_KEY}`);
      const json = await response.json();
      const { data: gif } = json;

      return [...notes, `![${gif.title}](${gif.url})\n`]
    }
  );
);
```

# Why

Thanking people is nice!

Todo:

- [x] Add tests
- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.10.0-canary.610.7923.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
