### PR TITLE
Add ability to manage sub-package contributor lists

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1,5 +1,3 @@
-/* eslint-disable complexity */
-
 import { ReposCreateReleaseResponse, Response } from '@octokit/rest';
 import dotenv from 'dotenv';
 import envCi from 'env-ci';

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1277,7 +1277,7 @@ export default class Auto {
     this.logger.log.error('Changed Files:\n', status);
 
     throw new Error(
-      'Working direction is not clean, make sure all files are commited'
+      'Working direction is not clean, make sure all files are committed'
     );
   };
 
@@ -1432,4 +1432,6 @@ export { IPlugin } from './utils/load-plugins';
 export { default as Auto } from './auto';
 export { default as SEMVER } from './semver';
 export { default as execPromise } from './utils/exec-promise';
+export { default as getLernaPackages } from './utils/get-lerna-packages';
+export { default as inFolder } from './utils/in-folder';
 export { VersionLabel } from './release';

--- a/packages/core/src/release.ts
+++ b/packages/core/src/release.ts
@@ -589,7 +589,7 @@ export default class Release {
         ...new Set([...labels, ...modifiedCommit.labels])
       ];
       modifiedCommit.pullRequest.body = info.data.body;
-      const hasPrOpener = modifiedCommit.authors.find(
+      const hasPrOpener = modifiedCommit.authors.some(
         author => author.username === info.data.user.login
       );
 

--- a/packages/core/src/utils/get-lerna-packages.ts
+++ b/packages/core/src/utils/get-lerna-packages.ts
@@ -1,0 +1,20 @@
+import execPromise from './exec-promise';
+
+interface LernaPackage {
+  /** Path to package */
+  path: string;
+  /** Name of package */
+  name: string;
+  /** Version of package */
+  version: string;
+}
+
+/** Get all of the packages in the lerna monorepo */
+export default async function getLernaPackages(): Promise<LernaPackage[]> {
+  return execPromise('npx', ['lerna', 'ls', '-pl']).then(res =>
+    res.split('\n').map(packageInfo => {
+      const [packagePath, name, version] = packageInfo.split(':');
+      return { path: packagePath, name, version };
+    })
+  );
+}

--- a/packages/core/src/utils/in-folder.ts
+++ b/packages/core/src/utils/in-folder.ts
@@ -1,0 +1,10 @@
+import path from 'path';
+
+/** Check if one path is within a parent path */
+const inFolder = (parent: string, child: string) => {
+  const relative = path.relative(parent, child);
+
+  return Boolean(!relative?.startsWith('..') && !path.isAbsolute(relative));
+};
+
+export default inFolder;

--- a/plugins/all-contributors/README.md
+++ b/plugins/all-contributors/README.md
@@ -5,7 +5,7 @@ Automatically add contributors as changelogs are produced.
 This plugin maps one of the [contribution type](vhttps://allcontributors.org/docs/en/emoji-key) to a glob or array of globs.
 Out of the box the plugin will only detect the following contribution types:
 
-- 📖 `doc` - Edits to any README, `['**/*.mdx', '**/*.md', '**/docs/**/*', '**/documentation/**/*']``
+- 📖 `doc` - Edits to any README `['**/*.mdx', '**/*.md', '**/docs/**/*', '**/documentation/**/*']`
 - 💡 `example` - Edits to `['**/*.stories*', '**/*.story.*']`
 - 🚇 `infra` - Edits to `['**/.circle/**/*', '**/.github/**/*', '**/travis.yml'],`
 - ⚠️ `test` - Edits to `['**/*.test.*']`
@@ -71,6 +71,36 @@ Useful for excluding bots from getting into your contributors.
       "all-contributors",
       {
         "exclude": ["dependabot", "ci-services"]
+      }
+    ]
+  ]
+}
+```
+
+### Sub-Package Contributors list
+
+Maintain contributors lists for sub-packages in a monorepo setup (`lerna`/`yarn`).
+
+You must initialize each sub-package you want contributors tracked in with an `.all-contributorsrc`. If no rc file is found nothing will happen for that package.
+
+```sh
+cd packages/your-package
+npx all-contributors init
+```
+
+::: message is-info
+ℹ️ Tip: If you only want 1 commit for new contributions set `commit` to false in all of your `.all-contributorsrc`. Otherwise a commit will be made for each package's contributor update.
+:::
+
+**`auto.rc`**
+
+```json
+{
+  "plugins": [
+    [
+      "all-contributors",
+      {
+        "subPackageContributors": true
       }
     ]
   ]

--- a/plugins/all-contributors/README.md
+++ b/plugins/all-contributors/README.md
@@ -81,7 +81,7 @@ Useful for excluding bots from getting into your contributors.
 
 Maintain contributors lists for sub-packages in a monorepo setup (`lerna`/`yarn`).
 
-You must initialize each sub-package you want contributors tracked in with an `.all-contributorsrc`. If no rc file is found nothing will happen for that package.
+All you need to do is initialize each sub-package you want contributors tracked in with an `.all-contributorsrc`. If no rc file is found nothing will happen for that package.
 
 ```sh
 cd packages/your-package
@@ -91,18 +91,3 @@ npx all-contributors init
 ::: message is-info
 ℹ️ Tip: If you only want 1 commit for new contributions set `commit` to false in all of your `.all-contributorsrc`. Otherwise a commit will be made for each package's contributor update.
 :::
-
-**`auto.rc`**
-
-```json
-{
-  "plugins": [
-    [
-      "all-contributors",
-      {
-        "subPackageContributors": true
-      }
-    ]
-  ]
-}
-```

--- a/plugins/all-contributors/__tests__/all-contributors.test.ts
+++ b/plugins/all-contributors/__tests__/all-contributors.test.ts
@@ -10,8 +10,11 @@ import AllContributors from '../src';
 const exec = jest.fn();
 const gitShow = jest.fn();
 const getLernaPackages = jest.fn();
+
+getLernaPackages.mockReturnValue(Promise.resolve([]));
 gitShow.mockReturnValue('');
 exec.mockReturnValue('');
+
 jest.mock('child_process');
 // @ts-ignore
 execSync.mockImplementation(exec);
@@ -148,7 +151,7 @@ describe('All Contributors Plugin', () => {
   });
 
   test('should update sub-packages', async () => {
-    const releasedLabel = new AllContributors({ subPackageContributors: true });
+    const releasedLabel = new AllContributors();
     const autoHooks = makeHooks();
 
     getLernaPackages.mockReturnValueOnce(

--- a/plugins/all-contributors/src/index.ts
+++ b/plugins/all-contributors/src/index.ts
@@ -1,10 +1,16 @@
-import { Auto, IPlugin, execPromise } from '@auto-it/core';
+import {
+  Auto,
+  IPlugin,
+  execPromise,
+  getLernaPackages,
+  inFolder
+} from '@auto-it/core';
 import fs from 'fs';
 import path from 'path';
 import match from 'anymatch';
 import { execSync } from 'child_process';
+import { IExtendedCommit } from '@auto-it/core/src/log-parse';
 
-const rcFile = path.join(process.cwd(), '.all-contributorsrc');
 const contributionTypes = [
   'blog',
   'bug',
@@ -36,11 +42,25 @@ const contributionTypes = [
 ] as const;
 type Contribution = typeof contributionTypes[number];
 
+/** Get an rc file if there is one. */
+function getRcFile() {
+  try {
+    const rcFile = path.join(process.cwd(), '.all-contributorsrc');
+    const config: AllContributorsRc = JSON.parse(
+      fs.readFileSync(rcFile, 'utf8')
+    );
+
+    return config;
+  } catch (error) {}
+}
+
 type IAllContributorsPluginOptions = {
   /** Usernames to exclude from the contributors */
   exclude?: string[];
   /** Globs to detect change types by */
   types?: Partial<Record<Contribution, string | string[]>>;
+  /** Whether to generate contributors for packages in a monorepo */
+  subPackageContributors?: boolean;
 };
 
 interface Contributor {
@@ -62,6 +82,7 @@ const defaultOptions: IAllContributorsPluginOptions = {
     'dependabot[bot]',
     'fossabot',
     'renovate',
+    'renovate-bot',
     'renovate[bot]',
     'renovate-approve'
   ],
@@ -85,6 +106,7 @@ export default class AllContributorsPlugin implements IPlugin {
   /** Initialize the plugin with it's options */
   constructor(options: IAllContributorsPluginOptions = {}) {
     this.options = {
+      subPackageContributors: Boolean(options.subPackageContributors),
       exclude: [...(defaultOptions.exclude || []), ...(options.exclude || [])],
       types: { ...defaultOptions.types, ...options.types }
     };
@@ -95,96 +117,153 @@ export default class AllContributorsPlugin implements IPlugin {
     auto.hooks.afterAddToChangelog.tapPromise(
       this.name,
       async ({ commits }) => {
-        const config: AllContributorsRc = JSON.parse(
-          fs.readFileSync(rcFile, 'utf8')
-        );
-        const authorContributions: Record<string, Set<Contribution>> = {};
-        let didUpdate = false;
+        await this.updateContributors(auto, commits);
+        const rootDir = process.cwd();
 
-        const commitsWithAllChangedFiles = await Promise.all(
-          commits.map(async commit => {
-            const extra = await execPromise('git', [
-              'show',
-              '--pretty=""',
-              '--name-only',
-              '--first-parent',
-              '-m',
-              commit.hash
-            ]);
+        if (this.options.subPackageContributors) {
+          const lernaPackages = await getLernaPackages();
 
-            commit.files = [
-              ...new Set([...commit.files, ...extra.split('\n')])
-            ];
+          // Cannot run git operations in parallel
+          await lernaPackages.reduce(async (last, lernaPackage) => {
+            await last;
 
-            return commit;
-          })
-        );
-
-        // 1. Find all the authors and their contribution types
-        commitsWithAllChangedFiles.forEach(commit => {
-          const { authors } = commit;
-          let { files } = commit;
-
-          Object.keys(this.options.types || {})
-            .filter((type): type is Contribution => {
-              /** Determine if path is the contribution type */
-              const isType = (file: string) =>
-                match(this.options.types[type as Contribution] || [], file);
-              const isMatch = files.some(isType);
-              files = files.filter(file => !isType(file));
-
-              return isMatch;
-            })
-            .forEach(contribution => {
-              authors.forEach(({ username, hash }) => {
-                if (!username) {
-                  return;
-                }
-
-                if (commit.hash !== hash) {
-                  return;
-                }
-
-                if (!authorContributions[username]) {
-                  authorContributions[username] = new Set();
-                }
-
-                authorContributions[username].add(contribution);
-              });
-            });
-        });
-
-        // 2. Determine if contributor has update
-        Object.entries(authorContributions).forEach(
-          ([username, contributions]) => {
-            const { contributions: old = [] } =
-              config.contributors.find(
-                contributor => contributor.login === username
-              ) || {};
-            const hasNew = [...contributions].find(
-              contribution => !old.includes(contribution)
+            auto.logger.verbose.info(
+              `Updating contributors for: ${lernaPackage.name}`
             );
 
-            if (hasNew && !this.options.exclude.includes(username)) {
-              const newContributions = new Set([...old, ...contributions]);
+            const includedCommits = commits.filter(commit =>
+              commit.files.some(file => inFolder(lernaPackage.path, file))
+            );
 
-              didUpdate = true;
-              auto.logger.log.info(`Adding "${username}"'s contributions...`);
-
-              execSync(
-                `npx all-contributors-cli add ${username} ${[
-                  ...newContributions
-                ].join(',')}`,
-                { stdio: 'inherit' }
+            if (includedCommits.length > 0) {
+              auto.logger.verbose.success(
+                `${lernaPackage.name} has ${includedCommits.length} new commits.`
               );
-            }
-          }
-        );
+              auto.logger.veryVerbose.info(
+                `With commits: ${JSON.stringify(includedCommits, null, 2)}`
+              );
 
-        if (didUpdate) {
-          auto.logger.log.success('Updated contributors!');
+              process.chdir(lernaPackage.path);
+              await this.updateContributors(auto, includedCommits);
+            }
+          }, Promise.resolve());
+        }
+
+        process.chdir(rootDir);
+        const changedFiles = await execPromise('git', [
+          'status',
+          '--porcelain'
+        ]);
+
+        if (changedFiles) {
+          await execPromise('git', ['add', 'README.md']);
+          await execPromise('git', ['add', '.all-contributorsrc']);
+          await execPromise('git', ['add', '**/README.md']);
+          await execPromise('git', ['add', '**/.all-contributorsrc']);
+          await execPromise('git', [
+            'commit',
+            '--no-verify',
+            '-m',
+            '"Update contributors [skip ci]"'
+          ]);
         }
       }
     );
+  }
+
+  /** Update the contributors rc for a package. */
+  private async updateContributors(auto: Auto, commits: IExtendedCommit[]) {
+    const config = getRcFile();
+
+    if (!config) {
+      return;
+    }
+
+    const authorContributions: Record<string, Set<Contribution>> = {};
+    let didUpdate = false;
+
+    const commitsWithAllChangedFiles = await Promise.all(
+      commits.map(async commit => {
+        const extra = await execPromise('git', [
+          'show',
+          '--pretty=""',
+          '--name-only',
+          '--first-parent',
+          '-m',
+          commit.hash
+        ]);
+
+        commit.files = [...new Set([...commit.files, ...extra.split('\n')])];
+
+        return commit;
+      })
+    );
+
+    // 1. Find all the authors and their contribution types
+    commitsWithAllChangedFiles.forEach(commit => {
+      const { authors } = commit;
+      let { files } = commit;
+
+      Object.keys(this.options.types || {})
+        .filter((type): type is Contribution => {
+          /** Determine if path is the contribution type */
+          const isType = (file: string) =>
+            match(this.options.types[type as Contribution] || [], file);
+          const isMatch = files.some(isType);
+          files = files.filter(file => !isType(file));
+
+          return isMatch;
+        })
+        .forEach(contribution => {
+          authors.forEach(({ username, hash }) => {
+            if (!username) {
+              return;
+            }
+
+            if (commit.hash !== hash) {
+              return;
+            }
+
+            if (!authorContributions[username]) {
+              authorContributions[username] = new Set();
+            }
+
+            authorContributions[username].add(contribution);
+          });
+        });
+    });
+
+    auto.logger.verbose.info('Found contributions:', authorContributions);
+
+    // 2. Determine if contributor has update
+    Object.entries(authorContributions).forEach(([username, contributions]) => {
+      const { contributions: old = [] } =
+        config.contributors.find(
+          contributor => contributor.login === username
+        ) || {};
+      const hasNew = [...contributions].find(
+        contribution => !old.includes(contribution)
+      );
+
+      if (hasNew && !this.options.exclude.includes(username)) {
+        const newContributions = new Set([...old, ...contributions]);
+
+        didUpdate = true;
+        auto.logger.log.info(`Adding "${username}"'s contributions...`);
+
+        execSync(
+          `npx all-contributors-cli add ${username} ${[
+            ...newContributions
+          ].join(',')}`,
+          { stdio: 'inherit' }
+        );
+      } else {
+        auto.logger.verbose.warn(`"${username}" had no new contributions...`);
+      }
+    });
+
+    if (didUpdate) {
+      auto.logger.log.success('Updated contributors!');
+    }
   }
 }

--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -8,6 +8,7 @@ import NPMPlugin, {
 } from '../src';
 
 const exec = jest.fn();
+const getLernaPackages = jest.fn();
 const monorepoPackages = jest.fn();
 const existsSync = jest.fn();
 const readFileSync = jest.fn();
@@ -20,6 +21,7 @@ readFileSync.mockReturnValue('{}');
 
 // @ts-ignore
 jest.spyOn(Auto, 'execPromise').mockImplementation(exec);
+jest.spyOn(Auto, 'getLernaPackages').mockImplementation(getLernaPackages);
 jest.mock('env-ci', () => () => ({ isCi: false }));
 jest.mock('get-monorepo-packages', () => () => monorepoPackages());
 jest.mock('fs', () => ({
@@ -658,14 +660,23 @@ describe('canary', () => {
       }
     `;
 
-    exec.mockReturnValue(
-      Promise.resolve(
-        `path/to/package:@foo/app:1.2.3-canary.0+abcd\npath/to/package:@foo/lib:1.2.3-canary.0+abcd`
-      )
+    getLernaPackages.mockImplementation(async () =>
+      Promise.resolve([
+        {
+          path: 'path/to/package',
+          name: '@foobar/app',
+          version: '1.2.3-canary.0+abcd'
+        },
+        {
+          path: 'path/to/package',
+          name: '@foobar/lib',
+          version: '1.2.3-canary.0+abcd'
+        }
+      ])
     );
 
     const value = await hooks.canary.promise(Auto.SEMVER.patch, '');
-    expect(exec.mock.calls[1][1]).toContain('lerna');
+    expect(exec.mock.calls[0][1]).toContain('lerna');
     expect(value).toBe('1.2.3-canary.0');
   });
 
@@ -690,10 +701,20 @@ describe('canary', () => {
         "name": "test"
       }
     `;
-    exec.mockReturnValue(
-      Promise.resolve(
-        `path/to/package:@foo/app:1.2.3\npath/to/package:@foo/lib:1.2.3`
-      )
+
+    getLernaPackages.mockImplementation(async () =>
+      Promise.resolve([
+        {
+          path: 'path/to/package',
+          name: '@foobar/app',
+          version: '1.2.3'
+        },
+        {
+          path: 'path/to/package',
+          name: '@foobar/lib',
+          version: '1.2.3'
+        }
+      ])
     );
 
     const value = await hooks.canary.promise(Auto.SEMVER.patch, '');
@@ -720,10 +741,20 @@ describe('canary', () => {
         "name": "test"
       }
     `;
-    exec.mockReturnValue(
-      Promise.resolve(
-        'path/to/package:@foo/app:1.2.4-canary.0\npath/to/package:@foo/lib:1.1.0-canary.0'
-      )
+
+    getLernaPackages.mockImplementation(async () =>
+      Promise.resolve([
+        {
+          path: 'path/to/package',
+          name: '@foobar/app',
+          version: '1.2.4-canary.0'
+        },
+        {
+          path: 'path/to/package',
+          name: '@foobar/lib',
+          version: '1.1.0-canary.0'
+        }
+      ])
     );
 
     await hooks.version.promise(Auto.SEMVER.patch);
@@ -762,10 +793,20 @@ describe('canary', () => {
         "name": "test"
       }
     `;
-    exec.mockReturnValue(
-      Promise.resolve(
-        'path/to/package:@foo/app:1.2.4\npath/to/package:@foo/lib:1.1.0'
-      )
+
+    getLernaPackages.mockImplementation(async () =>
+      Promise.resolve([
+        {
+          path: 'path/to/package',
+          name: '@foobar/app',
+          version: '1.2.4'
+        },
+        {
+          path: 'path/to/package',
+          name: '@foobar/lib',
+          version: '1.1.0'
+        }
+      ])
     );
 
     const value = await hooks.canary.promise(Auto.SEMVER.patch, '');

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -8,6 +8,8 @@ import {
   Auto,
   determineNextVersion,
   getCurrentBranch,
+  getLernaPackages,
+  inFolder,
   execPromise,
   ILogger,
   IPlugin,
@@ -69,13 +71,6 @@ interface IMonorepoPackage {
   /** Version to the monorepo package */
   version: string;
 }
-
-/** Check if one path is within a parent path */
-const inFolder = (parent: string, child: string) => {
-  const relative = path.relative(parent, child);
-
-  return Boolean(!relative?.startsWith('..') && !path.isAbsolute(relative));
-};
 
 interface ChangedPackagesArgs {
   /** Commit hash to find changes for */
@@ -158,25 +153,6 @@ export function getMonorepoPackage() {
 
     return greatest;
   }, {} as IPackageJSON);
-}
-
-interface LernaPackage {
-  /** Path to package */
-  path: string;
-  /** Name of package */
-  name: string;
-  /** Version of package */
-  version: string;
-}
-
-/** Get all of the packages in the lerna monorepo */
-export async function getLernaPackages(): Promise<LernaPackage[]> {
-  return execPromise('npx', ['lerna', 'ls', '-pl']).then(res =>
-    res.split('\n').map(packageInfo => {
-      const [packagePath, name, version] = packageInfo.split(':');
-      return { path: packagePath, name, version };
-    })
-  );
 }
 
 /** Get all of the packages+version in the lerna monorepo */


### PR DESCRIPTION
# What Changed

The all contributors plugin will keep a contributors list for sub-packages in a monorepo if an `.all-contributorsrc` is present.

# Why

Thanking contributors is nice 🎉 

Todo:

- [x] Add tests
- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: <details><summary>Published under canary scope @auto-canary</summary>
- `@auto-canary/auto@9.2.0-canary.887.11599.0`
- `@auto-canary/core@9.2.0-canary.887.11599.0`
- `@auto-canary/all-contributors@9.2.0-canary.887.11599.0`
- `@auto-canary/chrome@9.2.0-canary.887.11599.0`
- `@auto-canary/conventional-commits@9.2.0-canary.887.11599.0`
- `@auto-canary/crates@9.2.0-canary.887.11599.0`
- `@auto-canary/first-time-contributor@9.2.0-canary.887.11599.0`
- `@auto-canary/git-tag@9.2.0-canary.887.11599.0`
- `@auto-canary/jira@9.2.0-canary.887.11599.0`
- `@auto-canary/maven@9.2.0-canary.887.11599.0`
- `@auto-canary/npm@9.2.0-canary.887.11599.0`
- `@auto-canary/omit-commits@9.2.0-canary.887.11599.0`
- `@auto-canary/omit-release-notes@9.2.0-canary.887.11599.0`
- `@auto-canary/released@9.2.0-canary.887.11599.0`
- `@auto-canary/s3@9.2.0-canary.887.11599.0`
- `@auto-canary/slack@9.2.0-canary.887.11599.0`
- `@auto-canary/twitter@9.2.0-canary.887.11599.0`
- `@auto-canary/upload-assets@9.2.0-canary.887.11599.0`</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
