### PR TITLE
Update changelog to include prs without labels when using custom patch label

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/changelog.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/changelog.test.ts.snap
@@ -154,6 +154,16 @@ exports[`generateReleaseNotes should create note for PR commits without labels 1
 - Adam Dierkens (adam@dierkens.com)"
 `;
 
+exports[`generateReleaseNotes should create note for PR commits without labels with custom patch label 1`] = `
+"#### 🐛  Bug Fix
+
+- Some Feature [#1234](https://github.custom.com/foobar/auto/pull/1234) (adam@dierkens.com)
+
+#### Authors: 1
+
+- Adam Dierkens (adam@dierkens.com)"
+`;
+
 exports[`generateReleaseNotes should include PR-less commits as patches 1`] = `
 "#### 🚀  Enhancement
 

--- a/packages/core/src/__tests__/changelog.test.ts
+++ b/packages/core/src/__tests__/changelog.test.ts
@@ -163,6 +163,28 @@ describe('generateReleaseNotes', () => {
     expect(await changelog.generateReleaseNotes(normalized)).toMatchSnapshot();
   });
 
+  test('should create note for PR commits without labels with custom patch label', async () => {
+    const options = testOptions();
+    options.labels = {
+      ...options.labels,
+      patch: [
+        {
+          name: 'Version: Patch',
+          title: '🐛  Bug Fix',
+          description: 'N/A'
+        }
+      ]
+    };
+
+    const changelog = new Changelog(dummyLog(), options);
+    changelog.loadDefaultHooks();
+    const normalized = await logParse.normalizeCommits([
+      makeCommitFromMsg('Some Feature (#1234)')
+    ]);
+
+    expect(await changelog.generateReleaseNotes(normalized)).toMatchSnapshot();
+  });
+
   test('should create note for PR commits with only non config labels', async () => {
     const changelog = new Changelog(dummyLog(), testOptions());
     changelog.loadDefaultHooks();

--- a/packages/core/src/changelog.ts
+++ b/packages/core/src/changelog.ts
@@ -160,6 +160,10 @@ export default class Changelog {
       })
       .map(([, labels]) => labels)
       .reduce((acc, item) => [...acc, ...item], []);
+    const defaultPatchLabelName = this.getFirstLabelNameFromLabelKey(
+      this.options.labels,
+      'patch'
+    );
 
     commits
       .filter(
@@ -169,7 +173,7 @@ export default class Changelog {
           // in this case we auto attached a patch when it was merged
           (labels[0] === 'released' && labels.length === 1)
       )
-      .map(({ labels }) => labels.push('patch'));
+      .map(({ labels }) => labels.push(defaultPatchLabelName));
 
     return Object.assign(
       {},
@@ -183,6 +187,16 @@ export default class Changelog {
           ? {}
           : { [label.name]: matchedCommits };
       })
+    );
+  }
+
+  private getFirstLabelNameFromLabelKey(
+    labels: ILabelDefinitionMap,
+    labelKey: string
+  ) {
+    return (
+      (labels[labelKey] && labels[labelKey][0] && labels[labelKey][0].name) ||
+      labelKey
     );
   }
 


### PR DESCRIPTION
# What Changed
- updated `splitCommit` method to add pr merge commits to patch label name section rather than 'patch' section

# Why
- Fixes #639

# Todo:
- [x] Add tests
