### PR TITLE
require Node.js >=10.x

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,6 +21,9 @@
   "files": [
     "dist"
   ],
+  "engines": {
+    "node": ">=10.x"
+  },
   "keywords": [
     "automation",
     "semantic",


### PR DESCRIPTION
# What Changed

be explicit about supported node versions

# Why

Many deps have ended support for node 8 so we have to as well

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: <details><summary>Published under canary scope @auto-canary</summary>
- `@auto-canary/auto@9.0.0-canary.869.11368.0`
- `@auto-canary/core@9.0.0-canary.869.11368.0`
- `@auto-canary/all-contributors@9.0.0-canary.869.11368.0`
- `@auto-canary/chrome@9.0.0-canary.869.11368.0`
- `@auto-canary/conventional-commits@9.0.0-canary.869.11368.0`
- `@auto-canary/crates@9.0.0-canary.869.11368.0`
- `@auto-canary/first-time-contributor@9.0.0-canary.869.11368.0`
- `@auto-canary/git-tag@9.0.0-canary.869.11368.0`
- `@auto-canary/jira@9.0.0-canary.869.11368.0`
- `@auto-canary/maven@9.0.0-canary.869.11368.0`
- `@auto-canary/npm@9.0.0-canary.869.11368.0`
- `@auto-canary/omit-commits@9.0.0-canary.869.11368.0`
- `@auto-canary/omit-release-notes@9.0.0-canary.869.11368.0`
- `@auto-canary/released@9.0.0-canary.869.11368.0`
- `@auto-canary/s3@9.0.0-canary.869.11368.0`
- `@auto-canary/slack@9.0.0-canary.869.11368.0`
- `@auto-canary/twitter@9.0.0-canary.869.11368.0`
- `@auto-canary/upload-assets@9.0.0-canary.869.11368.0`</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
