### PR TITLE
move determineNextVersion to core

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -159,6 +159,25 @@ function getPrNumberFromEnv(pr?: number) {
 }
 
 /**
+ * Bump the version but no too much.
+ *
+ * @example
+ * currentVersion = 1.0.0
+ * nextVersion = 2.0.0-next.0
+ * output = 2.0.0-next.1
+ */
+export function determineNextVersion(
+  version: string,
+  current: string,
+  bump: SEMVER,
+  tag: string
+) {
+  const next = inc(version, `pre${bump}` as ReleaseType, tag) || 'prerelease';
+
+  return lte(next, current) ? 'prerelease' : next;
+}
+
+/**
  * The "auto" node API. Its public interface matches the
  * commands you can run from the CLI
  */
@@ -1089,25 +1108,6 @@ export default class Auto {
       ? release
       : `v${release}`;
   };
-
-  /** 
-   * Bump the version but no too much.
-   * 
-   * @example
-   * currentVersion = 1.0.0
-   * nextVersion = 2.0.0-next.0
-   * output = 2.0.0-next.1
-   */
-  readonly determineNextVersion = (
-    version: string,
-    current: string,
-    bump: SEMVER,
-    tag: string
-  ) => {
-    const next = inc(version, `pre${bump}` as ReleaseType, tag) || 'prerelease';
-
-    return lte(next, current) ? 'prerelease' : next;
-  }
 
   /** Create an auto initialization error */
   private createErrorMessage() {

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -3,7 +3,7 @@ import dotenv from 'dotenv';
 import envCi from 'env-ci';
 import fs from 'fs';
 import path from 'path';
-import { eq, gt, inc, parse, ReleaseType } from 'semver';
+import { eq, gt, lte, inc, parse, ReleaseType } from 'semver';
 import {
   AsyncParallelHook,
   AsyncSeriesBailHook,
@@ -1089,6 +1089,25 @@ export default class Auto {
       ? release
       : `v${release}`;
   };
+
+  /** 
+   * Bump the version but no too much.
+   * 
+   * @example
+   * currentVersion = 1.0.0
+   * nextVersion = 2.0.0-next.0
+   * output = 2.0.0-next.1
+   */
+  readonly determineNextVersion = (
+    version: string,
+    current: string,
+    bump: SEMVER,
+    tag: string
+  ) => {
+    const next = inc(version, `pre${bump}` as ReleaseType, tag) || 'prerelease';
+
+    return lte(next, current) ? 'prerelease' : next;
+  }
 
   /** Create an auto initialization error */
   private createErrorMessage() {

--- a/plugins/git-tag/src/index.ts
+++ b/plugins/git-tag/src/index.ts
@@ -1,4 +1,9 @@
-import { Auto, execPromise, IPlugin } from '@auto-it/core';
+import {
+  Auto,
+  determineNextVersion,
+  execPromise,
+  IPlugin
+} from '@auto-it/core';
 import { inc, ReleaseType } from 'semver';
 import { execSync } from 'child_process';
 
@@ -55,7 +60,12 @@ export default class GitTagPlugin implements IPlugin {
         : prereleaseBranches[0];
       const lastRelease = await auto.git.getLatestRelease();
       const current = await auto.getCurrentVersion(lastRelease);
-      const prerelease = auto.determineNextVersion(lastRelease, current, bump, prereleaseBranch)
+      const prerelease = determineNextVersion(
+        lastRelease,
+        current,
+        bump,
+        prereleaseBranch
+      );
 
       if (prerelease) {
         await execPromise('git', ['tag', prerelease]);

--- a/plugins/git-tag/src/index.ts
+++ b/plugins/git-tag/src/index.ts
@@ -1,5 +1,5 @@
 import { Auto, execPromise, IPlugin } from '@auto-it/core';
-import { inc, lte, ReleaseType } from 'semver';
+import { inc, ReleaseType } from 'semver';
 import { execSync } from 'child_process';
 
 /** When the next hook is running branch is also the tag to publish under (ex: next, beta) */
@@ -54,13 +54,8 @@ export default class GitTagPlugin implements IPlugin {
         ? branch
         : prereleaseBranches[0];
       const lastRelease = await auto.git.getLatestRelease();
-      const next =
-        inc(lastRelease, `pre${bump}` as ReleaseType, prereleaseBranch) ||
-        'prerelease';
       const current = await auto.getCurrentVersion(lastRelease);
-      const prerelease = lte(next, current)
-        ? inc(current, 'prerelease', prereleaseBranch)
-        : next;
+      const prerelease = auto.determineNextVersion(lastRelease, current, bump, prereleaseBranch)
 
       if (prerelease) {
         await execPromise('git', ['tag', prerelease]);

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -5,7 +5,14 @@ import parseAuthor from 'parse-author';
 import path from 'path';
 import { Memoize as memoize } from 'typescript-memoize';
 
-import { Auto, execPromise, ILogger, IPlugin, SEMVER } from '@auto-it/core';
+import {
+  Auto,
+  determineNextVersion,
+  execPromise,
+  ILogger,
+  IPlugin,
+  SEMVER
+} from '@auto-it/core';
 import getPackages from 'get-monorepo-packages';
 import { gt, gte, inc, ReleaseType } from 'semver';
 
@@ -492,7 +499,7 @@ export default class NPMPlugin implements IPlugin {
         const packagesBefore = await this.getLernaPackages();
         const next =
           (isIndependent && `pre${version}`) ||
-          auto.determineNextVersion(
+          determineNextVersion(
             lastRelease,
             packagesBefore[0].version,
             version,
@@ -590,7 +597,7 @@ export default class NPMPlugin implements IPlugin {
             // It's hard to accurately predict how we should bump independent versions.
             // So we just prerelease most of the time. (independent only)
             ((isIndependent && 'prerelease') ||
-              auto.determineNextVersion(
+              determineNextVersion(
                 lastRelease,
                 inPreRelease.version,
                 bump,
@@ -625,7 +632,7 @@ export default class NPMPlugin implements IPlugin {
         auto.logger.verbose.info('Detected single npm package');
 
         const current = await auto.getCurrentVersion(lastRelease);
-        const next = auto.determineNextVersion(
+        const next = determineNextVersion(
           lastRelease,
           current,
           bump,

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -7,7 +7,7 @@ import { Memoize as memoize } from 'typescript-memoize';
 
 import { Auto, execPromise, ILogger, IPlugin, SEMVER } from '@auto-it/core';
 import getPackages from 'get-monorepo-packages';
-import { gt, gte, lte, inc, ReleaseType } from 'semver';
+import { gt, gte, inc, ReleaseType } from 'semver';
 
 import getConfigFromPackageJson from './package-config';
 import setTokenOnCI from './set-npm-token';
@@ -206,18 +206,6 @@ const checkClean = async (auto: Auto) => {
 /** Render a list of string in markdown */
 const markdownList = (lines: string[]) =>
   lines.map(line => `- \`${line}\``).join('\n');
-
-/** Bump the version but no too much */
-function determineBump(
-  version: string,
-  current: string,
-  bump: SEMVER,
-  tag: string
-) {
-  const next = inc(version, `pre${bump}` as ReleaseType, tag) || 'prerelease';
-
-  return lte(next, current) ? 'prerelease' : next;
-}
 
 /** Publish to NPM. Works in both a monorepo setting and for a single package. */
 export default class NPMPlugin implements IPlugin {
@@ -504,7 +492,7 @@ export default class NPMPlugin implements IPlugin {
         const packagesBefore = await this.getLernaPackages();
         const next =
           (isIndependent && `pre${version}`) ||
-          determineBump(
+          auto.determineNextVersion(
             lastRelease,
             packagesBefore[0].version,
             version,
@@ -602,7 +590,7 @@ export default class NPMPlugin implements IPlugin {
             // It's hard to accurately predict how we should bump independent versions.
             // So we just prerelease most of the time. (independent only)
             ((isIndependent && 'prerelease') ||
-              determineBump(
+              auto.determineNextVersion(
                 lastRelease,
                 inPreRelease.version,
                 bump,
@@ -637,7 +625,7 @@ export default class NPMPlugin implements IPlugin {
         auto.logger.verbose.info('Detected single npm package');
 
         const current = await auto.getCurrentVersion(lastRelease);
-        const next = determineBump(
+        const next = auto.determineNextVersion(
           lastRelease,
           current,
           bump,


### PR DESCRIPTION
# Why

seemed useful for other plugins
<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `8.0.0-canary.747.9928.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
