### PR TITLE
shipit: add flag to only publish to 'latest' tag when "release" label is present

### DIFF
--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -445,7 +445,18 @@ export const commands: Command[] = [
       5. call locally when not on base/prerelease branch -> canary version released
     `,
     examples: ['{green $} auto shipit'],
-    options: [baseBranch, dryRun]
+    options: [
+      baseBranch,
+      dryRun,
+      {
+        name: 'only-graduate-with-release-label',
+        type: Boolean,
+        defaultValue: false,
+        group: 'main',
+        description:
+          'Make auto publish prerelease versions when merging to master. Only PRs merged with "release" label will generate a "latest" release. Only use this flag if you do not want to maintain a prerelease branch, and instead only want to use master.'
+      }
+    ]
   },
   {
     name: 'canary',

--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -1073,6 +1073,7 @@ describe('Auto', () => {
       auto.logger = dummyLog();
       await auto.loadConfig();
 
+      auto.release!.getCommitsInRelease = () => Promise.resolve([]);
       auto.git!.getLatestRelease = () => Promise.resolve('');
       auto.release!.getSemverBump = () => Promise.resolve(SEMVER.noVersion);
       const afterShipIt = jest.fn();

--- a/packages/core/src/auto-args.ts
+++ b/packages/core/src/auto-args.ts
@@ -119,6 +119,13 @@ export type IPRBodyOptions = ICommentOptions;
 export interface IShipItOptions {
   /** Do not actually do anything */
   dryRun?: boolean;
+  /**
+   * Make auto publish prerelease versions when merging to master.
+   * Only PRs merged with "release" label will generate a "latest" release.
+   * Only use this flag if you do not want to maintain a prerelease branch,
+   * and instead only want to use master.
+   */
+  onlyGraduateWithReleaseLabel?: boolean;
 }
 
 export interface ICanaryOptions {

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -257,6 +257,8 @@ export default class NPMPlugin implements IPlugin {
       auto.logger.logLevel === 'veryVerbose';
     const verboseArgs = isVerbose ? verbose : [];
     const prereleaseBranches = auto.config?.prereleaseBranches!;
+    // if ran from master we publish the prerelease to the first
+    // configured prerelease branch
     const prereleaseBranch = prereleaseBranches.includes(branch)
       ? branch
       : prereleaseBranches[0];


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `8.1.0-canary.731.9618.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
