### PR TITLE
next: post comment w/prerelease version on prerelease PR branches

### DIFF
--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -483,7 +483,14 @@ export const commands: Command[] = [
       2. Creates a "Pre Release" on GitHub releases page.
     `,
     examples: ['{green $} auto next'],
-    options: [dryRun]
+    options: [
+      dryRun,
+      {
+        ...message,
+        description:
+          'The message used when attaching the prerelease version to a PR'
+      }
+    ]
   }
 ];
 

--- a/packages/core/src/auto-args.ts
+++ b/packages/core/src/auto-args.ts
@@ -129,13 +129,15 @@ export interface ICanaryOptions {
   pr?: number;
   /** The build to attach the canary to */
   build?: number;
-  /** THe message used when attaching the canary version to a PR */
+  /** The message used when attaching the canary version to a PR */
   message?: string | 'false';
 }
 
 export interface INextOptions {
   /** Do not actually do anything */
   dryRun?: boolean;
+  /** The message used when attaching the prerelease version to a PR */
+  message?: string | 'false';
 }
 
 export type GlobalOptions = {

--- a/packages/core/src/auto-args.ts
+++ b/packages/core/src/auto-args.ts
@@ -137,7 +137,7 @@ export interface INextOptions {
   /** Do not actually do anything */
   dryRun?: boolean;
   /** The message used when attaching the prerelease version to a PR */
-  message?: string | 'false';
+  message?: string;
 }
 
 export type GlobalOptions = {

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -786,7 +786,7 @@ export default class Auto {
       const message = options.message || 'Published prerelease version: %v';
       const pr = 'pr' in env && env.pr;
 
-      if (message !== 'false' && pr) {
+      if (pr) {
         await this.prBody({
           pr: Number(pr),
           context: 'prerelease-version',

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -782,6 +782,19 @@ export default class Auto {
       `Published next version${result.length > 1 ? `s` : ''}: ${newVersion}`
     );
 
+    if ('isPr' in env && env.isPr) {
+      const message = options.message || 'Published prerelease version: %v';
+      const pr = 'pr' in env && env.pr;
+
+      if (message !== 'false' && pr) {
+        await this.prBody({
+          pr: Number(pr),
+          context: 'prerelease-version',
+          message: message.replace('%v', result.map(r => `\`${r}\``).join('\n'))
+        });
+      }
+    }
+
     return { newVersion, commitsInRelease: commits };
   }
 
@@ -801,11 +814,13 @@ export default class Auto {
     this.logger.verbose.info("Using command: 'shipit'");
     this.hooks.beforeShipIt.call();
 
-    // env-ci sets branch to target branch (ex: master) in some CI services.
-    // so we should make sure we aren't in a PR just to be safe
     const isPR = 'isPr' in env && env.isPr;
     const head = await this.release.getCommitsInRelease('HEAD^');
-    const currentBranch = 'branch' in env && env.branch;
+    // env-ci sets branch to target branch (ex: master) in some CI services.
+    // so we should make sure we aren't in a PR just to be safe
+    const currentBranch = isPR
+      ? 'prBranch' in env && env.prBranch
+      : 'branch' in env && env.branch;
     const isBaseBrach = !isPR && currentBranch === this.baseBranch;
     const shouldGraduate =
       !options.onlyGraduateWithReleaseLabel ||
@@ -828,7 +843,7 @@ export default class Auto {
       shouldGraduate,
       isPrereleaseBranch,
       publishPrerelease
-    })
+    });
     const publishInfo =
       isBaseBrach && shouldGraduate
         ? await this.publishLatest(options)


### PR DESCRIPTION
# What Changed

will now post to the pr-body the new next version


<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `8.0.0-canary.773.10171.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
