### PR TITLE
Fixed string interpolation on Lerna version bump

### DIFF
--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -395,7 +395,7 @@ describe('publish', () => {
       '--no-commit-hooks',
       '--yes',
       '-m',
-      "'Bump version to: %v [skip ci]'"
+      '"Bump version to: %v [skip ci]"'
     ]);
   });
 
@@ -423,7 +423,7 @@ describe('publish', () => {
       '--no-commit-hooks',
       '--yes',
       '-m',
-      "'Bump version to: %v [skip ci]'"
+      '"Bump version to: %v [skip ci]"'
     ]);
   });
 
@@ -495,7 +495,7 @@ describe('publish', () => {
       '--no-commit-hooks',
       '--yes',
       '-m',
-      "'Bump version to: %v [skip ci]'"
+      '"Bump version to: %v [skip ci]"'
     ]);
   });
 
@@ -683,7 +683,7 @@ describe('canary', () => {
       '--no-commit-hooks',
       '--yes',
       '-m',
-      "'Bump version to: %v [skip ci]'"
+      '"Bump version to: %v [skip ci]"'
     ]);
   });
 

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -445,7 +445,7 @@ export default class NPMPlugin implements IPlugin {
           '--no-commit-hooks',
           '--yes',
           '-m',
-          "'Bump version to: %v [skip ci]'",
+          '"Bump version to: %v [skip ci]"',
           ...verboseArgs
         ]);
         auto.logger.verbose.info('Successfully versioned repo');


### PR DESCRIPTION
resolves #692


<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.15.2-canary.693.9076.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
