### PR TITLE
Fix windows git refspec problem

### DIFF
--- a/plugins/chrome/src/index.ts
+++ b/plugins/chrome/src/index.ts
@@ -154,7 +154,7 @@ export default class ChromeWebStorePlugin implements IPlugin {
         '--follow-tags',
         '--set-upstream',
         'origin',
-        '$branch'
+        auto.options.baseBranch
       ]);
     });
   }

--- a/plugins/chrome/src/index.ts
+++ b/plugins/chrome/src/index.ts
@@ -154,7 +154,7 @@ export default class ChromeWebStorePlugin implements IPlugin {
         '--follow-tags',
         '--set-upstream',
         'origin',
-        auto.options.baseBranch
+        auto.baseBranch
       ]);
     });
   }

--- a/plugins/crates/__tests__/crates.test.ts
+++ b/plugins/crates/__tests__/crates.test.ts
@@ -226,7 +226,7 @@ describe('CratesPlugin', () => {
           '--follow-tags',
           '--set-upstream',
           'origin',
-          '$branch'
+          'master'
         ]);
       });
     });

--- a/plugins/crates/__tests__/crates.test.ts
+++ b/plugins/crates/__tests__/crates.test.ts
@@ -218,7 +218,11 @@ describe('CratesPlugin', () => {
       test('does publishing', async () => {
         const plugin = new CratesPlugin();
         const hooks = makeHooks();
-        plugin.apply({ hooks, logger: dummyLog() } as Auto.Auto);
+        plugin.apply({
+          hooks,
+          logger: dummyLog(),
+          baseBranch: 'master'
+        } as Auto.Auto);
         await hooks.publish.promise(Auto.SEMVER.patch);
         expect(exec).toHaveBeenCalledWith('cargo', ['publish']);
         expect(exec).toHaveBeenCalledWith('git', [

--- a/plugins/crates/src/index.ts
+++ b/plugins/crates/src/index.ts
@@ -102,7 +102,7 @@ export default class CratesPlugin implements IPlugin {
         '--follow-tags',
         '--set-upstream',
         'origin',
-        auto.options.baseBranch
+        auto.baseBranch
       ]);
       auto.logger.log.info('Push complete');
     });

--- a/plugins/crates/src/index.ts
+++ b/plugins/crates/src/index.ts
@@ -102,7 +102,7 @@ export default class CratesPlugin implements IPlugin {
         '--follow-tags',
         '--set-upstream',
         'origin',
-        '$branch'
+        auto.options.baseBranch
       ]);
       auto.logger.log.info('Push complete');
     });

--- a/plugins/git-tag/src/index.ts
+++ b/plugins/git-tag/src/index.ts
@@ -28,13 +28,12 @@ export default class GitTagPlugin implements IPlugin {
       }
 
       await execPromise('git', ['tag', newTag]);
-      auto.logger.verbose.info(`Created tag: ${newTag}`);
       await execPromise('git', [
         'push',
         '--follow-tags',
         '--set-upstream',
         'origin',
-        auto.options.baseBranch
+        auto.baseBranch
       ]);
     });
   }

--- a/plugins/git-tag/src/index.ts
+++ b/plugins/git-tag/src/index.ts
@@ -28,12 +28,13 @@ export default class GitTagPlugin implements IPlugin {
       }
 
       await execPromise('git', ['tag', newTag]);
+      auto.logger.verbose.info(`Created tag: ${newTag}`);
       await execPromise('git', [
         'push',
         '--follow-tags',
         '--set-upstream',
         'origin',
-        '$branch'
+        auto.options.baseBranch
       ]);
     });
   }

--- a/plugins/maven/src/index.ts
+++ b/plugins/maven/src/index.ts
@@ -154,7 +154,7 @@ export default class MavenPlugin implements IPlugin {
         '--follow-tags',
         '--set-upstream',
         'origin',
-        auto.options.baseBranch
+        auto.baseBranch
       ]);
 
       await execPromise('mvn', [
@@ -171,7 +171,7 @@ export default class MavenPlugin implements IPlugin {
       // prepare for next development iteration
       await execPromise('git', ['reset', '--hard', 'dev-snapshot']);
       await execPromise('git', ['branch', '-d', 'dev-snapshot']);
-      await execPromise('git', ['push', 'origin', auto.options.baseBranch]);
+      await execPromise('git', ['push', 'origin', auto.baseBranch]);
     });
   }
 }

--- a/plugins/maven/src/index.ts
+++ b/plugins/maven/src/index.ts
@@ -154,7 +154,7 @@ export default class MavenPlugin implements IPlugin {
         '--follow-tags',
         '--set-upstream',
         'origin',
-        '$branch'
+        auto.options.baseBranch
       ]);
 
       await execPromise('mvn', [
@@ -171,7 +171,7 @@ export default class MavenPlugin implements IPlugin {
       // prepare for next development iteration
       await execPromise('git', ['reset', '--hard', 'dev-snapshot']);
       await execPromise('git', ['branch', '-d', 'dev-snapshot']);
-      await execPromise('git', ['push', 'origin', '$branch']);
+      await execPromise('git', ['push', 'origin', auto.options.baseBranch]);
     });
   }
 }

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -479,12 +479,13 @@ export default class NPMPlugin implements IPlugin {
           ? ['publish', '--access', 'public', ...verboseArgs]
           : ['publish', ...verboseArgs]
       );
+      auto.logger.verbose.info('Pushing tag to github');
       await execPromise('git', [
         'push',
         '--follow-tags',
         '--set-upstream',
         'origin',
-        '$branch'
+        auto.options.baseBranch
       ]);
       auto.logger.verbose.info('Successfully published repo');
     });

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -479,13 +479,12 @@ export default class NPMPlugin implements IPlugin {
           ? ['publish', '--access', 'public', ...verboseArgs]
           : ['publish', ...verboseArgs]
       );
-      auto.logger.verbose.info('Pushing tag to github');
       await execPromise('git', [
         'push',
         '--follow-tags',
         '--set-upstream',
         'origin',
-        auto.options.baseBranch
+        auto.baseBranch
       ]);
       auto.logger.verbose.info('Successfully published repo');
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,8 +7,37 @@
   resolved "https://registry.yarnpkg.com/@atomist/slack-messages/-/slack-messages-1.1.1.tgz#9de42932e89065fb4fe4842978ca2d1ed3424cea"
   integrity sha512-m2OzlTDbhvzK4hgswH9Lx0cdpq1AntXu53Klz5RGkFfuoDvKsnlU7tmtVfNWtUiP0zZbGtrb/BZYH7aB6TRnMA==
 
+"@auto-it/core@7.1.2":
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@auto-it/core/-/core-7.1.2.tgz#e6aaa8df3d32c02bd2636d321f3831dc1f3bbaed"
+  integrity sha512-L0+E7FATs1YzZDPXsry4s6ZvQjnlMljvGtPazIG0mBWLsGYGo5o5UzV1dzaWiFuOUxKWQ3TCQ4RHOJAhmUPAog==
+  dependencies:
+    "@atomist/slack-messages" "~1.1.0"
+    "@octokit/graphql" "^2.1.2"
+    "@octokit/plugin-enterprise-compatibility" "^1.1.1"
+    "@octokit/plugin-retry" "^2.2.0"
+    "@octokit/plugin-throttling" "^2.6.0"
+    "@octokit/rest" "16.28.1"
+    arr-flatten "^1.1.0"
+    cosmiconfig "5.2.0"
+    dedent "^0.7.0"
+    deepmerge "^3.2.0"
+    dotenv "^8.0.0"
+    enquirer "^2.3.0"
+    env-ci "^3.2.0"
+    gitlog "^3.1.2"
+    import-cwd "^3.0.0"
+    lodash.chunk "^4.2.0"
+    node-fetch "2.5.0"
+    semver "^6.0.0"
+    signale "^1.4.0"
+    tapable "^2.0.0-beta.2"
+    tinycolor2 "^1.4.1"
+    typescript-memoize "^1.0.0-alpha.3"
+    url-join "^4.0.0"
+
 "@auto-it/core@link:packages/core":
-  version "7.11.0"
+  version "7.9.2"
   dependencies:
     "@atomist/slack-messages" "~1.1.0"
     "@octokit/graphql" "^4.0.0"
@@ -37,7 +66,7 @@
     url-join "^4.0.0"
 
 "@auto-it/npm@link:plugins/npm":
-  version "7.11.0"
+  version "7.9.2"
   dependencies:
     "@auto-it/core" "link:packages/core"
     env-ci "^4.1.1"
@@ -52,7 +81,7 @@
     user-home "^2.0.0"
 
 "@auto-it/released@link:plugins/released":
-  version "7.11.0"
+  version "7.9.2"
   dependencies:
     "@auto-it/core" "link:packages/core"
     deepmerge "^4.0.0"
@@ -2123,6 +2152,14 @@
     universal-user-agent "^2.0.1"
     url-template "^2.0.8"
 
+"@octokit/graphql@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-2.1.2.tgz#220bc814fbebd35b3796db4788b353b491dd6575"
+  integrity sha512-Vq+Ypj0rQNpeyvh3dhqyyOItyr4KUW4Zu/tdg00PQdlH/iOX+RJQBcDMRMg1oGwY5g2zVtXuhSMFCgR6QoujxA==
+  dependencies:
+    "@octokit/request" "^4.1.0"
+    universal-user-agent "^2.0.3"
+
 "@octokit/graphql@^4.0.0":
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-4.2.2.tgz#b998a16f7778fbb4204d1a9c4e2cde2525ba183a"
@@ -2163,6 +2200,19 @@
     deprecation "^2.0.0"
     once "^1.4.0"
 
+"@octokit/request@^4.0.1", "@octokit/request@^4.1.0":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-4.1.1.tgz#614262214f48417b4d3b14e047d09a9c8e2f7a09"
+  integrity sha512-LOyL0i3oxRo418EXRSJNk/3Q4I0/NKawTn6H/CQp+wnrG1UFLGu080gSsgnWobhPo5BpUNgSQ5BRk5FOOJhD1Q==
+  dependencies:
+    "@octokit/endpoint" "^5.1.0"
+    "@octokit/request-error" "^1.0.1"
+    deprecation "^2.0.0"
+    is-plain-object "^3.0.0"
+    node-fetch "^2.3.0"
+    once "^1.4.0"
+    universal-user-agent "^2.1.0"
+
 "@octokit/request@^5.0.0", "@octokit/request@^5.2.0":
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.2.1.tgz#d8076b4bd415802c2dbffc82cf9b8b78f49551a3"
@@ -2175,6 +2225,25 @@
     node-fetch "^2.3.0"
     once "^1.4.0"
     universal-user-agent "^4.0.0"
+
+"@octokit/rest@16.28.1":
+  version "16.28.1"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-16.28.1.tgz#a10c3d4fe61e994878d66a4c12b9923b18548236"
+  integrity sha512-9H/5F0f2bSVhk78ypu/A9dkK5GCH/aI8CxRJ0L8JU/XEYNIYozxqD6HVC7shsofrCfR61YORfjTE+GxfZ/wasQ==
+  dependencies:
+    "@octokit/request" "^4.0.1"
+    "@octokit/request-error" "^1.0.2"
+    atob-lite "^2.0.0"
+    before-after-hook "^1.4.0"
+    btoa-lite "^1.0.0"
+    deprecation "^2.0.0"
+    lodash.get "^4.4.2"
+    lodash.set "^4.3.2"
+    lodash.uniq "^4.5.0"
+    octokit-pagination-methods "^1.1.0"
+    once "^1.4.0"
+    universal-user-agent "^2.0.0"
+    url-template "^2.0.8"
 
 "@octokit/rest@16.33.1", "@octokit/rest@^16.28.1", "@octokit/rest@^16.28.4":
   version "16.33.1"
@@ -3408,6 +3477,11 @@ bcrypt-pbkdf@^1.0.0:
   integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
   dependencies:
     tweetnacl "^0.14.3"
+
+before-after-hook@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-1.4.0.tgz#2b6bf23dca4f32e628fd2747c10a37c74a4b484d"
+  integrity sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg==
 
 before-after-hook@^2.0.0:
   version "2.1.0"
@@ -4762,6 +4836,16 @@ cosmiconfig@5.0.7:
     js-yaml "^3.9.0"
     parse-json "^4.0.0"
 
+cosmiconfig@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.0.tgz#45038e4d28a7fe787203aede9c25bca4a08b12c8"
+  integrity sha512-nxt+Nfc3JAqf4WIWd0jXLjTJZmsPLrA9DDc4nRw2KFJQJK7DNooqSXrNI7tzLG50CF8axczly5UV929tBmh/7g==
+  dependencies:
+    import-fresh "^2.0.0"
+    is-directory "^0.3.1"
+    js-yaml "^3.13.0"
+    parse-json "^4.0.0"
+
 cosmiconfig@5.2.1, cosmiconfig@^5.0.0, cosmiconfig@^5.0.2, cosmiconfig@^5.1.0, cosmiconfig@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
@@ -5308,6 +5392,11 @@ deepmerge@^2.0.1:
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
   integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
 
+deepmerge@^3.2.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-3.3.0.tgz#d3c47fd6f3a93d517b14426b0628a17b0125f5f7"
+  integrity sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA==
+
 deepmerge@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.1.1.tgz#ee0866e4019fe62c1276b9062d4c4803d9aea14c"
@@ -5732,6 +5821,14 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
   integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
+
+env-ci@^3.2.0:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/env-ci/-/env-ci-3.2.2.tgz#06936f1fcfbc999102a2211fc2539df64062b61f"
+  integrity sha512-AOiNZ3lmxrtva3r/roqaYDF+1PX2V+ouUzuGqJf7KNxyyYkuU+CsfFbbUeibQPdixxjI/lP6eDtvtkX1/wymJw==
+  dependencies:
+    execa "^1.0.0"
+    java-properties "^1.0.0"
 
 env-ci@^4.1.1:
   version "4.1.3"
@@ -9192,7 +9289,7 @@ js-yaml@3.6.1:
     argparse "^1.0.7"
     esprima "^2.6.0"
 
-js-yaml@^3.13.1, js-yaml@^3.9.0:
+js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.9.0:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
@@ -10696,6 +10793,11 @@ node-fetch-npm@^2.0.2:
     encoding "^0.1.11"
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
+
+node-fetch@2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.5.0.tgz#8028c49fc1191bba56a07adc6e2a954644a48501"
+  integrity sha512-YuZKluhWGJwCcUu4RlZstdAxr8bFfOVHakc1mplwHkk8J+tqM1Y5yraYvIUpeX8aY7+crCwiELJq7Vl0o0LWXw==
 
 node-fetch@2.6.0, node-fetch@^2.3.0, node-fetch@^2.5.0:
   version "2.6.0"
@@ -14915,7 +15017,7 @@ unique-temp-dir@~1.0.0:
     os-tmpdir "^1.0.1"
     uid2 "0.0.3"
 
-universal-user-agent@^2.0.1:
+universal-user-agent@^2.0.0, universal-user-agent@^2.0.1, universal-user-agent@^2.0.3, universal-user-agent@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-2.1.0.tgz#5abfbcc036a1ba490cb941f8fd68c46d3669e8e4"
   integrity sha512-8itiX7G05Tu3mGDTdNY2fB4KJ8MgZLS54RdG6PkkfwMAavrXu1mV/lls/GABx9O3Rw4PnTtasxrvbMQoBYY92Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,37 +7,8 @@
   resolved "https://registry.yarnpkg.com/@atomist/slack-messages/-/slack-messages-1.1.1.tgz#9de42932e89065fb4fe4842978ca2d1ed3424cea"
   integrity sha512-m2OzlTDbhvzK4hgswH9Lx0cdpq1AntXu53Klz5RGkFfuoDvKsnlU7tmtVfNWtUiP0zZbGtrb/BZYH7aB6TRnMA==
 
-"@auto-it/core@7.1.2":
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/@auto-it/core/-/core-7.1.2.tgz#e6aaa8df3d32c02bd2636d321f3831dc1f3bbaed"
-  integrity sha512-L0+E7FATs1YzZDPXsry4s6ZvQjnlMljvGtPazIG0mBWLsGYGo5o5UzV1dzaWiFuOUxKWQ3TCQ4RHOJAhmUPAog==
-  dependencies:
-    "@atomist/slack-messages" "~1.1.0"
-    "@octokit/graphql" "^2.1.2"
-    "@octokit/plugin-enterprise-compatibility" "^1.1.1"
-    "@octokit/plugin-retry" "^2.2.0"
-    "@octokit/plugin-throttling" "^2.6.0"
-    "@octokit/rest" "16.28.1"
-    arr-flatten "^1.1.0"
-    cosmiconfig "5.2.0"
-    dedent "^0.7.0"
-    deepmerge "^3.2.0"
-    dotenv "^8.0.0"
-    enquirer "^2.3.0"
-    env-ci "^3.2.0"
-    gitlog "^3.1.2"
-    import-cwd "^3.0.0"
-    lodash.chunk "^4.2.0"
-    node-fetch "2.5.0"
-    semver "^6.0.0"
-    signale "^1.4.0"
-    tapable "^2.0.0-beta.2"
-    tinycolor2 "^1.4.1"
-    typescript-memoize "^1.0.0-alpha.3"
-    url-join "^4.0.0"
-
 "@auto-it/core@link:packages/core":
-  version "7.9.2"
+  version "7.11.0"
   dependencies:
     "@atomist/slack-messages" "~1.1.0"
     "@octokit/graphql" "^4.0.0"
@@ -66,7 +37,7 @@
     url-join "^4.0.0"
 
 "@auto-it/npm@link:plugins/npm":
-  version "7.9.2"
+  version "7.11.0"
   dependencies:
     "@auto-it/core" "link:packages/core"
     env-ci "^4.1.1"
@@ -81,7 +52,7 @@
     user-home "^2.0.0"
 
 "@auto-it/released@link:plugins/released":
-  version "7.9.2"
+  version "7.11.0"
   dependencies:
     "@auto-it/core" "link:packages/core"
     deepmerge "^4.0.0"
@@ -2152,14 +2123,6 @@
     universal-user-agent "^2.0.1"
     url-template "^2.0.8"
 
-"@octokit/graphql@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-2.1.2.tgz#220bc814fbebd35b3796db4788b353b491dd6575"
-  integrity sha512-Vq+Ypj0rQNpeyvh3dhqyyOItyr4KUW4Zu/tdg00PQdlH/iOX+RJQBcDMRMg1oGwY5g2zVtXuhSMFCgR6QoujxA==
-  dependencies:
-    "@octokit/request" "^4.1.0"
-    universal-user-agent "^2.0.3"
-
 "@octokit/graphql@^4.0.0":
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-4.2.2.tgz#b998a16f7778fbb4204d1a9c4e2cde2525ba183a"
@@ -2200,19 +2163,6 @@
     deprecation "^2.0.0"
     once "^1.4.0"
 
-"@octokit/request@^4.0.1", "@octokit/request@^4.1.0":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-4.1.1.tgz#614262214f48417b4d3b14e047d09a9c8e2f7a09"
-  integrity sha512-LOyL0i3oxRo418EXRSJNk/3Q4I0/NKawTn6H/CQp+wnrG1UFLGu080gSsgnWobhPo5BpUNgSQ5BRk5FOOJhD1Q==
-  dependencies:
-    "@octokit/endpoint" "^5.1.0"
-    "@octokit/request-error" "^1.0.1"
-    deprecation "^2.0.0"
-    is-plain-object "^3.0.0"
-    node-fetch "^2.3.0"
-    once "^1.4.0"
-    universal-user-agent "^2.1.0"
-
 "@octokit/request@^5.0.0", "@octokit/request@^5.2.0":
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.2.1.tgz#d8076b4bd415802c2dbffc82cf9b8b78f49551a3"
@@ -2225,25 +2175,6 @@
     node-fetch "^2.3.0"
     once "^1.4.0"
     universal-user-agent "^4.0.0"
-
-"@octokit/rest@16.28.1":
-  version "16.28.1"
-  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-16.28.1.tgz#a10c3d4fe61e994878d66a4c12b9923b18548236"
-  integrity sha512-9H/5F0f2bSVhk78ypu/A9dkK5GCH/aI8CxRJ0L8JU/XEYNIYozxqD6HVC7shsofrCfR61YORfjTE+GxfZ/wasQ==
-  dependencies:
-    "@octokit/request" "^4.0.1"
-    "@octokit/request-error" "^1.0.2"
-    atob-lite "^2.0.0"
-    before-after-hook "^1.4.0"
-    btoa-lite "^1.0.0"
-    deprecation "^2.0.0"
-    lodash.get "^4.4.2"
-    lodash.set "^4.3.2"
-    lodash.uniq "^4.5.0"
-    octokit-pagination-methods "^1.1.0"
-    once "^1.4.0"
-    universal-user-agent "^2.0.0"
-    url-template "^2.0.8"
 
 "@octokit/rest@16.33.1", "@octokit/rest@^16.28.1", "@octokit/rest@^16.28.4":
   version "16.33.1"
@@ -3477,11 +3408,6 @@ bcrypt-pbkdf@^1.0.0:
   integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
   dependencies:
     tweetnacl "^0.14.3"
-
-before-after-hook@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-1.4.0.tgz#2b6bf23dca4f32e628fd2747c10a37c74a4b484d"
-  integrity sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg==
 
 before-after-hook@^2.0.0:
   version "2.1.0"
@@ -4836,16 +4762,6 @@ cosmiconfig@5.0.7:
     js-yaml "^3.9.0"
     parse-json "^4.0.0"
 
-cosmiconfig@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.0.tgz#45038e4d28a7fe787203aede9c25bca4a08b12c8"
-  integrity sha512-nxt+Nfc3JAqf4WIWd0jXLjTJZmsPLrA9DDc4nRw2KFJQJK7DNooqSXrNI7tzLG50CF8axczly5UV929tBmh/7g==
-  dependencies:
-    import-fresh "^2.0.0"
-    is-directory "^0.3.1"
-    js-yaml "^3.13.0"
-    parse-json "^4.0.0"
-
 cosmiconfig@5.2.1, cosmiconfig@^5.0.0, cosmiconfig@^5.0.2, cosmiconfig@^5.1.0, cosmiconfig@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
@@ -5392,11 +5308,6 @@ deepmerge@^2.0.1:
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
   integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
 
-deepmerge@^3.2.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-3.3.0.tgz#d3c47fd6f3a93d517b14426b0628a17b0125f5f7"
-  integrity sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA==
-
 deepmerge@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.1.1.tgz#ee0866e4019fe62c1276b9062d4c4803d9aea14c"
@@ -5821,14 +5732,6 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
   integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
-
-env-ci@^3.2.0:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/env-ci/-/env-ci-3.2.2.tgz#06936f1fcfbc999102a2211fc2539df64062b61f"
-  integrity sha512-AOiNZ3lmxrtva3r/roqaYDF+1PX2V+ouUzuGqJf7KNxyyYkuU+CsfFbbUeibQPdixxjI/lP6eDtvtkX1/wymJw==
-  dependencies:
-    execa "^1.0.0"
-    java-properties "^1.0.0"
 
 env-ci@^4.1.1:
   version "4.1.3"
@@ -9289,7 +9192,7 @@ js-yaml@3.6.1:
     argparse "^1.0.7"
     esprima "^2.6.0"
 
-js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.9.0:
+js-yaml@^3.13.1, js-yaml@^3.9.0:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
@@ -10793,11 +10696,6 @@ node-fetch-npm@^2.0.2:
     encoding "^0.1.11"
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
-
-node-fetch@2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.5.0.tgz#8028c49fc1191bba56a07adc6e2a954644a48501"
-  integrity sha512-YuZKluhWGJwCcUu4RlZstdAxr8bFfOVHakc1mplwHkk8J+tqM1Y5yraYvIUpeX8aY7+crCwiELJq7Vl0o0LWXw==
 
 node-fetch@2.6.0, node-fetch@^2.3.0, node-fetch@^2.5.0:
   version "2.6.0"
@@ -15017,7 +14915,7 @@ unique-temp-dir@~1.0.0:
     os-tmpdir "^1.0.1"
     uid2 "0.0.3"
 
-universal-user-agent@^2.0.0, universal-user-agent@^2.0.1, universal-user-agent@^2.0.3, universal-user-agent@^2.1.0:
+universal-user-agent@^2.0.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-2.1.0.tgz#5abfbcc036a1ba490cb941f8fd68c46d3669e8e4"
   integrity sha512-8itiX7G05Tu3mGDTdNY2fB4KJ8MgZLS54RdG6PkkfwMAavrXu1mV/lls/GABx9O3Rw4PnTtasxrvbMQoBYY92Q==


### PR DESCRIPTION
# What Changed

Using the `baseBranch` from `auto` as the branch to push to since windows doesn't handle `$branch` 

Fixes #603 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.11.1-canary.613.7997.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
