### PR TITLE
only grant contributions for work in commit

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/release.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/release.test.ts.snap
@@ -166,6 +166,7 @@ Array [
     "authorName": "Andrew Lisowski",
     "authors": Array [
       Object {
+        "hash": undefined,
         "login": "andrew",
         "name": "Andrew Lisowski",
         "username": "andrew",
@@ -229,7 +230,10 @@ Array [
     "authors": Array [
       Object {
         "email": "adam@dierkens.com",
+        "hash": "1a2b",
+        "login": "adam",
         "name": "Adam Dierkens",
+        "username": "adam",
       },
     ],
     "files": Array [],
@@ -271,7 +275,10 @@ Array [
     "authors": Array [
       Object {
         "email": "adam@dierkens.com",
+        "hash": "1a2b",
+        "login": "adam",
         "name": "Adam Dierkens",
+        "username": "adam",
       },
     ],
     "files": Array [],
@@ -284,6 +291,59 @@ Array [
       "number": 123,
     },
     "subject": "I was rebased",
+  },
+]
+`;
+
+exports[`Release getCommits should not resolve authors with no PR commits 1`] = `
+Array [
+  Object {
+    "authorEmail": "adam@dierkens.com",
+    "authorName": "Adam Dierkens",
+    "authors": Array [
+      Object {
+        "email": "adam@dierkens.com",
+        "hash": "foo",
+        "name": "Adam Dierkens",
+      },
+    ],
+    "files": Array [],
+    "hash": "foo",
+    "labels": Array [],
+    "pullRequest": undefined,
+    "subject": "First",
+  },
+  Object {
+    "authorEmail": "adam@dierkens.com",
+    "authorName": "Adam Dierkens",
+    "authors": Array [
+      Object {
+        "email": "adam@dierkens.com",
+        "hash": "foo",
+        "name": "Adam Dierkens",
+      },
+    ],
+    "files": Array [],
+    "hash": "foo",
+    "labels": Array [],
+    "pullRequest": undefined,
+    "subject": "Second",
+  },
+  Object {
+    "authorEmail": "adam@dierkens.com",
+    "authorName": "Adam Dierkens",
+    "authors": Array [
+      Object {
+        "email": "adam@dierkens.com",
+        "hash": "foo",
+        "name": "Adam Dierkens",
+      },
+    ],
+    "files": Array [],
+    "hash": "foo",
+    "labels": Array [],
+    "pullRequest": undefined,
+    "subject": "Third",
   },
 ]
 `;
@@ -318,6 +378,7 @@ Array [
     "authors": Array [
       Object {
         "email": "adam@dierkens.com",
+        "hash": "foo",
         "login": "adam",
         "name": "Adam Dierkens",
         "username": "adam",
@@ -334,6 +395,7 @@ Array [
     "authorName": "Andrew Lisowski",
     "authors": Array [
       Object {
+        "hash": undefined,
         "login": "andrew",
         "name": "Andrew Lisowski",
         "username": "andrew",
@@ -370,6 +432,7 @@ Array [
     "authors": Array [
       Object {
         "email": "adam@dierkens.com",
+        "hash": "foo",
         "login": "adam",
         "name": "Adam Dierkens",
         "username": "adam",

--- a/packages/core/src/__tests__/release.test.ts
+++ b/packages/core/src/__tests__/release.test.ts
@@ -29,7 +29,7 @@ const getLatestRelease = jest.fn();
 const getSha = jest.fn();
 const getCommit = jest
   .fn()
-  .mockReturnValue({ data: { author: { login: '' } } });
+  .mockReturnValue(Promise.resolve({ data: { author: { login: '' } } }));
 const createStatus = jest.fn();
 const getProject = jest.fn();
 const createComment = jest.fn();
@@ -202,7 +202,9 @@ describe('Release', () => {
         ])
       );
 
-      getCommit.mockReturnValueOnce({ data: { author: { login: 'adam' } } });
+      getCommit.mockReturnValueOnce(
+        Promise.resolve({ data: { author: { login: 'adam' } } })
+      );
       getUserByUsername.mockImplementation(username => {
         if (username === 'andrew') {
           return {
@@ -244,7 +246,9 @@ describe('Release', () => {
         ])
       );
 
-      getCommit.mockReturnValueOnce({ data: { author: { login: 'adam' } } });
+      getCommit.mockReturnValueOnce(
+        Promise.resolve({ data: { author: { login: 'adam' } } })
+      );
       getUserByUsername.mockImplementation(username => {
         if (username === 'andrew') {
           return {

--- a/packages/core/src/__tests__/release.test.ts
+++ b/packages/core/src/__tests__/release.test.ts
@@ -27,12 +27,14 @@ const getPr = jest.fn();
 const getPullRequest = jest.fn();
 const getLatestRelease = jest.fn();
 const getSha = jest.fn();
+const getCommit = jest
+  .fn()
+  .mockReturnValue({ data: { author: { login: '' } } });
 const createStatus = jest.fn();
 const getProject = jest.fn();
 const createComment = jest.fn();
 const changedPackages = jest.fn();
 const getCommitsForPR = jest.fn().mockReturnValue(Promise.resolve(undefined));
-const getUserByEmail = jest.fn();
 const getUserByUsername = jest.fn();
 const getProjectLabels = jest.fn();
 const createLabel = jest.fn();
@@ -73,7 +75,6 @@ jest.mock(
       changedPackages = changedPackages;
       getCommitsForPR = getCommitsForPR;
       getUserByUsername = getUserByUsername;
-      getUserByEmail = getUserByEmail;
       getProjectLabels = getProjectLabels;
       createLabel = createLabel;
       updateLabel = updateLabel;
@@ -82,6 +83,7 @@ jest.mock(
       searchRepo = searchRepo;
       getCommitDate = getCommitDate;
       getFirstCommit = getFirstCommit;
+      getCommit = getCommit;
     }
 );
 
@@ -146,24 +148,11 @@ describe('getVersionMap', () => {
 
 describe('Release', () => {
   beforeEach(() => {
-    getGitLog.mockClear();
-    getPr.mockClear();
-    writeSpy.mockClear();
-    execSpy.mockClear();
-    execSpy.mockClear();
-    createLabel.mockClear();
+    jest.clearAllMocks();
+    getUserByUsername.mockReset();
   });
 
   describe('getCommits', () => {
-    test('should use options owner, repo, and token', async () => {
-      const gh = new Release(git);
-
-      await gh.getCommits('12345');
-
-      expect(constructor.mock.calls[0][0].owner).toBe('Andrew');
-      expect(constructor.mock.calls[0][0].repo).toBe('test');
-    });
-
     test('should default to HEAD', async () => {
       const gh = new Release(git);
       await gh.getCommits('12345');
@@ -185,8 +174,7 @@ describe('Release', () => {
 
       getGitLog.mockReturnValueOnce(commits);
       const gh = new Release(git);
-      await gh.getCommits('12345', '1234');
-      expect(getUserByUsername).not.toHaveBeenCalled();
+      expect(await gh.getCommits('12345', '1234')).toMatchSnapshot();
     });
 
     test('should resolve authors with PR commits', async () => {
@@ -213,17 +201,20 @@ describe('Release', () => {
           }
         ])
       );
-      getUserByUsername.mockReturnValueOnce({
-        login: 'andrew',
-        name: 'Andrew Lisowski'
-      });
-      getUserByEmail.mockReturnValueOnce({
-        login: 'adam',
-        name: 'Adam Dierkens'
-      });
-      getUserByEmail.mockReturnValueOnce({
-        login: 'adam',
-        name: 'Adam Dierkens'
+
+      getCommit.mockReturnValueOnce({ data: { author: { login: 'adam' } } });
+      getUserByUsername.mockImplementation(username => {
+        if (username === 'andrew') {
+          return {
+            login: 'andrew',
+            name: 'Andrew Lisowski'
+          };
+        }
+
+        return {
+          login: 'adam',
+          name: 'Adam Dierkens'
+        };
       });
 
       const gh = new Release(git);
@@ -252,17 +243,20 @@ describe('Release', () => {
           }
         ])
       );
-      getUserByUsername.mockReturnValueOnce({
-        login: 'andrew',
-        name: 'Andrew Lisowski'
-      });
-      getUserByEmail.mockReturnValueOnce({
-        login: 'adam',
-        name: 'Adam Dierkens'
-      });
-      getUserByEmail.mockReturnValueOnce({
-        login: 'adam',
-        name: 'Adam Dierkens'
+
+      getCommit.mockReturnValueOnce({ data: { author: { login: 'adam' } } });
+      getUserByUsername.mockImplementation(username => {
+        if (username === 'andrew') {
+          return {
+            login: 'andrew',
+            name: 'Andrew Lisowski'
+          };
+        }
+
+        return {
+          login: 'adam',
+          name: 'Adam Dierkens'
+        };
       });
 
       const gh = new Release(git);
@@ -310,6 +304,12 @@ describe('Release', () => {
           })
         ])
       );
+      getUserByUsername.mockImplementationOnce(username => {
+        return {
+          login: 'adam',
+          name: 'Adam Dierkens'
+        };
+      });
 
       expect(await gh.getCommits('12345', '1234')).toMatchSnapshot();
     });
@@ -337,6 +337,12 @@ describe('Release', () => {
           })
         ])
       );
+      getUserByUsername.mockImplementationOnce(() => {
+        return {
+          login: 'adam',
+          name: 'Adam Dierkens'
+        };
+      });
 
       expect(await gh.getCommits('12345', '1234')).toMatchSnapshot();
     });

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1044,10 +1044,7 @@ export default class Auto {
 
     const options = {
       bump,
-      commits: await this.release.getCommitsInRelease(
-        lastRelease,
-        to || undefined
-      ),
+      commits: await this.release.getCommits(lastRelease, to || undefined),
       releaseNotes,
       lastRelease,
       currentVersion

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -243,6 +243,24 @@ export default class Git {
     }
   }
 
+  /** Get information about specific commit */
+  @memoize()
+  async getCommit(sha: string) {
+    this.logger.verbose.info(`Getting info for commit: ${sha}`);
+
+    try {
+      const info = await this.github.repos.getCommit({
+        owner: this.options.owner,
+        repo: this.options.repo,
+        ref: sha
+      });
+      this.logger.veryVerbose.info('Got response for "issues.get":\n', info);
+      return info;
+    } catch (e) {
+      throw new GitAPIError('getPr', [], e);
+    }
+  }
+
   /** Get the labels for a the project */
   async getProjectLabels() {
     this.logger.verbose.info(

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -254,10 +254,13 @@ export default class Git {
         repo: this.options.repo,
         ref: sha
       });
-      this.logger.veryVerbose.info('Got response for "issues.get":\n', info);
+      this.logger.veryVerbose.info(
+        'Got response for "repos.getCommit":\n',
+        info
+      );
       return info;
     } catch (e) {
-      throw new GitAPIError('getPr', [], e);
+      throw new GitAPIError('getCommit', [], e);
     }
   }
 

--- a/packages/core/src/log-parse.ts
+++ b/packages/core/src/log-parse.ts
@@ -9,6 +9,8 @@ export interface ICommitAuthor {
   email?: string;
   /** Author's username */
   username?: string;
+  /** The commit this author created */
+  hash?: string;
 }
 
 export interface IPullRequest {

--- a/packages/core/src/release.ts
+++ b/packages/core/src/release.ts
@@ -784,7 +784,8 @@ export default class Release {
         resolvedAuthors.push({
           email: commit.authorEmail,
           name: commit.authorName,
-          ...author
+          ...author,
+          hash: commit.hash
         });
       }
     }

--- a/packages/core/src/release.ts
+++ b/packages/core/src/release.ts
@@ -766,16 +766,19 @@ export default class Release {
         })
       );
     } else if (commit.authorEmail) {
-      const username = (await this.git.getCommit(commit.hash)).data.author
-        .login;
-      const author = await this.git.getUserByUsername(username);
+      const [err, response] = await on(this.git.getCommit(commit.hash));
 
-      resolvedAuthors.push({
-        name: commit.authorName,
-        email: commit.authorEmail,
-        ...author,
-        hash: commit.hash
-      });
+      if (!err && response) {
+        const username = response.data.author.login;
+        const author = await this.git.getUserByUsername(username);
+
+        resolvedAuthors.push({
+          name: commit.authorName,
+          email: commit.authorEmail,
+          ...author,
+          hash: commit.hash
+        });
+      }
     }
 
     modifiedCommit.authors = resolvedAuthors.map(author => ({

--- a/packages/core/src/release.ts
+++ b/packages/core/src/release.ts
@@ -765,10 +765,10 @@ export default class Release {
           };
         })
       );
-    } else if (commit.authorEmail) {
-      const [err, response] = await on(this.git.getCommit(commit.hash));
+    } else {
+      const [, response] = await on(this.git.getCommit(commit.hash));
 
-      if (!err && response) {
+      if (response) {
         const username = response.data.author.login;
         const author = await this.git.getUserByUsername(username);
 
@@ -777,6 +777,14 @@ export default class Release {
           email: commit.authorEmail,
           ...author,
           hash: commit.hash
+        });
+      } else if (commit.authorEmail) {
+        const author = await this.git.getUserByEmail(commit.authorEmail);
+
+        resolvedAuthors.push({
+          email: commit.authorEmail,
+          name: commit.authorName,
+          ...author
         });
       }
     }

--- a/packages/core/src/release.ts
+++ b/packages/core/src/release.ts
@@ -760,21 +760,21 @@ export default class Release {
 
           return {
             ...prCommit.author,
-            ...(await this.git.getUserByUsername(prCommit.author.login))
+            ...(await this.git.getUserByUsername(prCommit.author.login)),
+            hash: prCommit.sha
           };
         })
       );
     } else if (commit.authorEmail) {
-      const author = commit.authorEmail.includes('@users.noreply.github.com')
-        ? await this.git.getUserByUsername(
-            commit.authorEmail.split('@users')[0]
-          )
-        : await this.git.getUserByEmail(commit.authorEmail);
+      const username = (await this.git.getCommit(commit.hash)).data.author
+        .login;
+      const author = await this.git.getUserByUsername(username);
 
       resolvedAuthors.push({
-        email: commit.authorEmail,
         name: commit.authorName,
-        ...author
+        email: commit.authorEmail,
+        ...author,
+        hash: commit.hash
       });
     }
 

--- a/plugins/all-contributors/__tests__/all-contributors.test.ts
+++ b/plugins/all-contributors/__tests__/all-contributors.test.ts
@@ -64,10 +64,13 @@ describe('All Contributors Plugin', () => {
       lastRelease: '0.0.0',
       releaseNotes: '',
       commits: [
-        makeCommitFromMsg('Do the thing', {
+        {
+          subject: 'Do the thing',
+          hash: '123',
+          labels: [],
           files: ['src/index.ts'],
-          username: 'Jeff'
-        })
+          authors: [{ username: 'Jeff', hash: '123' }]
+        }
       ]
     });
 
@@ -88,10 +91,13 @@ describe('All Contributors Plugin', () => {
       lastRelease: '0.0.0',
       releaseNotes: '',
       commits: [
-        makeCommitFromMsg('Do the thing', {
+        {
+          subject: 'Do the thing',
+          hash: '123',
+          labels: [],
           files: [],
-          username: 'Jeff'
-        })
+          authors: [{ username: 'Jeff', hash: '123' }]
+        }
       ]
     });
 
@@ -111,14 +117,21 @@ describe('All Contributors Plugin', () => {
       lastRelease: '0.0.0',
       releaseNotes: '',
       commits: [
-        makeCommitFromMsg('Do the thing', {
+        {
+          subject: 'Do the thing',
+          hash: '123',
+          labels: [],
           files: ['src/index.ts'],
-          username: 'Jeff'
-        }),
-        makeCommitFromMsg('Do other thing', {
+
+          authors: [{ username: 'Jeff', hash: '123' }]
+        },
+        {
+          subject: 'Do other thing',
+          hash: '123',
+          labels: [],
           files: ['src/index.test.ts'],
-          username: 'Jeff'
-        })
+          authors: [{ username: 'Jeff', hash: '123' }]
+        }
       ]
     });
 
@@ -142,10 +155,13 @@ describe('All Contributors Plugin', () => {
       lastRelease: '0.0.0',
       releaseNotes: '',
       commits: [
-        makeCommitFromMsg('Do the thing', {
+        {
+          subject: 'Do the thing',
+          hash: '123',
+          labels: [],
           files: ['src/index.ts'],
-          username: 'Jeff'
-        })
+          authors: [{ username: 'Jeff', hash: '123' }]
+        }
       ]
     });
 

--- a/plugins/all-contributors/src/index.ts
+++ b/plugins/all-contributors/src/index.ts
@@ -136,8 +136,12 @@ export default class AllContributorsPlugin implements IPlugin {
               return isMatch;
             })
             .forEach(contribution => {
-              authors.forEach(({ username }) => {
+              authors.forEach(({ username, hash }) => {
                 if (!username) {
+                  return;
+                }
+
+                if (commit.hash !== hash) {
                   return;
                 }
 

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -443,13 +443,13 @@ export default class NPMPlugin implements IPlugin {
           }
         });
 
-        this.renderMonorepoChangelog = true;
-
         // Cannot run git operations in parallel
         await promises.reduce(
           async (last, next) => last.then(() => next),
           Promise.resolve()
         );
+
+        this.renderMonorepoChangelog = true;
       }
     );
 


### PR DESCRIPTION
The all contributions plugin was giving contributions for every file changed, no matter the author. Now contributions are only granted for code and author actually wrote.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `8.0.0-canary.786.10356.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
