### PR TITLE
add non-npm docs

### DIFF
--- a/docs/generate-command-docs.js
+++ b/docs/generate-command-docs.js
@@ -30,7 +30,10 @@ commands.map(command => {
   }
 });
 
-fs.mkdirSync(path.join(__dirname, './pages/generated'));
+try {
+  fs.mkdirSync(path.join(__dirname, './pages/generated'));
+} catch (error) {}
+
 fs.writeFileSync(
   path.join(__dirname, './pages/generated/init.md'),
   initCommands.join('\n')

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,16 @@
 
 ---
 
+:gear: Configuration
+
+- [.autorc](pages/autorc.md)
+- [Plugins](pages/plugins.md)
+- [Non-npm Usage](pages/non-npm.md)
+- [Writing Plugins](pages/writing-plugins.md)
+- [Troubleshooting](pages/troubleshooting.md)
+
+---
+
 :hammer: Tool APIs :wrench:
 
 - [Setup](pages/generated/init.md)
@@ -25,14 +35,6 @@
   - [auto comment](pages/generated/comment.md)
 
 ---
-
-:gear: Configuration
-
-- [.autorc](pages/autorc.md)
-- [Plugins](pages/plugins.md)
-- [Non-npm Usage](pages/non-npm.md)
-- [Writing Plugins](pages/writing-plugins.md)
-- [Troubleshooting](pages/troubleshooting.md)
 
 Package Manager Plugins
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,7 @@
 
 - [.autorc](pages/autorc.md)
 - [Plugins](pages/plugins.md)
+- [Non-npm Usage](pages/non-npm.md)
 - [Writing Plugins](pages/writing-plugins.md)
 - [Troubleshooting](pages/troubleshooting.md)
 

--- a/docs/pages/getting-started.md
+++ b/docs/pages/getting-started.md
@@ -42,15 +42,41 @@ Now your github project is set up to use `auto`.
 Getting started with `auto` is super easy.
 
 1. `auto init` (optional)
-2. `auto create-labels`
-3. Configure environment variables
+2. Configure environment variables
+3. `auto create-labels`
 4. Set up script
 
 ### 1. Initialize Options
 
 Initialize all options and configure label text. If this is not run then `auto` will use the default configuration. This command will produce and `.autorc`, this contains advanced configuration and might not be needed.
 
-### 2. Labels
+### 2. Environment Variables
+
+You must configure some environment variables for publishing and releasing to work properly.
+
+- `GH_TOKEN` - Used for updating the changelog and publishing the GitHub release
+- `NPM_TOKEN` - Used to publish to npm. (only with NPM plugin)
+
+#### Local `.env`
+
+You can also store these values in a local file at the root of your project named `.env`. You should make sure to add this file to your `.gitignore` so you don't commit any keys! These env vars will override these any variable already set on the process. This enables you to have a per project configuration that isn't effected by your global setup.
+
+**`PROJECT_ROOT/.env`:**
+
+```bash
+GH_TOKEN=YOUR_TOKEN
+NPM_TOKEN=PUBLISH_TOKEN
+```
+
+#### HTTP Proxy
+
+If you are running auto behind a `http` or `https` proxy, add either the `http_proxy` or `https_proxy` environment variable to your environment. To test locally add it to .env file. Remember this file is only local, so you will need to set the variable in your CI as well.
+
+```bash
+https_proxy=<PROXYHOST>:<PROXYPORT>
+```
+
+### 3. Labels
 
 After that, you need to set up the labels on your github project. The types of labels that `auto` uses are:
 
@@ -61,26 +87,8 @@ To create the labels for your project on GitHub, run the following command with 
 
 ```sh
 GH_TOKEN=YOUR_TOKEN auto create-labels
-```
-
-### 3. Environment Variables
-
-You must configure some environment variables for publishing and releasing to work properly.
-
-- `GH_TOKEN` - Used for updating the changelog and publishing the GitHub release
-- `NPM_TOKEN` - Used to publish to npm. (only with NPM plugin)
-
-You can also store these values in a local file at the root of your project named `.env`. You should make sure to add this file to your `.gitignore` so you don't commit any keys! These env vars will override these any variable already set on the process. This enables you to have a per project configuration that isn't effected by your global setup.
-
-```bash
-GH_TOKEN=YOUR_TOKEN
-NPM_TOKEN=PUBLISH_TOKEN
-```
-
-If you are running auto behind a `http` or `https` proxy, add either the `http_proxy` or `https_proxy` environment variable to your environment. To test locally add it to .env file. Remember this file is only local, so you will need to set the variable in your CI as well.
-
-```bash
-https_proxy=<PROXYHOST>:<PROXYPORT>
+# or with .env file
+auto create-labels
 ```
 
 ### 4. Script

--- a/docs/pages/non-npm.md
+++ b/docs/pages/non-npm.md
@@ -1,0 +1,52 @@
+# Non-npm Usage
+
+`auto` by default works with [npm](https://npmjs.com) but you can configure it to work with a variety of package management platforms.
+
+## Installation
+
+If you're on some platform other than [npm](https://npmjs.com) it doesn't make sense to download `auto` through [npm](https://npmjs.com). For these situations we package `auto` for all major operating systems (`linux`, `osx`, `windows`).
+
+Simply download the appropriate executable for you operating system and make it executable.
+
+```sh
+# Download a platform specific version of auto. All official plugins included.
+curl -vkL -o - https://github.com/intuit/auto/releases/download/v7.2.0/auto-linux.gz | gunzip > ~/linux-auto
+# Make auto executable
+chmod a+x ~/linux-auto
+```
+
+## Configuration
+
+Using `auto` with any other package manager than [npm](https://npmjs.com) requires that you create an [`.autorc`](./autorc.md) at the root of your project.
+
+1. `.autorc` - No plugins, `shipit` doesn't work. Enables [advanced setup](https://intuit.github.io/auto/pages/getting-started.html#detailed-setup)
+
+   ```json
+   {
+     "repo": "my-project",
+     "owner": "hipstersmoothie",
+     "name": "Andrew Lisowski",
+     "email": "lisowski54@gmail.com",
+     "plugins": []
+   }
+   ```
+
+2. `.autorc` - `git-tag` plugin compatible with any platform. Enables [`shipit` usage](https://intuit.github.io/auto/pages/generated/shipit.html)
+
+   ```json
+   {
+     "repo": "my-project",
+     "owner": "hipstersmoothie",
+     "name": "Andrew Lisowski",
+     "email": "lisowski54@gmail.com",
+     "plugins": ["git-tag"]
+   }
+   ```
+
+3. `.autorc` - With package manager plugin. [`shipit`](https://intuit.github.io/auto/pages/generated/shipit.html) works, some configuration picked up from package manager package definition files. In the following `repo`, `owner`, `name`, and `email` are picked up from the `pom.xml`
+
+   ```json
+   {
+     "plugins": ["maven"]
+   }
+   ```

--- a/docs/pages/non-npm.md
+++ b/docs/pages/non-npm.md
@@ -1,19 +1,21 @@
 # Non-npm Usage
 
-`auto` by default works with [npm](https://npmjs.com) but you can configure it to work with a variety of package management platforms.
+`auto` by distributed through [npm](https://npmjs.com) but you can use it with a variety of package management platforms.
 
 ## Installation
 
 If you're on some platform other than [npm](https://npmjs.com) it doesn't make sense to download `auto` through [npm](https://npmjs.com). For these situations we package `auto` for all major operating systems (`linux`, `osx`, `windows`).
 
-Simply download the appropriate executable for you operating system and make it executable.
+Simply download the appropriate version for your operating system and make it executable.
 
 ```sh
-# Download a platform specific version of auto. All official plugins included.
-curl -vkL -o - https://github.com/intuit/auto/releases/download/v7.2.0/auto-linux.gz | gunzip > ~/linux-auto
+# Download a platform specific version of auto
+curl -vkL -o - https://github.com/intuit/auto/releases/download/v7.2.0/auto-linux.gz | gunzip > ~/auto
 # Make auto executable
-chmod a+x ~/linux-auto
+chmod a+x ~/auto
 ```
+
+This executable contains all of the official `auto` plugins so you do not have to download anything extra. This version of `auto` uses the [git-tag](../../plugins/git-tag/README.md) plugins as the default instead of [npm](../../plugins/npm/README.md). If you specify any plugins this will be overriden.
 
 ## Configuration
 
@@ -50,3 +52,15 @@ Using `auto` with any other package manager than [npm](https://npmjs.com) requir
      "plugins": ["maven"]
    }
    ```
+
+## Usage
+
+Now that you have `auto` all set up you can use all of it's commands!
+
+```sh
+~/auto shipit
+```
+
+::: message is-info
+ℹ️ Tip: Using `auto` locally with an `.env` file is a great experience. See how [here](./getting-started.md#local-.env).
+:::

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint-plugin-prettier": "^3.1.1",
     "graphql": "^14.2.1",
     "husky": "^3.0.3",
-    "ignite": "^1.10.6",
+    "ignite": "^1.10.7",
     "jest": "~24.9.0",
     "jest-serializer-path": "^0.1.15",
     "lerna": "^3.13.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,7 +8,7 @@
   integrity sha512-m2OzlTDbhvzK4hgswH9Lx0cdpq1AntXu53Klz5RGkFfuoDvKsnlU7tmtVfNWtUiP0zZbGtrb/BZYH7aB6TRnMA==
 
 "@auto-it/core@link:packages/core":
-  version "7.13.2"
+  version "7.15.0"
   dependencies:
     "@octokit/graphql" "^4.0.0"
     "@octokit/plugin-enterprise-compatibility" "1.1.1"
@@ -36,7 +36,7 @@
     url-join "^4.0.0"
 
 "@auto-it/npm@link:plugins/npm":
-  version "7.13.2"
+  version "7.15.0"
   dependencies:
     "@auto-it/core" "link:packages/core"
     env-ci "^4.1.1"
@@ -51,7 +51,7 @@
     user-home "^2.0.0"
 
 "@auto-it/released@link:plugins/released":
-  version "7.13.2"
+  version "7.15.0"
   dependencies:
     "@auto-it/core" "link:packages/core"
     deepmerge "^4.0.0"
@@ -7880,10 +7880,10 @@ iferr@^0.1.5:
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
 
-ignite@^1.10.6:
-  version "1.10.6"
-  resolved "https://registry.yarnpkg.com/ignite/-/ignite-1.10.6.tgz#7437adb122add8eb87ad5371ff31407e7b3a11c4"
-  integrity sha512-kfn+Ayc2YdgsmKBWjPEAyqP50rdo7K51gy2Fs6QMKuCnRHbMPM8VQmf8OLndNMXriH9i3JGjUn2KOuhRUlsIgg==
+ignite@^1.10.7:
+  version "1.10.7"
+  resolved "https://registry.yarnpkg.com/ignite/-/ignite-1.10.7.tgz#5e466980c6b429ff57404addacba2b116e6f6c56"
+  integrity sha512-AI7UEYdbn4BS8sxKPRRFUVX8H+fYW4jF3bT+qC6cMhnBQ6eMRqSeEKZ9W+wCO0DaH3GVua63oiLGGFXF1R/tAQ==
   dependencies:
     "@babel/cli" "7.2.0"
     "@babel/core" "7.2.0"


### PR DESCRIPTION
# What Changed

see title

# Why

It was pretty unclear on how you would accomplish this.

Todo:

- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.13.4-canary.679.8911.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
