### PR TITLE
add better messaging when pr number cannot be detected

### DIFF
--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -355,14 +355,14 @@ describe('Auto', () => {
 
     test('should catch exceptions when status fails to post', async () => {
       const auto = new Auto(defaults);
+
+      process.exit = jest.fn() as any;
       auto.logger = dummyLog();
       await auto.loadConfig();
       auto.git!.createStatus = createStatus;
-      createStatus.mockRejectedValueOnce({ status: 400 });
 
-      await expect(
-        auto.prStatus({ ...required, sha: '1234' })
-      ).rejects.toBeInstanceOf(Error);
+      auto.prStatus({ ...required, sha: '1234' });
+      expect(process.exit).toHaveBeenCalled();
       expect(createStatus).toHaveBeenCalled();
     });
 

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1077,9 +1077,15 @@ export default class Auto {
     const prNumber = getPrNumberFromEnv(pr);
 
     if (!prNumber) {
-      throw new Error(
-        `Could not detect PR number. ${command} must be run from either a PR or have the PR number supplied via the --pr flag.`
+      this.logger.log.error(
+        endent`
+          Could not detect PR number. ${command} must be run from either a PR or have the PR number supplied via the --pr flag.
+          
+          In some CIs your branch might be built before you open a PR and posting the canary version will fail. In this case subsequent builds should succeed. 
+        `
       );
+
+      process.exit(1);
     }
 
     return prNumber;


### PR DESCRIPTION
# What Changed

add more informative error message

# Why

there were states where this error would throw and it wasn't immediately obvious why 


<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: <details><summary>1.2.3-canary.0</summary>
Test out this PR locally via:
```sh
npm install @foobar/app@1.2.3-canary.0
npm install @foobar/lib@1.2.3-canary.0
# or 
yarn add @foobar/app@1.2.3-canary.0
yarn add @foobar/lib@1.2.3-canary.0
```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
