### PR TITLE
NPM: manage a changelog for each sub-package in monorepo

### DIFF
--- a/docs/pages/writing-plugins.md
+++ b/docs/pages/writing-plugins.md
@@ -91,18 +91,39 @@ auto.hooks.beforeRun.tapPromise('NPM', async config => {
 });
 ```
 
-#### afterAddToChangelog
+#### beforeCommitChangelog
 
-Ran after the `changelog` command adds the new release notes to `CHANGELOG.md`.
-Useful for getting extra commits into a release before publishing.
+Ran before the `changelog` command commits the new release notes to `CHANGELOG.md`.
+Useful for modifying the changelog as a whole or creating extra `changelog` files. These files can be apart of the commit that updates the changelog.
 
+- bump - the semver bump
 - commits - the commits in the changelog
 - currentVersion - version that was just released
 - lastRelease - the version before the current version
 - releaseNotes - generated release notes for the release
 
 ```ts
-auto.hooks.afterRelease.tap(
+auto.hooks.beforeCommitChangelog.tap(
+  'MyPlugin',
+  async ({ currentVersion, commits, releaseNotes, lastRelease }) => {
+    // do something
+  }
+);
+```
+
+#### afterAddToChangelog
+
+Ran after the `changelog` command adds the new release notes to `CHANGELOG.md`.
+Useful for getting extra commits into a release before publishing.
+
+- bump - the semver bump
+- commits - the commits in the changelog
+- currentVersion - version that was just released
+- lastRelease - the version before the current version
+- releaseNotes - generated release notes for the release
+
+```ts
+auto.hooks.afterAddToChangelog.tap(
   'MyPlugin',
   async ({ currentVersion, commits, releaseNotes, lastRelease }) => {
     // do something

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "husky": "^3.0.3",
     "ignite": "^1.10.5",
     "jest": "~24.9.0",
+    "jest-serializer-path": "^0.1.15",
     "lerna": "^3.13.4",
     "lint-staged": "^9.4.0",
     "prettier": "^1.16.4",
@@ -95,6 +96,9 @@
       "**/__tests__/*.test.+(ts|tsx|js)",
       "!**/dist/**/*",
       "!**/scripts/template-plugin/**/*"
+    ],
+    "snapshotSerializers": [
+      "jest-serializer-path"
     ],
     "coverageDirectory": "./coverage",
     "collectCoverageFrom": [

--- a/packages/core/src/__tests__/__snapshots__/git.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/git.test.ts.snap
@@ -6,7 +6,7 @@ Array [
     "authorEmail": "lisowski54@gmail.com",
     "authorName": "Andrew Lisowski",
     "files": Array [
-      "src/__tests__/git.test.ts",
+      "<PROJECT_ROOT>/src/__tests__/git.test.ts",
     ],
     "hash": "a7f6634429731055a5a44bae24ac88c5f9822e58",
     "subject": "update tests

--- a/packages/core/src/__tests__/auto-make-changelog.test.ts
+++ b/packages/core/src/__tests__/auto-make-changelog.test.ts
@@ -1,0 +1,71 @@
+import Auto from '../auto';
+import { dummyLog } from '../utils/logger';
+
+const importMock = jest.fn();
+jest.mock('import-cwd', () => (path: string) => importMock(path));
+jest.mock('env-ci', () => () => ({ isCi: false, branch: 'master' }));
+jest.mock('../utils/exec-promise', () => () => '');
+
+const defaults = {
+  owner: 'foo',
+  repo: 'bar',
+  token: 'XXXX'
+};
+
+const search = jest.fn();
+jest.mock('cosmiconfig', () => ({
+  cosmiconfig: () => ({
+    search
+  })
+}));
+
+jest.mock('@octokit/rest', () => {
+  const instance = class MockOctokit {
+    static plugin = () => instance;
+
+    authenticate = () => undefined;
+
+    search = {
+      issuesAndPullRequests: () => ({ data: { items: [] } })
+    };
+
+    hook = {
+      error: () => undefined
+    };
+  };
+
+  return instance;
+});
+
+// @ts-ignore
+jest.mock('gitlog', () => (a, cb) => {
+  cb(undefined, [
+    {
+      rawBody: 'foo'
+    },
+    {
+      rawBody: 'foo'
+    }
+  ]);
+});
+
+describe('Auto', () => {
+  test('should add to changelog', async () => {
+    const auto = new Auto({
+      plugins: [],
+      ...defaults
+    });
+
+    auto.logger = dummyLog();
+    auto.hooks.getRepository.tap('test', () => ({ token: '1234' }));
+    await auto.loadConfig();
+
+    const addToChangelog = jest.fn();
+    auto.release!.addToChangelog = addToChangelog;
+    jest.spyOn(auto.release!, 'generateReleaseNotes').mockImplementation();
+    jest.spyOn(auto.release!, 'getCommitsInRelease').mockImplementation();
+
+    await auto.changelog({ from: 'v1.0.0' });
+    expect(addToChangelog).toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -742,24 +742,6 @@ describe('Auto', () => {
       expect(addToChangelog).not.toHaveBeenCalled();
     });
 
-    test('should add to changelog', async () => {
-      const auto = new Auto({
-        plugins: [],
-        ...defaults
-      });
-      auto.logger = dummyLog();
-      auto.hooks.getRepository.tap('test', () => ({ token: '1234' }));
-      await auto.loadConfig();
-
-      const addToChangelog = jest.fn();
-      auto.release!.addToChangelog = addToChangelog;
-      jest.spyOn(auto.release!, 'generateReleaseNotes').mockImplementation();
-      jest.spyOn(auto.release!, 'getCommitsInRelease').mockImplementation();
-
-      await auto.changelog({ from: 'v1.0.0' });
-      expect(addToChangelog).toHaveBeenCalled();
-    });
-
     test('should skip getRepository hook if passed in via cli', async () => {
       process.env.GH_TOKEN = 'XXXX';
       const auto = new Auto({
@@ -1069,6 +1051,8 @@ describe('Auto', () => {
       auto.logger = dummyLog();
       await auto.loadConfig();
 
+      // @ts-ignore
+      auto.makeChangelog = () => Promise.resolve();
       auto.git!.getLatestRelease = () => Promise.resolve('1.2.3');
       jest.spyOn(auto.git!, 'publish').mockImplementation();
       jest.spyOn(auto.release!, 'getCommitsInRelease').mockImplementation();

--- a/packages/core/src/__tests__/release.test.ts
+++ b/packages/core/src/__tests__/release.test.ts
@@ -374,22 +374,6 @@ describe('Release', () => {
       );
       expect(writeSpy.mock.calls[0][1].includes(readResult)).toBe(true);
     });
-
-    test('should be able to configure message', async () => {
-      const gh = new Release(git);
-      const message = 'pony foo';
-
-      existsSync.mockReturnValueOnce(true);
-      readResult = '# My old Notes';
-
-      await gh.addToChangelog(
-        '# My new Notes',
-        'asdklfhlkh24387513',
-        'v0.0.0',
-        message
-      );
-      expect(execSpy.mock.calls[1][1].includes(`"${message}"`)).toBe(true);
-    });
   });
 
   describe('generateReleaseNotes', () => {

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -1,5 +1,6 @@
 import { graphql } from '@octokit/graphql';
 import enterpriseCompat from '@octokit/plugin-enterprise-compatibility';
+import path from 'path';
 import retry from '@octokit/plugin-retry';
 import throttling from '@octokit/plugin-throttling';
 import Octokit from '@octokit/rest';
@@ -256,7 +257,7 @@ export default class Git {
         authorName: commit.authorName,
         authorEmail: commit.authorEmail,
         subject: commit.rawBody!,
-        files: commit.files
+        files: (commit.files || []).map(file => path.resolve(file))
       }));
     } catch (error) {
       const tag = error.match(/ambiguous argument '(\S+)\.\.HEAD'/);

--- a/packages/core/src/utils/make-hooks.ts
+++ b/packages/core/src/utils/make-hooks.ts
@@ -3,7 +3,8 @@ import {
   AsyncSeriesBailHook,
   AsyncSeriesWaterfallHook,
   SyncHook,
-  SyncWaterfallHook
+  SyncWaterfallHook,
+  AsyncSeriesHook
 } from 'tapable';
 import { IAutoHooks } from '../auto';
 import { IChangelogHooks } from '../changelog';
@@ -14,7 +15,8 @@ export const makeHooks = (): IAutoHooks => ({
   beforeRun: new SyncHook(['config']),
   modifyConfig: new SyncWaterfallHook(['config']),
   beforeShipIt: new SyncHook([]),
-  afterAddToChangelog: new AsyncParallelHook(['context']),
+  afterAddToChangelog: new AsyncSeriesHook(['context']),
+  beforeCommitChangelog: new AsyncSeriesHook(['context']),
   afterShipIt: new AsyncParallelHook(['version', 'commits']),
   afterRelease: new AsyncParallelHook(['releaseInfo']),
   onCreateRelease: new SyncHook(['options']),

--- a/plugins/all-contributors/__tests__/all-contributors.test.ts
+++ b/plugins/all-contributors/__tests__/all-contributors.test.ts
@@ -1,4 +1,4 @@
-import Auto from '@auto-it/core';
+import Auto, { SEMVER } from '@auto-it/core';
 import { execSync } from 'child_process';
 import { makeHooks } from '@auto-it/core/dist/utils/make-hooks';
 import makeCommitFromMsg from '@auto-it/core/dist/__tests__/make-commit-from-msg';
@@ -32,6 +32,7 @@ describe('All Contributors Plugin', () => {
     releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto);
 
     await autoHooks.afterAddToChangelog.promise({
+      bump: SEMVER.patch,
       currentVersion: '0.0.0',
       lastRelease: '0.0.0',
       releaseNotes: '',
@@ -54,6 +55,7 @@ describe('All Contributors Plugin', () => {
     releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto);
 
     await autoHooks.afterAddToChangelog.promise({
+      bump: SEMVER.patch,
       currentVersion: '0.0.0',
       lastRelease: '0.0.0',
       releaseNotes: '',
@@ -76,6 +78,7 @@ describe('All Contributors Plugin', () => {
     releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto);
 
     await autoHooks.afterAddToChangelog.promise({
+      bump: SEMVER.patch,
       currentVersion: '0.0.0',
       lastRelease: '0.0.0',
       releaseNotes: '',
@@ -106,6 +109,7 @@ describe('All Contributors Plugin', () => {
     releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto);
 
     await autoHooks.afterAddToChangelog.promise({
+      bump: SEMVER.patch,
       currentVersion: '0.0.0',
       lastRelease: '0.0.0',
       releaseNotes: '',
@@ -132,6 +136,7 @@ describe('All Contributors Plugin', () => {
     releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto);
 
     await autoHooks.afterAddToChangelog.promise({
+      bump: SEMVER.patch,
       currentVersion: '0.0.0',
       lastRelease: '0.0.0',
       releaseNotes: '',

--- a/plugins/npm/README.md
+++ b/plugins/npm/README.md
@@ -62,3 +62,21 @@ By default `auto` will force publish all packages for monorepos. To disable this
   ]
 }
 ```
+
+### subPackageChangelogs
+
+`auto` will create a changelog for each sub-package in a monorepo.
+You can disable this behavior by using the `subPackageChangelogs` option.
+
+```json
+{
+  "plugins": [
+    [
+      "npm",
+      {
+        "subPackageChangelogs": false
+      }
+    ]
+  ]
+}
+```

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -165,10 +165,12 @@ const checkClean = async (auto: Auto) => {
 export default class NPMPlugin implements IPlugin {
   name = 'NPM';
 
+  private renderMonorepoChangelog: boolean;
   private readonly setRcToken: boolean;
   private readonly forcePublish: boolean;
 
   constructor(config: INpmConfig = {}) {
+    this.renderMonorepoChangelog = true;
     this.setRcToken =
       typeof config.setRcToken === 'boolean' ? config.setRcToken : true;
     this.forcePublish =
@@ -293,38 +295,85 @@ export default class NPMPlugin implements IPlugin {
       );
     });
 
-    auto.hooks.onCreateChangelog.tap(this.name, (changelog, version) => {
-      changelog.hooks.renderChangelogLine.tapPromise(
-        'NPM - Monorepo',
-        async ([commit, line]) => {
-          if (!isMonorepo()) {
-            return [commit, line];
+    auto.hooks.onCreateChangelog.tap(
+      this.name,
+      (changelog, version = SEMVER.patch) => {
+        changelog.hooks.renderChangelogLine.tapPromise(
+          'NPM - Monorepo',
+          async ([commit, line]) => {
+            if (!isMonorepo() || !this.renderMonorepoChangelog) {
+              return [commit, line];
+            }
+
+            const lernaPackages = await this.getLernaPackages();
+            const lernaJson = getLernaJson();
+
+            const packages = await changedPackages({
+              sha: commit.hash,
+              packages: lernaPackages,
+              lernaJson,
+              logger: auto.logger,
+              version
+            });
+
+            const section =
+              packages && packages.length
+                ? packages.map(p => `\`${p}\``).join(', ')
+                : 'monorepo';
+
+            if (section === 'monorepo') {
+              return [commit, line];
+            }
+
+            return [commit, [`- ${section}`, `  ${line}`].join('\n')];
           }
+        );
+      }
+    );
 
-          const lernaPackages = await this.getLernaPackages();
-          const lernaJson = getLernaJson();
-
-          const packages = await changedPackages({
-            sha: commit.hash,
-            packages: lernaPackages,
-            lernaJson,
-            logger: auto.logger,
-            version
-          });
-
-          const section =
-            packages && packages.length
-              ? packages.map(p => `\`${p}\``).join(', ')
-              : 'monorepo';
-
-          if (section === 'monorepo') {
-            return [commit, line];
-          }
-
-          return [commit, [`- ${section}`, `  ${line}`].join('\n')];
+    auto.hooks.beforeCommitChangelog.tapPromise(
+      this.name,
+      async ({ commits, bump }) => {
+        if (!isMonorepo() || !auto.release) {
+          return;
         }
-      );
-    });
+
+        const lernaPackages = await this.getLernaPackages();
+        const changelog = await auto.release.makeChangelog(bump);
+
+        this.renderMonorepoChangelog = false;
+
+        const promises = lernaPackages.map(async lernaPackage => {
+          const includedCommits = commits.filter(commit =>
+            commit.files.some(file => {
+              const relative = path.relative(lernaPackage.path, file);
+
+              return (
+                relative &&
+                !relative.startsWith('..') &&
+                !path.isAbsolute(relative)
+              );
+            })
+          );
+          const title = `v${inc(lernaPackage.version, bump as ReleaseType)}`;
+          const releaseNotes = await changelog.generateReleaseNotes(
+            includedCommits
+          );
+
+          await auto.release!.updateChangelogFile(
+            title,
+            releaseNotes,
+            path.join(lernaPackage.path, 'CHANGELOG.md')
+          );
+        });
+
+        // Cannot run git operations in parallel
+        await promises.reduce(
+          async (last, next) => last.then(() => next),
+          Promise.resolve()
+        );
+      }
+    );
 
     auto.hooks.version.tapPromise(this.name, async version => {
       await checkClean(auto);

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -143,6 +143,7 @@ async function bumpLatest(
 const verbose = ['--loglevel', 'silly'];
 
 interface INpmConfig {
+  subPackageChangelogs?: boolean;
   setRcToken?: boolean;
   forcePublish?: boolean;
 }
@@ -166,11 +167,14 @@ export default class NPMPlugin implements IPlugin {
   name = 'NPM';
 
   private renderMonorepoChangelog: boolean;
+
+  private readonly subPackageChangelogs: boolean;
   private readonly setRcToken: boolean;
   private readonly forcePublish: boolean;
 
   constructor(config: INpmConfig = {}) {
     this.renderMonorepoChangelog = true;
+    this.subPackageChangelogs = config.subPackageChangelogs || true;
     this.setRcToken =
       typeof config.setRcToken === 'boolean' ? config.setRcToken : true;
     this.forcePublish =
@@ -334,7 +338,7 @@ export default class NPMPlugin implements IPlugin {
     auto.hooks.beforeCommitChangelog.tapPromise(
       this.name,
       async ({ commits, bump }) => {
-        if (!isMonorepo() || !auto.release) {
+        if (!isMonorepo() || !auto.release || !this.subPackageChangelogs) {
           return;
         }
 

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -360,11 +360,13 @@ export default class NPMPlugin implements IPlugin {
             includedCommits
           );
 
-          await auto.release!.updateChangelogFile(
-            title,
-            releaseNotes,
-            path.join(lernaPackage.path, 'CHANGELOG.md')
-          );
+          if (releaseNotes.trim()) {
+            await auto.release!.updateChangelogFile(
+              title,
+              releaseNotes,
+              path.join(lernaPackage.path, 'CHANGELOG.md')
+            );
+          }
         });
 
         // Cannot run git operations in parallel

--- a/yarn.lock
+++ b/yarn.lock
@@ -9058,6 +9058,15 @@ jest-runtime@^24.9.0:
     strip-bom "^3.0.0"
     yargs "^13.3.0"
 
+jest-serializer-path@^0.1.15:
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/jest-serializer-path/-/jest-serializer-path-0.1.15.tgz#68528c98e3f8be652484f1c3876228f6864bd662"
+  integrity sha512-sXb+Ckz9LK5bB5sRAXFeG/nwhGn1XBKayy9xhPpgOmAWaljJiS+VN/xJ3P4I19jZ+WejowvO/kES+A9HePTMvQ==
+  dependencies:
+    lodash.clonedeep "^4.5.0"
+    lodash.iserror "^3.1.1"
+    slash "^2.0.0"
+
 jest-serializer@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-24.9.0.tgz#e6d7d7ef96d31e8b9079a714754c5d5c58288e73"
@@ -9768,6 +9777,11 @@ lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
+lodash.iserror@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.iserror/-/lodash.iserror-3.1.1.tgz#297b9a05fab6714bc2444d7cc19d1d7c44b5ecec"
+  integrity sha1-KXuaBfq2cUvCRE18wZ0dfES17Ow=
 
 lodash.ismatch@^4.4.0:
   version "4.4.0"


### PR DESCRIPTION
# What Changed

If you are using a npm monorepo setup a sub-package changelog.md will be generated and included in the repo.

# Why

Closes #657 

Todo:

- [x] Add tests
- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.13.0-canary.658.8511.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
