### PR TITLE
add context of what type of release was made during shipit

### DIFF
--- a/docs/pages/writing-plugins.md
+++ b/docs/pages/writing-plugins.md
@@ -171,6 +171,20 @@ auto.hooks.afterRelease.tap(
 
 Ran after the `shipit` command has run.
 
+- `newVersion` - The new version that was release
+- `commits` - the commits in the release
+- `data`
+  - `context` - The type of release that was created (`latest`, `next`, `canary`, or `old`)
+
+```ts
+auto.hooks.afterShipIt.tap(
+  'MyPlugin',
+  async (newVersion, commits, { context }) => {
+    // do something
+  }
+);
+```
+
 #### getAuthor
 
 Get git author. Typically from a package distribution description file.

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -73,18 +73,12 @@ interface TestingToken {
 type ShipitContext = 'canary' | 'next' | 'latest' | 'old';
 
 interface ShipitInfo {
-  /**
-   *
-   */
-newVersion?: string;
-  /**
-   *
-   */
-commitsInRelease: IExtendedCommit[];
-  /**
-   *
-   */
-context: ShipitContext;
+  /** The Version published when shipit ran */
+  newVersion?: string;
+  /** The commits released during shipit */
+  commitsInRelease: IExtendedCommit[];
+  /** The type of release made */
+  context: ShipitContext;
 }
 
 export interface IAutoHooks {
@@ -100,10 +94,14 @@ export interface IAutoHooks {
   afterAddToChangelog: AsyncSeriesHook<[ChangelogLifecycle]>;
   /** Ran after the `shipit` command has run. */
   afterShipIt: AsyncParallelHook<
-    [string | undefined, IExtendedCommit[], { /**
-                                               *
-                                               */
-context: ShipitContext }]
+    [
+      string | undefined,
+      IExtendedCommit[],
+      {
+        /** The type of release made by shipit */
+        context: ShipitContext;
+      }
+    ]
   >;
   /** Ran after the `release` command has run. */
   afterRelease: AsyncParallelHook<

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -70,6 +70,23 @@ interface TestingToken {
   token?: string;
 }
 
+type ShipitContext = 'canary' | 'next' | 'latest' | 'old';
+
+interface ShipitInfo {
+  /**
+   *
+   */
+newVersion?: string;
+  /**
+   *
+   */
+commitsInRelease: IExtendedCommit[];
+  /**
+   *
+   */
+context: ShipitContext;
+}
+
 export interface IAutoHooks {
   /** Modify what is in the config. You must return the config in this hook. */
   modifyConfig: SyncWaterfallHook<[IAutoConfig]>;
@@ -82,7 +99,12 @@ export interface IAutoHooks {
   /** Ran after the `changelog` command adds the new release notes to `CHANGELOG.md`. */
   afterAddToChangelog: AsyncSeriesHook<[ChangelogLifecycle]>;
   /** Ran after the `shipit` command has run. */
-  afterShipIt: AsyncParallelHook<[string | undefined, IExtendedCommit[]]>;
+  afterShipIt: AsyncParallelHook<
+    [string | undefined, IExtendedCommit[], { /**
+                                               *
+                                               */
+context: ShipitContext }]
+  >;
   /** Ran after the `release` command has run. */
   afterRelease: AsyncParallelHook<
     [
@@ -690,7 +712,7 @@ export default class Auto {
   }
 
   /** Create a canary (or test) version of the project */
-  async canary(options: ICanaryOptions = {}) {
+  async canary(options: ICanaryOptions = {}): Promise<ShipitInfo | undefined> {
     if (!this.git || !this.release) {
       throw this.createErrorMessage();
     }
@@ -793,14 +815,14 @@ export default class Auto {
     }
 
     const commitsInRelease = await this.release.getCommits(latestTag);
-    return { newVersion, commitsInRelease };
+    return { newVersion, commitsInRelease, context: 'canary' };
   }
 
   /**
    * Create a next (or test) version of the project. If on master will
    * release to the default "next" branch.
    */
-  async next(options: INextOptions) {
+  async next(options: INextOptions): Promise<ShipitInfo | undefined> {
     if (!this.git || !this.release) {
       throw this.createErrorMessage();
     }
@@ -833,7 +855,7 @@ export default class Auto {
         `Would have created prerelease version with: ${bump}`
       );
 
-      return { newVersion: '', commitsInRelease: commits };
+      return { newVersion: '', commitsInRelease: commits, context: 'next' };
     }
 
     this.logger.verbose.info(`Calling "next" hook with: ${bump}`);
@@ -882,7 +904,7 @@ export default class Auto {
       }
     }
 
-    return { newVersion, commitsInRelease: commits };
+    return { newVersion, commitsInRelease: commits, context: 'next' };
   }
 
   /**
@@ -942,8 +964,10 @@ export default class Auto {
       return;
     }
 
-    const { newVersion, commitsInRelease } = publishInfo;
-    await this.hooks.afterShipIt.promise(newVersion, commitsInRelease);
+    const { newVersion, commitsInRelease, context } = publishInfo;
+    await this.hooks.afterShipIt.promise(newVersion, commitsInRelease, {
+      context
+    });
   }
 
   /** Get the latest version number of the project */
@@ -979,9 +1003,20 @@ export default class Auto {
   }
 
   /** Make a release to an old version */
-  private async oldRelease(options: IShipItOptions) {
+  private async oldRelease(
+    options: IShipItOptions
+  ): Promise<ShipitInfo | undefined> {
     const latestTag = await this.git?.getLatestTagInBranch();
-    return this.publishFullRelease({ ...options, from: latestTag });
+    const result = await this.publishFullRelease({
+      ...options,
+      from: latestTag
+    });
+
+    if (result) {
+      result.context = 'old';
+    }
+
+    return result;
   }
 
   /** On master: publish a new latest version */
@@ -990,7 +1025,7 @@ export default class Auto {
       /** Internal option to shipt from a certain tag or commit */
       from?: string;
     }
-  ) {
+  ): Promise<ShipitInfo | undefined> {
     if (!this.git || !this.release) {
       throw this.createErrorMessage();
     }
@@ -1037,7 +1072,7 @@ export default class Auto {
       }
     }
 
-    return { newVersion, commitsInRelease };
+    return { newVersion, commitsInRelease, context: 'latest' };
   }
 
   /** Get a pr number from user input or the env */

--- a/packages/core/src/utils/make-hooks.ts
+++ b/packages/core/src/utils/make-hooks.ts
@@ -18,7 +18,7 @@ export const makeHooks = (): IAutoHooks => ({
   beforeShipIt: new SyncHook(),
   afterAddToChangelog: new AsyncSeriesHook(['context']),
   beforeCommitChangelog: new AsyncSeriesHook(['context']),
-  afterShipIt: new AsyncParallelHook(['version', 'commits']),
+  afterShipIt: new AsyncParallelHook(['version', 'commits', 'context']),
   afterRelease: new AsyncParallelHook(['releaseInfo']),
   onCreateRelease: new SyncHook(['options']),
   onCreateChangelog: new SyncHook(['changelog', 'version']),


### PR DESCRIPTION
# What Changed

Add a little more info to the `afterShipit` hook

# Why

You can do some cool automation based

Todo:

- [ ] Add tests
- [ ] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: <details><summary>Published under canary scope @auto-canary</summary>
- `@auto-canary/auto@8.7.0-canary.821.10911.0`
- `@auto-canary/core@8.7.0-canary.821.10911.0`
- `@auto-canary/all-contributors@8.7.0-canary.821.10911.0`
- `@auto-canary/chrome@8.7.0-canary.821.10911.0`
- `@auto-canary/conventional-commits@8.7.0-canary.821.10911.0`
- `@auto-canary/crates@8.7.0-canary.821.10911.0`
- `@auto-canary/first-time-contributor@8.7.0-canary.821.10911.0`
- `@auto-canary/git-tag@8.7.0-canary.821.10911.0`
- `@auto-canary/jira@8.7.0-canary.821.10911.0`
- `@auto-canary/maven@8.7.0-canary.821.10911.0`
- `@auto-canary/npm@8.7.0-canary.821.10911.0`
- `@auto-canary/omit-commits@8.7.0-canary.821.10911.0`
- `@auto-canary/omit-release-notes@8.7.0-canary.821.10911.0`
- `@auto-canary/released@8.7.0-canary.821.10911.0`
- `@auto-canary/s3@8.7.0-canary.821.10911.0`
- `@auto-canary/slack@8.7.0-canary.821.10911.0`
- `@auto-canary/twitter@8.7.0-canary.821.10911.0`
- `@auto-canary/upload-assets@8.7.0-canary.821.10911.0`</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
