### PR TITLE
Add documentation and tests for label changelog label section assignment behavior

### DIFF
--- a/docs/pages/autorc.md
+++ b/docs/pages/autorc.md
@@ -199,7 +199,10 @@ If paired with a SEMVER label, the release is not skipped.
 
 #### Changelog Titles
 
-Each PR included in the release will be matched to the first label defined in the config with a `changelogTitle` in priority order of the `releaseType` (major, minor, patch, then all others) and included as an entry within that section
+Each PR included in the release will be assigned to a label section based upon the matching label with the highest `releaseType` that has a `changelogTitle`.
+
+- Priority order of `releaseType` from highest to lowest is: major, minor, patch, and then all others
+- If a PR has multiple labels of the same `releaseType`, then the PR is assigned based upon the label that is assigned first in the config
 
 By default auto will create sections in the changelog for the following labels:
 

--- a/docs/pages/autorc.md
+++ b/docs/pages/autorc.md
@@ -95,6 +95,55 @@ To customize your project's labels use the `labels` section in your `.autorc`.
 }
 ```
 
+<details><summary>Click here to see the default label configuration</summary>
+
+```json
+[
+  {
+    "name": "major",
+    "changelogTitle": "💥  Breaking Change",
+    "description": "Increment the major version when merged",
+    "releaseType": "major"
+  },
+  {
+    "name": "minor",
+    "changelogTitle": "🚀  Enhancement",
+    "description": "Increment the minor version when merged",
+    "releaseType": "minor"
+  },
+  {
+    "name": "patch",
+    "changelogTitle": "🐛  Bug Fix",
+    "description": "Increment the patch version when merged",
+    "releaseType": "patch"
+  },
+  {
+    "name": "skip-release",
+    "description": "Preserve the current version when merged",
+    "releaseType": "skip"
+  },
+  {
+    "name": "release",
+    "description": "Create a release when this pr is merged",
+    "releaseType": "release"
+  },
+  {
+    "name": "internal",
+    "changelogTitle": "🏠  Internal",
+    "description": "Changes only affect the internal API",
+    "releaseType": "none"
+  },
+  {
+    "name": "documentation",
+    "changelogTitle": "📝  Documentation",
+    "description": "Changes only affect the documentation",
+    "releaseType": "none"
+  }
+]
+```
+
+</details>
+
 #### Label Customization
 
 You can customize everything about a label
@@ -120,15 +169,40 @@ You can customize everything about a label
 }
 ```
 
+#### Release Type: `none`
+
+A label with the `none` release type will not create a release when merged.
+If paired with a SEMVER label, the release is not skipped.
+
+```json
+{
+  "labels": [
+    {
+      "name": "documentation",
+      "releaseType": "none"
+    }
+  ]
+}
+```
+
 #### Changelog Titles
 
-By default auto will create sections in the changelog for the following labels.
+Each PR included in the release will be matched to the first label defined in the config with a `changelogTitle` in priority order of the `releaseType` (major, minor, patch, then all others) and included as an entry within that section
+
+By default auto will create sections in the changelog for the following labels:
 
 - major
 - minor
 - patch
 - internal
 - documentation
+
+For example:
+
+- Using the default config, if a given PR has the labels `minor` and `internal`, then it will be included in the `minor` label section
+- Using the default config, if a given PR has the labels `documentation` and `internal`, then it will be included in the `internal` label section
+
+##### Updating Default Label Changelog Titles
 
 To customize the title for the section in the changelog you can
 
@@ -142,6 +216,8 @@ To customize the title for the section in the changelog you can
   ]
 }
 ```
+
+##### Adding Additional Changelog Title Sections
 
 If you want more sections in your changelog to further detail the change-set you can
 use the `labels` section to add more. Any label in the label section with a changelogTitle
@@ -161,6 +237,8 @@ related to a TypeScript re-write.
 }
 ```
 
+##### Removing Default Label Changelog Title Sections
+
 You can remove the existing default label sections by adding a custom overwrite label with the same `releaseType`.
 
 The following removes the default internal and documentation label sections:
@@ -173,22 +251,6 @@ The following removes the default internal and documentation label sections:
       "changelogTitle": "Docz",
       "releaseType": "none",
       "overwrite": true
-    }
-  ]
-}
-```
-
-#### `none` Release
-
-A label with the `none` release type will not create a release when merged.
-If paired with a SEMVER label, the release is not skipped.
-
-```json
-{
-  "labels": [
-    {
-      "name": "documentation",
-      "releaseType": "none"
     }
   ]
 }

--- a/packages/core/src/__tests__/__snapshots__/changelog.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/changelog.test.ts.snap
@@ -270,6 +270,36 @@ exports[`generateReleaseNotes should order the section major, minor, patch, then
 - Adam Dierkens (adam@dierkens.com)"
 `;
 
+exports[`generateReleaseNotes should prefer section with highest releaseType for PR with multiple labels 1`] = `
+"#### Minor Section
+
+- Some Feature [#1234](https://github.custom.com/foobar/auto/pull/1234) (adam@dierkens.com)
+
+#### Authors: 1
+
+- Adam Dierkens (adam@dierkens.com)"
+`;
+
+exports[`generateReleaseNotes should prefer section defined first in config for PR with multiple labels of same releaseType 1`] = `
+"#### Internal Section
+
+- Some Feature [#1234](https://github.custom.com/foobar/auto/pull/1234) (adam@dierkens.com)
+
+#### Authors: 1
+
+- Adam Dierkens (adam@dierkens.com)"
+`;
+
+exports[`generateReleaseNotes should prefer section of default label for PR with multiple labels of same releaseType 1`] = `
+"#### 🚀  Enhancement
+
+- Some Feature [#1234](https://github.custom.com/foobar/auto/pull/1234) (adam@dierkens.com)
+
+#### Authors: 1
+
+- Adam Dierkens (adam@dierkens.com)"
+`;
+
 exports[`generateReleaseNotes should use only email if author name doesn't exist 1`] = `
 "#### 🐛  Bug Fix
 

--- a/packages/core/src/__tests__/changelog.test.ts
+++ b/packages/core/src/__tests__/changelog.test.ts
@@ -170,7 +170,6 @@ describe('generateReleaseNotes', () => {
   test('should create note for PR commits without labels with custom patch label', async () => {
     const options = testOptions();
     options.labels = [
-      ...options.labels,
       {
         name: 'Version: Patch',
         changelogTitle: '🐛  Bug Fix',


### PR DESCRIPTION
# What Changed

- Took attempt at updating label config docs to better communicate (a) default labels & (b) how PRs are assigned to a label section
- Added a few tests for changelog / releaseNote generation to check for documented behavior

# Why

- To improve accessibility of new auto users to understand what the default changelog / release notes will look like and how they might modify the config to achieve desired customization
- See [this comment](https://github.com/intuit/auto/issues/476#issuecomment-565922977) 

# Todo:

- [x] Add tests
- [x] Add docs

# Callouts

- I'm not 100% liking the way the changes to the docs turned out so far... but wanted to create a PR to get feedback / start the conversation of how to best improve the existing docs
<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: <details><summary>Published under canary scope @auto-canary</summary>
- `@auto-canary/auto@8.7.3-canary.822.10958.0`
- `@auto-canary/core@8.7.3-canary.822.10958.0`
- `@auto-canary/all-contributors@8.7.3-canary.822.10958.0`
- `@auto-canary/chrome@8.7.3-canary.822.10958.0`
- `@auto-canary/conventional-commits@8.7.3-canary.822.10958.0`
- `@auto-canary/crates@8.7.3-canary.822.10958.0`
- `@auto-canary/first-time-contributor@8.7.3-canary.822.10958.0`
- `@auto-canary/git-tag@8.7.3-canary.822.10958.0`
- `@auto-canary/jira@8.7.3-canary.822.10958.0`
- `@auto-canary/maven@8.7.3-canary.822.10958.0`
- `@auto-canary/npm@8.7.3-canary.822.10958.0`
- `@auto-canary/omit-commits@8.7.3-canary.822.10958.0`
- `@auto-canary/omit-release-notes@8.7.3-canary.822.10958.0`
- `@auto-canary/released@8.7.3-canary.822.10958.0`
- `@auto-canary/s3@8.7.3-canary.822.10958.0`
- `@auto-canary/slack@8.7.3-canary.822.10958.0`
- `@auto-canary/twitter@8.7.3-canary.822.10958.0`
- `@auto-canary/upload-assets@8.7.3-canary.822.10958.0`</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
