### PR TITLE
fallback to 0.0.0 in git-tag plugin with no previous releases

### DIFF
--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -83,9 +83,7 @@ export default async function main(command: string, args: ApiOptions) {
   try {
     await run(command, args);
   } catch (error) {
-    if (error) {
-      console.log(error);
-      process.exit(1);
-    }
+    console.log(error);
+    process.exit(1);
   }
 }

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -735,7 +735,8 @@ export default class Auto {
 
     this.logger.verbose.info('Canary info found:', { pr, build });
 
-    const head = await this.release.getCommitsInRelease('HEAD^');
+    const from = await this.git.shaExists('HEAD^') ? 'HEAD^' : 'HEAD';
+    const head = await this.release.getCommitsInRelease(from);
     const labels = head.map(commit => commit.labels);
     const version =
       calculateSemVerBump(labels, this.semVerLabels!, this.config) ||
@@ -913,7 +914,8 @@ export default class Auto {
     this.hooks.beforeShipIt.call();
 
     const isPR = 'isPr' in env && env.isPr;
-    const head = await this.release.getCommitsInRelease('HEAD^');
+    const from = await this.git.shaExists('HEAD^') ? 'HEAD^' : 'HEAD';
+    const head = await this.release.getCommitsInRelease(from);
     // env-ci sets branch to target branch (ex: master) in some CI services.
     // so we should make sure we aren't in a PR just to be safe
     const currentBranch = getCurrentBranch();

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -197,6 +197,20 @@ export default class Git {
     return result;
   }
 
+    /** Get the SHA of the latest commit */
+    async shaExists(sha?: string): Promise<boolean> {
+      try {
+        await execPromise('git', [
+          'rev-parse',
+          '--verify',
+          sha
+        ]);
+        return true
+      } catch (error) {
+        return false;
+      }
+    }
+
   /** Get the labels for a PR */
   @memoize()
   async getLabels(prNumber: number) {

--- a/plugins/git-tag/__tests__/git-tag.test.ts
+++ b/plugins/git-tag/__tests__/git-tag.test.ts
@@ -39,6 +39,16 @@ describe('Git Tag Plugin', () => {
       const previousVersion = await hooks.getPreviousVersion.promise();
       expect(previousVersion).toBe('v1.0.0');
     });
+
+    test('should default to 0.0.0 when no previous version', async () => {
+      const hooks = setup({
+        getLatestTagInBranch: () => {
+          throw new Error();
+        }
+      });
+      const previousVersion = await hooks.getPreviousVersion.promise();
+      expect(previousVersion).toBe('0.0.0');
+    });
   });
 
   describe('version', () => {


### PR DESCRIPTION
# What Changed

Default to 0.0.0 when no previous release detected in git-tag plugin.

# Why

closes #886 

Todo:

- [ ] Add tests
- [ ] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: <details><summary>Published under canary scope @auto-canary</summary>
- `@auto-canary/auto@9.2.1-canary.888.11616.0`
- `@auto-canary/core@9.2.1-canary.888.11616.0`
- `@auto-canary/all-contributors@9.2.1-canary.888.11616.0`
- `@auto-canary/chrome@9.2.1-canary.888.11616.0`
- `@auto-canary/conventional-commits@9.2.1-canary.888.11616.0`
- `@auto-canary/crates@9.2.1-canary.888.11616.0`
- `@auto-canary/first-time-contributor@9.2.1-canary.888.11616.0`
- `@auto-canary/git-tag@9.2.1-canary.888.11616.0`
- `@auto-canary/jira@9.2.1-canary.888.11616.0`
- `@auto-canary/maven@9.2.1-canary.888.11616.0`
- `@auto-canary/npm@9.2.1-canary.888.11616.0`
- `@auto-canary/omit-commits@9.2.1-canary.888.11616.0`
- `@auto-canary/omit-release-notes@9.2.1-canary.888.11616.0`
- `@auto-canary/released@9.2.1-canary.888.11616.0`
- `@auto-canary/s3@9.2.1-canary.888.11616.0`
- `@auto-canary/slack@9.2.1-canary.888.11616.0`
- `@auto-canary/twitter@9.2.1-canary.888.11616.0`
- `@auto-canary/upload-assets@9.2.1-canary.888.11616.0`</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
