### PR TITLE
Making the docs a little more solid...

### DIFF
--- a/docs/pages/build-platforms/github-actions.md
+++ b/docs/pages/build-platforms/github-actions.md
@@ -19,22 +19,16 @@ on: [push]
 jobs:
   release:
     runs-on: ubuntu-latest
-
+    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
     steps:
       - uses: actions/checkout@v1
-      - name: Skip CI
-        uses: veggiemonk/skip-commit@master
-        env:
-          COMMIT_FILTER: skip ci
       - name: Prepare repository
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git checkout "${GITHUB_REF:11}" --
+          git checkout ${GITHUB_REF:11} --
           git remote rm origin
-          git remote add origin "https://$GH_TOKEN@github.com/hipstersmoothie/my-test-project"
-          git fetch origin
-          git branch --set-upstream-to origin/master
+          git remote add origin https://$<your-github-user>:GITHUB_TOKEN@github.com/<project-owner>/<project-repo>
+          git fetch origin --tags
+          git branch --set-upstream-to origin/${GITHUB_REF:11} ${GITHUB_REF:11}
       - name: Use Node.js 12.x
         uses: actions/setup-node@v1
         with:
@@ -61,6 +55,7 @@ jobs:
 If you are having problems make sure you have done the following:
 
 - Any required secrets for plugins are set (Ex; `NPM_TOKEN` with the NPM plugin)
+- Update references of `<your-github-user>`, `<project-owner>`, and `<project-repo>` with the appropriate values
 
 To add a secret for actions go to https://github.com/<owner>/<repo>/settings/secrets/new
 


### PR DESCRIPTION
# What Changed

- The `skip-commit` action isn't needed because you can test that inline (https://github.com/veggiemonk/skip-commit/issues/5)
- You should use provide a user associated with the token (in the remote) or it can cause problems
- You should also fetch tags or it doesn't behave well if you're adding this to a project that's already had some releases
- You want to set the upstream to whatever the current branch is. You don't want `master` to be the upstream branch for some canary branch. 

# Why

Because I <3 auto

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.16.4-canary.752.9888.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
