### PR TITLE
fix bug where merging a none would skip previously meged semver bump

### DIFF
--- a/packages/core/src/__tests__/semver.test.ts
+++ b/packages/core/src/__tests__/semver.test.ts
@@ -33,4 +33,10 @@ describe('calculateSemVerBump', () => {
       SEMVER.major
     );
   });
+
+  test('should not skip things before none', () => {
+    expect(calculateSemVerBump([['none'], ['major']], semverMap)).toBe(
+      SEMVER.major
+    );
+  });
 });

--- a/packages/core/src/semver.ts
+++ b/packages/core/src/semver.ts
@@ -65,12 +65,15 @@ export function calculateSemVerBump(
       : labels[0].some(label => skipReleaseLabels.includes(label));
   }
 
-  // If the pr has only 1 `none` release label, skip the release
-  if (
-    labels.length > 0 &&
-    labels[0].length === 1 &&
-    noReleaseLabels.includes(labels[0][0])
-  ) {
+  // If PRs only have none or skip labels, skip the release
+  const onlyNoReleaseLabels = [...labelSet].reduce(
+    (condition, label) =>
+      condition &&
+      (noReleaseLabels.includes(label) || skipReleaseLabels.includes(label)),
+    true
+  );
+
+  if (labelSet.size > 0 && onlyNoReleaseLabels) {
     return SEMVER.noVersion;
   }
 


### PR DESCRIPTION
# What Changed

My original thinking when implementing none was that it is a skip release until paired with a semver label on the **same** pr. 

This doesn't handle the case where:

A: next branch with `none` label
B: feature branch merged into next

When A gets merged the previous code would see the top PR had a `none` label and now semver, so the release was skipped.

What we really want is to see if there are only `none` or `skip` release labels or **all** PRs. This way previous merged PRs aren't skipped.

# Why

v8.1 wasn't released.

ex: merge next into master and next has a none label

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: <details><summary>Published under canary scope @auto-canary</summary>
- `@auto-canary/auto@8.1.0-canary.794.10457.0`
- `@auto-canary/core@8.1.0-canary.794.10457.0`
- `@auto-canary/all-contributors@8.1.0-canary.794.10457.0`
- `@auto-canary/chrome@8.1.0-canary.794.10457.0`
- `@auto-canary/conventional-commits@8.1.0-canary.794.10457.0`
- `@auto-canary/crates@8.1.0-canary.794.10457.0`
- `@auto-canary/first-time-contributor@8.1.0-canary.794.10457.0`
- `@auto-canary/git-tag@8.1.0-canary.794.10457.0`
- `@auto-canary/jira@8.1.0-canary.794.10457.0`
- `@auto-canary/maven@8.1.0-canary.794.10457.0`
- `@auto-canary/npm@8.1.0-canary.794.10457.0`
- `@auto-canary/omit-commits@8.1.0-canary.794.10457.0`
- `@auto-canary/omit-release-notes@8.1.0-canary.794.10457.0`
- `@auto-canary/released@8.1.0-canary.794.10457.0`
- `@auto-canary/s3@8.1.0-canary.794.10457.0`
- `@auto-canary/slack@8.1.0-canary.794.10457.0`
- `@auto-canary/twitter@8.1.0-canary.794.10457.0`
- `@auto-canary/upload-assets@8.1.0-canary.794.10457.0`</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
