### PR TITLE
determine first time contributor by using PR count instead of git history

### DIFF
--- a/plugins/first-time-contributor/__tests__/__snapshots__/first-time-contributor.test.ts.snap
+++ b/plugins/first-time-contributor/__tests__/__snapshots__/first-time-contributor.test.ts.snap
@@ -4,7 +4,7 @@ exports[`First Time Contributor Plugin should exclude a past contributor 1`] = `
 Array [
   ":tada: This release contains work from a new contributor! :tada:
 
-Thank you, Jeff, for all your work!",
+Thank you, Jeff ([@Jeff](https://github.com/Jeff)), for all your work!",
 ]
 `;
 
@@ -12,7 +12,7 @@ exports[`First Time Contributor Plugin should exclude a past contributor by user
 Array [
   ":tada: This release contains work from a new contributor! :tada:
 
-Thank you, Jeff123, for all your work!",
+Thank you, Jeff123 ([@Jeff123](https://github.com/Jeff123)), for all your work!",
 ]
 `;
 
@@ -34,9 +34,9 @@ Array [
 
 Thanks for all your work!
 
-:heart: Jeff
+:heart: Jeff ([@Jeff](https://github.com/Jeff))
 
-:heart: Andrew",
+:heart: Andrew ([@Andrew](https://github.com/Andrew))",
 ]
 `;
 
@@ -47,7 +47,5 @@ Array [
 Thank you, [@jeff-the-snake](https://github.com/jeff-the-snake), for all your work!",
 ]
 `;
-
-exports[`First Time Contributor Plugin should not include past contributors - email 1`] = `Array []`;
 
 exports[`First Time Contributor Plugin should not include past contributors 1`] = `Array []`;

--- a/plugins/first-time-contributor/src/index.ts
+++ b/plugins/first-time-contributor/src/index.ts
@@ -34,14 +34,14 @@ export default class FirstTimeContributorPlugin implements IPlugin {
                 }
 
                 const prs = await auto.git?.graphql(`
-                {
-                  search(first: 2, type: ISSUE, query: "user:${auto.git?.options.owner} repo:${auto.git?.options.repo} author:${author.username} state:closed") {
-                    issueCount
+                  {
+                    search(first: 2, type: ISSUE, query: "user:${auto.git?.options.owner} repo:${auto.git?.options.repo} author:${author.username} state:closed") {
+                      issueCount
+                    }
                   }
-                }
-              `);
+                `);
 
-                if (prs && prs.search.issueCount === 1) {
+                if (prs && prs.search.issueCount <= 1) {
                   return author;
                 }
               })


### PR DESCRIPTION
# What Changed

Previously we tried to determine first time contributors (FTC) by looking at the git history. This was flaky and didn't work most of the time. Now we just look at how many PRs have been made by a user.

# Why

It was broke.

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: <details><summary>Published under canary scope @auto-canary</summary>
- `@auto-canary/auto@9.2.3-canary.890.11643.0`
- `@auto-canary/core@9.2.3-canary.890.11643.0`
- `@auto-canary/all-contributors@9.2.3-canary.890.11643.0`
- `@auto-canary/chrome@9.2.3-canary.890.11643.0`
- `@auto-canary/conventional-commits@9.2.3-canary.890.11643.0`
- `@auto-canary/crates@9.2.3-canary.890.11643.0`
- `@auto-canary/first-time-contributor@9.2.3-canary.890.11643.0`
- `@auto-canary/git-tag@9.2.3-canary.890.11643.0`
- `@auto-canary/jira@9.2.3-canary.890.11643.0`
- `@auto-canary/maven@9.2.3-canary.890.11643.0`
- `@auto-canary/npm@9.2.3-canary.890.11643.0`
- `@auto-canary/omit-commits@9.2.3-canary.890.11643.0`
- `@auto-canary/omit-release-notes@9.2.3-canary.890.11643.0`
- `@auto-canary/released@9.2.3-canary.890.11643.0`
- `@auto-canary/s3@9.2.3-canary.890.11643.0`
- `@auto-canary/slack@9.2.3-canary.890.11643.0`
- `@auto-canary/twitter@9.2.3-canary.890.11643.0`
- `@auto-canary/upload-assets@9.2.3-canary.890.11643.0`</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
