### PR TITLE
Fix multiple first-time-contributor thank you

### DIFF
--- a/plugins/first-time-contributor/__tests__/__snapshots__/first-time-contributor.test.ts.snap
+++ b/plugins/first-time-contributor/__tests__/__snapshots__/first-time-contributor.test.ts.snap
@@ -8,6 +8,14 @@ Thank you, Jeff, for all your work!",
 ]
 `;
 
+exports[`First Time Contributor Plugin should exclude a past contributor by username 1`] = `
+Array [
+  ":tada: This release contains work from a new contributor! :tada:
+
+Thank you, Jeff123, for all your work!",
+]
+`;
+
 exports[`First Time Contributor Plugin should include a username if it exists 1`] = `
 Array [
   ":tada: This release contains work from new contributors! :tada:

--- a/plugins/first-time-contributor/src/index.ts
+++ b/plugins/first-time-contributor/src/index.ts
@@ -37,7 +37,15 @@ export default class FirstTimeContributorPlugin implements IPlugin {
 
           const contributors = await Promise.all([
             getContributors(JUST_NAME),
-            getContributors(JUST_EMAIL)
+            getContributors(JUST_EMAIL),
+            auto
+              .git!.github.repos.listContributors({
+                repo: auto.git!.options.repo,
+                owner: auto.git!.options.owner
+              })
+              .then(response =>
+                response.data.map(collaborator => collaborator.login).join('\n')
+              )
           ]).then(lists => lists.join('\n').split('\n'));
 
           const newContributors = authors.filter(


### PR DESCRIPTION
# What Changed

Use the `listContributors` endpoint to determine who has contributed to the repo.

# Why

Fix a bug where a contributor was thanked multiple times in the changelog.

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.12.7-canary.660.8528.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
