### PR TITLE
update docs to show JS plugins and how to use versionBranches

### DIFF
--- a/docs/pages/autorc.md
+++ b/docs/pages/autorc.md
@@ -22,6 +22,18 @@ auto init
 
 These options can be set exclusively in the `.autorc` and do not exist as CLI flags.
 
+### versionBranches
+
+Create and manage old major releases.
+
+```json
+{
+  "versionBranches": true,
+  // or customize the branch prefix
+  "versionBranches": "major-"
+}
+```
+
 ### Prerelease Branches
 
 You can configure what branches `auto` treats as prerelease branches.

--- a/docs/pages/extras/shipit.md
+++ b/docs/pages/extras/shipit.md
@@ -9,6 +9,29 @@ The following shows how those flags can effect the workflow.
 
 ![The entire shipit workflow](../../images/complete-auto.png)
 
+## Managing Old Major Versions
+
+This command also has the ability to help you manage old major versions too!
+This feature is off by default, to enable set `versionBranches` to `true` in your [.autorc](../autorc.md#versionbranches).
+
+With this feature enabled `auto shipit` will:
+
+- Create a version branch when a `major` happens (prefixed with `version-`)
+- When ran from a `versionBranch` make a release to that version
+
+Now that you have a branch for an old major release, it is super easy to release patches to it!
+People can make PRs to the the `version-` branch and once merged create a new release of that version.
+
+### Customize Branch Prefix
+
+You can customize what the branch names will be by setting `versionBranches` to a string.
+
+```json
+{
+  "versionBranches": "Major-"
+}
+```
+
 ## Prereleases
 
 If you are interested in pre-releases (ex: `alpha`, `beta`, `next`) `auto` has the ability to publish pre-releases in various ways.

--- a/docs/pages/writing-plugins.md
+++ b/docs/pages/writing-plugins.md
@@ -23,6 +23,24 @@ export default class TestPlugin implements IPlugin {
 }
 ```
 
+Or in JavaScript:
+
+```js
+module.exports = class TestPlugin {
+  constructor(config) {
+    this.config = config;
+  }
+
+  /**
+   * Setup the plugin
+   * @param {import('@auto-it/core').default} auto
+   */
+  apply(auto) {
+    // hook into auto
+  }
+};
+```
+
 ## Constructor
 
 In the constructor you have access to any plugin specific config provided in the `.autorc`. It might be useful to write a more type-safe interface for your config.

--- a/scripts/update-tap.js
+++ b/scripts/update-tap.js
@@ -27,6 +27,10 @@ module.exports = class {
     this.name = 'brew';
   }
 
+  /**
+   * Setup the plugin
+   * @param {import('@auto-it/core').default} auto
+   */
   apply(auto) {
     auto.hooks.afterVersion.tap('Update brew', () => {
       try {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: <details><summary>Published under canary scope @auto-canary</summary>
- `@auto-canary/auto@8.6.1-canary.816.10835.0`
- `@auto-canary/core@8.6.1-canary.816.10835.0`
- `@auto-canary/all-contributors@8.6.1-canary.816.10835.0`
- `@auto-canary/chrome@8.6.1-canary.816.10835.0`
- `@auto-canary/conventional-commits@8.6.1-canary.816.10835.0`
- `@auto-canary/crates@8.6.1-canary.816.10835.0`
- `@auto-canary/first-time-contributor@8.6.1-canary.816.10835.0`
- `@auto-canary/git-tag@8.6.1-canary.816.10835.0`
- `@auto-canary/jira@8.6.1-canary.816.10835.0`
- `@auto-canary/maven@8.6.1-canary.816.10835.0`
- `@auto-canary/npm@8.6.1-canary.816.10835.0`
- `@auto-canary/omit-commits@8.6.1-canary.816.10835.0`
- `@auto-canary/omit-release-notes@8.6.1-canary.816.10835.0`
- `@auto-canary/released@8.6.1-canary.816.10835.0`
- `@auto-canary/s3@8.6.1-canary.816.10835.0`
- `@auto-canary/slack@8.6.1-canary.816.10835.0`
- `@auto-canary/twitter@8.6.1-canary.816.10835.0`
- `@auto-canary/upload-assets@8.6.1-canary.816.10835.0`</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
