### PR TITLE
next: check origin head instead of local branch for tags

### DIFF
--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -749,7 +749,7 @@ export default class Git {
       'tag',
       "--sort='creatordate'",
       '--merged',
-      `heads/${branch}`
+      branch
     ]);
 
     return tags
@@ -760,8 +760,10 @@ export default class Git {
 
   /** Get the last tag that isn't in the base branch */
   async getLastTagNotInBaseBranch(branch: string) {
-    const baseTags = (await this.getTags(this.options.baseBranch)).reverse();
-    const branchTags = (await this.getTags(branch)).reverse();
+    const baseTags = (
+      await this.getTags(`origin/${this.options.baseBranch}`)
+    ).reverse();
+    const branchTags = (await this.getTags(`heads/${branch}`)).reverse();
     const firstGreatestUnique = branchTags.reduce((result, tag) => {
       if (!baseTags.includes(tag) && (!result || gt(tag, result))) {
         return tag;


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: <details><summary>Published under canary scope @auto-canary</summary>
- `@auto-canary/auto@8.7.3-canary.827.10963.0`
- `@auto-canary/core@8.7.3-canary.827.10963.0`
- `@auto-canary/all-contributors@8.7.3-canary.827.10963.0`
- `@auto-canary/chrome@8.7.3-canary.827.10963.0`
- `@auto-canary/conventional-commits@8.7.3-canary.827.10963.0`
- `@auto-canary/crates@8.7.3-canary.827.10963.0`
- `@auto-canary/first-time-contributor@8.7.3-canary.827.10963.0`
- `@auto-canary/git-tag@8.7.3-canary.827.10963.0`
- `@auto-canary/jira@8.7.3-canary.827.10963.0`
- `@auto-canary/maven@8.7.3-canary.827.10963.0`
- `@auto-canary/npm@8.7.3-canary.827.10963.0`
- `@auto-canary/omit-commits@8.7.3-canary.827.10963.0`
- `@auto-canary/omit-release-notes@8.7.3-canary.827.10963.0`
- `@auto-canary/released@8.7.3-canary.827.10963.0`
- `@auto-canary/s3@8.7.3-canary.827.10963.0`
- `@auto-canary/slack@8.7.3-canary.827.10963.0`
- `@auto-canary/twitter@8.7.3-canary.827.10963.0`
- `@auto-canary/upload-assets@8.7.3-canary.827.10963.0`</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
