### PR TITLE
omit next branch PR Title from being in release notes

### DIFF
--- a/docs/pages/extras/next.md
+++ b/docs/pages/extras/next.md
@@ -1,0 +1,10 @@
+### Setting up Protected Branches
+
+You should make your pre-release branches protected on GitHub. This will prevent a bunch of unwanted behavior from happening.
+
+1. Go to you project's setting on [GitHub](https://github.com)
+2. Click `Branches`
+3. Click `Add Rule`
+4. Enter the name of your prerelease branch (ex: `next`)
+5. Configure extra branch protection settings
+6. (Optional) Set the base branch in GitHub to your prerelease branch (this ensure new PRs go to this branch)

--- a/docs/pages/extras/shipit.md
+++ b/docs/pages/extras/shipit.md
@@ -2,16 +2,7 @@
 
 If you are interested in pre-releases (ex: `alpha`, `beta`, `next`) `auto` has the ability to publish pre-releases in various ways.
 
-### Setup
-
-You should make your pre-release branches protected on GitHub. This will prevent a bunch of unwanted behavior from happening.
-
-1. Go to you project's setting on [GitHub](https://github.com)
-2. Click `Branches`
-3. Click `Add Rule`
-4. Enter the name of your prerelease branch (ex: `next`)
-5. Configure extra branch protection settings
-6. (Optional) Set the base branch in GitHub to your prerelease branch (this ensure new PRs go to this branch)
+Read more about preparing you project for pre-releases [here](../generated/next.md#setting-up-protected-branches).
 
 ### Strategies
 

--- a/packages/core/src/__tests__/__snapshots__/changelog.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/changelog.test.ts.snap
@@ -223,6 +223,27 @@ exports[`generateReleaseNotes should omit authors with invalid email addresses 1
 - Some Feature [#1234](https://github.custom.com/foobar/auto/pull/1234)"
 `;
 
+exports[`generateReleaseNotes should omit changelog item for next branches 1`] = `
+"### Release Notes
+
+_From #123_
+
+foobar
+
+---
+
+#### 🚀  Enhancement
+
+- First Feature [#1235](https://github.custom.com/foobar/auto/pull/1235) (adam@dierkens.com)
+
+#### 🐛  Bug Fix
+
+
+#### Authors: 1
+
+- Adam Dierkens (adam@dierkens.com)"
+`;
+
 exports[`generateReleaseNotes should order the section major, minor, patch, then the rest 1`] = `
 "#### 💥  Breaking Change
 

--- a/packages/core/src/__tests__/changelog.test.ts
+++ b/packages/core/src/__tests__/changelog.test.ts
@@ -426,6 +426,43 @@ describe('generateReleaseNotes', () => {
     expect(await changelog.generateReleaseNotes(commits)).toMatchSnapshot();
   });
 
+  test('should omit changelog item for next branches', async () => {
+    const options = testOptions();
+    const changelog = new Changelog(dummyLog(), options);
+    changelog.loadDefaultHooks();
+
+    const commits = await logParse.normalizeCommits([
+      {
+        hash: '2',
+        files: [],
+        authorName: 'Adam Dierkens',
+        authorEmail: 'adam@dierkens.com',
+        subject: 'First Feature (#1235)',
+        labels: ['minor']
+      }
+    ]);
+
+    expect(
+      await changelog.generateReleaseNotes([
+        {
+          ...commits[0],
+          hash: '1',
+          files: [],
+          authorName: 'Adam Dierkens',
+          authorEmail: 'adam@dierkens.com',
+          subject: 'V8\n\n',
+          labels: [''],
+          pullRequest: {
+            base: 'intuit/next',
+            number: 123,
+            body: '# Release Notes\n\nfoobar'
+          }
+        },
+        ...commits
+      ])
+    ).toMatchSnapshot();
+  });
+
   test('should be able to customize titles', async () => {
     const options = testOptions();
     options.labels = [

--- a/packages/core/src/__tests__/changelog.test.ts
+++ b/packages/core/src/__tests__/changelog.test.ts
@@ -12,7 +12,8 @@ const testOptions = (): IGenerateReleaseNotesOptions => ({
   repo: 'auto',
   baseUrl: 'https://github.custom.com/foobar/auto',
   labels: defaultLabels,
-  baseBranch: 'master'
+  baseBranch: 'master',
+  prereleaseBranches: ['next']
 });
 
 const logParse = new LogParse();
@@ -24,7 +25,8 @@ describe('createUserLink', () => {
       repo: '',
       baseUrl: 'https://github.custom.com/',
       labels: defaultLabels,
-      baseBranch: 'master'
+      baseBranch: 'master',
+      prereleaseBranches: ['next']
     });
     changelog.loadDefaultHooks();
 
@@ -63,7 +65,8 @@ describe('createUserLink', () => {
       repo: '',
       baseUrl: 'https://github.custom.com/',
       labels: defaultLabels,
-      baseBranch: 'master'
+      baseBranch: 'master',
+      prereleaseBranches: ['next']
     });
     changelog.loadDefaultHooks();
 

--- a/packages/core/src/__tests__/release.test.ts
+++ b/packages/core/src/__tests__/release.test.ts
@@ -308,7 +308,7 @@ describe('Release', () => {
           })
         ])
       );
-      getUserByUsername.mockImplementationOnce(username => {
+      getUserByUsername.mockImplementationOnce(() => {
         return {
           login: 'adam',
           name: 'Adam Dierkens'

--- a/packages/core/src/release.ts
+++ b/packages/core/src/release.ts
@@ -303,7 +303,8 @@ export default class Release {
       repo: this.git.options.repo,
       baseUrl: project.html_url,
       labels: this.config.labels,
-      baseBranch: this.config.baseBranch
+      baseBranch: this.config.baseBranch,
+      prereleaseBranches: this.config.prereleaseBranches
     });
 
     this.hooks.onCreateChangelog.call(changelog, version);

--- a/plugins/jira/__tests__/jira.test.ts
+++ b/plugins/jira/__tests__/jira.test.ts
@@ -112,7 +112,8 @@ const testOptions = (): IGenerateReleaseNotesOptions => ({
   repo: 'auto',
   baseUrl: 'https://github.custom.com/foobar/auto',
   labels: defaultLabels,
-  baseBranch: 'master'
+  baseBranch: 'master',
+  prereleaseBranches: ['next']
 });
 const logParse = new LogParse();
 

--- a/plugins/npm/__tests__/monorepo-log.test.ts
+++ b/plugins/npm/__tests__/monorepo-log.test.ts
@@ -77,7 +77,8 @@ test('should create sections for packages', async () => {
     repo: 'test',
     baseUrl: 'https://github.custom.com/',
     labels: defaultLabels,
-    baseBranch: 'master'
+    baseBranch: 'master',
+    prereleaseBranches: ['next']
   });
 
   plugin.apply({
@@ -125,7 +126,8 @@ test('should add versions for independent packages', async () => {
     repo: 'test',
     baseUrl: 'https://github.custom.com/',
     labels: defaultLabels,
-    baseBranch: 'master'
+    baseBranch: 'master',
+    prereleaseBranches: ['next']
   });
 
   plugin.apply({
@@ -171,7 +173,8 @@ test('should create extra change logs for sub-packages', async () => {
           repo: 'test',
           baseUrl: 'https://github.custom.com/',
           labels: defaultLabels,
-          baseBranch: 'master'
+          baseBranch: 'master',
+          prereleaseBranches: ['next']
         });
         t.hooks.renderChangelogTitle.tap('test', label => label);
         return t;


### PR DESCRIPTION
# What Changed

We want to keep the release notes for a prerelease branch but omit the changelog item.

# Why

It will generally never be a useful changelog item? We can add an option to have it present but I don't think it adds value.

Todo:

- [ ] Add tests
- [ ] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: <details><summary>Published under canary scope @auto-canary</summary>
- `@auto-canary/auto@8.1.3-canary.796.10511.0`
- `@auto-canary/core@8.1.3-canary.796.10511.0`
- `@auto-canary/all-contributors@8.1.3-canary.796.10511.0`
- `@auto-canary/chrome@8.1.3-canary.796.10511.0`
- `@auto-canary/conventional-commits@8.1.3-canary.796.10511.0`
- `@auto-canary/crates@8.1.3-canary.796.10511.0`
- `@auto-canary/first-time-contributor@8.1.3-canary.796.10511.0`
- `@auto-canary/git-tag@8.1.3-canary.796.10511.0`
- `@auto-canary/jira@8.1.3-canary.796.10511.0`
- `@auto-canary/maven@8.1.3-canary.796.10511.0`
- `@auto-canary/npm@8.1.3-canary.796.10511.0`
- `@auto-canary/omit-commits@8.1.3-canary.796.10511.0`
- `@auto-canary/omit-release-notes@8.1.3-canary.796.10511.0`
- `@auto-canary/released@8.1.3-canary.796.10511.0`
- `@auto-canary/s3@8.1.3-canary.796.10511.0`
- `@auto-canary/slack@8.1.3-canary.796.10511.0`
- `@auto-canary/twitter@8.1.3-canary.796.10511.0`
- `@auto-canary/upload-assets@8.1.3-canary.796.10511.0`</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
