### PR TITLE
Fix `none` releases: they were not handling extra labels

### DIFF
--- a/packages/core/src/__tests__/semver.test.ts
+++ b/packages/core/src/__tests__/semver.test.ts
@@ -32,6 +32,10 @@ describe('calculateSemVerBump', () => {
     expect(calculateSemVerBump([['none', 'major']], semverMap)).toBe(
       SEMVER.major
     );
+
+    expect(
+      calculateSemVerBump([['none'], ['unknown'], ['documentation']], semverMap)
+    ).toBe(SEMVER.noVersion);
   });
 
   test('should not skip things before none', () => {

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -246,10 +246,10 @@ export default class Auto {
    */
   async loadConfig() {
     const configLoader = new Config(this.logger);
-    const config = this.hooks.modifyConfig.call({
+    const config = {
       ...(await configLoader.loadConfig(this.options)),
       baseBranch: this.baseBranch
-    });
+    };
 
     this.logger.verbose.success('Loaded `auto` with config:', config);
 
@@ -257,6 +257,7 @@ export default class Auto {
     this.labels = config.labels;
     this.semVerLabels = getVersionMap(config.labels);
     this.loadPlugins(config);
+    this.config = this.hooks.modifyConfig.call(config)
     this.hooks.beforeRun.call(config);
 
     const repository = await this.getRepo(config);

--- a/packages/core/src/semver.ts
+++ b/packages/core/src/semver.ts
@@ -44,14 +44,16 @@ export function calculateSemVerBump(
 ) {
   const labelSet = new Set<string>();
   const skipReleaseLabels = labelMap.get('skip') || [];
-  const noReleaseLabels = labelMap.get('none') || [];
 
   labels.forEach(pr => {
     pr.forEach(label => {
       const userLabel = [...labelMap.entries()].find(pair =>
         pair[1].includes(label)
       );
-      labelSet.add(userLabel ? userLabel[0] : label);
+
+      if (userLabel) {
+        labelSet.add(userLabel[0]);
+      }
     });
   });
 
@@ -67,9 +69,8 @@ export function calculateSemVerBump(
 
   // If PRs only have none or skip labels, skip the release
   const onlyNoReleaseLabels = [...labelSet].reduce(
-    (condition, label) =>
-      condition &&
-      (noReleaseLabels.includes(label) || skipReleaseLabels.includes(label)),
+    (condition, releaseType) =>
+      condition && (releaseType === 'none' || releaseType === 'skip'),
     true
   );
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: <details><summary>Published under canary scope @auto-canary</summary>
- `@auto-canary/auto@8.1.2-canary.797.10492.0`
- `@auto-canary/core@8.1.2-canary.797.10492.0`
- `@auto-canary/all-contributors@8.1.2-canary.797.10492.0`
- `@auto-canary/chrome@8.1.2-canary.797.10492.0`
- `@auto-canary/conventional-commits@8.1.2-canary.797.10492.0`
- `@auto-canary/crates@8.1.2-canary.797.10492.0`
- `@auto-canary/first-time-contributor@8.1.2-canary.797.10492.0`
- `@auto-canary/git-tag@8.1.2-canary.797.10492.0`
- `@auto-canary/jira@8.1.2-canary.797.10492.0`
- `@auto-canary/maven@8.1.2-canary.797.10492.0`
- `@auto-canary/npm@8.1.2-canary.797.10492.0`
- `@auto-canary/omit-commits@8.1.2-canary.797.10492.0`
- `@auto-canary/omit-release-notes@8.1.2-canary.797.10492.0`
- `@auto-canary/released@8.1.2-canary.797.10492.0`
- `@auto-canary/s3@8.1.2-canary.797.10492.0`
- `@auto-canary/slack@8.1.2-canary.797.10492.0`
- `@auto-canary/twitter@8.1.2-canary.797.10492.0`
- `@auto-canary/upload-assets@8.1.2-canary.797.10492.0`</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
