### PR TITLE
docs(introduction): fix typo

### DIFF
--- a/docs/pages/introduction.md
+++ b/docs/pages/introduction.md
@@ -2,7 +2,7 @@
 
 # :rocket: auto :rocket:/.has-text-centered\
 
-Automated releases powered by pull request labels. Streamline you release workflow and publish constantly! `auto` is meant to be run in a continuous integration (CI) environment, but all the commands work locally as well.
+Automated releases powered by pull request labels. Streamline your release workflow and publish constantly! `auto` is meant to be run in a continuous integration (CI) environment, but all the commands work locally as well.
 
 Release Features:
 


### PR DESCRIPTION
Auto looks interesting - hoping to try it out soon. Noticed this in the docs

# What Changed

The second sentence from https://intuit.github.io/auto/index.html

# Why

~you~ your
<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.16.4-canary.755.9939.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
