### PR TITLE
omit commits that have already been released

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "semver:check": "./scripts/post-install.sh",
     "build": "tsc -b tsconfig.dev.json",
     "start": "npm run build -- --watch",
-    "lint": "eslint packages plugins --ext .ts",
+    "lint": "eslint packages plugins --ext .ts --cache",
     "test": "jest --runInBand",
     "test:coverage": "npm run test -- --coverage",
     "auto": "chmod +x ./packages/cli/dist/bin/auto.js && ./packages/cli/dist/bin/auto.js",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "build": "tsc -b tsconfig.dev.json",
     "start": "npm run build -- --watch",
     "lint": "eslint packages plugins --ext .ts",
-    "precommit": "lint-staged",
     "test": "jest --runInBand",
     "test:coverage": "npm run test -- --coverage",
     "auto": "chmod +x ./packages/cli/dist/bin/auto.js && ./packages/cli/dist/bin/auto.js",

--- a/packages/core/src/__tests__/__snapshots__/release.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/release.test.ts.snap
@@ -288,6 +288,28 @@ Array [
 ]
 `;
 
+exports[`Release getCommits should omit commits that have already been released 1`] = `
+Array [
+  Object {
+    "authorEmail": "adam@dierkens.com",
+    "authorName": "Adam Dierkens",
+    "authors": Array [
+      Object {
+        "email": "adam@dierkens.com",
+        "name": "Adam Dierkens",
+      },
+    ],
+    "files": Array [],
+    "hash": "foo",
+    "labels": Array [],
+    "pullRequest": Object {
+      "number": 124,
+    },
+    "subject": "Feature",
+  },
+]
+`;
+
 exports[`Release getCommits should resolve authors with PR commits 1`] = `
 Array [
   Object {

--- a/packages/core/src/__tests__/auto-make-changelog.test.ts
+++ b/packages/core/src/__tests__/auto-make-changelog.test.ts
@@ -1,5 +1,13 @@
 import Auto from '../auto';
 import { dummyLog } from '../utils/logger';
+import child from 'child_process';
+
+const { execSync } = child;
+child.execSync = jest.fn().mockReturnValue('');
+
+afterAll(() => {
+  child.execSync = execSync;
+});
 
 const importMock = jest.fn();
 jest.mock('import-cwd', () => (path: string) => importMock(path));

--- a/packages/core/src/__tests__/auto-make-changelog.test.ts
+++ b/packages/core/src/__tests__/auto-make-changelog.test.ts
@@ -2,12 +2,11 @@ import Auto from '../auto';
 import { dummyLog } from '../utils/logger';
 import child from 'child_process';
 
-const { execSync } = child;
-child.execSync = jest.fn().mockReturnValue('');
-
-afterAll(() => {
-  child.execSync = execSync;
-});
+jest
+  .spyOn(child, 'execSync')
+  .mockImplementation()
+  // @ts-ignore
+  .mockReturnValue('');
 
 const importMock = jest.fn();
 jest.mock('import-cwd', () => (path: string) => importMock(path));

--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -4,11 +4,15 @@ import SEMVER from '../semver';
 import { dummyLog } from '../utils/logger';
 import makeCommitFromMsg from './make-commit-from-msg';
 import loadPlugin from '../utils/load-plugins';
+import child from 'child_process';
 
 const importMock = jest.fn();
 jest.mock('../utils/load-plugins.ts');
 jest.mock('import-cwd', () => (path: string) => importMock(path));
 jest.mock('env-ci', () => () => ({ isCi: false, branch: 'master' }));
+
+const { execSync } = child;
+child.execSync = jest.fn().mockReturnValue('');
 
 const defaults = {
   owner: 'foo',
@@ -57,6 +61,10 @@ jest.mock('gitlog', () => (a, cb) => {
       rawBody: 'foo'
     }
   ]);
+});
+
+afterAll(() => {
+  child.execSync = execSync;
 });
 
 describe('Auto', () => {

--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -11,8 +11,11 @@ jest.mock('../utils/load-plugins.ts');
 jest.mock('import-cwd', () => (path: string) => importMock(path));
 jest.mock('env-ci', () => () => ({ isCi: false, branch: 'master' }));
 
-const { execSync } = child;
-child.execSync = jest.fn().mockReturnValue('');
+jest
+  .spyOn(child, 'execSync')
+  .mockImplementation()
+  // @ts-ignore
+  .mockReturnValue('');
 
 const defaults = {
   owner: 'foo',
@@ -61,10 +64,6 @@ jest.mock('gitlog', () => (a, cb) => {
       rawBody: 'foo'
     }
   ]);
-});
-
-afterAll(() => {
-  child.execSync = execSync;
 });
 
 describe('Auto', () => {

--- a/packages/core/src/__tests__/release.test.ts
+++ b/packages/core/src/__tests__/release.test.ts
@@ -10,6 +10,14 @@ import Release, {
 import SEMVER from '../semver';
 import { dummyLog } from '../utils/logger';
 import makeCommitFromMsg from './make-commit-from-msg';
+import child from 'child_process';
+
+const { execSync } = child;
+child.execSync = jest.fn().mockReturnValue('');
+
+afterAll(() => {
+  child.execSync = execSync;
+});
 
 const constructor = jest.fn();
 const getGitLog = jest.fn();


### PR DESCRIPTION
Problem:

1. Develop on next
2. merge master into next (with new releases)
3. When merging next into master all of masters PRs/commits get included in changelog

Now:

The commits already on master will not be included in any calcs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `8.0.0-canary.783.10271.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
