### PR TITLE
Don't create a version commit for prereleases

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,7 +2,7 @@
   "name": "auto",
   "bin": "dist/bin/auto.js",
   "description": "CLI tools to help facilitate semantic versioning based on GitHub PR labels",
-  "version": "8.0.0-next.8",
+  "version": "7.16.3",
   "author": {
     "name": "Andrew Lisowski",
     "email": "lisowski54@gmail.com"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auto-it/core",
-  "version": "8.0.0-next.8",
+  "version": "7.16.3",
   "description": "Node API for using auto.",
   "main": "dist/auto.js",
   "author": {

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -167,14 +167,17 @@ function getPrNumberFromEnv(pr?: number) {
  * output = 2.0.0-next.1
  */
 export function determineNextVersion(
-  version: string,
-  current: string,
+  lastVersion: string,
+  currentVersion: string,
   bump: SEMVER,
   tag: string
 ) {
-  const next = inc(version, `pre${bump}` as ReleaseType, tag) || 'prerelease';
+  const next =
+    inc(lastVersion, `pre${bump}` as ReleaseType, tag) || 'prerelease';
 
-  return lte(next, current) ? 'prerelease' : next;
+  return lte(next, currentVersion)
+    ? inc(currentVersion, 'prerelease', tag) || 'prerelease'
+    : next;
 }
 
 /**
@@ -1104,7 +1107,6 @@ export default class Auto {
     return newVersion;
   }
 
-
   /** Check if `git status` is clean. */
   readonly checkClean = async () => {
     const status = await execPromise('git', ['status', '--porcelain']);
@@ -1118,7 +1120,7 @@ export default class Auto {
     throw new Error(
       'Working direction is not clean, make sure all files are commited'
     );
-  }
+  };
 
   /** Prefix a version with a "v" if needed */
   readonly prefixRelease = (release: string) => {

--- a/packages/core/src/utils/exec-promise.ts
+++ b/packages/core/src/utils/exec-promise.ts
@@ -1,4 +1,7 @@
 import { spawn } from 'child_process';
+import createLog from './logger';
+
+const log = createLog('verbose');
 
 /**
  * Wraps up running a command into a single promise,
@@ -11,6 +14,7 @@ export default async function execPromise(
   cmd: string,
   args: (string | undefined | false)[] = []
 ) {
+  const callSite = new Error().stack;
   const filteredArgs = args.filter(
     (arg): arg is string => typeof arg === 'string'
   );
@@ -55,11 +59,18 @@ export default async function execPromise(
         appendedStdErr += allStdout.length ? `\n\n${allStdout}` : '';
         appendedStdErr += allStderr.length ? `\n\n${allStderr}` : '';
 
-        reject(new Error(`Running command '${cmd}' failed${appendedStdErr}`));
+        reject(
+          new Error(
+            `Running command '${cmd}' with args [${args.join(
+              ', '
+            )}] failed${appendedStdErr}`
+          )
+        );
+        log.verbose.error('Called from:', callSite);
       } else {
         // Tools can occasionally print to stderr but not fail, so print that just in case.
         if (allStderr.length) {
-          console.log(allStderr);
+          log.log.warn(allStderr);
         }
 
         // Resolve the string of the whole stdout

--- a/plugins/all-contributors/package.json
+++ b/plugins/all-contributors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auto-it/all-contributors",
-  "version": "8.0.0-next.8",
+  "version": "7.16.3",
   "main": "dist/index.js",
   "description": "Automatically add contributors as changelogs are produced.",
   "author": {

--- a/plugins/chrome/package.json
+++ b/plugins/chrome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auto-it/chrome",
-  "version": "8.0.0-next.8",
+  "version": "7.16.3",
   "main": "dist/index.js",
   "description": "Chrome publishing plugin for auto",
   "author": {

--- a/plugins/conventional-commits/package.json
+++ b/plugins/conventional-commits/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auto-it/conventional-commits",
-  "version": "8.0.0-next.8",
+  "version": "7.16.3",
   "main": "dist/index.js",
   "description": "Conventional commit plugin for auto",
   "author": {

--- a/plugins/crates/package.json
+++ b/plugins/crates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auto-it/crates",
-  "version": "8.0.0-next.8",
+  "version": "7.16.3",
   "main": "dist/index.js",
   "description": "Deploy Rust crates to crates.io",
   "author": {

--- a/plugins/first-time-contributor/package.json
+++ b/plugins/first-time-contributor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auto-it/first-time-contributor",
-  "version": "8.0.0-next.8",
+  "version": "7.16.3",
   "main": "dist/index.js",
   "description": "Thank first time contributors for their work right in your release notes.",
   "author": {

--- a/plugins/git-tag/package.json
+++ b/plugins/git-tag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auto-it/git-tag",
-  "version": "8.0.0-next.8",
+  "version": "7.16.3",
   "main": "dist/index.js",
   "description": "Manage your projects version through just a git tag",
   "author": {

--- a/plugins/jira/package.json
+++ b/plugins/jira/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auto-it/jira",
-  "version": "8.0.0-next.8",
+  "version": "7.16.3",
   "main": "dist/index.js",
   "description": "Jira plugin for auto",
   "author": {

--- a/plugins/maven/package.json
+++ b/plugins/maven/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auto-it/maven",
-  "version": "8.0.0-next.8",
+  "version": "7.16.3",
   "main": "dist/index.js",
   "description": "Maven publishing plugin for auto",
   "author": {

--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -333,8 +333,6 @@ describe('publish', () => {
     exec.mockClear();
   });
 
-
-
   test('should use silly logging in verbose mode', async () => {
     const plugin = new NPMPlugin();
     const hooks = makeHooks();
@@ -594,7 +592,10 @@ describe('canary', () => {
       hooks,
       logger: dummyLog(),
       getCurrentVersion: () => '1.2.3',
-      git: { getLatestRelease: () => '1.2.3' }
+      git: {
+        getLatestRelease: () => '1.2.3',
+        getLatestTagInBranch: () => '1.2.3'
+      }
     } as unknown) as Auto.Auto);
 
     readResult = `
@@ -605,7 +606,7 @@ describe('canary', () => {
 
     await hooks.canary.promise(Auto.SEMVER.patch, '.123.1');
     expect(exec.mock.calls[0]).toContain('npm');
-    expect(exec.mock.calls[0][1]).toContain('1.2.4-canary.123.1');
+    expect(exec.mock.calls[0][1]).toContain('1.2.4-canary.123.1.0');
   });
 
   test('publishes to public for scoped packages', async () => {
@@ -617,7 +618,10 @@ describe('canary', () => {
       hooks,
       logger: dummyLog(),
       getCurrentVersion: () => '1.2.3',
-      git: { getLatestRelease: () => '1.2.3' }
+      git: {
+        getLatestRelease: () => '1.2.3',
+        getLatestTagInBranch: () => '1.2.3'
+      }
     } as unknown) as Auto.Auto);
 
     readResult = `
@@ -638,8 +642,11 @@ describe('canary', () => {
       config: { prereleaseBranches: ['next'] },
       hooks,
       logger: dummyLog(),
-      git: { getLatestRelease: () => Promise.resolve('1.2.3') }
-    } as Auto.Auto);
+      git: {
+        getLatestRelease: () => Promise.resolve('1.2.3'),
+        getLatestTagInBranch: () => '1.2.3'
+      }
+    } as any);
     existsSync.mockReturnValueOnce(true);
 
     readResult = `
@@ -667,8 +674,11 @@ describe('canary', () => {
       config: { prereleaseBranches: ['next'] },
       hooks,
       logger: dummyLog(),
-      git: { getLatestRelease: () => Promise.resolve('1.2.3') }
-    } as Auto.Auto);
+      git: {
+        getLatestRelease: () => Promise.resolve('1.2.3'),
+        getLatestTagInBranch: () => '1.2.3'
+      }
+    } as any);
     existsSync.mockReturnValueOnce(true);
 
     readResult = `
@@ -733,8 +743,11 @@ describe('canary', () => {
       config: { prereleaseBranches: ['next'] },
       hooks,
       logger: dummyLog(),
-      git: { getLatestRelease: () => Promise.resolve('@foo/lib:1.1.0') }
-    } as Auto.Auto);
+      git: {
+        getLatestRelease: () => Promise.resolve('@foo/lib:1.1.0'),
+        getLatestTagInBranch: () => '1.2.3'
+      }
+    } as any);
     existsSync.mockReturnValueOnce(true);
     readFileSync.mockReturnValue('{ "version": "independent" }');
 

--- a/plugins/npm/package.json
+++ b/plugins/npm/package.json
@@ -45,7 +45,6 @@
     "registry-url": "^5.1.0",
     "semver": "^6.0.0",
     "tslib": "1.10.0",
-    "typescript-memoize": "^1.0.0-alpha.3",
     "url-join": "^4.0.0",
     "user-home": "^2.0.0"
   },

--- a/plugins/npm/package.json
+++ b/plugins/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auto-it/npm",
-  "version": "8.0.0-next.8",
+  "version": "7.16.3",
   "main": "dist/index.js",
   "description": "NPM publishing plugin for auto",
   "author": {

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -482,13 +482,14 @@ export default class NPMPlugin implements IPlugin {
         auto.logger.verbose.info('Detected monorepo, using lerna');
 
         const packagesBefore = await getLernaPackages();
+        const preid = `canary${postFix}`;
         const next =
           (isIndependent && `pre${bump}`) ||
           determineNextVersion(
             lastRelease,
             inPrerelease ? latestTag : packagesBefore[0].version,
             bump,
-            'canary'
+            preid
           );
 
         await execPromise('npx', [
@@ -497,13 +498,12 @@ export default class NPMPlugin implements IPlugin {
           next,
           '--dist-tag',
           'canary',
-          '--preid',
-          `canary${postFix}`,
           '--force-publish', // you always want a canary version to publish
           '--yes', // skip prompts,
           '--no-git-reset', // so we can get the version that just published
           '--no-git-tag-version', // no need to tag and commit,
           '--exact', // do not add ^ to canary versions, this can result in `npm i` resolving the wrong canary version
+          ...(isIndependent ? ['--preid', preid] : []),
           ...verboseArgs
         ]);
 

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -473,6 +473,10 @@ export default class NPMPlugin implements IPlugin {
 
       const lastRelease = await auto.git!.getLatestRelease();
       const isIndependent = getLernaJson().version === 'independent';
+      const latestTag = (await auto.git?.getLatestTagInBranch()) || lastRelease;
+      const inPrerelease = prereleaseBranches.some(b =>
+        latestTag.includes(`-${b}.`)
+      );
 
       if (isMonorepo()) {
         auto.logger.verbose.info('Detected monorepo, using lerna');
@@ -482,7 +486,7 @@ export default class NPMPlugin implements IPlugin {
           (isIndependent && `pre${version}`) ||
           determineNextVersion(
             lastRelease,
-            packagesBefore[0].version,
+            inPrerelease ? latestTag : packagesBefore[0].version,
             version,
             'canary'
           );

--- a/plugins/omit-commits/package.json
+++ b/plugins/omit-commits/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auto-it/omit-commits",
-  "version": "8.0.0-next.8",
+  "version": "7.16.3",
   "main": "dist/index.js",
   "description": "Omit commits plugin for auto",
   "author": {

--- a/plugins/omit-release-notes/package.json
+++ b/plugins/omit-release-notes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auto-it/omit-release-notes",
-  "version": "8.0.0-next.8",
+  "version": "7.16.3",
   "main": "dist/index.js",
   "description": "Omit release notes plugin for auto",
   "author": {

--- a/plugins/released/package.json
+++ b/plugins/released/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auto-it/released",
-  "version": "8.0.0-next.8",
+  "version": "7.16.3",
   "main": "dist/index.js",
   "description": "Released plugin for auto. Comments with version + extra",
   "author": {

--- a/plugins/s3/package.json
+++ b/plugins/s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auto-it/s3",
-  "version": "8.0.0-next.8",
+  "version": "7.16.3",
   "main": "dist/index.js",
   "description": "Post your built artifacts to s3",
   "author": {

--- a/plugins/slack/package.json
+++ b/plugins/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auto-it/slack",
-  "version": "8.0.0-next.8",
+  "version": "7.16.3",
   "main": "dist/index.js",
   "description": "Slack plugin for auto",
   "author": {

--- a/plugins/twitter/package.json
+++ b/plugins/twitter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auto-it/twitter",
-  "version": "8.0.0-next.8",
+  "version": "7.16.3",
   "main": "dist/index.js",
   "description": "Twitter plugin for auto",
   "author": {

--- a/plugins/upload-assets/package.json
+++ b/plugins/upload-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auto-it/upload-assets",
-  "version": "8.0.0-next.8",
+  "version": "7.16.3",
   "main": "dist/index.js",
   "description": "Upload assets plugin for auto",
   "author": {


### PR DESCRIPTION
# What Changed

Do not create commits for the next version tags. If we do a user will encounter a bunch of merge conflicts when trying to merge a prerelease branch into master.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `8.0.0-canary.768.10106.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
