### PR TITLE
warn when canary not implemented

### DIFF
--- a/docs/pages/autorc.md
+++ b/docs/pages/autorc.md
@@ -2,7 +2,7 @@
 
 All options for the CLI tools can also be configured via the `.autorc`. As CLI options you supply them in snake-case (`--foo-bar`), but as `.autorc` options you supply them in camelCase (`fooBar`),
 
-We use [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) to find your config, so that means you can define this file a variety of ways. Our Cosmiconfig setup is a little custom and will start at the root of your project and start to search up the directory tree for the following:
+We use [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) to find your config. This means you can define this file a variety of ways. Our `cosmiconfig` setup is a little custom and will start at the root of your project and start to search up the directory tree for the following:
 
 - a JSON or YAML, extension-less "rc file"
 - an "rc file" with the extensions `.json`, `.yaml`, or `.yml`

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint-plugin-prettier": "^3.1.1",
     "graphql": "^14.2.1",
     "husky": "^3.0.3",
-    "ignite": "^1.10.5",
+    "ignite": "^1.10.6",
     "jest": "~24.9.0",
     "jest-serializer-path": "^0.1.15",
     "lerna": "^3.13.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7880,10 +7880,10 @@ iferr@^0.1.5:
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
 
-ignite@^1.10.5:
-  version "1.10.5"
-  resolved "https://registry.yarnpkg.com/ignite/-/ignite-1.10.5.tgz#08f63b2ed0153f1784a1f11c716e793595410eab"
-  integrity sha512-g2qsPS6asvtN9hLus1lPWdipcB6cz3ZA3q5QaJgqyVBIf0BhGlClQp/YoVnhHM68z4bsqsXDYl3EtMJ4cd6g3w==
+ignite@^1.10.6:
+  version "1.10.6"
+  resolved "https://registry.yarnpkg.com/ignite/-/ignite-1.10.6.tgz#7437adb122add8eb87ad5371ff31407e7b3a11c4"
+  integrity sha512-kfn+Ayc2YdgsmKBWjPEAyqP50rdo7K51gy2Fs6QMKuCnRHbMPM8VQmf8OLndNMXriH9i3JGjUn2KOuhRUlsIgg==
   dependencies:
     "@babel/cli" "7.2.0"
     "@babel/core" "7.2.0"


### PR DESCRIPTION
# What Changed

See title

# Why

`canary` would make it seem like something happened when nothing actually did.

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.13.3-canary.678.8898.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
