### PR TITLE
Fix private package previous version calculation + Improve dry run messaging

### DIFF
--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -146,6 +146,10 @@ export function getMonorepoPackage() {
         return subPackage.package;
       }
 
+      if (subPackage.package.private) {
+        return greatest;
+      }
+
       return gt(greatest.version, subPackage.package.version)
         ? greatest
         : subPackage.package;


### PR DESCRIPTION
# What Changed

Fixes an odd bug + I took the chance to make the dry run experience a little better with clearer messaging.

# Why

Addresses the issue described in https://github.com/intuit/auto/issues/893#issuecomment-578369819

Todo:

- [x] Add tests
- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: <details><summary>Published under canary scope @auto-canary</summary>
- `@auto-canary/auto@9.3.2-canary.894.11684.0`
- `@auto-canary/core@9.3.2-canary.894.11684.0`
- `@auto-canary/all-contributors@9.3.2-canary.894.11684.0`
- `@auto-canary/chrome@9.3.2-canary.894.11684.0`
- `@auto-canary/conventional-commits@9.3.2-canary.894.11684.0`
- `@auto-canary/crates@9.3.2-canary.894.11684.0`
- `@auto-canary/first-time-contributor@9.3.2-canary.894.11684.0`
- `@auto-canary/git-tag@9.3.2-canary.894.11684.0`
- `@auto-canary/jira@9.3.2-canary.894.11684.0`
- `@auto-canary/maven@9.3.2-canary.894.11684.0`
- `@auto-canary/npm@9.3.2-canary.894.11684.0`
- `@auto-canary/omit-commits@9.3.2-canary.894.11684.0`
- `@auto-canary/omit-release-notes@9.3.2-canary.894.11684.0`
- `@auto-canary/released@9.3.2-canary.894.11684.0`
- `@auto-canary/s3@9.3.2-canary.894.11684.0`
- `@auto-canary/slack@9.3.2-canary.894.11684.0`
- `@auto-canary/twitter@9.3.2-canary.894.11684.0`
- `@auto-canary/upload-assets@9.3.2-canary.894.11684.0`</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
