### PR TITLE
Fix bug where 'all-contributors' plugin wasn't picking up changes

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -126,6 +126,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "karenclo",
+      "name": "Karen Lo",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/8535239?v=4",
+      "profile": "https://github.com/karenclo",
+      "contributions": [
+        "doc"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds
     <td align="center"><a href="https://github.com/su7edja"><img src="https://avatars0.githubusercontent.com/u/2717065?v=4" width="100px;" alt="su7edja"/><br /><sub><b>su7edja</b></sub></a><br /><a href="https://github.com/intuit/auto/commits?author=su7edja" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/yogikhan"><img src="https://avatars3.githubusercontent.com/u/16071601?v=4" width="100px;" alt="Yogesh Khandlewal"/><br /><sub><b>Yogesh Khandlewal</b></sub></a><br /><a href="https://github.com/intuit/auto/commits?author=yogikhan" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/Celeo"><img src="https://avatars1.githubusercontent.com/u/772507?v=4" width="100px;" alt="Matt Boulanger"/><br /><sub><b>Matt Boulanger</b></sub></a><br /><a href="https://github.com/intuit/auto/commits?author=Celeo" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/karenclo"><img src="https://avatars1.githubusercontent.com/u/8535239?v=4" width="100px;" alt="Karen Lo"/><br /><sub><b>Karen Lo</b></sub></a><br /><a href="https://github.com/intuit/auto/commits?author=karenclo" title="Documentation">📖</a></td>
   </tr>
 </table>
 

--- a/plugins/all-contributors/__tests__/all-contributors.test.ts
+++ b/plugins/all-contributors/__tests__/all-contributors.test.ts
@@ -1,4 +1,4 @@
-import Auto, { SEMVER } from '@auto-it/core';
+import * as Auto from '@auto-it/core';
 import { execSync } from 'child_process';
 import { makeHooks } from '@auto-it/core/dist/utils/make-hooks';
 import makeCommitFromMsg from '@auto-it/core/dist/__tests__/make-commit-from-msg';
@@ -8,10 +8,14 @@ import fs from 'fs';
 import AllContributors from '../src';
 
 const exec = jest.fn();
+const gitShow = jest.fn();
+gitShow.mockReturnValue('');
 exec.mockReturnValue('');
 jest.mock('child_process');
 // @ts-ignore
 execSync.mockImplementation(exec);
+// @ts-ignore
+jest.spyOn(Auto, 'execPromise').mockImplementation(gitShow);
 
 const mockRead = (result: string) =>
   jest
@@ -29,10 +33,10 @@ describe('All Contributors Plugin', () => {
     const autoHooks = makeHooks();
     mockRead('{ "contributors": [] }');
 
-    releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto);
+    releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto.Auto);
 
     await autoHooks.afterAddToChangelog.promise({
-      bump: SEMVER.patch,
+      bump: Auto.SEMVER.patch,
       currentVersion: '0.0.0',
       lastRelease: '0.0.0',
       releaseNotes: '',
@@ -52,10 +56,10 @@ describe('All Contributors Plugin', () => {
     const autoHooks = makeHooks();
     mockRead('{ "contributors": [] }');
 
-    releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto);
+    releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto.Auto);
 
     await autoHooks.afterAddToChangelog.promise({
-      bump: SEMVER.patch,
+      bump: Auto.SEMVER.patch,
       currentVersion: '0.0.0',
       lastRelease: '0.0.0',
       releaseNotes: '',
@@ -75,10 +79,10 @@ describe('All Contributors Plugin', () => {
     const autoHooks = makeHooks();
     mockRead('{ "contributors": [] }');
 
-    releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto);
+    releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto.Auto);
 
     await autoHooks.afterAddToChangelog.promise({
-      bump: SEMVER.patch,
+      bump: Auto.SEMVER.patch,
       currentVersion: '0.0.0',
       lastRelease: '0.0.0',
       releaseNotes: '',
@@ -106,10 +110,10 @@ describe('All Contributors Plugin', () => {
       '{ "contributors": [ { "login": "Jeff", "contributions": ["infra"] } ] }'
     );
 
-    releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto);
+    releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto.Auto);
 
     await autoHooks.afterAddToChangelog.promise({
-      bump: SEMVER.patch,
+      bump: Auto.SEMVER.patch,
       currentVersion: '0.0.0',
       lastRelease: '0.0.0',
       releaseNotes: '',
@@ -133,10 +137,10 @@ describe('All Contributors Plugin', () => {
       '{ "contributors": [ { "login": "Jeff", "contributions": ["code"] } ] }'
     );
 
-    releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto);
+    releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto.Auto);
 
     await autoHooks.afterAddToChangelog.promise({
-      bump: SEMVER.patch,
+      bump: Auto.SEMVER.patch,
       currentVersion: '0.0.0',
       lastRelease: '0.0.0',
       releaseNotes: '',

--- a/plugins/all-contributors/__tests__/all-contributors.test.ts
+++ b/plugins/all-contributors/__tests__/all-contributors.test.ts
@@ -74,6 +74,30 @@ describe('All Contributors Plugin', () => {
     expect(exec.mock.calls[0][0]).toBe('npx all-contributors add Jeff code');
   });
 
+  test('should find contributions from merge commit', async () => {
+    const releasedLabel = new AllContributors();
+    const autoHooks = makeHooks();
+    mockRead('{ "contributors": [] }');
+    gitShow.mockReturnValueOnce('src/index.ts');
+
+    releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto.Auto);
+
+    await autoHooks.afterAddToChangelog.promise({
+      bump: Auto.SEMVER.patch,
+      currentVersion: '0.0.0',
+      lastRelease: '0.0.0',
+      releaseNotes: '',
+      commits: [
+        makeCommitFromMsg('Do the thing', {
+          files: [],
+          username: 'Jeff'
+        })
+      ]
+    });
+
+    expect(exec.mock.calls[0][0]).toBe('npx all-contributors add Jeff code');
+  });
+
   test('should find a multiple contributions', async () => {
     const releasedLabel = new AllContributors();
     const autoHooks = makeHooks();
@@ -130,7 +154,7 @@ describe('All Contributors Plugin', () => {
     );
   });
 
-  test('should not update if no new contribution tpyes', async () => {
+  test('should not update if no new contribution types', async () => {
     const releasedLabel = new AllContributors();
     const autoHooks = makeHooks();
     mockRead(


### PR DESCRIPTION
# What Changed

Get all the files changes for a merge commit. Help find contributions for `all-contributors` plugin to work off.

# Why

Merge commits don't actually contain the files that were changed.

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.13.4-canary.683.8949.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
