### PR TITLE
Fix onlyPublishWithReleaseLabel w/o labels

### DIFF
--- a/packages/core/src/__tests__/semver.test.ts
+++ b/packages/core/src/__tests__/semver.test.ts
@@ -43,4 +43,12 @@ describe('calculateSemVerBump', () => {
       SEMVER.major
     );
   });
+
+  test('should respect onlyPublishWithReleaseLabel when no labels present', () => {
+    expect(
+      calculateSemVerBump([[]], semverMap, {
+        onlyPublishWithReleaseLabel: true
+      })
+    ).toBe(SEMVER.noVersion);
+  });
 });

--- a/packages/core/src/semver.ts
+++ b/packages/core/src/semver.ts
@@ -65,7 +65,7 @@ export function calculateSemVerBump(
 
   let skipRelease = false;
 
-  if (labels.length > 0 && labels[0].length > 0) {
+  if (labels.length > 0) {
     const releaseLabels = labelMap.get('release') || [];
 
     skipRelease = onlyPublishWithReleaseLabel


### PR DESCRIPTION
# What Changed

Ensure onlyPublishWithReleaseLabel is checked and respected.

# Why

When you had a PR with no labels at all, `auto` would skip the check for the `release` label. Making it so that there was always a release created.

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: <details><summary>Published under canary scope @auto-canary</summary>
- `@auto-canary/auto@9.1.1-canary.883.11552.0`
- `@auto-canary/core@9.1.1-canary.883.11552.0`
- `@auto-canary/all-contributors@9.1.1-canary.883.11552.0`
- `@auto-canary/chrome@9.1.1-canary.883.11552.0`
- `@auto-canary/conventional-commits@9.1.1-canary.883.11552.0`
- `@auto-canary/crates@9.1.1-canary.883.11552.0`
- `@auto-canary/first-time-contributor@9.1.1-canary.883.11552.0`
- `@auto-canary/git-tag@9.1.1-canary.883.11552.0`
- `@auto-canary/jira@9.1.1-canary.883.11552.0`
- `@auto-canary/maven@9.1.1-canary.883.11552.0`
- `@auto-canary/npm@9.1.1-canary.883.11552.0`
- `@auto-canary/omit-commits@9.1.1-canary.883.11552.0`
- `@auto-canary/omit-release-notes@9.1.1-canary.883.11552.0`
- `@auto-canary/released@9.1.1-canary.883.11552.0`
- `@auto-canary/s3@9.1.1-canary.883.11552.0`
- `@auto-canary/slack@9.1.1-canary.883.11552.0`
- `@auto-canary/twitter@9.1.1-canary.883.11552.0`
- `@auto-canary/upload-assets@9.1.1-canary.883.11552.0`</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
