### PR TITLE
only access auto login if it all exists

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/release.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/release.test.ts.snap
@@ -231,9 +231,7 @@ Array [
       Object {
         "email": "adam@dierkens.com",
         "hash": "1a2b",
-        "login": "adam",
         "name": "Adam Dierkens",
-        "username": "adam",
       },
     ],
     "files": Array [],
@@ -276,9 +274,7 @@ Array [
       Object {
         "email": "adam@dierkens.com",
         "hash": "1a2b",
-        "login": "adam",
         "name": "Adam Dierkens",
-        "username": "adam",
       },
     ],
     "files": Array [],
@@ -433,9 +429,7 @@ Array [
       Object {
         "email": "adam@dierkens.com",
         "hash": "foo",
-        "login": "adam",
         "name": "Adam Dierkens",
-        "username": "adam",
       },
     ],
     "files": Array [],

--- a/packages/core/src/__tests__/release.test.ts
+++ b/packages/core/src/__tests__/release.test.ts
@@ -23,6 +23,7 @@ afterAll(() => {
 const constructor = jest.fn();
 const getGitLog = jest.fn();
 const graphql = jest.fn();
+const getUserByEmail = jest.fn();
 const getPr = jest.fn();
 const getPullRequest = jest.fn();
 const getLatestRelease = jest.fn();
@@ -84,6 +85,7 @@ jest.mock(
       getCommitDate = getCommitDate;
       getFirstCommit = getFirstCommit;
       getCommit = getCommit;
+      getUserByEmail = getUserByEmail;
     }
 );
 
@@ -244,6 +246,10 @@ describe('Release', () => {
             }
           }
         ])
+      );
+
+      getCommit.mockReturnValueOnce(
+        Promise.resolve({ data: { author: { login: 'adam' } } })
       );
 
       getCommit.mockReturnValueOnce(

--- a/packages/core/src/release.ts
+++ b/packages/core/src/release.ts
@@ -776,7 +776,7 @@ export default class Release {
     } else {
       const [, response] = await on(this.git.getCommit(commit.hash));
 
-      if (response) {
+      if (response?.data?.author?.login) {
         const username = response.data.author.login;
         const author = await this.git.getUserByUsername(username);
 


### PR DESCRIPTION
Sometimes it could be undefined
<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: <details><summary>Published under canary scope @auto-canary</summary>
- `@auto-canary/auto@8.6.2-canary.819.10874.0`
- `@auto-canary/core@8.6.2-canary.819.10874.0`
- `@auto-canary/all-contributors@8.6.2-canary.819.10874.0`
- `@auto-canary/chrome@8.6.2-canary.819.10874.0`
- `@auto-canary/conventional-commits@8.6.2-canary.819.10874.0`
- `@auto-canary/crates@8.6.2-canary.819.10874.0`
- `@auto-canary/first-time-contributor@8.6.2-canary.819.10874.0`
- `@auto-canary/git-tag@8.6.2-canary.819.10874.0`
- `@auto-canary/jira@8.6.2-canary.819.10874.0`
- `@auto-canary/maven@8.6.2-canary.819.10874.0`
- `@auto-canary/npm@8.6.2-canary.819.10874.0`
- `@auto-canary/omit-commits@8.6.2-canary.819.10874.0`
- `@auto-canary/omit-release-notes@8.6.2-canary.819.10874.0`
- `@auto-canary/released@8.6.2-canary.819.10874.0`
- `@auto-canary/s3@8.6.2-canary.819.10874.0`
- `@auto-canary/slack@8.6.2-canary.819.10874.0`
- `@auto-canary/twitter@8.6.2-canary.819.10874.0`
- `@auto-canary/upload-assets@8.6.2-canary.819.10874.0`</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
