### PR TITLE
More flexible monorepo publishing

### DIFF
--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -442,7 +442,7 @@ describe('publish', () => {
       'lerna',
       'publish',
       '--yes',
-      'from-git'
+      'from-package'
     ]);
   });
 

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -564,7 +564,10 @@ export default class NPMPlugin implements IPlugin {
           'lerna',
           'publish',
           '--yes',
-          'from-git',
+          // Plugins can add as many commits as they want, lerna will still
+          // publish the changed package versions. from-git broke when HEAD
+          // didn't contain the tags
+          'from-package',
           ...verboseArgs
         ]);
       } else {

--- a/scripts/update-tap.js
+++ b/scripts/update-tap.js
@@ -50,7 +50,7 @@ module.exports = class {
         auto.logger.verbose.info(`Wrote new formula to: ${output}`);
 
         execSync(`git add ${output}`);
-        execSync('git commit -m "Bump brew formula [skip ci]", --no-verify');
+        execSync('git commit -m "Bump brew formula [skip ci]" --no-verify');
         auto.logger.verbose.info('Committed new formula');
       } catch (error) {
         auto.logger.log.error(error);


### PR DESCRIPTION
# What Changed

Plugins can add as many commits as they want, `lerna` will still publish the changed package versions. 

# Why

`from-git` broke when HEAD didn't contain the tags.

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.16.2-canary.698.9144.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
