### PR TITLE
fix issue with latest enterprise compat plugin

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@octokit/graphql": "^4.0.0",
-    "@octokit/plugin-enterprise-compatibility": "^1.1.1",
+    "@octokit/plugin-enterprise-compatibility": "1.1.1",
     "@octokit/plugin-retry": "^2.2.0",
     "@octokit/plugin-throttling": "^2.6.0",
     "@octokit/rest": "16.34.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,7 +11,7 @@
   version "7.12.5"
   dependencies:
     "@octokit/graphql" "^4.0.0"
-    "@octokit/plugin-enterprise-compatibility" "^1.1.1"
+    "@octokit/plugin-enterprise-compatibility" "1.1.1"
     "@octokit/plugin-retry" "^2.2.0"
     "@octokit/plugin-throttling" "^2.6.0"
     "@octokit/rest" "16.34.0"
@@ -2134,7 +2134,7 @@
     "@octokit/types" "^1.0.0"
     universal-user-agent "^4.0.0"
 
-"@octokit/plugin-enterprise-compatibility@^1.1.1":
+"@octokit/plugin-enterprise-compatibility@1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@octokit/plugin-enterprise-compatibility/-/plugin-enterprise-compatibility-1.1.1.tgz#1d4189d588eccb1bbc23cd72278129491cfba5d2"
   integrity sha512-/o09y5I1JJMGGTU2y//QXBKjILX0BaDgBK27NRBJPRxD4BsDVzIsRFQm7ejPWW3l2xOao8tvN7Yh73D5cXBBbg==


### PR DESCRIPTION
# What Changed

see title

# Why

It was breaking


<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.12.6-canary.655.8392.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
