### PR TITLE
Add 📦 emoji to canary PR message to make it more noticeable

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -775,7 +775,8 @@ export default class Auto {
       }
 
       newVersion = result;
-      const message = options.message || 'Published PR with canary version: %v';
+      const message =
+        options.message || '📦 Published PR as canary version: %v';
 
       if (message !== 'false' && pr) {
         await this.prBody({


### PR DESCRIPTION
# What Changed

> Published PR with canary version: `0.5.1-canary.58.fea0a94.0`

becomes

> 📦 Published PR as canary version: `0.5.1-canary.58.fea0a94.0`

# Why

When adding `auto` to [codelift](https://github.com/ericclemmons/codelift/) I didn't even realize that this message was added to the PR body. (Was expecting a comment or something in the GitHub check to appear).

In retrospect, this is a good place to keep it so that (1) it doesn't create noise in the thread and (2) users who visit a PR can immediately see how to test it.

There _is_ some opportunity to potentially make it look like the following, but it would require knowledge of `npm` or `yarn` being used to publish:

<details>
<summary>📦 Published PR as canary version: <code>0.5.1-canary.58.fea0a94.0</code></summary>


Test out this PR locally via:

```shell
npm install codelift@0.5.1-canary.58.fea0a94.0
# or 
yarn add codelift@0.5.1-canary.58.fea0a94.0
```
</details>
