### PR TITLE
Fix GitHub Release's release notes for monorepo during shipit

### DIFF
--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -373,6 +373,8 @@ export default class NPMPlugin implements IPlugin {
           }
         });
 
+        this.renderMonorepoChangelog = true;
+
         // Cannot run git operations in parallel
         await promises.reduce(
           async (last, next) => last.then(() => next),


### PR DESCRIPTION


# What Changed

must set renderMonorepoChangelog to true so when shipit runs the release's release notes are monorepo aware

# Why

See https://github.com/intuit/auto/releases/tag/v7.13.0


<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.12.10-canary.663.8581.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
