### PR TITLE
do not call afterRelease hooks during dry run

### DIFF
--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -1178,11 +1178,12 @@ describe('Auto', () => {
       jest.spyOn(auto.release!, 'getCommitsInRelease').mockImplementation();
       jest.spyOn(auto.release!, 'generateReleaseNotes').mockImplementation();
       jest.spyOn(auto.release!, 'addToChangelog').mockImplementation();
-      const version = jest.fn();
-      auto.hooks.version.tap('test', version);
+      const spy = jest.fn();
+      auto.hooks.version.tap('test', spy);
+      auto.hooks.afterRelease.tap('test', spy);
 
       await auto.shipit({ dryRun: true });
-      expect(version).not.toHaveBeenCalled();
+      expect(spy).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1127,15 +1127,15 @@ export default class Auto {
     } else {
       this.logger.log.info(`Releasing ${newVersion} to GitHub.`);
       release = await this.git.publish(releaseNotes, newVersion);
-    }
 
-    await this.hooks.afterRelease.promise({
-      lastRelease,
-      newVersion,
-      commits: commitsInRelease,
-      releaseNotes,
-      response: release
-    });
+      await this.hooks.afterRelease.promise({
+        lastRelease,
+        newVersion,
+        commits: commitsInRelease,
+        releaseNotes,
+        response: release
+      });
+    }
 
     return newVersion;
   }

--- a/plugins/released/__tests__/released-label.test.ts
+++ b/plugins/released/__tests__/released-label.test.ts
@@ -239,31 +239,6 @@ describe('release label plugin', () => {
     );
   });
 
-  test('should do nothing with dryRun flag', async () => {
-    const releasedLabel = new ReleasedLabelPlugin();
-    const autoHooks = makeHooks();
-
-    releasedLabel.apply(({
-      hooks: autoHooks,
-      labels: defaultLabels,
-      logger: dummyLog(),
-      options: { dryRun: true },
-      comment,
-      git
-    } as unknown) as Auto);
-
-    await autoHooks.afterRelease.promise({
-      newVersion: '1.0.0',
-      lastRelease: '0.1.0',
-      commits: await log.normalizeCommits([
-        makeCommitFromMsg('normal commit with no bump (#123)')
-      ]),
-      releaseNotes: ''
-    });
-
-    expect(comment).not.toHaveBeenCalled();
-  });
-
   test('should do nothing when label is already present', async () => {
     const releasedLabel = new ReleasedLabelPlugin();
     const autoHooks = makeHooks();

--- a/plugins/released/src/index.ts
+++ b/plugins/released/src/index.ts
@@ -69,10 +69,6 @@ export default class ReleasedLabelPlugin implements IPlugin {
           return;
         }
 
-        if ('dryRun' in auto.options && auto.options.dryRun) {
-          return;
-        }
-
         const head = commits[0];
 
         if (!head) {

--- a/plugins/slack/__tests__/slack.test.ts
+++ b/plugins/slack/__tests__/slack.test.ts
@@ -48,24 +48,6 @@ describe('postToSlack', () => {
     expect(plugin.postToSlack).not.toHaveBeenCalled();
   });
 
-  test("doesn't post in dry run", async () => {
-    const plugin = new SlackPlugin('https://custom-slack-url');
-    const hooks = makeHooks();
-
-    jest.spyOn(plugin, 'postToSlack').mockImplementation();
-    // @ts-ignore
-    plugin.apply({ hooks, options: { dryRun: true } } as Auto);
-
-    await hooks.afterRelease.promise({
-      newVersion: '1.0.0',
-      lastRelease: '0.1.0',
-      commits: [],
-      releaseNotes: '# My Notes'
-    });
-
-    expect(plugin.postToSlack).not.toHaveBeenCalled();
-  });
-
   test("doesn't post with no commits", async () => {
     const plugin = new SlackPlugin('https://custom-slack-url');
     const hooks = makeHooks();

--- a/plugins/slack/src/index.ts
+++ b/plugins/slack/src/index.ts
@@ -53,10 +53,6 @@ export default class SlackPlugin implements IPlugin {
           return;
         }
 
-        if ('dryRun' in auto.options && auto.options.dryRun) {
-          return;
-        }
-
         const head = commits[0];
 
         if (!head) {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `8.0.0-canary.780.10252.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
