### PR TITLE
Deprecate "--very-verbose, -w" in favor of "-vv"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
       - run: mkdir ~/.ssh/ && echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
       - run:
           name: Release
-          command: yarn auto shipit
+          command: yarn auto shipit -vv
 
   publishDocs:
     <<: *defaults

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -165,8 +165,7 @@ Release Commands
 Global Options
 
   -V, --version         Display auto's version
-  -v, --verbose         Show some more logs
-  -w, --very-verbose    Show a lot more logs
+  -v, -vv, --verbose    Show some more logs. Pass -vv for very verbose logs.
   --repo string         The repo to set the status on. Defaults to looking in the package definition
                         for the platform
   --owner string        The owner of the GitHub repo. Defaults to reading from the package definition

--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -69,15 +69,9 @@ const defaultOptions = [
     name: 'verbose',
     alias: 'v',
     type: Boolean,
-    description: 'Show some more logs',
-    group: 'global'
-  },
-  {
-    name: 'very-verbose',
-    alias: 'w',
-    type: Boolean,
-    description: 'Show a lot more logs',
-    group: 'global'
+    description: 'Show some more logs. Pass -vv for very verbose logs.',
+    group: 'global',
+    multiple: true
   },
   {
     name: 'repo',

--- a/packages/core/src/auto-args.ts
+++ b/packages/core/src/auto-args.ts
@@ -14,9 +14,7 @@ export interface IRepoOptions {
 
 export interface ILogOptions {
   /** Show more logs */
-  verbose?: boolean;
-  /** Show a lot more logs */
-  veryVerbose?: boolean;
+  verbose?: boolean | boolean[];
 }
 
 export interface IInitOptions {

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -213,7 +213,7 @@ export default class Auto {
     this.options = options;
     this.baseBranch = options.baseBranch || 'master';
     this.logger = createLog(
-      options.veryVerbose
+      Array.isArray(options.verbose) && options.verbose.length === 2
         ? 'veryVerbose'
         : options.verbose
         ? 'verbose'

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -821,6 +821,14 @@ export default class Auto {
       (currentBranch === this.baseBranch &&
         options.onlyGraduateWithReleaseLabel);
 
+    this.logger.veryVerbose.info({
+      currentBranch,
+      isBaseBrach,
+      isPR,
+      shouldGraduate,
+      isPrereleaseBranch,
+      publishPrerelease
+    })
     const publishInfo =
       isBaseBrach && shouldGraduate
         ? await this.publishLatest(options)

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -213,7 +213,7 @@ export default class Auto {
     this.options = options;
     this.baseBranch = options.baseBranch || 'master';
     this.logger = createLog(
-      Array.isArray(options.verbose) && options.verbose.length === 2
+      Array.isArray(options.verbose) && options.verbose.length > 1
         ? 'veryVerbose'
         : options.verbose
         ? 'verbose'


### PR DESCRIPTION
# What Changed

This PR switches to the more standard `-vv`. A user could also technically provide `--verbose --verbose` as well.

# Why

Using `-w` for very verbose logs was a very odd choice on my part (two `v`s next to each other look like a `w` 😓). 

Todo:

- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `8.0.0-canary.771.10143.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
