### PR TITLE
don't run released plugin on "next" branch PRs

### DIFF
--- a/plugins/released/src/index.ts
+++ b/plugins/released/src/index.ts
@@ -52,7 +52,11 @@ export default class ReleasedLabelPlugin implements IPlugin {
 
     auto.hooks.afterRelease.tapPromise(
       this.name,
-      async ({ newVersion, commits }) => {
+      async ({ newVersion, commits, response }) => {
+        if (response?.data.prerelease) {
+          return;
+        }
+
         if (!newVersion) {
           return;
         }


### PR DESCRIPTION


<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.17.1-canary.728.9567.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
