### PR TITLE
Add ability for "next" branch publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
       - run: mkdir ~/.ssh/ && echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
       - run:
           name: Release
-          command: yarn run release
+          command: npx auto shipit
 
   publishDocs:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ defaults: &defaults
   docker:
     - image: circleci/node:8.14-browsers
   environment:
-    TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+    TZ: '/usr/share/zoneinfo/America/Los_Angeles'
 
 aliases:
   # Circle related commands
@@ -89,7 +89,7 @@ jobs:
       - run: mkdir ~/.ssh/ && echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
       - run:
           name: Release
-          command: npx auto shipit
+          command: yarn auto shipit
 
   publishDocs:
     <<: *defaults

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "precommit": "lint-staged",
     "test": "jest --runInBand",
     "test:coverage": "npm run test -- --coverage",
-    "release": "chmod +x ./packages/cli/dist/bin/auto.js && ./packages/cli/dist/bin/auto.js shipit",
+    "auto": "chmod +x ./packages/cli/dist/bin/auto.js && ./packages/cli/dist/bin/auto.js",
     "contributors:add": "all-contributors",
     "contributors:generate": "all-contributors generate",
     "docs": "yarn docs:build && ignite",

--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -439,8 +439,10 @@ export const commands: Command[] = [
       Run the full \`auto\` release pipeline. Detects if in a lerna project.
 
       1. call from base branch -> latest version released
-      2. call from PR in CI -> canary version released
-      3. call locally when not on base branch -> canary version released
+      2. call from next branch -> next version released
+      3. call from PR in CI -> canary version released
+      4. call locally when on next branch -> next version released
+      5. call locally when not on base/next branch -> canary version released
     `,
     examples: ['{green $} auto shipit'],
     options: [baseBranch, dryRun]

--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -480,6 +480,18 @@ export const commands: Command[] = [
           "Message to comment on PR with. Defaults to 'Published PR with canary version: %v'. Pass false to disable the comment"
       }
     ]
+  },
+  {
+    name: 'next',
+    group: 'Release Commands',
+    description: dedent`
+      Make a release for your "next" release line.
+
+      1. Creates a prerelease on package management platform
+      2. Creates a prerelease on GitHub releases page.
+    `,
+    examples: ['{green $} auto next'],
+    options: [dryRun]
   }
 ];
 

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -68,6 +68,10 @@ export async function run(command: string, args: ApiOptions) {
       await auto.loadConfig();
       await auto.canary(args as ICanaryOptions);
       break;
+    case 'next':
+      await auto.loadConfig();
+      await auto.next();
+      break;
     default:
       throw new Error(`idk what i'm doing.`);
   }

--- a/packages/core/src/auto-args.ts
+++ b/packages/core/src/auto-args.ts
@@ -132,6 +132,11 @@ export interface ICanaryOptions {
   message?: string | 'false';
 }
 
+export interface INextOptions {
+  /** Do not actually do anything */
+  dryRun?: boolean;
+}
+
 export type GlobalOptions = {
   /** The GitHub api to communicate with through octokit */
   githubApi?: string;

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -706,12 +706,12 @@ export default class Auto {
 
     if (!this.hooks.next.isUsed()) {
       this.logger.log.error(dedent`
-          None of the plugins that you are using implement the \`next\` command!
+        None of the plugins that you are using implement the \`next\` command!
 
-          "next" releases are pre-releases such as betas or alphas. They make sense on some platforms (ex: npm) but not all!
+        "next" releases are pre-releases such as betas or alphas. They make sense on some platforms (ex: npm) but not all!
 
-          If you think your package manager has the ability to support canaries please file an issue or submit a pull request,
-        `);
+        If you think your package manager has the ability to support "next" releases please file an issue or submit a pull request,
+      `);
       process.exit(1);
     }
 
@@ -772,10 +772,11 @@ export default class Auto {
     const isBaseBranch =
       !isPR && 'branch' in env && env.branch === this.baseBranch;
     const isNextBranch = 'branch' in env && env.branch === 'next';
-    const publishInfo =
-      (isBaseBranch && (await this.publishLatest(options))) ||
-      (isNextBranch && (await this.next())) ||
-      (await this.canary(options));
+    const publishInfo = isBaseBranch
+      ? await this.publishLatest(options)
+      : isNextBranch
+      ? await this.next()
+      : await this.canary(options);
 
     if (!publishInfo) {
       return;

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -771,9 +771,11 @@ export default class Auto {
     const isPR = 'isPr' in env && env.isPr;
     const isBaseBranch =
       !isPR && 'branch' in env && env.branch === this.baseBranch;
-    const publishInfo = isBaseBranch
-      ? await this.publishLatest(options)
-      : await this.canary(options);
+    const isNextBranch = 'branch' in env && env.branch === 'next';
+    const publishInfo =
+      (isBaseBranch && (await this.publishLatest(options))) ||
+      (isNextBranch && (await this.next())) ||
+      (await this.canary(options));
 
     if (!publishInfo) {
       return;

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -9,7 +9,8 @@ import {
   AsyncSeriesBailHook,
   SyncHook,
   SyncWaterfallHook,
-  AsyncSeriesHook
+  AsyncSeriesHook,
+  AsyncSeriesWaterfallHook
 } from 'tapable';
 import dedent from 'dedent';
 
@@ -126,6 +127,12 @@ export interface IAutoHooks {
         error: string;
       }
   >;
+  /**
+   * Used to publish a next release. In this hook you get the semver bump
+   * and an array of next versions that been released. If you make another
+   * next release be sure to add it the the array.
+   */
+  next: AsyncSeriesWaterfallHook<[string[], SEMVER]>;
   /** Ran after the package has been published. */
   afterPublish: AsyncParallelHook<[]>;
 }
@@ -689,6 +696,61 @@ export default class Auto {
   }
 
   /**
+   * Create a next (or test) version of the project. If on master will
+   * release to the default "next" branch.
+   */
+  async next() {
+    if (!this.git || !this.release) {
+      throw this.createErrorMessage();
+    }
+
+    if (!this.hooks.next.isUsed()) {
+      this.logger.log.error(dedent`
+          None of the plugins that you are using implement the \`next\` command!
+
+          "next" releases are pre-releases such as betas or alphas. They make sense on some platforms (ex: npm) but not all!
+
+          If you think your package manager has the ability to support canaries please file an issue or submit a pull request,
+        `);
+      process.exit(1);
+    }
+
+    const lastTag = await this.git.getLatestTagInBranch();
+    const commits = await this.release.getCommitsInRelease(lastTag);
+    const releaseNotes = await this.release.generateReleaseNotes(lastTag);
+    const labels = commits.map(commit => commit.labels);
+    const bump =
+      calculateSemVerBump(labels, this.semVerLabels!, this.config) ||
+      SEMVER.patch;
+
+    this.logger.verbose.info(`Calling "next" hook with: ${bump}`);
+    const result = await this.hooks.next.promise([], bump);
+    const newVersion = result.join(', ');
+
+    await Promise.all(
+      result.map(async prerelease => {
+        const release = await this.git?.publish(releaseNotes, prerelease, true);
+
+        this.logger.verbose.info(release);
+
+        await this.hooks.afterRelease.promise({
+          lastRelease: lastTag,
+          newVersion: prerelease,
+          commits,
+          releaseNotes,
+          response: release
+        });
+      })
+    );
+
+    this.logger.log.success(
+      `Published next version${result.length > 1 ? `s` : ''}: ${newVersion}`
+    );
+
+    return { newVersion, commitsInRelease: commits };
+  }
+
+  /**
    * Run the full workflow.
    *
    * 1. Calculate version
@@ -994,7 +1056,7 @@ export default class Auto {
   }
 
   /** Prefix a version with a "v" if needed */
-  private readonly prefixRelease = (release: string) => {
+  readonly prefixRelease = (release: string) => {
     if (!this.release) {
       throw this.createErrorMessage();
     }

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -670,14 +670,15 @@ export default class Git {
   }
 
   /** Create a release for the GitHub projecct */
-  async publish(releaseNotes: string, tag: string) {
+  async publish(releaseNotes: string, tag: string, prerelease = false) {
     this.logger.verbose.info('Creating release on GitHub for tag:', tag);
 
     const result = await this.github.repos.createRelease({
       owner: this.options.owner,
       repo: this.options.repo,
       tag_name: tag,
-      body: releaseNotes
+      body: releaseNotes,
+      prerelease
     });
 
     this.logger.veryVerbose.info('Got response from createRelease\n', result);

--- a/packages/core/src/utils/make-hooks.ts
+++ b/packages/core/src/utils/make-hooks.ts
@@ -30,7 +30,8 @@ export const makeHooks = (): IAutoHooks => ({
   afterVersion: new AsyncParallelHook([]),
   publish: new AsyncParallelHook(['version']),
   afterPublish: new AsyncParallelHook([]),
-  canary: new AsyncSeriesBailHook(['canaryVersion', 'postFix'])
+  canary: new AsyncSeriesBailHook(['canaryVersion', 'postFix']),
+  next: new AsyncSeriesWaterfallHook(['preReleaseVersions', 'bump'])
 });
 
 /** Make the hooks for "Release" */

--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -396,7 +396,7 @@ describe('publish', () => {
       '--yes',
       '--no-push',
       '-m',
-      '"Bump version to: %v [skip ci]"'
+      '"Bump version to: %s [skip ci]"'
     ]);
   });
 
@@ -425,7 +425,7 @@ describe('publish', () => {
       '--yes',
       '--no-push',
       '-m',
-      '"Bump version to: %v [skip ci]"'
+      '"Bump version to: %s [skip ci]"'
     ]);
   });
 
@@ -498,7 +498,7 @@ describe('publish', () => {
       '--yes',
       '--no-push',
       '-m',
-      '"Bump version to: %v [skip ci]"'
+      '"Bump version to: %s [skip ci]"'
     ]);
   });
 
@@ -687,7 +687,7 @@ describe('canary', () => {
       '--yes',
       '--no-push',
       '-m',
-      '"Bump version to: %v [skip ci]"'
+      '"Bump version to: %s [skip ci]"'
     ]);
   });
 


### PR DESCRIPTION
# What Changed

New command/hook `auto next` to publish a next version. only npm has it implemented.

# Why

closes #346 

Todo:

- [ ] Add tests
- [ ] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.17.0-canary.726.9550.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
