### PR TITLE
canary hook can return void to not bail

### DIFF
--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -1004,6 +1004,7 @@ describe('Auto', () => {
       auto.release!.getCommitsInRelease = () =>
         Promise.resolve([makeCommitFromMsg('Test Commit')]);
       const canary = jest.fn();
+      canary.mockReturnValueOnce('1.2.3');
       auto.hooks.canary.tap('test', canary);
       jest.spyOn(auto.release!, 'getCommits').mockImplementation();
 
@@ -1032,6 +1033,7 @@ describe('Auto', () => {
         .mockImplementation()
         .mockReturnValue(Promise.resolve([makeCommitFromMsg('Test Commit')]));
       const canary = jest.fn();
+      canary.mockReturnValue('abcd');
       auto.hooks.canary.tap('test', canary);
       jest.spyOn(auto.release!, 'getCommits').mockImplementation();
 

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -126,6 +126,7 @@ export interface IAutoHooks {
         /** Error when creating the canary release */
         error: string;
       }
+    | void
   >;
   /**
    * Used to publish a next release. In this hook you get the semver bump

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -758,6 +758,10 @@ export default class Auto {
         return;
       }
 
+      if (!result) {
+        return;
+      }
+
       newVersion = result;
       const message = options.message || 'Published PR with canary version: %v';
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: <details><summary>Published under canary scope @auto-canary</summary>
- `@auto-canary/auto@8.6.1-canary.817.10853.0`
- `@auto-canary/core@8.6.1-canary.817.10853.0`
- `@auto-canary/all-contributors@8.6.1-canary.817.10853.0`
- `@auto-canary/chrome@8.6.1-canary.817.10853.0`
- `@auto-canary/conventional-commits@8.6.1-canary.817.10853.0`
- `@auto-canary/crates@8.6.1-canary.817.10853.0`
- `@auto-canary/first-time-contributor@8.6.1-canary.817.10853.0`
- `@auto-canary/git-tag@8.6.1-canary.817.10853.0`
- `@auto-canary/jira@8.6.1-canary.817.10853.0`
- `@auto-canary/maven@8.6.1-canary.817.10853.0`
- `@auto-canary/npm@8.6.1-canary.817.10853.0`
- `@auto-canary/omit-commits@8.6.1-canary.817.10853.0`
- `@auto-canary/omit-release-notes@8.6.1-canary.817.10853.0`
- `@auto-canary/released@8.6.1-canary.817.10853.0`
- `@auto-canary/s3@8.6.1-canary.817.10853.0`
- `@auto-canary/slack@8.6.1-canary.817.10853.0`
- `@auto-canary/twitter@8.6.1-canary.817.10853.0`
- `@auto-canary/upload-assets@8.6.1-canary.817.10853.0`</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
