### PR TITLE
add more defaults to all-contributors plugin

### DIFF
--- a/plugins/all-contributors/src/index.ts
+++ b/plugins/all-contributors/src/index.ts
@@ -60,13 +60,16 @@ const defaultOptions: IAllContributorsPluginOptions = {
     'dependabot-preview[bot]',
     'greenkeeper[bot]',
     'dependabot[bot]',
-    'fossabot'
+    'fossabot',
+    'renovate',
+    'renovate[bot]',
+    'renovate-approve'
   ],
   types: {
     doc: ['**/*.mdx', '**/*.md', '**/docs/**/*', '**/documentation/**/*'],
     example: ['**/*.stories*', '**/*.story.*'],
     infra: ['**/.circle/**/*', '**/.github/**/*', '**/travis.yml'],
-    test: ['**/*.test.*'],
+    test: ['**/*.test.*', '**/test/**', '**/__tests__/**'],
     code: ['**/src/**/*', '**/lib/**/*', '**/package.json', '**/tsconfig.json']
   }
 };


### PR DESCRIPTION
# What Changed

less configuration is better 🎉 

# Why

closes #754 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `7.17.0-canary.756.9951.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
