### PR TITLE
Update released plugin message creation to replace all tokens

### DIFF
--- a/plugins/released/__tests__/released-label.test.ts
+++ b/plugins/released/__tests__/released-label.test.ts
@@ -205,6 +205,37 @@ describe('release label plugin', () => {
     );
   });
 
+  test('should comment and label PRs with custom message', async () => {
+    const releasedLabel = new ReleasedLabelPlugin({
+      message:
+        ':rocket: %TYPE is fixed. %TYPE was released in [%VERSION](https://github.com/intuit/auto/releases/tag/%VERSION) :rocket:'
+    });
+    const autoHooks = makeHooks();
+    releasedLabel.apply(({
+      hooks: autoHooks,
+      labels: defaultLabelDefinition,
+      logger: dummyLog(),
+      options: {},
+      comment,
+      git
+    } as unknown) as Auto);
+
+    const commit = makeCommitFromMsg('normal commit with no bump (#123)');
+    await autoHooks.afterRelease.promise({
+      newVersion: '1.0.0',
+      lastRelease: '0.1.0',
+      commits: await log.normalizeCommits([commit]),
+      releaseNotes: ''
+    });
+
+    expect(comment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message:
+          ':rocket: PR is fixed. PR was released in [1.0.0](https://github.com/intuit/auto/releases/tag/1.0.0) :rocket:'
+      })
+    );
+  });
+
   test('should do nothing with dryRun flag', async () => {
     const releasedLabel = new ReleasedLabelPlugin();
     const autoHooks = makeHooks();

--- a/plugins/released/src/index.ts
+++ b/plugins/released/src/index.ts
@@ -147,7 +147,7 @@ export default class ReleasedLabelPlugin implements IPlugin {
 
   private createReleasedComment(isIssue: boolean, version: string) {
     return this.options.message
-      .replace(TYPE, isIssue ? 'Issue' : 'PR')
-      .replace(VERSION, version);
+      .replace(new RegExp(TYPE, 'g'), isIssue ? 'Issue' : 'PR')
+      .replace(new RegExp(VERSION, 'g'), version);
   }
 }


### PR DESCRIPTION
# What Changed
- Updates `released` plugin's `createdReleasedComment` function to replace all instances of `%VERSION` and replace all instances of `%TYPE` instead of just the first instances

# Why
- In the use case a user wants to comment on pr with release version and link to the github release, the comment would look something like: 

  ```
  [%VERSION](https://github.com/intuit/auto/releases/tag/%VERSION)
  ```
  
  where if `%VERSION` needs to replaced multiple times by `v1.0.0`, then it should resolve to 

  ```
  [v1.0.0](https://github.com/intuit/auto/releases/tag/v1.0.0)
  ```

- Existing code only replaces the first instance giving

  ```
  [v1.0.0](https://github.com/intuit/auto/releases/tag/%VERSION)
  ```

# Todo:
- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.12.4-canary.638.8272.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
