### PR TITLE
release: add flag to publish prerelease

### DIFF
--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -404,7 +404,13 @@ export const commands: Command[] = [
         description:
           'Version number to publish as. Defaults to reading from the package definition for the platform.'
       },
-      baseBranch
+      baseBranch,
+      {
+        name: 'prerelease',
+        type: Boolean,
+        group: 'main',
+        description: 'Publish a prerelease.'
+      }
     ],
     examples: [
       '{green $} auto release',

--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -834,7 +834,47 @@ describe('Auto', () => {
         undefined,
         undefined
       );
-      expect(auto.git!.publish).toHaveBeenCalledWith('releaseNotes', 'v1.2.4');
+      expect(auto.git!.publish).toHaveBeenCalledWith(
+        'releaseNotes',
+        'v1.2.4',
+        false
+      );
+      expect(afterRelease).toHaveBeenCalledWith(
+        expect.objectContaining({
+          lastRelease: 'v1.2.3',
+          newVersion: 'v1.2.4'
+        })
+      );
+    });
+
+    test('should a prerelease', async () => {
+      const auto = new Auto({ ...defaults, plugins: [] });
+      auto.logger = dummyLog();
+      await auto.loadConfig();
+      auto.git!.getLatestRelease = () => Promise.resolve('1.2.3');
+      jest.spyOn(auto.git!, 'publish').mockImplementation();
+      jest
+        .spyOn(auto.release!, 'generateReleaseNotes')
+        .mockImplementation(() => Promise.resolve('releaseNotes'));
+      auto.release!.getCommitsInRelease = () =>
+        Promise.resolve([makeCommitFromMsg('Test Commit')]);
+
+      auto.hooks.getPreviousVersion.tap('test', () => '1.2.4');
+      const afterRelease = jest.fn();
+      auto.hooks.afterRelease.tap('test', afterRelease);
+      jest.spyOn(auto.release!, 'getCommits').mockImplementation();
+
+      await auto.runRelease({ prerelease: true });
+      expect(auto.release!.generateReleaseNotes).toHaveBeenCalledWith(
+        'v1.2.3',
+        undefined,
+        undefined
+      );
+      expect(auto.git!.publish).toHaveBeenCalledWith(
+        'releaseNotes',
+        'v1.2.4',
+        true
+      );
       expect(afterRelease).toHaveBeenCalledWith(
         expect.objectContaining({
           lastRelease: 'v1.2.3',
@@ -868,7 +908,11 @@ describe('Auto', () => {
         undefined,
         undefined
       );
-      expect(auto.git!.publish).toHaveBeenCalledWith('releaseNotes', 'v1.2.4');
+      expect(auto.git!.publish).toHaveBeenCalledWith(
+        'releaseNotes',
+        'v1.2.4',
+        false
+      );
       expect(afterRelease).toHaveBeenCalledWith(
         expect.objectContaining({
           lastRelease: 'v1.2.0',
@@ -902,7 +946,11 @@ describe('Auto', () => {
         undefined,
         undefined
       );
-      expect(auto.git!.publish).toHaveBeenCalledWith('releaseNotes', 'v1.3.0');
+      expect(auto.git!.publish).toHaveBeenCalledWith(
+        'releaseNotes',
+        'v1.3.0',
+        false
+      );
       expect(afterRelease).toHaveBeenCalledWith(
         expect.objectContaining({
           lastRelease: 'v1.2.3',

--- a/packages/core/src/auto-args.ts
+++ b/packages/core/src/auto-args.ts
@@ -91,6 +91,8 @@ export interface IReleaseOptions extends IAuthorOptions {
   from?: string;
   /** Override the version to release */
   useVersion?: string;
+  /** Create a prerelease */
+  prerelease?: boolean;
 }
 
 export interface ICommentOptions {

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -257,7 +257,7 @@ export default class Auto {
     this.labels = config.labels;
     this.semVerLabels = getVersionMap(config.labels);
     this.loadPlugins(config);
-    this.config = this.hooks.modifyConfig.call(config)
+    this.config = this.hooks.modifyConfig.call(config);
     this.hooks.beforeRun.call(config);
 
     const repository = await this.getRepo(config);
@@ -1062,7 +1062,8 @@ export default class Auto {
   private async makeRelease({
     dryRun,
     from,
-    useVersion
+    useVersion,
+    prerelease = false
   }: IReleaseOptions = {}) {
     if (!this.release || !this.git) {
       throw this.createErrorMessage();
@@ -1124,7 +1125,7 @@ export default class Auto {
       );
     } else {
       this.logger.log.info(`Releasing ${newVersion} to GitHub.`);
-      release = await this.git.publish(releaseNotes, newVersion);
+      release = await this.git.publish(releaseNotes, newVersion, prerelease);
 
       await this.hooks.afterRelease.promise({
         lastRelease,


### PR DESCRIPTION
# What Changed

See title

# Why

For non-shipit users it makes sense to have a flag to publish prereleases.

Todo:

- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: <details><summary>Published under canary scope @auto-canary</summary>
- `@auto-canary/auto@8.2.0-canary.800.10552.0`
- `@auto-canary/core@8.2.0-canary.800.10552.0`
- `@auto-canary/all-contributors@8.2.0-canary.800.10552.0`
- `@auto-canary/chrome@8.2.0-canary.800.10552.0`
- `@auto-canary/conventional-commits@8.2.0-canary.800.10552.0`
- `@auto-canary/crates@8.2.0-canary.800.10552.0`
- `@auto-canary/first-time-contributor@8.2.0-canary.800.10552.0`
- `@auto-canary/git-tag@8.2.0-canary.800.10552.0`
- `@auto-canary/jira@8.2.0-canary.800.10552.0`
- `@auto-canary/maven@8.2.0-canary.800.10552.0`
- `@auto-canary/npm@8.2.0-canary.800.10552.0`
- `@auto-canary/omit-commits@8.2.0-canary.800.10552.0`
- `@auto-canary/omit-release-notes@8.2.0-canary.800.10552.0`
- `@auto-canary/released@8.2.0-canary.800.10552.0`
- `@auto-canary/s3@8.2.0-canary.800.10552.0`
- `@auto-canary/slack@8.2.0-canary.800.10552.0`
- `@auto-canary/twitter@8.2.0-canary.800.10552.0`
- `@auto-canary/upload-assets@8.2.0-canary.800.10552.0`</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
