### PR TITLE
match npm behavior for scoped packages

### DIFF
--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -581,27 +581,6 @@ describe('publish', () => {
     ]);
   });
 
-  test('should publish public scoped packages to public', async () => {
-    const plugin = new NPMPlugin();
-    const hooks = makeHooks();
-
-    plugin.apply({
-      config: { prereleaseBranches: ['next'] },
-      hooks,
-      baseBranch: 'master',
-      logger: dummyLog()
-    } as Auto.Auto);
-
-    readResult = `
-      {
-        "name": "@scope/test"
-      }
-    `;
-
-    await hooks.publish.promise(Auto.SEMVER.patch);
-    expect(exec).toHaveBeenCalledWith('npm', ['publish', '--access', 'public']);
-  });
-
   test('should publish private scoped packages to private', async () => {
     const plugin = new NPMPlugin();
     const hooks = makeHooks();
@@ -655,32 +634,6 @@ describe('canary', () => {
     await hooks.canary.promise(Auto.SEMVER.patch, '.123.1');
     expect(exec.mock.calls[0]).toContain('npm');
     expect(exec.mock.calls[0][1]).toContain('1.2.4-canary.123.1.0');
-  });
-
-  test('publishes to public for scoped packages', async () => {
-    const plugin = new NPMPlugin();
-    const hooks = makeHooks();
-
-    plugin.apply(({
-      config: { prereleaseBranches: ['next'] },
-      hooks,
-      baseBranch: 'master',
-      logger: dummyLog(),
-      getCurrentVersion: () => '1.2.3',
-      git: {
-        getLatestRelease: () => '1.2.3',
-        getLatestTagInBranch: () => '1.2.3'
-      }
-    } as unknown) as Auto.Auto);
-
-    readResult = `
-      {
-        "name": "@scope/test"
-      }
-    `;
-
-    await hooks.canary.promise(Auto.SEMVER.patch, '');
-    expect(exec.mock.calls[1][1]).toContain('public');
   });
 
   test('use lerna for monorepo package', async () => {

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -624,8 +624,6 @@ export default class NPMPlugin implements IPlugin {
       }
 
       auto.logger.verbose.info('Detected single npm package');
-      const { private: isPrivate, name } = await loadPackageJson();
-      const isScopedPackage = name.match(/@\S+\/\S+/);
       const current = await auto.getCurrentVersion(lastRelease);
       const canaryVersion = determineNextVersion(
         lastRelease,
@@ -644,13 +642,9 @@ export default class NPMPlugin implements IPlugin {
         '--no-git-tag-version',
         ...verboseArgs
       ]);
+
       const publishArgs = ['--tag', 'canary'];
-      await execPromise(
-        'npm',
-        !isPrivate && isScopedPackage
-          ? ['publish', '--access', 'public', ...publishArgs, ...verboseArgs]
-          : ['publish', ...publishArgs, ...verboseArgs]
-      );
+      await execPromise('npm', ['publish', ...publishArgs, ...verboseArgs]);
 
       if (this.canaryScope) {
         await gitReset();
@@ -800,15 +794,7 @@ export default class NPMPlugin implements IPlugin {
           ...verboseArgs
         ]);
       } else {
-        const { private: isPrivate, name } = await loadPackageJson();
-        const isScopedPackage = name.match(/@\S+\/\S+/);
-
-        await execPromise(
-          'npm',
-          !isPrivate && isScopedPackage
-            ? ['publish', '--access', 'public', ...tag, ...verboseArgs]
-            : ['publish', ...tag, ...verboseArgs]
-        );
+        await execPromise('npm', ['publish', ...tag, ...verboseArgs]);
       }
 
       await execPromise('git', [


### PR DESCRIPTION
# What Changed

Remove weird logic for scoped packages.

# Why

closes #858 

Todo:

- [x] Add tests
- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: <details><summary>Published under canary scope @auto-canary</summary>
- `@auto-canary/auto@8.8.1-canary.868.11361.0`
- `@auto-canary/core@8.8.1-canary.868.11361.0`
- `@auto-canary/all-contributors@8.8.1-canary.868.11361.0`
- `@auto-canary/chrome@8.8.1-canary.868.11361.0`
- `@auto-canary/conventional-commits@8.8.1-canary.868.11361.0`
- `@auto-canary/crates@8.8.1-canary.868.11361.0`
- `@auto-canary/first-time-contributor@8.8.1-canary.868.11361.0`
- `@auto-canary/git-tag@8.8.1-canary.868.11361.0`
- `@auto-canary/jira@8.8.1-canary.868.11361.0`
- `@auto-canary/maven@8.8.1-canary.868.11361.0`
- `@auto-canary/npm@8.8.1-canary.868.11361.0`
- `@auto-canary/omit-commits@8.8.1-canary.868.11361.0`
- `@auto-canary/omit-release-notes@8.8.1-canary.868.11361.0`
- `@auto-canary/released@8.8.1-canary.868.11361.0`
- `@auto-canary/s3@8.8.1-canary.868.11361.0`
- `@auto-canary/slack@8.8.1-canary.868.11361.0`
- `@auto-canary/twitter@8.8.1-canary.868.11361.0`
- `@auto-canary/upload-assets@8.8.1-canary.868.11361.0`</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
