### PR TITLE
remove old use of prerelease label + add prerelease label to released plugin

### DIFF
--- a/docs/pages/extras/version.md
+++ b/docs/pages/extras/version.md
@@ -1,9 +1,5 @@
 Useful in conjunction with `npm version` to auto-version releases.
 
-## Prerelease
-
-To create a prerelease add the `prerelease` label to your pull request.
-
 ## Skip Release
 
 To not create a release for a pull request add the `skip-release` label. Any pull request with this tag will make `auto version` return `''`.

--- a/packages/core/src/__tests__/__snapshots__/auto.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/auto.test.ts.snap
@@ -40,13 +40,6 @@ exports[`Auto createLabels should create the labels 1`] = `
             "title": "🐛  Bug Fix",
           },
         ],
-        "prerelease": Array [
-          Object {
-            "description": "Create a pre-release version when merged",
-            "name": "prerelease",
-            "title": "🚧 Prerelease",
-          },
-        ],
         "release": Array [
           Object {
             "description": "Create a release when this pr is merged",
@@ -112,13 +105,6 @@ Object {
         "title": "🐛  Bug Fix",
       },
     ],
-    "prerelease": Array [
-      Object {
-        "description": "Create a pre-release version when merged",
-        "name": "prerelease",
-        "title": "🚧 Prerelease",
-      },
-    ],
     "release": Array [
       Object {
         "description": "Create a release when this pr is merged",
@@ -181,13 +167,6 @@ Object {
         "description": "Increment the patch version when merged",
         "name": "patch",
         "title": "🐛  Bug Fix",
-      },
-    ],
-    "prerelease": Array [
-      Object {
-        "description": "Create a pre-release version when merged",
-        "name": "prerelease",
-        "title": "🚧 Prerelease",
       },
     ],
     "release": Array [

--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -162,7 +162,6 @@ describe('Auto', () => {
       ['Version: Patch'],
       ['skip-release'],
       ['release'],
-      ['prerelease']
     ]);
   });
 

--- a/packages/core/src/__tests__/release.test.ts
+++ b/packages/core/src/__tests__/release.test.ts
@@ -119,8 +119,7 @@ describe('getVersionMap', () => {
         ['minor', ['minor']],
         ['patch', ['patch']],
         ['skip-release', ['skip-release']],
-        ['release', ['release']],
-        ['prerelease', ['prerelease']]
+        ['release', ['release']]
       ])
     );
   });

--- a/packages/core/src/__tests__/semver.test.ts
+++ b/packages/core/src/__tests__/semver.test.ts
@@ -10,18 +10,6 @@ test('ranks releases right', () => {
 });
 
 describe('calculateSemVerBump', () => {
-  test('publishes pre-releases', () => {
-    expect(calculateSemVerBump([['minor', 'prerelease']], semverMap)).toBe(
-      SEMVER.preminor
-    );
-    expect(calculateSemVerBump([['patch', 'prerelease']], semverMap)).toBe(
-      SEMVER.prepatch
-    );
-    expect(calculateSemVerBump([['major', 'prerelease']], semverMap)).toBe(
-      SEMVER.premajor
-    );
-  });
-
   test('should be able to use multiple labels for skip-release', () => {
     expect(
       calculateSemVerBump([['skip-release', 'major']], semverMap, {

--- a/packages/core/src/auto-rc.json
+++ b/packages/core/src/auto-rc.json
@@ -25,10 +25,6 @@
         "release": {
           "type": "string",
           "description": "Only used when in 'onlyPublishWithReleaseLabel' to publish pull requests."
-        },
-        "prerelease": {
-          "type": "string",
-          "description": "Label used to mark a pull request as a prerelease"
         }
       }
     },

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -466,6 +466,23 @@ export default class Git {
     return result;
   }
 
+  /** Add a label to and issue or pull request */
+  async removeLabel(pr: number, label: string) {
+    this.logger.verbose.info(`Removing "${label}" from #${pr}`);
+
+    const result = await this.github.issues.removeLabel({
+      issue_number: pr,
+      owner: this.options.owner,
+      repo: this.options.repo,
+      name: label
+    });
+
+    this.logger.veryVerbose.info('Got response from removeLabel\n', result);
+    this.logger.verbose.info('Removed label on Pull Request.');
+
+    return result;
+  }
+
   /** Lock an issue */
   async lockIssue(issue: number) {
     this.logger.verbose.info(`Locking #${issue} issue...`);

--- a/packages/core/src/release.ts
+++ b/packages/core/src/release.ts
@@ -27,16 +27,14 @@ export type VersionLabel =
   | SEMVER.minor
   | SEMVER.patch
   | 'skip-release'
-  | 'release'
-  | 'prerelease';
+  | 'release';
 
 export const defaultLabels: VersionLabel[] = [
   SEMVER.major,
   SEMVER.minor,
   SEMVER.patch,
   'skip-release',
-  'release',
-  'prerelease'
+  'release'
 ];
 
 /** Determine if a label is a label used for versioning */
@@ -136,13 +134,6 @@ export const defaultLabelDefinition: ILabelDefinitionMap = {
     {
       name: 'release',
       description: 'Create a release when this pr is merged'
-    }
-  ],
-  prerelease: [
-    {
-      name: 'prerelease',
-      title: '🚧 Prerelease',
-      description: 'Create a pre-release version when merged'
     }
   ],
   internal: [

--- a/packages/core/src/semver.ts
+++ b/packages/core/src/semver.ts
@@ -63,12 +63,10 @@ export function calculateSemVerBump(
   });
 
   let skipRelease = false;
-  let isPrerelease = false;
 
   if (labels.length > 0 && labels[0].length > 0) {
-    const prereleaseLabels = labelMap.get('prerelease') || [];
     const releaseLabels = labelMap.get('release') || [];
-    isPrerelease = labels[0].some(label => prereleaseLabels.includes(label));
+
     skipRelease = onlyPublishWithReleaseLabel
       ? !labels[0].some(label => releaseLabels.includes(label))
       : labels[0].some(label => skipReleaseLabels.includes(label));
@@ -78,18 +76,6 @@ export function calculateSemVerBump(
 
   if (skipRelease) {
     return SEMVER.noVersion;
-  }
-
-  if (isPrerelease) {
-    if (version === SEMVER.major) {
-      return SEMVER.premajor;
-    }
-
-    if (version === SEMVER.minor) {
-      return SEMVER.preminor;
-    }
-
-    return SEMVER.prepatch;
   }
 
   return version;

--- a/plugins/released/README.md
+++ b/plugins/released/README.md
@@ -50,6 +50,23 @@ Customize the label this plugin attaches to merged pull requests.
 }
 ```
 
+### Prerelease Label
+
+Customize the prerelease label this plugin attaches to pull requests merged to prerelease branches.
+
+```json
+{
+  "plugins": [
+    [
+      "released",
+      {
+        "prereleaseLabel": "🚧"
+      }
+    ]
+  ]
+}
+```
+
 ### Message
 
 To customize the message this plugin uses on issues and pull requests use the following format.

--- a/plugins/released/__tests__/released-label.test.ts
+++ b/plugins/released/__tests__/released-label.test.ts
@@ -55,6 +55,10 @@ describe('release label plugin', () => {
           {
             description: 'This issue/pull request has been released.',
             name: 'released'
+          },
+          {
+            description: 'This change is available in a prerelease.',
+            name: 'prerelease'
           }
         ]
       }

--- a/plugins/released/src/index.ts
+++ b/plugins/released/src/index.ts
@@ -184,6 +184,10 @@ export default class ReleasedLabelPlugin implements IPlugin {
       }
     } else if (!labels.includes(this.options.label)) {
       await auto.git!.addLabelToPr(prOrIssue, this.options.label);
+
+      if (labels.includes(this.options.prereleaseLabel)) {
+        await auto.git!.removeLabel(prOrIssue, this.options.prereleaseLabel);
+      }
     }
   }
 

--- a/plugins/released/src/index.ts
+++ b/plugins/released/src/index.ts
@@ -109,7 +109,8 @@ export default class ReleasedLabelPlugin implements IPlugin {
       await this.addCommentAndLabel({
         auto,
         newVersion,
-        prOrIssue: commit.pullRequest.number
+        prOrIssue: commit.pullRequest.number,
+        isPrerelease
       });
 
       const pr = await auto.git!.getPullRequest(commit.pullRequest.number);


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `8.0.0-canary.729.9588.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
