### PR TITLE
Fix creating old changelogs

### DIFF
--- a/plugins/released/__tests__/released-label.test.ts
+++ b/plugins/released/__tests__/released-label.test.ts
@@ -59,30 +59,6 @@ describe('release label plugin', () => {
     });
   });
 
-  test('should omit released PRs', async () => {
-    const releasedLabel = new ReleasedLabelPlugin();
-    const autoHooks = makeHooks();
-    const logParseHooks = makeLogParseHooks();
-
-    releasedLabel.apply(({
-      hooks: autoHooks,
-      labels: defaultLabelDefinition,
-      logger: dummyLog(),
-      options: {},
-      comment,
-      git
-    } as unknown) as Auto);
-    autoHooks.onCreateLogParse.call({ hooks: logParseHooks } as LogParse);
-
-    const included = makeCommitFromMsg('normal commit with no bump');
-    expect(await logParseHooks.omitCommit.promise(included)).toBeUndefined();
-
-    const omitted = makeCommitFromMsg('normal commit with no bump', {
-      labels: ['released']
-    });
-    expect(await logParseHooks.omitCommit.promise(omitted)).toBe(true);
-  });
-
   test('should do nothing without PRs', async () => {
     const releasedLabel = new ReleasedLabelPlugin();
     const autoHooks = makeHooks();

--- a/plugins/released/__tests__/released-label.test.ts
+++ b/plugins/released/__tests__/released-label.test.ts
@@ -59,6 +59,30 @@ describe('release label plugin', () => {
     });
   });
 
+  test('should not omit released PRs', async () => {
+    const releasedLabel = new ReleasedLabelPlugin();
+    const autoHooks = makeHooks();
+    const logParseHooks = makeLogParseHooks();
+
+    releasedLabel.apply(({
+      hooks: autoHooks,
+      labels: defaultLabelDefinition,
+      logger: dummyLog(),
+      options: {},
+      comment,
+      git
+    } as unknown) as Auto);
+    autoHooks.onCreateLogParse.call({ hooks: logParseHooks } as LogParse);
+
+    const included = makeCommitFromMsg('normal commit with no bump');
+    expect(await logParseHooks.omitCommit.promise(included)).not.toBe(true);
+
+    const omitted = makeCommitFromMsg('normal commit with no bump', {
+      labels: ['released']
+    });
+    expect(await logParseHooks.omitCommit.promise(omitted)).not.toBe(true);
+  });
+
   test('should do nothing without PRs', async () => {
     const releasedLabel = new ReleasedLabelPlugin();
     const autoHooks = makeHooks();

--- a/plugins/released/src/index.ts
+++ b/plugins/released/src/index.ts
@@ -38,14 +38,6 @@ export default class ReleasedLabelPlugin implements IPlugin {
       return config;
     });
 
-    auto.hooks.onCreateLogParse.tap(this.name, logParse => {
-      logParse.hooks.omitCommit.tapPromise(this.name, async commit => {
-        if (commit.labels.includes(this.options.label)) {
-          return true;
-        }
-      });
-    });
-
     auto.hooks.afterRelease.tapPromise(
       this.name,
       async ({ newVersion, commits }) => {


### PR DESCRIPTION
# What Changed

fix bug where we couldn't reproduce old changelogs. 

ex: 

```sh
yarn auto changelog --from v0.107.0 -d
```

# Why

for the changelog to generate correctly you need all of the merge commits (they were getting omitted). If you tried to create a changelog after the pr was released it would contain all sub commits.

Todo:

- [x] Add tests


<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.12.7-canary.659.8524.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
