### PR TITLE
implement prerelease branches for git-tag plugin

### DIFF
--- a/plugins/git-tag/src/index.ts
+++ b/plugins/git-tag/src/index.ts
@@ -1,5 +1,9 @@
 import { Auto, execPromise, IPlugin } from '@auto-it/core';
-import { inc, ReleaseType } from 'semver';
+import { inc, lte, ReleaseType } from 'semver';
+import { execSync } from 'child_process';
+
+/** When the next hook is running branch is also the tag to publish under (ex: next, beta) */
+const branch = execSync('git symbolic-ref --short HEAD', { encoding: 'utf8' });
 
 /** Manage your projects version through just a git tag. */
 export default class GitTagPlugin implements IPlugin {
@@ -38,6 +42,32 @@ export default class GitTagPlugin implements IPlugin {
         'origin',
         auto.baseBranch
       ]);
+    });
+
+    auto.hooks.next.tapPromise(this.name, async (preReleaseVersions, bump) => {
+      if (!auto.git) {
+        return preReleaseVersions;
+      }
+
+      const prereleaseBranches = auto.config?.prereleaseBranches!;
+      const prereleaseBranch = prereleaseBranches.includes(branch)
+        ? branch
+        : prereleaseBranches[0];
+      const lastRelease = await auto.git.getLatestRelease();
+      const next =
+        inc(lastRelease, `pre${bump}` as ReleaseType, prereleaseBranch) ||
+        'prerelease';
+      const current = await auto.getCurrentVersion(lastRelease);
+      const prerelease = lte(next, current)
+        ? inc(current, 'prerelease', prereleaseBranch)
+        : next;
+
+      if (prerelease) {
+        await execPromise('git', ['tag', prerelease]);
+        await execPromise('git', ['push', '--follow-tags']);
+      }
+
+      return preReleaseVersions;
     });
   }
 }


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `8.1.0-canary.732.9629.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
