### PR TITLE
add docs on how to use within a lerna monorepo

### DIFF
--- a/plugins/npm/README.md
+++ b/plugins/npm/README.md
@@ -21,11 +21,17 @@ yarn add -D @auto-it/npm
 ```json
 {
   "plugins": [
-    "npm"
+    "npm",
+    // or with options
+    ["npm", { "forcePublish": false }]
     // other plugins
   ]
 }
 ```
+
+## Monorepo Usage
+
+The `npm` plugin works out of the box with `lerna` in both [`independent`](https://github.com/lerna/lerna#independent-mode) and [`fixed`](https://github.com/lerna/lerna#fixedlocked-mode-default) mode. `auto` works on a repo basis and should be run from the root of the repo, not on each sub-package. No additional setup is required.
 
 ## Options
 


### PR DESCRIPTION
# What Changed

It was unclear on how exactly to use with a `lerna` monorepo.

# Why

closes #654 

Todo:

- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.15.1-canary.685.8979.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
