### PR TITLE
canary: try to match commit to PR if not found in env

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/match-sha-to-pr.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/match-sha-to-pr.test.ts.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`buildSearchQuery generates a valid query 1`] = `
+"{
+    hash_abc123: search(query: \\"repo:Andrew/test abc123\\", type: ISSUE, first: 1) {
+  edges {
+    node {
+      ... on PullRequest {
+        number
+        state
+        body
+        labels(first: 10) {
+          edges {
+            node {
+              name
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+hash_3def78: search(query: \\"repo:Andrew/test 3def78\\", type: ISSUE, first: 1) {
+  edges {
+    node {
+      ... on PullRequest {
+        number
+        state
+        body
+        labels(first: 10) {
+          edges {
+            node {
+              name
+            }
+          }
+        }
+      }
+    }
+  }
+}
+    rateLimit {
+      limit
+      cost
+      remaining
+      resetAt
+    }
+  }"
+`;

--- a/packages/core/src/__tests__/__snapshots__/release.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/release.test.ts.snap
@@ -1,53 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Release buildSearchQuery generates a valid query 1`] = `
-"{
-    hash_abc123: search(query: \\"repo:Andrew/test abc123\\", type: ISSUE, first: 1) {
-  edges {
-    node {
-      ... on PullRequest {
-        number
-        state
-        body
-        labels(first: 10) {
-          edges {
-            node {
-              name
-            }
-          }
-        }
-      }
-    }
-  }
-}
-
-hash_3def78: search(query: \\"repo:Andrew/test 3def78\\", type: ISSUE, first: 1) {
-  edges {
-    node {
-      ... on PullRequest {
-        number
-        state
-        body
-        labels(first: 10) {
-          edges {
-            node {
-              name
-            }
-          }
-        }
-      }
-    }
-  }
-}
-    rateLimit {
-      limit
-      cost
-      remaining
-      resetAt
-    }
-  }"
-`;
-
 exports[`Release generateReleaseNotes should allow user to configure section headings 1`] = `
 "#### 💥  Breaking Change
 

--- a/packages/core/src/__tests__/match-sha-to-pr.test.ts
+++ b/packages/core/src/__tests__/match-sha-to-pr.test.ts
@@ -1,0 +1,16 @@
+import { parse } from 'graphql';
+
+import { buildSearchQuery } from '../match-sha-to-pr';
+
+describe('buildSearchQuery', () => {
+  test('generates a valid query', () => {
+    const query = buildSearchQuery('Andrew', 'test', ['abc123', '3def78']);
+    expect(() => parse(query!)).not.toThrow();
+    expect(query).toMatchSnapshot();
+  });
+
+  test("doesn't generate a query without commits", () => {
+    const query = buildSearchQuery('Andrew', 'test', []);
+    expect(query).toBeUndefined();
+  });
+});

--- a/packages/core/src/__tests__/release.test.ts
+++ b/packages/core/src/__tests__/release.test.ts
@@ -1,8 +1,6 @@
-import { parse } from 'graphql';
 import Git from '../git';
 import LogParse from '../log-parse';
 import Release, {
-  buildSearchQuery,
   defaultLabels,
   getVersionMap,
   ILabelDefinition
@@ -763,22 +761,6 @@ describe('Release', () => {
       await expect(
         gh.generateReleaseNotes('1234', '123')
       ).resolves.toBeDefined();
-    });
-  });
-
-  describe('buildSearchQuery', () => {
-    test('generates a valid query', () => {
-      const query = buildSearchQuery('Andrew', 'test', [
-        makeCommitFromMsg('first', { hash: 'abc123' }),
-        makeCommitFromMsg('second', { hash: '3def78' })
-      ]);
-      expect(() => parse(query!)).not.toThrow();
-      expect(query).toMatchSnapshot();
-    });
-
-    test("doesn't generate a query without commits", () => {
-      const query = buildSearchQuery('Andrew', 'test', []);
-      expect(query).toBeUndefined();
     });
   });
 

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1,3 +1,5 @@
+/* eslint-disable complexity */
+
 import { ReposCreateReleaseResponse, Response } from '@octokit/rest';
 import dotenv from 'dotenv';
 import envCi from 'env-ci';
@@ -48,6 +50,7 @@ import createLog, { ILogger } from './utils/logger';
 import { makeHooks } from './utils/make-hooks';
 import { IAuthorOptions, IRepoOptions } from './auto-args';
 import { execSync } from 'child_process';
+import { buildSearchQuery, ISearchResult } from './match-sha-to-pr';
 
 const proxyUrl = process.env.https_proxy || process.env.http_proxy;
 const env = envCi();
@@ -669,20 +672,9 @@ export default class Auto {
       process.exit(1);
     }
 
-    await this.checkClean();
+    // await this.checkClean();
 
-    // SailEnv falls back to commit SHA
-    let pr: string | undefined;
-    let build: string | undefined;
-
-    if ('pr' in env && 'build' in env) {
-      ({ pr } = env);
-      ({ build } = env);
-    } else if ('pr' in env && 'commit' in env) {
-      ({ pr } = env);
-      build = env.commit;
-    }
-
+    let { pr, build } = await this.getPrEnvInfo();
     pr = options.pr ? String(options.pr) : pr;
     build = options.build ? String(options.build) : build;
 
@@ -819,9 +811,10 @@ export default class Auto {
       `Published next version${result.length > 1 ? `s` : ''}: ${newVersion}`
     );
 
-    if ('isPr' in env && env.isPr) {
+    const { pr } = await this.getPrEnvInfo();
+
+    if (pr) {
       const message = options.message || 'Published prerelease version: %v';
-      const pr = 'pr' in env && env.pr;
 
       if (pr) {
         await this.prBody({
@@ -1302,6 +1295,44 @@ If a command fails manually run:
         this.logger.verbose.info(`Using ${plugin.name} Plugin...`);
         plugin.apply(this);
       });
+  }
+
+  /** Get the branch and build number when in CI environment */
+  private async getPrEnvInfo() {
+    // SailEnv falls back to commit SHA
+    let pr: string | undefined;
+    let build: string | undefined;
+
+    if ('pr' in env && 'build' in env) {
+      ({ pr } = env);
+      ({ build } = env);
+    } else if ('pr' in env && 'commit' in env) {
+      ({ pr } = env);
+      build = env.commit;
+    }
+
+    // If we haven't detected the PR from the env vars try to match
+    // the commit to a PR
+    if (env.isCi && !pr && this.git?.options.owner && this.git?.options.repo) {
+      const commit = await this.git.getSha();
+      const query = buildSearchQuery(
+        this.git?.options.owner,
+        this.git?.options.repo,
+        [commit]
+      );
+
+      if (query) {
+        const result = await this.git.graphql(query);
+
+        if (result && result[`hash_${commit}`]) {
+          pr = String(
+            (result[`hash_${commit}`] as ISearchResult).edges[0]?.node?.number
+          );
+        }
+      }
+    }
+
+    return { pr, build };
   }
 }
 

--- a/packages/core/src/match-sha-to-pr.ts
+++ b/packages/core/src/match-sha-to-pr.ts
@@ -1,0 +1,125 @@
+import endent from 'endent';
+
+import { IExtendedCommit } from './log-parse';
+
+interface ISearchEdge {
+  /** Graphql search node */
+  node: {
+    /** PR number */
+    number: number;
+    /** State of the PR */
+    state: 'MERGED' | 'CLOSED' | 'OPEN';
+    /** Body of the PR */
+    body: string;
+    /** Labels attached to the PR */
+    labels: {
+      /** Edges of the Query */
+      edges: [
+        {
+          /** Graphql search node */
+          node: {
+            /** Name of the label */
+            name: string;
+          };
+        }
+      ];
+    };
+  };
+}
+
+export interface ISearchResult {
+  /** Results in the search */
+  edges: ISearchEdge[];
+}
+
+/**
+ * Generate a GitHub graphql query to find all the commits related
+ * to a PR.
+ */
+export function buildSearchQuery(
+  owner: string,
+  project: string,
+  commits: string[]
+) {
+  const repo = `${owner}/${project}`;
+  const query = commits.reduce((q, commit) => {
+    const subQuery = `repo:${repo} ${commit}`;
+
+    return endent`
+      ${q}
+
+      hash_${commit}: search(query: "${subQuery}", type: ISSUE, first: 1) {
+        edges {
+          node {
+            ... on PullRequest {
+              number
+              state
+              body
+              labels(first: 10) {
+                edges {
+                  node {
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    `;
+  }, '');
+
+  if (!query) {
+    return;
+  }
+
+  return `{
+    ${query}
+    rateLimit {
+      limit
+      cost
+      remaining
+      resetAt
+    }
+  }`;
+}
+
+/** Use the graphql query result to fill in more information about a commit */
+export function processQueryResult(
+  key: string,
+  result: ISearchResult,
+  commitsWithoutPR: IExtendedCommit[]
+) {
+  const hash = key.split('hash_')[1];
+  const commit = commitsWithoutPR.find(
+    commitWithoutPR => commitWithoutPR.hash === hash
+  );
+
+  if (!commit) {
+    return;
+  }
+
+  if (result.edges.length > 0) {
+    if (result.edges[0].node.state === 'CLOSED') {
+      return;
+    }
+
+    const labels: {
+      /** The label */
+      name: string;
+    }[] = result.edges[0].node.labels
+      ? result.edges[0].node.labels.edges.map(edge => edge.node)
+      : [];
+    commit.pullRequest = {
+      number: result.edges[0].node.number,
+      body: result.edges[0].node.body
+    };
+    commit.labels = [...labels.map(label => label.name), ...commit.labels];
+  } else {
+    commit.labels = ['pushToBaseBranch', ...commit.labels];
+  }
+
+  commit.subject = commit.subject.split('\n')[0];
+
+  return commit;
+}

--- a/packages/core/src/release.ts
+++ b/packages/core/src/release.ts
@@ -1,7 +1,6 @@
 import { GraphQlQueryResponse } from '@octokit/graphql/dist-types/types';
 import GHub from '@octokit/rest';
 import on from 'await-to-js';
-import endent from 'endent';
 import * as fs from 'fs';
 import chunk from 'lodash.chunk';
 import { inc, ReleaseType } from 'semver';
@@ -22,6 +21,11 @@ import execPromise from './utils/exec-promise';
 import { dummyLog, ILogger } from './utils/logger';
 import { makeReleaseHooks } from './utils/make-hooks';
 import { execSync } from 'child_process';
+import {
+  buildSearchQuery,
+  ISearchResult,
+  processQueryResult
+} from './match-sha-to-pr';
 
 export type VersionLabel =
   | SEMVER.major
@@ -57,36 +61,6 @@ export type IAutoConfig = IAuthorOptions &
     /** The labels configured by the user */
     labels: ILabelDefinition[];
   };
-
-interface ISearchEdge {
-  /** Graphql search node */
-  node: {
-    /** PR number */
-    number: number;
-    /** State of the PR */
-    state: 'MERGED' | 'CLOSED' | 'OPEN';
-    /** Body of the PR */
-    body: string;
-    /** Labels attached to the PR */
-    labels: {
-      /** Edges of the Query */
-      edges: [
-        {
-          /** Graphql search node */
-          node: {
-            /** Name of the label */
-            name: string;
-          };
-        }
-      ];
-    };
-  };
-}
-
-interface ISearchResult {
-  /** Results in the search */
-  edges: ISearchEdge[];
-}
 
 export interface ILabelDefinition {
   /** The label text */
@@ -167,98 +141,6 @@ export interface IReleaseHooks {
   createChangelogTitle: AsyncSeriesBailHook<[], string | void>;
   /** This is where you hook into the LogParse's hooks. This hook is exposed for convenience on during `this.hooks.onCreateRelease` and at the root `this.hooks` */
   onCreateLogParse: SyncHook<[LogParse]>;
-}
-
-/**
- * Generate a GitHub graphql query to find all the commits related
- * to a PR.
- */
-export function buildSearchQuery(
-  owner: string,
-  project: string,
-  commits: IExtendedCommit[]
-) {
-  const repo = `${owner}/${project}`;
-  const query = commits.reduce((q, commit) => {
-    const subQuery = `repo:${repo} ${commit.hash}`;
-
-    return endent`
-      ${q}
-
-      hash_${commit.hash}: search(query: "${subQuery}", type: ISSUE, first: 1) {
-        edges {
-          node {
-            ... on PullRequest {
-              number
-              state
-              body
-              labels(first: 10) {
-                edges {
-                  node {
-                    name
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    `;
-  }, '');
-
-  if (!query) {
-    return;
-  }
-
-  return `{
-    ${query}
-    rateLimit {
-      limit
-      cost
-      remaining
-      resetAt
-    }
-  }`;
-}
-
-/** Use the graphql query result to fill in more information about a commit */
-function processQueryResult(
-  key: string,
-  result: ISearchResult,
-  commitsWithoutPR: IExtendedCommit[]
-) {
-  const hash = key.split('hash_')[1];
-  const commit = commitsWithoutPR.find(
-    commitWithoutPR => commitWithoutPR.hash === hash
-  );
-
-  if (!commit) {
-    return;
-  }
-
-  if (result.edges.length > 0) {
-    if (result.edges[0].node.state === 'CLOSED') {
-      return;
-    }
-
-    const labels: {
-      /** The label */
-      name: string;
-    }[] = result.edges[0].node.labels
-      ? result.edges[0].node.labels.edges.map(edge => edge.node)
-      : [];
-    commit.pullRequest = {
-      number: result.edges[0].node.number,
-      body: result.edges[0].node.body
-    };
-    commit.labels = [...labels.map(label => label.name), ...commit.labels];
-  } else {
-    commit.labels = ['pushToBaseBranch', ...commit.labels];
-  }
-
-  commit.subject = commit.subject.split('\n')[0];
-
-  return commit;
 }
 
 /**
@@ -364,7 +246,11 @@ export default class Release {
     const queries = await Promise.all(
       batches
         .map(batch =>
-          buildSearchQuery(this.git.options.owner, this.git.options.repo, batch)
+          buildSearchQuery(
+            this.git.options.owner,
+            this.git.options.repo,
+            batch.map(c => c.hash)
+          )
         )
         .filter((q): q is string => Boolean(q))
         .map(q => this.git.graphql(q))


### PR DESCRIPTION
# What Changed

If we can't find pr in env info, use github api to match commit to PR.

# Why

closes #481 

@glambert could you test this version out for me and see if it now works as intended?
<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: <details><summary>Published under canary scope @auto-canary</summary>
- `@auto-canary/auto@8.4.2-canary.812.10761.0`
- `@auto-canary/core@8.4.2-canary.812.10761.0`
- `@auto-canary/all-contributors@8.4.2-canary.812.10761.0`
- `@auto-canary/chrome@8.4.2-canary.812.10761.0`
- `@auto-canary/conventional-commits@8.4.2-canary.812.10761.0`
- `@auto-canary/crates@8.4.2-canary.812.10761.0`
- `@auto-canary/first-time-contributor@8.4.2-canary.812.10761.0`
- `@auto-canary/git-tag@8.4.2-canary.812.10761.0`
- `@auto-canary/jira@8.4.2-canary.812.10761.0`
- `@auto-canary/maven@8.4.2-canary.812.10761.0`
- `@auto-canary/npm@8.4.2-canary.812.10761.0`
- `@auto-canary/omit-commits@8.4.2-canary.812.10761.0`
- `@auto-canary/omit-release-notes@8.4.2-canary.812.10761.0`
- `@auto-canary/released@8.4.2-canary.812.10761.0`
- `@auto-canary/s3@8.4.2-canary.812.10761.0`
- `@auto-canary/slack@8.4.2-canary.812.10761.0`
- `@auto-canary/twitter@8.4.2-canary.812.10761.0`
- `@auto-canary/upload-assets@8.4.2-canary.812.10761.0`</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
