### PR TITLE
Add more logs for next release calculation

### DIFF
--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -756,7 +756,14 @@ export default class Git {
   async getLastTagNotInBaseBranch(branch: string) {
     const baseTags = await this.getTags(this.options.baseBranch);
     const branchTags = await this.getTags(branch);
+    const firstUnique = branchTags
+      .reverse()
+      .find(tag => !baseTags.includes(tag));
 
-    return branchTags.reverse().find(tag => !baseTags.includes(tag));
+    this.logger.verbose.info('Tags found in base branch:', branchTags);
+    this.logger.verbose.info('Tags found in branch:', baseTags);
+    this.logger.verbose.info('Latest tag in branch:', branchTags);
+
+    return firstUnique;
   }
 }

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -674,20 +674,29 @@ export default class NPMPlugin implements IPlugin {
       if (isMonorepo()) {
         auto.logger.verbose.info('Detected monorepo, using lerna');
         const isIndependent = getLernaJson().version === 'independent';
+        // It's hard to accurately predict how we should bump independent versions.
+        // So we just prerelease most of the time. (independent only)
+        const next = isIndependent
+          ? 'prerelease'
+          : determineNextVersion(
+              lastRelease,
+              latestTag,
+              bump,
+              prereleaseBranch
+            );
+
+        auto.logger.verbose.info({
+          lastRelease,
+          latestTag,
+          bump,
+          prereleaseBranch,
+          next
+        });
 
         await execPromise('npx', [
           'lerna',
           'publish',
-          // It's hard to accurately predict how we should bump independent versions.
-          // So we just prerelease most of the time. (independent only)
-          isIndependent
-            ? 'prerelease'
-            : determineNextVersion(
-                lastRelease,
-                latestTag,
-                bump,
-                prereleaseBranch
-              ),
+          next,
           '--dist-tag',
           prereleaseBranch,
           '--preid',


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: <details><summary>Published under canary scope @auto-canary</summary>
- `@auto-canary/auto@8.7.1-canary.824.10934.0`
- `@auto-canary/core@8.7.1-canary.824.10934.0`
- `@auto-canary/all-contributors@8.7.1-canary.824.10934.0`
- `@auto-canary/chrome@8.7.1-canary.824.10934.0`
- `@auto-canary/conventional-commits@8.7.1-canary.824.10934.0`
- `@auto-canary/crates@8.7.1-canary.824.10934.0`
- `@auto-canary/first-time-contributor@8.7.1-canary.824.10934.0`
- `@auto-canary/git-tag@8.7.1-canary.824.10934.0`
- `@auto-canary/jira@8.7.1-canary.824.10934.0`
- `@auto-canary/maven@8.7.1-canary.824.10934.0`
- `@auto-canary/npm@8.7.1-canary.824.10934.0`
- `@auto-canary/omit-commits@8.7.1-canary.824.10934.0`
- `@auto-canary/omit-release-notes@8.7.1-canary.824.10934.0`
- `@auto-canary/released@8.7.1-canary.824.10934.0`
- `@auto-canary/s3@8.7.1-canary.824.10934.0`
- `@auto-canary/slack@8.7.1-canary.824.10934.0`
- `@auto-canary/twitter@8.7.1-canary.824.10934.0`
- `@auto-canary/upload-assets@8.7.1-canary.824.10934.0`</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
