### PR TITLE
fix omitting renovate release notes when a user manually rebases the renovate PR

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/release.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/release.test.ts.snap
@@ -157,6 +157,38 @@ Array [
 ]
 `;
 
+exports[`Release getCommits should include PR opener in authors (in case of external rebase) 1`] = `
+Array [
+  Object {
+    "authorEmail": "adam@dierkens.com",
+    "authorName": "Adam Dierkens",
+    "authors": Array [
+      Object {
+        "email": "adam@dierkens.com",
+        "name": "Adam Dierkens",
+      },
+      Object {
+        "email": "renovate@automation.com",
+        "login": "renovate",
+        "name": "Renovate",
+        "username": "renovate",
+      },
+    ],
+    "files": Array [],
+    "hash": "foo",
+    "labels": Array [
+      "skip-release",
+      "minor",
+    ],
+    "pullRequest": Object {
+      "body": undefined,
+      "number": 124,
+    },
+    "subject": "Feature",
+  },
+]
+`;
+
 exports[`Release getCommits should match rebased commits to PRs 1`] = `
 Array [
   Object {

--- a/packages/core/src/__tests__/release.test.ts
+++ b/packages/core/src/__tests__/release.test.ts
@@ -384,6 +384,39 @@ describe('Release', () => {
 
       expect(await gh.getCommits('12345', '1234')).toMatchSnapshot();
     });
+
+    test('should include PR opener in authors (in case of external rebase)', async () => {
+      const gh = new Release(git);
+
+      const info = {
+        data: {
+          number: 124,
+          merge_commit_sha: '1a2b',
+          labels: [{ name: 'skip-release' }, { name: 'minor' }],
+          user: {login: 'renovate'}
+        }
+      }
+
+      getLatestReleaseInfo.mockReturnValueOnce({
+        published_at: '2019-01-16'
+      });
+      searchRepo.mockReturnValueOnce({ items: [{ number: 124 }] });
+      getPullRequest.mockReturnValueOnce(info);
+      getGitLog.mockReturnValueOnce(
+        await logParse.normalizeCommits([
+          makeCommitFromMsg('Feature (#124)')
+        ])
+      );
+      getPr.mockReturnValueOnce(Promise.resolve(info))
+      getUserByUsername.mockReturnValueOnce({
+        name: 'Renovate',
+        email: 'renovate@automation.com',
+        login: 'renovate'
+      })
+      exec.mockReturnValueOnce('1');
+
+      expect(await gh.getCommits('12345', '1234')).toMatchSnapshot();
+    });
   });
 
   describe('addToChangelog', () => {

--- a/packages/core/src/release.ts
+++ b/packages/core/src/release.ts
@@ -589,8 +589,13 @@ export default class Release {
         ...new Set([...labels, ...modifiedCommit.labels])
       ];
       modifiedCommit.pullRequest.body = info.data.body;
+      const hasPrOpener = modifiedCommit.authors.find(
+        author => author.username === info.data.user.login
+      );
 
-      if (!modifiedCommit.authors.find(author => Boolean(author.username))) {
+      // If we can't find the use who opened the PR in authors attempt
+      // to add that user.
+      if (!hasPrOpener) {
         const user = await this.git.getUserByUsername(info.data.user.login);
 
         if (user) {


### PR DESCRIPTION
# What Changed

Ensure that the user who opened the PR is included in author array for commit.

# Why

We want to attribute all authors + filter out release notes from renovate. If a user rebased a renovate PR all the commits would be for that user, and all the extra release notes would be included with the release.

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: <details><summary>Published under canary scope @auto-canary</summary>
- `@auto-canary/auto@9.1.2-canary.884.11565.0`
- `@auto-canary/core@9.1.2-canary.884.11565.0`
- `@auto-canary/all-contributors@9.1.2-canary.884.11565.0`
- `@auto-canary/chrome@9.1.2-canary.884.11565.0`
- `@auto-canary/conventional-commits@9.1.2-canary.884.11565.0`
- `@auto-canary/crates@9.1.2-canary.884.11565.0`
- `@auto-canary/first-time-contributor@9.1.2-canary.884.11565.0`
- `@auto-canary/git-tag@9.1.2-canary.884.11565.0`
- `@auto-canary/jira@9.1.2-canary.884.11565.0`
- `@auto-canary/maven@9.1.2-canary.884.11565.0`
- `@auto-canary/npm@9.1.2-canary.884.11565.0`
- `@auto-canary/omit-commits@9.1.2-canary.884.11565.0`
- `@auto-canary/omit-release-notes@9.1.2-canary.884.11565.0`
- `@auto-canary/released@9.1.2-canary.884.11565.0`
- `@auto-canary/s3@9.1.2-canary.884.11565.0`
- `@auto-canary/slack@9.1.2-canary.884.11565.0`
- `@auto-canary/twitter@9.1.2-canary.884.11565.0`
- `@auto-canary/upload-assets@9.1.2-canary.884.11565.0`</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
