### PR TITLE
Surface plugin syntax errors to user

### DIFF
--- a/packages/core/src/utils/__tests__/load-plugin.test.ts
+++ b/packages/core/src/utils/__tests__/load-plugin.test.ts
@@ -16,6 +16,15 @@ describe('loadPlugins', () => {
     );
   });
 
+  test('should require custom plugins -- surface errors', async () => {
+    expect(() =>
+      loadPlugin(
+        [path.join(__dirname, './test-plugin-malformed.js'), {}],
+        logger
+      )
+    ).toThrow();
+  });
+
   test('should load config', async () => {
     expect(
       loadPlugin(

--- a/packages/core/src/utils/__tests__/test-plugin-malformed.js
+++ b/packages/core/src/utils/__tests__/test-plugin-malformed.js
@@ -1,0 +1,12 @@
+module.expss Test {
+  /** The name of the plugin */
+  name = 'foo';
+
+  /** The options of the plugin */
+  config: {};
+
+  /** Initialize the plugin with it's options */
+  constructor(config: {}) {
+    this.config = config;
+  }
+};

--- a/packages/core/src/utils/try-require.ts
+++ b/packages/core/src/utils/try-require.ts
@@ -12,6 +12,11 @@ export default function tryRequire(tryPath: string) {
       return;
     }
 
+    // If a plugin has any errors we want to inform the user
+    if (!error.message.includes('Cannot find module')) {
+      throw error;
+    }
+
     try {
       // Require from __dirname. Needed for npx and global installs
       return require(tryPath);


### PR DESCRIPTION
# What Changed

When trying to require plugins throw any error other than not found. This will surface plugin errors to users

# Why

closes #841 

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: <details><summary>Published under canary scope @auto-canary</summary>
- `@auto-canary/auto@9.3.1-canary.892.11672.0`
- `@auto-canary/core@9.3.1-canary.892.11672.0`
- `@auto-canary/all-contributors@9.3.1-canary.892.11672.0`
- `@auto-canary/chrome@9.3.1-canary.892.11672.0`
- `@auto-canary/conventional-commits@9.3.1-canary.892.11672.0`
- `@auto-canary/crates@9.3.1-canary.892.11672.0`
- `@auto-canary/first-time-contributor@9.3.1-canary.892.11672.0`
- `@auto-canary/git-tag@9.3.1-canary.892.11672.0`
- `@auto-canary/jira@9.3.1-canary.892.11672.0`
- `@auto-canary/maven@9.3.1-canary.892.11672.0`
- `@auto-canary/npm@9.3.1-canary.892.11672.0`
- `@auto-canary/omit-commits@9.3.1-canary.892.11672.0`
- `@auto-canary/omit-release-notes@9.3.1-canary.892.11672.0`
- `@auto-canary/released@9.3.1-canary.892.11672.0`
- `@auto-canary/s3@9.3.1-canary.892.11672.0`
- `@auto-canary/slack@9.3.1-canary.892.11672.0`
- `@auto-canary/twitter@9.3.1-canary.892.11672.0`
- `@auto-canary/upload-assets@9.3.1-canary.892.11672.0`</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
