### PR TITLE
match behavior between lerna and npm when pushing git tags

### DIFF
--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -394,6 +394,7 @@ describe('publish', () => {
       '--force-publish',
       '--no-commit-hooks',
       '--yes',
+      '--no-push',
       '-m',
       '"Bump version to: %v [skip ci]"'
     ]);
@@ -422,6 +423,7 @@ describe('publish', () => {
       false,
       '--no-commit-hooks',
       '--yes',
+      '--no-push',
       '-m',
       '"Bump version to: %v [skip ci]"'
     ]);
@@ -494,6 +496,7 @@ describe('publish', () => {
       '--force-publish',
       '--no-commit-hooks',
       '--yes',
+      '--no-push',
       '-m',
       '"Bump version to: %v [skip ci]"'
     ]);
@@ -682,6 +685,7 @@ describe('canary', () => {
       false,
       '--no-commit-hooks',
       '--yes',
+      '--no-push',
       '-m',
       '"Bump version to: %v [skip ci]"'
     ]);

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -444,6 +444,7 @@ export default class NPMPlugin implements IPlugin {
           !isIndependent && this.forcePublish && '--force-publish',
           '--no-commit-hooks',
           '--yes',
+          '--no-push',
           '-m',
           '"Bump version to: %v [skip ci]"',
           ...verboseArgs
@@ -566,20 +567,18 @@ export default class NPMPlugin implements IPlugin {
           'from-git',
           ...verboseArgs
         ]);
+      } else {
+        const { private: isPrivate, name } = await loadPackageJson();
+        const isScopedPackage = name.match(/@\S+\/\S+/);
 
-        auto.logger.verbose.info('Successfully published repo');
-        return;
+        await execPromise(
+          'npm',
+          !isPrivate && isScopedPackage
+            ? ['publish', '--access', 'public', ...verboseArgs]
+            : ['publish', ...verboseArgs]
+        );
       }
 
-      const { private: isPrivate, name } = await loadPackageJson();
-      const isScopedPackage = name.match(/@\S+\/\S+/);
-
-      await execPromise(
-        'npm',
-        !isPrivate && isScopedPackage
-          ? ['publish', '--access', 'public', ...verboseArgs]
-          : ['publish', ...verboseArgs]
-      );
       await execPromise('git', [
         'push',
         '--follow-tags',

--- a/scripts/update-tap.js
+++ b/scripts/update-tap.js
@@ -47,11 +47,11 @@ module.exports = class {
         const output = './Formula/auto.rb';
 
         fs.writeFileSync(output, newFormula);
-        auto.logger.debug.info(`Wrote new formula to: ${output}`);
+        auto.logger.verbose.info(`Wrote new formula to: ${output}`);
 
         execSync(`git add ${output}`);
         execSync('git commit -m "Bump brew formula [skip ci]", --no-verify');
-        auto.logger.debug.info('Committed new formula');
+        auto.logger.verbose.info('Committed new formula');
       } catch (error) {
         auto.logger.log.error(error);
       }

--- a/scripts/update-tap.js
+++ b/scripts/update-tap.js
@@ -22,32 +22,39 @@ const createFormula = (version, sha) => dedent`
   end
 `;
 
-const updateFormula = () => {
-  const pathToExecutable = path.join(
-    __dirname,
-    '../packages/cli/binary/auto-macos.gz'
-  );
-  const sha = execSync(`shasum --algorithm 256 ${pathToExecutable}`, {
-    encoding: 'utf8'
-  }).split(' ')[0];
-  const version = JSON.parse(
-    fs.readFileSync(path.join(__dirname, '../lerna.json'))
-  ).version;
-
-  const newFormula = createFormula(version, sha);
-
-  fs.writeFileSync('./Formula/auto.rb', newFormula);
-
-  execSync('git add ./Formula/auto.rb');
-  execSync('git commit -m "Bump brew formula [skip ci]", --no-verify');
-};
-
 module.exports = class {
   constructor() {
     this.name = 'brew';
   }
 
   apply(auto) {
-    auto.hooks.afterVersion.tap('Update brew', updateFormula);
+    auto.hooks.afterVersion.tap('Update brew', () => {
+      try {
+        const pathToExecutable = path.join(
+          __dirname,
+          '../packages/cli/binary/auto-macos.gz'
+        );
+        const sha = execSync(`shasum --algorithm 256 ${pathToExecutable}`, {
+          encoding: 'utf8'
+        }).split(' ')[0];
+        const version = JSON.parse(
+          fs.readFileSync(path.join(__dirname, '../lerna.json'))
+        ).version;
+
+        auto.logger.log.info(`Updating brew formula: v${version}#${sha}`);
+
+        const newFormula = createFormula(version, sha);
+        const output = './Formula/auto.rb';
+
+        fs.writeFileSync(output, newFormula);
+        auto.logger.debug.info(`Wrote new formula to: ${output}`);
+
+        execSync(`git add ${output}`);
+        execSync('git commit -m "Bump brew formula [skip ci]", --no-verify');
+        auto.logger.debug.info('Committed new formula');
+      } catch (error) {
+        auto.logger.log.error(error);
+      }
+    });
   }
 };


### PR DESCRIPTION
# What Changed

monorepos would push to origin during `version` and non-monorepos would do this at the end of `publish`. now both push tags during `publish`.

# Why

It makes it easier to write plugins if things are done in a normal fashion.

Say for instance you want to add files to a release after the `version` step runs so you know the new version. before it would push before you had a chance to commit anything, now you have time
<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.16.1-canary.697.9123.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
