### PR TITLE
version: detect prerelease branch

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -31,6 +31,7 @@ import {
   INextOptions
 } from './auto-args';
 import Changelog from './changelog';
+import { preVersionMap } from './semver';
 import Config from './config';
 import Git, { IGitOptions, IPRInfo } from './git';
 import init from './init';
@@ -1032,8 +1033,15 @@ export default class Auto {
       throw this.createErrorMessage();
     }
 
-    const lastRelease = from || (await this.git.getLatestRelease());
-    const bump = await this.release.getSemverBump(lastRelease);
+    const isPrerelease = this.inPrereleaseBranch();
+    const lastRelease =
+      from ||
+      (isPrerelease && (await this.git.getLatestTagInBranch())) ||
+      (await this.git.getLatestRelease());
+    const calculatedBump = await this.release.getSemverBump(lastRelease);
+    const bump =
+      (isPrerelease && preVersionMap.get(calculatedBump)) || calculatedBump;
+
     this.versionBump = bump;
 
     return bump;

--- a/packages/core/src/semver.ts
+++ b/packages/core/src/semver.ts
@@ -10,6 +10,12 @@ enum SEMVER {
   noVersion = ''
 }
 
+export const preVersionMap = new Map([
+  [SEMVER.major, SEMVER.premajor],
+  [SEMVER.minor, SEMVER.preminor],
+  [SEMVER.patch, SEMVER.prepatch]
+]);
+
 export type IVersionLabels = Map<VersionLabel | 'none', string[]>;
 
 export default SEMVER;


### PR DESCRIPTION
With this you can now easily publish next versions without using shipit
<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: <details><summary>Published under canary scope @auto-canary</summary>
- `@auto-canary/auto@8.4.0-canary.811.10681.0`
- `@auto-canary/core@8.4.0-canary.811.10681.0`
- `@auto-canary/all-contributors@8.4.0-canary.811.10681.0`
- `@auto-canary/chrome@8.4.0-canary.811.10681.0`
- `@auto-canary/conventional-commits@8.4.0-canary.811.10681.0`
- `@auto-canary/crates@8.4.0-canary.811.10681.0`
- `@auto-canary/first-time-contributor@8.4.0-canary.811.10681.0`
- `@auto-canary/git-tag@8.4.0-canary.811.10681.0`
- `@auto-canary/jira@8.4.0-canary.811.10681.0`
- `@auto-canary/maven@8.4.0-canary.811.10681.0`
- `@auto-canary/npm@8.4.0-canary.811.10681.0`
- `@auto-canary/omit-commits@8.4.0-canary.811.10681.0`
- `@auto-canary/omit-release-notes@8.4.0-canary.811.10681.0`
- `@auto-canary/released@8.4.0-canary.811.10681.0`
- `@auto-canary/s3@8.4.0-canary.811.10681.0`
- `@auto-canary/slack@8.4.0-canary.811.10681.0`
- `@auto-canary/twitter@8.4.0-canary.811.10681.0`
- `@auto-canary/upload-assets@8.4.0-canary.811.10681.0`</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
