### PR TITLE
change getPreviousVersion hook args. can access prefixRelease from root class instead

### DIFF
--- a/docs/pages/writing-plugins.md
+++ b/docs/pages/writing-plugins.md
@@ -172,11 +172,11 @@ auto.hooks.getAuthor.tapPromise('NPM', async () => {
 Get the previous version. Typically from a package distribution description file.
 
 ```ts
-auto.hooks.getPreviousVersion.tapPromise('NPM', async prefixRelease => {
+auto.hooks.getPreviousVersion.tapPromise('NPM', async () => {
   const { version } = JSON.parse(await readFile('package.json', 'utf-8'));
 
   if (version) {
-    return prefixRelease(
+    return auto.prefixRelease(
       JSON.parse(await readFile('package.json', 'utf-8')).version
     );
   }
@@ -469,7 +469,7 @@ export default class NPMPlugin {
       }
     });
 
-    auto.hooks.getPreviousVersion.tapPromise('NPM', async prefixRelease => {
+    auto.hooks.getPreviousVersion.tapPromise('NPM', async () => {
       const { version } = JSON.parse(await readFile('package.json', 'utf-8'));
 
       auto.logger.log.info(
@@ -478,7 +478,7 @@ export default class NPMPlugin {
       );
 
       if (version) {
-        return prefixRelease(
+        return auto.prefixRelease(
           JSON.parse(await readFile('package.json', 'utf-8')).version
         );
       }

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -100,10 +100,7 @@ export interface IAutoHooks {
   /** Get git author. Typically from a package distribution description file. */
   getAuthor: AsyncSeriesBailHook<[], IAuthorOptions | void>;
   /** Get the previous version. Typically from a package distribution description file. */
-  getPreviousVersion: AsyncSeriesBailHook<
-    [(release: string) => string],
-    string
-  >;
+  getPreviousVersion: AsyncSeriesBailHook<[], string>;
   /** Get owner and repository. Typically from a package distribution description file. */
   getRepository: AsyncSeriesBailHook<[], (IRepoOptions & TestingToken) | void>;
   /** Tap into the things the Release class makes. This isn't the same as `auto release`, but the main class that does most of the work. */
@@ -812,9 +809,7 @@ export default class Auto {
       return this.prefixRelease('0.0.0');
     });
 
-    const lastVersion = await this.hooks.getPreviousVersion.promise(
-      this.prefixRelease
-    );
+    const lastVersion = await this.hooks.getPreviousVersion.promise();
 
     if (
       parse(lastRelease) &&

--- a/packages/core/src/utils/make-hooks.ts
+++ b/packages/core/src/utils/make-hooks.ts
@@ -24,7 +24,7 @@ export const makeHooks = (): IAutoHooks => ({
   onCreateChangelog: new SyncHook(['changelog', 'version']),
   onCreateLogParse: new SyncHook(['logParse']),
   getAuthor: new AsyncSeriesBailHook([]),
-  getPreviousVersion: new AsyncSeriesBailHook(['prefixRelease']),
+  getPreviousVersion: new AsyncSeriesBailHook([]),
   getRepository: new AsyncSeriesBailHook([]),
   version: new AsyncParallelHook(['version']),
   afterVersion: new AsyncParallelHook([]),

--- a/packages/core/src/utils/make-hooks.ts
+++ b/packages/core/src/utils/make-hooks.ts
@@ -15,7 +15,7 @@ import { IReleaseHooks } from '../release';
 export const makeHooks = (): IAutoHooks => ({
   beforeRun: new SyncHook(['config']),
   modifyConfig: new SyncWaterfallHook(['config']),
-  beforeShipIt: new SyncHook([]),
+  beforeShipIt: new SyncHook(),
   afterAddToChangelog: new AsyncSeriesHook(['context']),
   beforeCommitChangelog: new AsyncSeriesHook(['context']),
   afterShipIt: new AsyncParallelHook(['version', 'commits']),
@@ -23,13 +23,13 @@ export const makeHooks = (): IAutoHooks => ({
   onCreateRelease: new SyncHook(['options']),
   onCreateChangelog: new SyncHook(['changelog', 'version']),
   onCreateLogParse: new SyncHook(['logParse']),
-  getAuthor: new AsyncSeriesBailHook([]),
-  getPreviousVersion: new AsyncSeriesBailHook([]),
-  getRepository: new AsyncSeriesBailHook([]),
+  getAuthor: new AsyncSeriesBailHook(),
+  getPreviousVersion: new AsyncSeriesBailHook(),
+  getRepository: new AsyncSeriesBailHook(),
   version: new AsyncParallelHook(['version']),
-  afterVersion: new AsyncParallelHook([]),
+  afterVersion: new AsyncParallelHook(),
   publish: new AsyncParallelHook(['version']),
-  afterPublish: new AsyncParallelHook([]),
+  afterPublish: new AsyncParallelHook(),
   canary: new AsyncSeriesBailHook(['canaryVersion', 'postFix']),
   next: new AsyncSeriesWaterfallHook(['preReleaseVersions', 'bump'])
 });

--- a/plugins/chrome/src/index.ts
+++ b/plugins/chrome/src/index.ts
@@ -111,9 +111,9 @@ export default class ChromeWebStorePlugin implements IPlugin {
       );
     });
 
-    auto.hooks.getPreviousVersion.tapPromise(this.name, async prefixRelease => {
+    auto.hooks.getPreviousVersion.tapPromise(this.name, async () => {
       const manifest = await getManifest(this.options.manifest);
-      const version = prefixRelease(manifest.version);
+      const version = auto.prefixRelease(manifest.version);
 
       auto.logger.verbose.info(
         `${this.name}: Got previous version from package.json`,

--- a/plugins/crates/__tests__/crates.test.ts
+++ b/plugins/crates/__tests__/crates.test.ts
@@ -184,10 +184,8 @@ describe('CratesPlugin', () => {
         readFileSync.mockReturnValueOnce(sampleCargoToml);
         const plugin = new CratesPlugin();
         const hooks = makeHooks();
-        plugin.apply({ hooks, logger: dummyLog() } as Auto.Auto);
-        expect(
-          await hooks.getPreviousVersion.promise(prefixRelease)
-        ).toStrictEqual('1.2.3');
+        plugin.apply({ hooks, logger: dummyLog(), prefixRelease } as Auto.Auto);
+        expect(await hooks.getPreviousVersion.promise()).toStrictEqual('1.2.3');
       });
     });
 

--- a/plugins/crates/src/index.ts
+++ b/plugins/crates/src/index.ts
@@ -78,9 +78,9 @@ export default class CratesPlugin implements IPlugin {
       return authors;
     });
 
-    auto.hooks.getPreviousVersion.tapPromise(this.name, async prefixRelease => {
+    auto.hooks.getPreviousVersion.tapPromise(this.name, async () => {
       const config = await getCargoConfig();
-      const version = prefixRelease(config.package.version);
+      const version = auto.prefixRelease(config.package.version);
       auto.logger.log.info(`Crate version: ${version}`);
       return version;
     });

--- a/plugins/git-tag/__tests__/git-tag.test.ts
+++ b/plugins/git-tag/__tests__/git-tag.test.ts
@@ -10,7 +10,11 @@ const setup = (mockGit?: { getLatestTagInBranch(): string }) => {
   const plugin = new GitTag();
   const hooks = makeHooks();
 
-  plugin.apply(({ hooks, git: mockGit } as unknown) as Auto.Auto);
+  plugin.apply(({
+    hooks,
+    git: mockGit,
+    prefixRelease: (r: string) => r
+  } as unknown) as Auto.Auto);
 
   return hooks;
 };
@@ -23,14 +27,14 @@ describe('Git Tag Plugin', () => {
   describe('getPreviousVersion', () => {
     test('should error without git', async () => {
       const hooks = setup();
-      await expect(
-        hooks.getPreviousVersion.promise(r => r)
-      ).rejects.toBeInstanceOf(Error);
+      await expect(hooks.getPreviousVersion.promise()).rejects.toBeInstanceOf(
+        Error
+      );
     });
 
     test('should get previous version', async () => {
       const hooks = setup({ getLatestTagInBranch: () => 'v1.0.0' });
-      const previousVersion = await hooks.getPreviousVersion.promise(r => r);
+      const previousVersion = await hooks.getPreviousVersion.promise();
       expect(previousVersion).toBe('v1.0.0');
     });
   });

--- a/plugins/maven/__tests__/maven.test.ts
+++ b/plugins/maven/__tests__/maven.test.ts
@@ -17,7 +17,11 @@ describe('maven', () => {
   beforeEach(() => {
     const plugin = new MavenPlugin();
     hooks = makeHooks();
-    plugin.apply({ hooks, logger: dummyLog() } as Auto.Auto);
+    plugin.apply({
+      hooks,
+      logger: dummyLog(),
+      prefixRelease: r => r
+    } as Auto.Auto);
   });
 
   describe('getAuthor', () => {
@@ -165,14 +169,14 @@ describe('maven', () => {
         </project>
       `);
 
-      expect(await hooks.getPreviousVersion.promise(r => r)).toBe('1.0.0');
+      expect(await hooks.getPreviousVersion.promise()).toBe('1.0.0');
     });
 
     test('should throw when no version in pom.xml', async () => {
       mockRead('');
-      await expect(
-        hooks.getPreviousVersion.promise(r => r)
-      ).rejects.toBeInstanceOf(Error);
+      await expect(hooks.getPreviousVersion.promise()).rejects.toBeInstanceOf(
+        Error
+      );
     });
   });
 

--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -233,7 +233,8 @@ describe('getPreviousVersion', () => {
     plugin.apply({
       config: { prereleaseBranches: ['next'] },
       hooks,
-      logger: dummyLog()
+      logger: dummyLog(),
+      prefixRelease: str => str
     } as Auto.Auto);
 
     readResult = `
@@ -241,7 +242,7 @@ describe('getPreviousVersion', () => {
         "name": "test"
       }
     `;
-    expect(await hooks.getPreviousVersion.promise(str => str)).toBe('0.0.0');
+    expect(await hooks.getPreviousVersion.promise()).toBe('0.0.0');
   });
 
   test('should get version from the package.json', async () => {
@@ -253,7 +254,8 @@ describe('getPreviousVersion', () => {
     plugin.apply({
       config: { prereleaseBranches: ['next'] },
       hooks,
-      logger: dummyLog()
+      logger: dummyLog(),
+      prefixRelease: str => str
     } as Auto.Auto);
 
     readResult = `
@@ -262,7 +264,7 @@ describe('getPreviousVersion', () => {
         "version": "1.0.0"
       }
     `;
-    expect(await hooks.getPreviousVersion.promise(str => str)).toBe('1.0.0');
+    expect(await hooks.getPreviousVersion.promise()).toBe('1.0.0');
   });
 
   test('should get version from the lerna.json', async () => {
@@ -274,7 +276,8 @@ describe('getPreviousVersion', () => {
     plugin.apply({
       config: { prereleaseBranches: ['next'] },
       hooks,
-      logger: dummyLog()
+      logger: dummyLog(),
+      prefixRelease: str => str
     } as Auto.Auto);
 
     readResult = `
@@ -283,7 +286,7 @@ describe('getPreviousVersion', () => {
         "version": "2.0.0"
       }
     `;
-    expect(await hooks.getPreviousVersion.promise(str => str)).toBe('2.0.0');
+    expect(await hooks.getPreviousVersion.promise()).toBe('2.0.0');
   });
 
   test('should get version greatest published monorepo package', async () => {
@@ -305,10 +308,11 @@ describe('getPreviousVersion', () => {
     plugin.apply({
       config: { prereleaseBranches: ['next'] },
       hooks,
-      logger: dummyLog()
+      logger: dummyLog(),
+      prefixRelease: str => str
     } as Auto.Auto);
 
-    expect(await hooks.getPreviousVersion.promise(str => str)).toBe('0.1.2');
+    expect(await hooks.getPreviousVersion.promise()).toBe('0.1.2');
   });
 });
 

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -290,7 +290,7 @@ export default class NPMPlugin implements IPlugin {
       return author;
     });
 
-    auto.hooks.getPreviousVersion.tapPromise(this.name, async prefixRelease => {
+    auto.hooks.getPreviousVersion.tapPromise(this.name, async () => {
       let previousVersion = '';
 
       if (isMonorepo()) {
@@ -310,12 +310,12 @@ export default class NPMPlugin implements IPlugin {
           const releasedPackage = getMonorepoPackage();
 
           if (!releasedPackage.name && !releasedPackage.version) {
-            previousVersion = prefixRelease(monorepoVersion);
+            previousVersion = auto.prefixRelease(monorepoVersion);
           } else {
             previousVersion = await greaterRelease(
-              prefixRelease,
+              auto.prefixRelease,
               releasedPackage.name,
-              prefixRelease(monorepoVersion),
+              auto.prefixRelease(monorepoVersion),
               prereleaseBranch
             );
           }
@@ -328,9 +328,9 @@ export default class NPMPlugin implements IPlugin {
 
         previousVersion = version
           ? await greaterRelease(
-              prefixRelease,
+              auto.prefixRelease,
               name,
-              prefixRelease(version),
+              auto.prefixRelease(version),
               prereleaseBranch
             )
           : '0.0.0';


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `9.0.0-canary.734.9659.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
