### PR TITLE
More resilient test case

### DIFF
--- a/plugins/upload-assets/__tests__/upload-assets.test.ts
+++ b/plugins/upload-assets/__tests__/upload-assets.test.ts
@@ -118,7 +118,11 @@ describe('Upload Assets Plugin', () => {
     });
 
     expect(uploadReleaseAsset).toHaveBeenCalledTimes(2);
-    expect(uploadReleaseAsset.mock.calls[0][0].name).toBe('test-2.txt');
-    expect(uploadReleaseAsset.mock.calls[1][0].name).toBe('test.txt');
+    expect(uploadReleaseAsset).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'test-2.txt' })
+    );
+    expect(uploadReleaseAsset).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'test.txt' })
+    );
   });
 });


### PR DESCRIPTION
async glob could result in different call order
<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `8.0.0-canary.772.10156.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
