### PR TITLE
Add glob support to the upload-assets plugin

### DIFF
--- a/plugins/upload-assets/README.md
+++ b/plugins/upload-assets/README.md
@@ -21,7 +21,9 @@ Simply supply the paths to the assets to add to the release.
   "plugins": [
     ["upload-assets", { "assets": ["./path/to/file"] }],
     // or
-    ["upload-assets", ["./path/to/file"]]
+    ["upload-assets", ["./path/to/file"]],
+    // or use globs to upload multiple things
+    ["upload-assets", ["./path/**/to/*.file"]]
   ]
 }
 ```

--- a/plugins/upload-assets/__tests__/upload-assets.test.ts
+++ b/plugins/upload-assets/__tests__/upload-assets.test.ts
@@ -93,4 +93,32 @@ describe('Upload Assets Plugin', () => {
 
     expect(uploadReleaseAsset).toHaveBeenCalledTimes(2);
   });
+
+  test('should upload multiple assets using a glob', async () => {
+    const plugin = new UploadAssets({
+      assets: [path.join(__dirname, './test-assets/test*.txt')]
+    });
+    const hooks = makeHooks();
+    const uploadReleaseAsset = jest.fn();
+
+    plugin.apply(({
+      hooks,
+      logger: dummyLog(),
+      git: { github: { repos: { uploadReleaseAsset } } }
+    } as unknown) as Auto);
+
+    await hooks.afterRelease.promise({
+      newVersion: '1.0.0',
+      lastRelease: '0.1.0',
+      commits: [],
+      releaseNotes: '',
+      response: {
+        data: { upload_url: 'https://foo.com' }
+      } as Response<ReposCreateReleaseResponse>
+    });
+
+    expect(uploadReleaseAsset).toHaveBeenCalledTimes(2);
+    expect(uploadReleaseAsset.mock.calls[0][0].name).toBe('test-2.txt');
+    expect(uploadReleaseAsset.mock.calls[1][0].name).toBe('test.txt');
+  });
 });

--- a/plugins/upload-assets/package.json
+++ b/plugins/upload-assets/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@auto-it/core": "link:../../packages/core",
     "dedent": "^0.7.0",
+    "fast-glob": "^3.1.1",
     "file-type": "^12.1.0",
     "tslib": "1.10.0"
   },

--- a/plugins/upload-assets/src/index.ts
+++ b/plugins/upload-assets/src/index.ts
@@ -2,6 +2,7 @@ import { Auto, IPlugin } from '@auto-it/core';
 import dedent from 'dedent';
 import fileType from 'file-type';
 import fs from 'fs';
+import fg from 'fast-glob';
 import path from 'path';
 import { promisify } from 'util';
 
@@ -29,15 +30,17 @@ export default class UploadAssetsPlugin implements IPlugin {
   /** Tap into auto plugin points. */
   apply(auto: Auto) {
     auto.hooks.afterRelease.tapPromise(this.name, async ({ response }) => {
+      const assets = await fg(this.options.assets);
+
       auto.logger.log.info(dedent`
         Uploading:
 
-        ${this.options.assets.map(asset => `\t- ${asset}`).join('\n')}
+        ${assets.map(asset => `\t- ${asset}`).join('\n')}
 
       `);
 
       await Promise.all(
-        this.options.assets.map(async asset => {
+        assets.map(async asset => {
           if (!auto.git || !response) {
             return;
           }

--- a/plugins/upload-assets/src/index.ts
+++ b/plugins/upload-assets/src/index.ts
@@ -2,7 +2,7 @@ import { Auto, IPlugin } from '@auto-it/core';
 import dedent from 'dedent';
 import fileType from 'file-type';
 import fs from 'fs';
-import fg from 'fast-glob';
+import glob from 'fast-glob';
 import path from 'path';
 import { promisify } from 'util';
 
@@ -30,7 +30,7 @@ export default class UploadAssetsPlugin implements IPlugin {
   /** Tap into auto plugin points. */
   apply(auto: Auto) {
     auto.hooks.afterRelease.tapPromise(this.name, async ({ response }) => {
-      const assets = await fg(this.options.assets);
+      const assets = await glob(this.options.assets);
 
       auto.logger.log.info(dedent`
         Uploading:

--- a/yarn.lock
+++ b/yarn.lock
@@ -46,7 +46,6 @@
     registry-url "^5.1.0"
     semver "^6.0.0"
     tslib "1.10.0"
-    typescript-memoize "^1.0.0-alpha.3"
     url-join "^4.0.0"
     user-home "^2.0.0"
 
@@ -2097,10 +2096,23 @@
     "@nodelib/fs.stat" "2.0.2"
     run-parallel "^1.1.9"
 
+"@nodelib/fs.scandir@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
+  integrity sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==
+  dependencies:
+    "@nodelib/fs.stat" "2.0.3"
+    run-parallel "^1.1.9"
+
 "@nodelib/fs.stat@2.0.2", "@nodelib/fs.stat@^2.0.1":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.2.tgz#2762aea8fe78ea256860182dcb52d61ee4b8fda6"
   integrity sha512-z8+wGWV2dgUhLqrtRYa03yDx4HWMvXKi1z8g3m2JyxAx8F7xk74asqPk5LAETjqDSGLFML/6CDl0+yFunSYicw==
+
+"@nodelib/fs.stat@2.0.3", "@nodelib/fs.stat@^2.0.2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz#34dc5f4cabbc720f4e60f75a747e7ecd6c175bd3"
+  integrity sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==
 
 "@nodelib/fs.stat@^1.1.2":
   version "1.1.3"
@@ -2113,6 +2125,14 @@
   integrity sha512-l6t8xEhfK9Sa4YO5mIRdau7XSOADfmh3jCr0evNHdY+HNkW6xuQhgMH7D73VV6WpZOagrW0UludvMTiifiwTfA==
   dependencies:
     "@nodelib/fs.scandir" "2.1.2"
+    fastq "^1.6.0"
+
+"@nodelib/fs.walk@^1.2.3":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz#011b9202a70a6366e436ca5c065844528ab04976"
+  integrity sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==
+  dependencies:
+    "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
 "@octokit/endpoint@^5.5.0":
@@ -6597,6 +6617,17 @@ fast-glob@^3.0.3:
     merge2 "^1.2.3"
     micromatch "^4.0.2"
 
+fast-glob@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.1.1.tgz#87ee30e9e9f3eb40d6f254a7997655da753d7c82"
+  integrity sha512-nTCREpBY8w8r+boyFYAx21iL6faSsQynliPHM4Uf56SbkyohCNxpVPEH9xrF5TXKy+IsjkPUHDKiUkzBVRXn9g==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.0"
+    merge2 "^1.3.0"
+    micromatch "^4.0.2"
+
 fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
@@ -7271,6 +7302,13 @@ glob-parent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.0.0.tgz#1dc99f0f39b006d3e92c2c284068382f0c20e954"
   integrity sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==
+  dependencies:
+    is-glob "^4.0.1"
+
+glob-parent@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.0.tgz#5f4c1d1e748d30cd73ad2944b3577a81b081e8c2"
+  integrity sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==
   dependencies:
     is-glob "^4.0.1"
 
@@ -10404,6 +10442,11 @@ merge2@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.2.3.tgz#7ee99dbd69bb6481689253f018488a1b902b0ed5"
   integrity sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==
+
+merge2@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.3.0.tgz#5b366ee83b2f1582c48f87e47cf1a9352103ca81"
+  integrity sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==
 
 methods@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
# What Changed

Adding support for glob syntax in the `upload-assets` plugin. 

# Why

I want to upload multiple files from `/dist` and I'm lazy. I also have a use-case where I don't know the file-name (a vscode extension w/ a version number in the name), but I know the pattern (`foo-bar-vXX.vsix`) that I want to upload. 

Todo:

- [x] Add tests
- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `8.0.0-canary.770.10132.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
