### PR TITLE
add clearer docs around creating GH_TOKEN

### DIFF
--- a/docs/pages/getting-started.md
+++ b/docs/pages/getting-started.md
@@ -54,7 +54,7 @@ Initialize all options and configure label text. If this is not run then `auto` 
 
 You must configure some environment variables for publishing and releasing to work properly.
 
-- `GH_TOKEN` - Used for updating the changelog and publishing the GitHub release
+- `GH_TOKEN` - Used for updating the changelog and publishing the GitHub release ([create one here](https://github.com/settings/tokens))
 - `NPM_TOKEN` - Used to publish to npm. (only with NPM plugin)
 
 #### Local `.env`

--- a/docs/pages/non-npm.md
+++ b/docs/pages/non-npm.md
@@ -28,6 +28,13 @@ brew install auto
 
 ## Configuration
 
+To configure `auto` to work with your project you will need to do two things
+
+1. Create and configure a [`GH_TOKEN`](https://github.com/settings/tokens) environment variable
+2. Create an `.autorc` for your project
+
+### Making an `.autorc`
+
 Using `auto` with any other package manager than [npm](https://npmjs.com) requires that you create an [`.autorc`](./autorc.md) at the root of your project.
 
 1. `.autorc` - No plugins, `shipit` doesn't work. Enables [advanced setup](https://intuit.github.io/auto/pages/getting-started.html#detailed-setup)

--- a/docs/pages/troubleshooting.md
+++ b/docs/pages/troubleshooting.md
@@ -2,7 +2,7 @@
 
 ## Error: Can't find a GitHub token to use
 
-You must set a `GH_TOKEN` for `auto` to work. Make sure to add your `NPM_TOKEN` while you're at it.
+You must set a [`GH_TOKEN`](https://github.com/settings/tokens) for `auto` to work. If you publish to npm make sure to add your `NPM_TOKEN` while you're at it as well.
 
 ## npm ERR! Git working directory not clean
 

--- a/plugins/chrome/src/index.ts
+++ b/plugins/chrome/src/index.ts
@@ -91,7 +91,7 @@ export default class ChromeWebStorePlugin implements IPlugin {
 
     auto.hooks.getAuthor.tapPromise(this.name, async () => {
       auto.logger.verbose.info(
-        `${this.name}: Getting author information from package.json`
+        `${this.name}: Getting author information from manifest.json`
       );
 
       const manifest = await getManifest(this.options.manifest);
@@ -116,7 +116,7 @@ export default class ChromeWebStorePlugin implements IPlugin {
       const version = auto.prefixRelease(manifest.version);
 
       auto.logger.verbose.info(
-        `${this.name}: Got previous version from package.json`,
+        `${this.name}: Got previous version from manifest.json`,
         version
       );
 

--- a/plugins/maven/src/index.ts
+++ b/plugins/maven/src/index.ts
@@ -24,7 +24,7 @@ async function getPreviousVersion(auto: Auto): Promise<string> {
   }
 
   auto.logger.verbose.info(
-    'Maven: Got previous version from package.json',
+    'Maven: Got previous version from pom.xml',
     previousVersion
   );
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: <details><summary>Published under canary scope @auto-canary</summary>
- `@auto-canary/auto@9.1.1-canary.882.11540.0`
- `@auto-canary/core@9.1.1-canary.882.11540.0`
- `@auto-canary/all-contributors@9.1.1-canary.882.11540.0`
- `@auto-canary/chrome@9.1.1-canary.882.11540.0`
- `@auto-canary/conventional-commits@9.1.1-canary.882.11540.0`
- `@auto-canary/crates@9.1.1-canary.882.11540.0`
- `@auto-canary/first-time-contributor@9.1.1-canary.882.11540.0`
- `@auto-canary/git-tag@9.1.1-canary.882.11540.0`
- `@auto-canary/jira@9.1.1-canary.882.11540.0`
- `@auto-canary/maven@9.1.1-canary.882.11540.0`
- `@auto-canary/npm@9.1.1-canary.882.11540.0`
- `@auto-canary/omit-commits@9.1.1-canary.882.11540.0`
- `@auto-canary/omit-release-notes@9.1.1-canary.882.11540.0`
- `@auto-canary/released@9.1.1-canary.882.11540.0`
- `@auto-canary/s3@9.1.1-canary.882.11540.0`
- `@auto-canary/slack@9.1.1-canary.882.11540.0`
- `@auto-canary/twitter@9.1.1-canary.882.11540.0`
- `@auto-canary/upload-assets@9.1.1-canary.882.11540.0`</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
