### PR TITLE
Explicitly add npm & yarn step for all-contributors

### DIFF
--- a/plugins/all-contributors/README.md
+++ b/plugins/all-contributors/README.md
@@ -16,12 +16,12 @@ Out of the box the plugin will only detect the following contribution types:
 This plugin is not included with the `auto` CLI installed via NPM. To install:
 
 ```sh
-npx install-peerdeps --dev @auto-it/all-contributors
+npm i --save-dev @auto-it/all-contributors all-contributors-cli
+# or
+yarn add -D @auto-it/all-contributors all-contributors-cli
 ```
 
 ## Prerequisites
-
-You must have already installed and initialized `all-contributors-cli`;
 
 ```sh
 npx all-contributors init


### PR DESCRIPTION
# What Changed

Prefer `npm` or `yarn` over `npx install-peerdeps`.

# Why

After prompting to use yarn or not (`y/n`), `install-peerdeps` only exited.  `node_modules` nor `package.json` changed.

Since the purpose is to install both packages together, I listed them explicitly.

It's a great tool & idea (especially if there's concern in `all-contributors-cli` becoming incompatible with the plugin), but I couldn't continue the setup in https://github.com/ericclemmons/codelift/pull/78 otherwise.

