### PR TITLE
Canary scope

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ defaults: &defaults
   docker:
     - image: circleci/node:8.14-browsers
   environment:
-    TZ: '/usr/share/zoneinfo/America/Los_Angeles'
+    TZ: "/usr/share/zoneinfo/America/Los_Angeles"
 
 aliases:
   # Circle related commands
@@ -120,6 +120,7 @@ workflows:
             - build
 
       - release:
+          context: "@auto-canary"
           requires:
             - test
             - lint

--- a/docs/blog/npm-canary-scope.md
+++ b/docs/blog/npm-canary-scope.md
@@ -1,0 +1,54 @@
+---
+title: 'npm: More Secure Canary Publishing'
+author:
+  name: Andrew Lisowski
+  url: https://twitter.com/HipsterSmoothie
+  email: lisowski54@gmail.com
+---
+
+Publishing canary version comes with some security risks.
+If your project is private you have nothing to worry about, but if your project is open source there are some security holes.
+
+Depending on the build platform you might be able to pass secrets to PR builds for forked repos.
+While this makes the developer experience of you project nice, in `auto`'s case publishing canary versions, it exposes your keys.
+
+An attacker could:
+
+1. print the secret
+2. send the secret to some server
+3. modify `auto` to publish to the latest tag instead of `canary`
+
+No amount of code can fix this problem.
+An attacker can do any number of things to modify what you intend for `auto` (or any other release method run in the CI) to do if your release keys are in everyone's CI builds.
+
+The solution for this is actually quite simple:
+
+1. Create a test scope that you publish canaries under (ex: `@auto-canary` or `@auto-test`)
+2. Set the default `NPM_TOKEN` to a token that can publish to that scope (this is used for any pull request)
+3. Set up a `secure` token that is only accessible on the main fork (still named `NPM_TOKEN`)
+
+Step 3 might not be possible on your build platform.
+
+The following are the ways the `auto` team knows how to do it.
+If you do not see the method for you build platform, please make a pull request!
+
+- [CircleCI Context](https://circleci.com/docs/2.0/contexts/) - Contexts provide a mechanism for securing and sharing environment variables across projects. The environment variables are defined as name/value pairs and are injected at runtime.
+
+```json
+{
+  "plugins": [
+    [
+      "npm",
+      {
+        "canaryScope": "@auto-canary"
+      }
+    ]
+  ]
+}
+```
+
+Now when people make pull requests to their repos it will get published under your `canaryScope`.
+
+::: message is-success
+Tip: Every npm account is also a scope! So you can set `canaryScope` to your username. :tada:
+:::

--- a/package.json
+++ b/package.json
@@ -126,7 +126,12 @@
   },
   "auto": {
     "plugins": [
-      "npm",
+      [
+        "npm",
+        {
+          "canaryScope": "@auto-canary"
+        }
+      ],
       "released",
       "first-time-contributor",
       [

--- a/plugins/npm/README.md
+++ b/plugins/npm/README.md
@@ -95,8 +95,9 @@ If your project is private you have nothing to worry about, but if your project 
 #### Setup
 
 1. Create a test scope that you publish canaries under (ex: `@auto-canary` or `@auto-test`)
-2. Set the default `NPM_TOKEN` to a token that can publish to that scope (this is used for any pull request)
-3. Set up a `secure` token that is only accessible on the main fork (still named `NPM_TOKEN`)
+2. Create a user that only has access to that scope
+3. Set the default `NPM_TOKEN` to a token that can publish to that scope (this is used for any pull request)
+4. Set up a `secure` token that is only accessible on the main fork (still named `NPM_TOKEN`)
 
 Step 3 might not be possible on your build platform.
 The following are the ways the `auto` team knows how to do it.

--- a/plugins/npm/README.md
+++ b/plugins/npm/README.md
@@ -86,3 +86,37 @@ You can disable this behavior by using the `subPackageChangelogs` option.
   ]
 }
 ```
+
+### canaryScope
+
+Publishing canary version comes with some security risks.
+If your project is private you have nothing to worry about, but if your project is open source there are some security holes.
+
+#### Setup
+
+1. Create a test scope that you publish canaries under (ex: `@auto-canary` or `@auto-test`)
+2. Set the default `NPM_TOKEN` to a token that can publish to that scope (this is used for any pull request)
+3. Set up a `secure` token that is only accessible on the main fork (still named `NPM_TOKEN`)
+
+Step 3 might not be possible on your build platform.
+The following are the ways the `auto` team knows how to do it.
+If you do not see the method for you build platform, please make a pull request!
+
+**Platform Solutions:**
+
+- [CircleCI Context](https://circleci.com/docs/2.0/contexts/) - Contexts provide a mechanism for securing and sharing environment variables across projects. The environment variables are defined as name/value pairs and are injected at runtime.
+
+```json
+{
+  "plugins": [
+    [
+      "npm",
+      {
+        "canaryScope": "@auto-canary"
+      }
+    ]
+  ]
+}
+```
+
+> Tip: Every npm account is also a scope! So you can set `canaryScope` to your username. :tada:

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -321,7 +321,7 @@ async function gitReset() {
 
 /** Make a HTML detail */
 const makeDetail = (summary: string, body: string[]) =>
-  `<details><summary>${summary}</summary>${markdownList(body)}</details>`;
+  `<details><summary>${summary}</summary>\n${markdownList(body)}</details>`;
 
 /** Publish to NPM. Works in both a monorepo setting and for a single package. */
 export default class NPMPlugin implements IPlugin {
@@ -602,7 +602,9 @@ export default class NPMPlugin implements IPlugin {
 
         return this.canaryScope
           ? makeDetail(
-              `Published under canary scope ${sanitizeScope(this.canaryScope)}`,
+              `Published under canary scope @${sanitizeScope(
+                this.canaryScope
+              )}`,
               packageList
             )
           : version;

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -306,7 +306,10 @@ async function setCanaryScope(canaryScope: string, paths: string[]) {
         : packageJson.name;
 
       newJson.name = addCanaryScope(canaryScope, name);
-      await writeFile(p, JSON.stringify(newJson, null, 2));
+      await writeFile(
+        path.join(p, 'package.json'),
+        JSON.stringify(newJson, null, 2)
+      );
     })
   );
 }

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -18,7 +18,7 @@ import { gt, gte, inc, ReleaseType } from 'semver';
 
 import getConfigFromPackageJson from './package-config';
 import setTokenOnCI from './set-npm-token';
-import { loadPackageJson, readFile } from './utils';
+import { loadPackageJson, readFile, writeFile } from './utils';
 
 const { isCi } = envCi();
 /** When the next hook is running branch is also the tag to publish under (ex: next, beta) */
@@ -92,7 +92,7 @@ const inFolder = (parent: string, child: string) => {
 interface ChangedPackagesArgs {
   /** Commit hash to find changes for */
   sha: string;
-  /** All of the pacakges in the monorepo */
+  /** All of the packages in the monorepo */
   packages: IMonorepoPackage[];
   /** The lerna.json for the monorepo */
   lernaJson: {
@@ -191,8 +191,8 @@ async function getLernaPackages(): Promise<LernaPackage[]> {
   );
 }
 
-/** Get all of the packages+version in the lerna "independent" monorepo */
-async function getIndependentPackageList() {
+/** Get all of the packages+version in the lerna monorepo */
+async function getPackageList() {
   return getLernaPackages().then(packages =>
     packages.map(p => `${p.name}@${p.version.split('+')[0]}`)
   );
@@ -223,6 +223,8 @@ interface INpmConfig {
   setRcToken?: boolean;
   /** Whether to force publish all the packages in a monorepo */
   forcePublish?: boolean;
+  /** A scope to publish canary versions under */
+  canaryScope?: string;
 }
 
 /** Parse the lerna.json file. */
@@ -246,7 +248,7 @@ async function getPreviousVersion(auto: Auto, prereleaseBranch: string) {
     if (monorepoVersion === 'independent') {
       previousVersion =
         'dryRun' in auto.options && auto.options.dryRun
-          ? markdownList(await getIndependentPackageList())
+          ? markdownList(await getPackageList())
           : '';
     } else {
       const releasedPackage = getMonorepoPackage();
@@ -286,6 +288,38 @@ async function getPreviousVersion(auto: Auto, prereleaseBranch: string) {
   return previousVersion;
 }
 
+/** Remove the @ sign */
+const sanitizeScope = (canaryScope: string) => canaryScope.replace('@', '');
+
+/** Add a npm scope to a package name. Can have leading @ or not. */
+const addCanaryScope = (canaryScope: string, name: string) =>
+  `@${sanitizeScope(canaryScope)}/${name}`;
+
+/** Change the scope of all the packages to the canary scope */
+async function setCanaryScope(canaryScope: string, paths: string[]) {
+  await Promise.all(
+    paths.map(async p => {
+      const packageJson = await loadPackageJson(path.dirname(p));
+      const newJson = { ...packageJson };
+      const name = packageJson.name.match(/@\S+\/\S+/)
+        ? packageJson.name.split('/')[1]
+        : packageJson.name;
+
+      newJson.name = addCanaryScope(canaryScope, name);
+      await writeFile(p, JSON.stringify(newJson, null, 2));
+    })
+  );
+}
+
+/** Reset the scope changes of all the packages  */
+async function gitReset() {
+  await execPromise('git', ['reset', '--hard', 'HEAD']);
+}
+
+/** Make a HTML detail */
+const makeDetail = (summary: string, body: string[]) =>
+  `<details><summary>${summary}</summary>${markdownList(body)}</details>`;
+
 /** Publish to NPM. Works in both a monorepo setting and for a single package. */
 export default class NPMPlugin implements IPlugin {
   /** The name of the plugin */
@@ -300,6 +334,8 @@ export default class NPMPlugin implements IPlugin {
   private readonly setRcToken: boolean;
   /** Whether to always publish all packages in a monorepo */
   private readonly forcePublish: boolean;
+  /** A scope to publish canary versions under */
+  private readonly canaryScope: string | undefined;
 
   /** Initialize the plugin with it's options */
   constructor(config: INpmConfig = {}) {
@@ -309,6 +345,7 @@ export default class NPMPlugin implements IPlugin {
       typeof config.setRcToken === 'boolean' ? config.setRcToken : true;
     this.forcePublish =
       typeof config.forcePublish === 'boolean' ? config.forcePublish : true;
+    this.canaryScope = config.canaryScope || undefined;
   }
 
   /** A memoized version of getLernaPackages */
@@ -516,6 +553,13 @@ export default class NPMPlugin implements IPlugin {
             preid
           );
 
+        if (this.canaryScope) {
+          await setCanaryScope(
+            this.canaryScope,
+            packagesBefore.map(p => p.path)
+          );
+        }
+
         await execPromise('npx', [
           'lerna',
           'publish',
@@ -533,18 +577,16 @@ export default class NPMPlugin implements IPlugin {
 
         auto.logger.verbose.info('Successfully published canary version');
         const packages = await getLernaPackages();
-        const independentPackages = await getIndependentPackageList();
-        // Reset after we read the packages from the system
-        await execPromise('git', ['reset', '--hard', 'HEAD']);
+        const packageList = await getPackageList();
+        // Reset after we read the packages from the system!
+        await gitReset();
 
         if (isIndependent) {
-          if (!independentPackages.some(p => p.includes('canary'))) {
+          if (!packageList.some(p => p.includes('canary'))) {
             return { error: 'No packages were changed. No canary published.' };
           }
 
-          return `<details><summary>Canary Versions</summary>${markdownList(
-            independentPackages
-          )}</details>`;
+          return makeDetail('Canary Versions', packageList);
         }
 
         const versioned = packages.find(p => p.version.includes('canary'));
@@ -553,7 +595,14 @@ export default class NPMPlugin implements IPlugin {
           return { error: 'No packages were changed. No canary published.' };
         }
 
-        return versioned.version.split('+')[0];
+        const version = versioned.version.split('+')[0];
+
+        return this.canaryScope
+          ? makeDetail(
+              `Published under canary scope ${sanitizeScope(this.canaryScope)}`,
+              packageList
+            )
+          : version;
       }
 
       auto.logger.verbose.info('Detected single npm package');
@@ -566,6 +615,10 @@ export default class NPMPlugin implements IPlugin {
         bump,
         `canary${postFix}`
       );
+
+      if (this.canaryScope) {
+        await setCanaryScope(this.canaryScope, ['./package.json']);
+      }
 
       await execPromise('npm', [
         'version',
@@ -580,6 +633,10 @@ export default class NPMPlugin implements IPlugin {
           ? ['publish', '--access', 'public', ...publishArgs, ...verboseArgs]
           : ['publish', ...publishArgs, ...verboseArgs]
       );
+
+      if (this.canaryScope) {
+        await gitReset();
+      }
 
       auto.logger.verbose.info('Successfully published canary version');
       return canaryVersion;

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -299,7 +299,7 @@ const addCanaryScope = (canaryScope: string, name: string) =>
 async function setCanaryScope(canaryScope: string, paths: string[]) {
   await Promise.all(
     paths.map(async p => {
-      const packageJson = await loadPackageJson(path.dirname(p));
+      const packageJson = await loadPackageJson(p);
       const newJson = { ...packageJson };
       const name = packageJson.name.match(/@\S+\/\S+/)
         ? packageJson.name.split('/')[1]
@@ -617,7 +617,7 @@ export default class NPMPlugin implements IPlugin {
       );
 
       if (this.canaryScope) {
-        await setCanaryScope(this.canaryScope, ['./package.json']);
+        await setCanaryScope(this.canaryScope, ['./']);
       }
 
       await execPromise('npm', [

--- a/plugins/npm/src/utils.ts
+++ b/plugins/npm/src/utils.ts
@@ -1,10 +1,11 @@
 import * as fs from 'fs';
+import path from 'path';
 import { promisify } from 'util';
 
 export const readFile = promisify(fs.readFile);
 export const writeFile = promisify(fs.writeFile);
 
 /** Load and parse the root package json for the project */
-export async function loadPackageJson(): Promise<IPackageJSON> {
-  return JSON.parse(await readFile('package.json', 'utf-8'));
+export async function loadPackageJson(root = './'): Promise<IPackageJSON> {
+  return JSON.parse(await readFile(path.join(root, 'package.json'), 'utf-8'));
 }


### PR DESCRIPTION
# What Changed

# Why

Todo:

- [ ] Add tests
- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: <details><summary>Published under canary scope @auto-canary</summary>
- `@auto-canary/auto@8.1.0-canary.789.10413.0`
- `@auto-canary/core@8.1.0-canary.789.10413.0`
- `@auto-canary/all-contributors@8.1.0-canary.789.10413.0`
- `@auto-canary/chrome@8.1.0-canary.789.10413.0`
- `@auto-canary/conventional-commits@8.1.0-canary.789.10413.0`
- `@auto-canary/crates@8.1.0-canary.789.10413.0`
- `@auto-canary/first-time-contributor@8.1.0-canary.789.10413.0`
- `@auto-canary/git-tag@8.1.0-canary.789.10413.0`
- `@auto-canary/jira@8.1.0-canary.789.10413.0`
- `@auto-canary/maven@8.1.0-canary.789.10413.0`
- `@auto-canary/npm@8.1.0-canary.789.10413.0`
- `@auto-canary/omit-commits@8.1.0-canary.789.10413.0`
- `@auto-canary/omit-release-notes@8.1.0-canary.789.10413.0`
- `@auto-canary/released@8.1.0-canary.789.10413.0`
- `@auto-canary/s3@8.1.0-canary.789.10413.0`
- `@auto-canary/slack@8.1.0-canary.789.10413.0`
- `@auto-canary/twitter@8.1.0-canary.789.10413.0`
- `@auto-canary/upload-assets@8.1.0-canary.789.10413.0`</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
