### PR TITLE
better error messaging when tags aren't present

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,7 +36,6 @@
     "test": "jest --maxWorkers=2 --config ../../package.json"
   },
   "dependencies": {
-    "@atomist/slack-messages": "~1.1.0",
     "@octokit/graphql": "^4.0.0",
     "@octokit/plugin-enterprise-compatibility": "^1.1.1",
     "@octokit/plugin-retry": "^2.2.0",

--- a/plugins/first-time-contributor/__tests__/first-time-contributor.test.ts
+++ b/plugins/first-time-contributor/__tests__/first-time-contributor.test.ts
@@ -94,8 +94,6 @@ describe('First Time Contributor Plugin', () => {
       makeCommitFromMsg('foo', { username: 'jeff-the-snake', name: '' })
     ];
 
-    console.log(commits);
-
     expect(await hooks.addToBody.promise([], commits)).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
# What Changed

detect `fatal: ambiguous argument` and suggest command to run


<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.12.3-canary.626.8159.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
