### PR TITLE
release: detect prerelease branch + be smarter about commit range

### DIFF
--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -851,7 +851,10 @@ describe('Auto', () => {
       const auto = new Auto({ ...defaults, plugins: [] });
       auto.logger = dummyLog();
       await auto.loadConfig();
-      auto.git!.getLatestRelease = () => Promise.resolve('1.2.3');
+
+      auto.git!.getPreviousTagInBranch = () => Promise.resolve('1.2.3');
+      auto.git!.getLatestTagInBranch = () => Promise.resolve('1.2.4');
+
       jest.spyOn(auto.git!, 'publish').mockImplementation();
       jest
         .spyOn(auto.release!, 'generateReleaseNotes')

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -733,4 +733,14 @@ export default class Git {
   async getLatestTagInBranch() {
     return execPromise('git', ['describe', '--tags', '--abbrev=0']);
   }
+
+  /** Get the tag before latest in the git tree */
+  async getPreviousTagInBranch() {
+    return execPromise('git', [
+      'describe',
+      '--tags',
+      '--abbrev=0',
+      '$(git describe --tags --abbrev=0)^1'
+    ]);
+  }
 }

--- a/plugins/git-tag/src/index.ts
+++ b/plugins/git-tag/src/index.ts
@@ -2,13 +2,10 @@ import {
   Auto,
   determineNextVersion,
   execPromise,
-  IPlugin
+  IPlugin,
+  getCurrentBranch
 } from '@auto-it/core';
 import { inc, ReleaseType } from 'semver';
-import { execSync } from 'child_process';
-
-/** When the next hook is running branch is also the tag to publish under (ex: next, beta) */
-const branch = execSync('git symbolic-ref --short HEAD', { encoding: 'utf8' });
 
 /** Manage your projects version through just a git tag. */
 export default class GitTagPlugin implements IPlugin {
@@ -55,6 +52,7 @@ export default class GitTagPlugin implements IPlugin {
       }
 
       const prereleaseBranches = auto.config?.prereleaseBranches!;
+      const branch = getCurrentBranch() || '';
       const prereleaseBranch = prereleaseBranches.includes(branch)
         ? branch
         : prereleaseBranches[0];


### PR DESCRIPTION
# What Changed

see title

# Why

needed to do a little more when release a prerelease. also detecting that we are in a prerelease branch seems in line with what auto does elsewhere.


<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: <details><summary>Published under canary scope @auto-canary</summary>
- `@auto-canary/auto@8.3.0-canary.810.10665.0`
- `@auto-canary/core@8.3.0-canary.810.10665.0`
- `@auto-canary/all-contributors@8.3.0-canary.810.10665.0`
- `@auto-canary/chrome@8.3.0-canary.810.10665.0`
- `@auto-canary/conventional-commits@8.3.0-canary.810.10665.0`
- `@auto-canary/crates@8.3.0-canary.810.10665.0`
- `@auto-canary/first-time-contributor@8.3.0-canary.810.10665.0`
- `@auto-canary/git-tag@8.3.0-canary.810.10665.0`
- `@auto-canary/jira@8.3.0-canary.810.10665.0`
- `@auto-canary/maven@8.3.0-canary.810.10665.0`
- `@auto-canary/npm@8.3.0-canary.810.10665.0`
- `@auto-canary/omit-commits@8.3.0-canary.810.10665.0`
- `@auto-canary/omit-release-notes@8.3.0-canary.810.10665.0`
- `@auto-canary/released@8.3.0-canary.810.10665.0`
- `@auto-canary/s3@8.3.0-canary.810.10665.0`
- `@auto-canary/slack@8.3.0-canary.810.10665.0`
- `@auto-canary/twitter@8.3.0-canary.810.10665.0`
- `@auto-canary/upload-assets@8.3.0-canary.810.10665.0`</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
