### PR TITLE
Fix wrong author in changelog

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/changelog.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/changelog.test.ts.snap
@@ -253,7 +253,7 @@ exports[`generateReleaseNotes should use only email if author name doesn't exist
 "#### 🐛  Bug Fix
 
 - Another Feature [#1234](https://github.custom.com/foobar/auto/pull/1234) (adam@dierkens.com)
-- One Feature [#1235](https://github.custom.com/foobar/auto/pull/1235) (adam@dierkens.com)
+- One Feature [#1235](https://github.custom.com/foobar/auto/pull/1235)
 
 #### Authors: 1
 

--- a/packages/core/src/__tests__/__snapshots__/changelog.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/changelog.test.ts.snap
@@ -189,6 +189,23 @@ exports[`generateReleaseNotes should include prs with released label 1`] = `
 - Adam Dierkens (adam@dierkens.com)"
 `;
 
+exports[`generateReleaseNotes should match authors correctly 1`] = `
+"#### 🏠  Internal
+
+- something  (andrew@email.com)
+
+#### 📝  Documentation
+
+- docs  (kendall@email.com)
+- another  ([@rdubzz](https://github.custom.com/rdubzz))
+
+#### Authors: 3
+
+- [@rdubzz](https://github.custom.com/rdubzz)
+- kendall@email.com
+- andrew@email.com"
+`;
+
 exports[`generateReleaseNotes should merge sections with same changelog title 1`] = `
 "#### Enhancement
 

--- a/packages/core/src/__tests__/changelog.test.ts
+++ b/packages/core/src/__tests__/changelog.test.ts
@@ -284,6 +284,14 @@ describe('generateReleaseNotes', () => {
 
   test('should order the section major, minor, patch, then the rest', async () => {
     const options = testOptions();
+    options.labels = {
+      documentation: options.labels.documentation,
+      internal: options.labels.internal,
+      patch: options.labels.patch,
+      minor: options.labels.minor,
+      major: options.labels.major
+    };
+
     const changelog = new Changelog(dummyLog(), options);
     changelog.loadDefaultHooks();
 

--- a/packages/core/src/__tests__/changelog.test.ts
+++ b/packages/core/src/__tests__/changelog.test.ts
@@ -284,14 +284,6 @@ describe('generateReleaseNotes', () => {
 
   test('should order the section major, minor, patch, then the rest', async () => {
     const options = testOptions();
-    options.labels = {
-      documentation: options.labels.documentation,
-      internal: options.labels.internal,
-      patch: options.labels.patch,
-      minor: options.labels.minor,
-      major: options.labels.major
-    };
-
     const changelog = new Changelog(dummyLog(), options);
     changelog.loadDefaultHooks();
 
@@ -338,6 +330,50 @@ describe('generateReleaseNotes', () => {
         labels: ['major']
       }
     ]);
+
+    expect(await changelog.generateReleaseNotes(commits)).toMatchSnapshot();
+  });
+
+  test.only('should match authors correctly', async () => {
+    const options = testOptions();
+    const changelog = new Changelog(dummyLog(), options);
+    changelog.loadDefaultHooks();
+
+    const commits = await logParse.normalizeCommits([
+      {
+        hash: '0a',
+        files: [],
+        subject: 'something\n\n',
+        labels: ['internal']
+      },
+      {
+        hash: '0',
+        files: [],
+        subject: 'docs\n\n',
+        labels: ['documentation']
+      },
+      {
+        hash: '0',
+        files: [],
+        subject: 'another\n\n',
+        labels: ['documentation']
+      }
+    ]);
+
+    commits.map((commit, index) => {
+      switch (index) {
+        case 0:
+          commit.authors = [{ email: 'andrew@email.com' }];
+          break;
+        case 1:
+          commit.authors = [{ email: 'kendall@email.com' }];
+          break;
+        case 2:
+          commit.authors = [{ username: 'rdubzz' }];
+          break;
+        default:
+      }
+    });
 
     expect(await changelog.generateReleaseNotes(commits)).toMatchSnapshot();
   });

--- a/packages/core/src/__tests__/changelog.test.ts
+++ b/packages/core/src/__tests__/changelog.test.ts
@@ -334,7 +334,7 @@ describe('generateReleaseNotes', () => {
     expect(await changelog.generateReleaseNotes(commits)).toMatchSnapshot();
   });
 
-  test.only('should match authors correctly', async () => {
+  test('should match authors correctly', async () => {
     const options = testOptions();
     const changelog = new Changelog(dummyLog(), options);
     changelog.loadDefaultHooks();
@@ -360,7 +360,7 @@ describe('generateReleaseNotes', () => {
       }
     ]);
 
-    commits.map((commit, index) => {
+    commits.forEach((commit, index) => {
       switch (index) {
         case 0:
           commit.authors = [{ email: 'andrew@email.com' }];

--- a/packages/core/src/changelog.ts
+++ b/packages/core/src/changelog.ts
@@ -207,8 +207,15 @@ export default class Changelog {
       commit.authors.map(async rawAuthor => {
         const data = (this.authors!.find(
           ([, commitAuthor]) =>
-            commitAuthor.name === rawAuthor.name ||
-            commitAuthor.email === rawAuthor.email
+            (commitAuthor.name &&
+              rawAuthor.name &&
+              commitAuthor.name === rawAuthor.name) ||
+            (commitAuthor.email &&
+              rawAuthor.email &&
+              commitAuthor.email === rawAuthor.email) ||
+            (commitAuthor.username &&
+              rawAuthor.username &&
+              commitAuthor.username === rawAuthor.username)
         ) as [IExtendedCommit, ICommitAuthor]) || [{}, rawAuthor];
 
         const link = await this.hooks.renderChangelogAuthor.promise(
@@ -216,6 +223,7 @@ export default class Changelog {
           commit,
           this.options
         );
+
         if (link) {
           result.add(link);
         }


### PR DESCRIPTION
# What Changed

check for falsy values before matching an author.

# Why

If two users didn't have a attr set (ex: name) the `null` names would match, attributing the commit to the wrong person.

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.12.7-canary.661.8554.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
