### PR TITLE
alias the canary scope

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,6 +47,7 @@
     "chalk": "^3.0.0",
     "command-line-application": "^0.9.3",
     "endent": "^1.3.0",
+    "module-alias": "^2.2.2",
     "signale": "^1.4.0",
     "tslib": "1.10.0"
   },

--- a/packages/cli/src/bin/auto.ts
+++ b/packages/cli/src/bin/auto.ts
@@ -1,5 +1,20 @@
 #!/usr/bin/env node
 
+import moduleAlias from 'module-alias';
+import path from 'path';
+
+try {
+  // eslint-disable-next-line
+  const json = require(path.join(__dirname, '../../package.json'));
+
+  if (json.name.startsWith('@auto-canary')) {
+    moduleAlias.addAliases({
+      '@auto-it': (fromPath: string, request: string) =>
+        request.startsWith('@auto-it') ? '@auto-canary' : '@auto-it'
+    });
+  }
+} catch (error) {}
+
 import chalk from 'chalk';
 import parseArgs from '../parse-args';
 import run from '../run';

--- a/plugins/npm/README.md
+++ b/plugins/npm/README.md
@@ -90,7 +90,11 @@ You can disable this behavior by using the `subPackageChangelogs` option.
 ### canaryScope
 
 Publishing canary versions comes with some security risks.
-If your project is private you have nothing to worry about, but if your project is open source there are some security holes.
+If your project is private you have nothing to worry about and can skip these, but if your project is open source there are some security holes.
+
+::: message is-warning
+This feature works pretty easily/well for single packages. In a monorepo we have to deal with a lot more, and this options should be treated as experimental.
+:::
 
 #### Setup
 
@@ -98,6 +102,7 @@ If your project is private you have nothing to worry about, but if your project 
 2. Create a user that only has access to that scope
 3. Set the default `NPM_TOKEN` to a token that can publish to that scope (this is used for any pull request)
 4. Set up a `secure` token that is only accessible on the main fork (still named `NPM_TOKEN`)
+5. Set up alias (only monorepos)
 
 Step 3 might not be possible on your build platform.
 
@@ -120,3 +125,15 @@ If you do not see the method for you build platform, please make a pull request!
   ]
 }
 ```
+
+##### Set up alias
+
+If you are managing a non-monorepo you do not have to do anything for this step!
+If you manage a monorepo we still have to do handle our packages importing each other.
+Since we just changed the name of the package all imports to our packages are now broken!
+
+There are multiple ways to make this work and the solution might be different depending on your build target.
+
+- [module-alias](https://www.npmjs.com/package/module-alias) - Modifiy node's require for your canary deploys (This is what `auto` uses). Useful for node packages
+- [Webpack Aliases](https://webpack.js.org/configuration/resolve/) Modify scoped requires for webpack based projects.
+- [babel-plugin-module-resolver](https://www.npmjs.com/package/babel-plugin-module-resolver) - A Babel plugin to add a new resolver for your modules when compiling your code using Babel.

--- a/typings/module-alias.d.ts
+++ b/typings/module-alias.d.ts
@@ -1,0 +1,1 @@
+declare module 'module-alias';

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,7 +8,7 @@
   integrity sha512-m2OzlTDbhvzK4hgswH9Lx0cdpq1AntXu53Klz5RGkFfuoDvKsnlU7tmtVfNWtUiP0zZbGtrb/BZYH7aB6TRnMA==
 
 "@auto-it/core@link:packages/core":
-  version "8.2.0"
+  version "8.3.0"
   dependencies:
     "@octokit/graphql" "^4.0.0"
     "@octokit/plugin-enterprise-compatibility" "1.1.1"
@@ -36,7 +36,7 @@
     url-join "^4.0.0"
 
 "@auto-it/npm@link:plugins/npm":
-  version "8.2.0"
+  version "8.3.0"
   dependencies:
     "@auto-it/core" "link:packages/core"
     env-ci "^4.1.1"
@@ -51,7 +51,7 @@
     user-home "^2.0.0"
 
 "@auto-it/released@link:plugins/released":
-  version "8.2.0"
+  version "8.3.0"
   dependencies:
     "@auto-it/core" "link:packages/core"
     deepmerge "^4.0.0"
@@ -2515,15 +2515,6 @@
     regexpp "^3.0.0"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@2.10.0":
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.10.0.tgz#8db1656cdfd3d9dcbdbf360b8274dea76f0b2c2c"
-  integrity sha512-FZhWq6hWWZBP76aZ7bkrfzTMP31CCefVIImrwP3giPLcoXocmLTmr92NLZxuIcTL4GTEOE33jQMWy9PwelL+yQ==
-  dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.10.0"
-    eslint-scope "^5.0.0"
-
 "@typescript-eslint/experimental-utils@2.11.0", "@typescript-eslint/experimental-utils@^2.5.0":
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.11.0.tgz#cef18e6b122706c65248a5d8984a9779ed1e52ac"
@@ -2559,19 +2550,6 @@
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.5.0"
-
-"@typescript-eslint/typescript-estree@2.10.0":
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.10.0.tgz#89cdabd5e8c774e9d590588cb42fb9afd14dcbd9"
-  integrity sha512-oOYnplddQNm/LGVkqbkAwx4TIBuuZ36cAQq9v3nFIU9FmhemHuVzAesMSXNQDdAzCa5bFgCrfD3JWhYVKlRN2g==
-  dependencies:
-    debug "^4.1.1"
-    eslint-visitor-keys "^1.1.0"
-    glob "^7.1.6"
-    is-glob "^4.0.1"
-    lodash.unescape "4.0.1"
-    semver "^6.3.0"
-    tsutils "^3.17.1"
 
 "@typescript-eslint/typescript-estree@2.11.0":
   version "2.11.0"
@@ -10543,6 +10521,11 @@ modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
+
+module-alias@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/module-alias/-/module-alias-2.2.2.tgz#151cdcecc24e25739ff0aa6e51e1c5716974c0e0"
+  integrity sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q==
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
# What Changed

When `@auto-canary/auto` is installed it will change nodes module resolution to alias any import to `@auto-it`to the canary scope. Add warning around experimental nature of canaryScope 

# Why

During testing found that a few things about canary scope were broken.

- had to change deps to use canary scope
- add docs about aliasing things

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: <details><summary>Published under canary scope @auto-canary</summary>
- `@auto-canary/auto@8.4.1-canary.813.10751.0`
- `@auto-canary/core@8.4.1-canary.813.10751.0`
- `@auto-canary/all-contributors@8.4.1-canary.813.10751.0`
- `@auto-canary/chrome@8.4.1-canary.813.10751.0`
- `@auto-canary/conventional-commits@8.4.1-canary.813.10751.0`
- `@auto-canary/crates@8.4.1-canary.813.10751.0`
- `@auto-canary/first-time-contributor@8.4.1-canary.813.10751.0`
- `@auto-canary/git-tag@8.4.1-canary.813.10751.0`
- `@auto-canary/jira@8.4.1-canary.813.10751.0`
- `@auto-canary/maven@8.4.1-canary.813.10751.0`
- `@auto-canary/npm@8.4.1-canary.813.10751.0`
- `@auto-canary/omit-commits@8.4.1-canary.813.10751.0`
- `@auto-canary/omit-release-notes@8.4.1-canary.813.10751.0`
- `@auto-canary/released@8.4.1-canary.813.10751.0`
- `@auto-canary/s3@8.4.1-canary.813.10751.0`
- `@auto-canary/slack@8.4.1-canary.813.10751.0`
- `@auto-canary/twitter@8.4.1-canary.813.10751.0`
- `@auto-canary/upload-assets@8.4.1-canary.813.10751.0`</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
