### PR TITLE
Default to `git-tag` plugin when run from binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ Auto has an extensive plugin system and wide variety of official plugins. Make a
 
 - [chrome](./plugins/chrome) - Publish code to Chrome Web Store
 - [crates](./plugins/crates) - Publish Rust crates
-- [git-tag](./plugins/git-tag) - Manage your projects version through just a git tag
+- [git-tag](./plugins/git-tag) - Manage your projects version through just a git tag (`default` when used with binary)
 - [maven](./plugins/maven) - Publish code with maven
-- [npm](./plugins/npm) - Publish code to npm (DEFAULT)
+- [npm](./plugins/npm) - Publish code to npm (`default` when installed through `npm`)
 
 **Extra Functionality:**
 

--- a/docs/pages/autorc.md
+++ b/docs/pages/autorc.md
@@ -268,7 +268,7 @@ If you are using enterprise github and your company hosts the graphql at some ot
 
 ### name
 
-Git name to commit and release with. Defaults to package.json. Used in `auto changelog` and `auto release`
+Git name to commit and release with. Used in `auto changelog` and `auto release`
 
 ```json
 {
@@ -278,7 +278,7 @@ Git name to commit and release with. Defaults to package.json. Used in `auto cha
 
 ### email
 
-Git email to commit and release with. Defaults to package.json. Used in `auto changelog` and `auto release`
+Git email to commit and release with. Used in `auto changelog` and `auto release`
 
 ```json
 {

--- a/docs/pages/extras/changelog.md
+++ b/docs/pages/extras/changelog.md
@@ -1,5 +1,5 @@
 ::: message is-warning
-:warning: This should be run before `npm version` so the `CHANGELOG.md` changes are committed before the release gets tagged.
+:warning: This should be run before you version your project so the `CHANGELOG.md` changes are committed before the release gets tagged.
 :::
 
 ## Changelog Titles

--- a/docs/pages/extras/label.md
+++ b/docs/pages/extras/label.md
@@ -14,4 +14,7 @@ fi
 
 ## Without PR Number
 
-Running `auto label` without the PR number enables it to run in master after a PR has been merged. You can use these labels to automate more things in your merge build pipeline other than the release.
+Running `auto label` without the PR number will:
+
+- When run in master will get the labels for the last merged PR
+- When run for a PR in CI will use the PR's number

--- a/docs/pages/plugins.md
+++ b/docs/pages/plugins.md
@@ -6,13 +6,16 @@
 
 To use a plugin you can either supply the plugin via a CLI arg or in your [.autorc](./autorc.md#plugins). Specifying a plugin overrides the defaults.
 
-::: message is-warning
-:warning: By default, `auto` defaults to use the `npm` plugin if you don't configure plugins in your `.autorc` configuration file.
-:::
+### Defaults
 
-### None
+If you don't configure plugins in your `.autorc` configuration file `auto` will use a default package manager plugin.
 
-If you don't want to include the default plugins (ex: you're publishing to a platform other than npm), you can supply an empty array in the `.autorc` configuration file like the following:
+- Installed through `npm` => uses [`npm`](../../plugins/npm/README.md)
+- Installed through executable => uses [`git-tag`](../../plugins/git-tag/README.md)
+
+### No Plugins
+
+If you don't want to include the default plugins, you can supply an empty array in the `.autorc` configuration file like the following:
 
 ```json
 {

--- a/docs/pages/troubleshooting.md
+++ b/docs/pages/troubleshooting.md
@@ -14,7 +14,7 @@ This error will occur when you do not have a `NPM_TOKEN` set.
 
 ### Still getting errors?!
 
-Make sure that npm is trying to publish to the correct registry. Force npm/lerna to use the public registry by adding the following to your package.json:
+Make sure that `npm` is trying to publish to the correct registry. Force `npm`/`lerna` to use the public registry by adding the following to your package.json:
 
 ```json
 {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,33 +1,33 @@
 # auto CLI
 
-`auto` is a tool designed to seamlessly automate the release workflow. It is powered by semantic version labels on pull requests, so does not require you to change your code or make drastic changes to your current workflow. 
+`auto` is a tool designed to seamlessly automate the release workflow. It is powered by semantic version labels on pull requests, so does not require you to change your code or make drastic changes to your current workflow.
 
 While intended to run in a continuous integration (CI) environment, all `auto` commands can run locally as well.
 
 ## Installation
 
-```
-$ npm install auto
+```sh
+npm install auto
 ```
 
 ## Getting Started
 
 Interactive setup for most configurable options
 
-```
-$ auto init
+```sh
+auto init
 ```
 
 Create your project's labels on github. If labels already exist, it will update them.
 
-```
-$ auto create-labels
+```sh
+auto create-labels
 ```
 
 ## Usage
 
-```
-$ auto -h
+```sh
+$ auto --help
 
 Synopsis
 
@@ -48,7 +48,7 @@ Release Commands
               1. call from base branch -> latest version released
               2. call from PR in CI -> canary version released
               3. call locally when not on base branch -> canary version released
-  canary      Make a canary release of the project. Useful on PRs. If ran locally, `canary` will release  
+  canary      Make a canary release of the project. Useful on PRs. If ran locally, `canary` will release
               a canary version for your current git HEAD.
 
               1. In PR: 1.2.3-canary.123.0 + add version to PR body
@@ -59,9 +59,9 @@ Pull Request Interaction Commands
   label      Get the labels for a pull request
   pr-check   Check that a pull request has a SemVer label
   pr         Set the status on a PR commit
-  comment    Comment on a pull request with a markdown message. Each comment has a context, and each                 
+  comment    Comment on a pull request with a markdown message. Each comment has a context, and each
              context only has one comment.
-  pr-body    Update the body of a PR with a message. Appends to PR and will not overwrite user content.              
+  pr-body    Update the body of a PR with a message. Appends to PR and will not overwrite user content.
              Each comment has a context, and each context only has one comment.
 ```
 
@@ -77,5 +77,5 @@ Pull Request Interaction Commands
   --owner string        The owner of the GitHub repo. Defaults to reading from the package definition
                         for the platform
   --github-api string   GitHub API to use
-  --plugins string[]    Plugins to load auto with. (defaults to just npm)
+  --plugins string[]    Plugins to load auto with. (defaults to just `npm` or `git-tag`)
 ```

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1079,9 +1079,11 @@ If a command fails manually run:
    * Apply all of the plugins in the config.
    */
   private loadPlugins(config: IAutoConfig) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const defaultPlugins = [(process as any).pkg ? 'git-tag' : 'npm'];
     const pluginsPaths = [
       require.resolve('./plugins/filter-non-pull-request'),
-      ...(config.plugins || ['npm'])
+      ...(config.plugins || defaultPlugins)
     ];
 
     pluginsPaths

--- a/plugins/git-tag/README.md
+++ b/plugins/git-tag/README.md
@@ -1,6 +1,6 @@
 # Git Tag Plugin
 
-Manage your projects version through just a git tag.
+Manage your projects version through just a git tag. This plugin is loaded by default when `auto` is installed through the binaries released on GitHub.
 
 If you're using this plugin you aren't releasing your code to any platform (npm, maven, etc). Instead you version calculations is done entirely though git tags.
 

--- a/plugins/npm/README.md
+++ b/plugins/npm/README.md
@@ -1,6 +1,6 @@
 # NPM Plugin
 
-Publish to NPM. Works in both a monorepo setting and for a single package. This plugin is loaded by default. If you configure `auto` to use any other plugin this will be lost. So you must add the `npm` plugin to your plugins array if you still want NPM functionality.
+Publish to NPM. Works in both a monorepo setting and for a single package. This plugin is loaded by default when `auto` is installed through `npm`. If you configure `auto` to use any other plugin this will be lost. So you must add the `npm` plugin to your plugins array if you still want NPM functionality.
 
 ## Prerequisites
 


### PR DESCRIPTION
# What Changed

Mostly docs. Relavant code: https://github.com/intuit/auto/pull/684/files#diff-54899627ccbe2e33cc90970d5e6d5191

# Why

Defaulting the the `npm` plugin in the binary made no sense since people using the binary are most likely using a different language/platform. The recommended advice was to use the `git-tag` plugin so it made sense to just use it as the default. This should help with non-`npm` people trying to use `auto`.

Todo:

- [x] Add tests
- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.15.0-canary.684.8966.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
