### PR TITLE
docs: fixed incorrect afterRelease hook object

### DIFF
--- a/docs/pages/writing-plugins.md
+++ b/docs/pages/writing-plugins.md
@@ -151,9 +151,10 @@ auto.hooks.afterAddToChangelog.tap(
 
 #### afterRelease
 
-Ran after the `release` command has run. This hooks gets the following arguments:
+Ran after the `release` command has run. This async hooks gets the following arguments:
 
-- version - version that was just released
+- lastVersion - the version that existed prior to the current release
+- nextVersion - version that was just released
 - commits - the commits in the release
 - releaseNotes - generated release notes for the release
 - response - the response returned from making the release
@@ -161,7 +162,7 @@ Ran after the `release` command has run. This hooks gets the following arguments
 ```ts
 auto.hooks.afterRelease.tap(
   'MyPlugin',
-  async ({ version, commits, releaseNotes, response }) => {
+  async ({ lastVersion, nextVersion, commits, releaseNotes, response }) => {
     // do something
   }
 );


### PR DESCRIPTION
# What Changed

Updated docs to accurately reflect the object that is passed to `afterRelease`. They differed from https://github.com/intuit/auto/blob/master/packages/core/src/auto.ts#L107
<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: <details><summary>Published under canary scope @auto-canary</summary>
- `@auto-canary/auto@8.7.4-canary.842.11033.0`
- `@auto-canary/core@8.7.4-canary.842.11033.0`
- `@auto-canary/all-contributors@8.7.4-canary.842.11033.0`
- `@auto-canary/chrome@8.7.4-canary.842.11033.0`
- `@auto-canary/conventional-commits@8.7.4-canary.842.11033.0`
- `@auto-canary/crates@8.7.4-canary.842.11033.0`
- `@auto-canary/first-time-contributor@8.7.4-canary.842.11033.0`
- `@auto-canary/git-tag@8.7.4-canary.842.11033.0`
- `@auto-canary/jira@8.7.4-canary.842.11033.0`
- `@auto-canary/maven@8.7.4-canary.842.11033.0`
- `@auto-canary/npm@8.7.4-canary.842.11033.0`
- `@auto-canary/omit-commits@8.7.4-canary.842.11033.0`
- `@auto-canary/omit-release-notes@8.7.4-canary.842.11033.0`
- `@auto-canary/released@8.7.4-canary.842.11033.0`
- `@auto-canary/s3@8.7.4-canary.842.11033.0`
- `@auto-canary/slack@8.7.4-canary.842.11033.0`
- `@auto-canary/twitter@8.7.4-canary.842.11033.0`
- `@auto-canary/upload-assets@8.7.4-canary.842.11033.0`</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
