### PR TITLE
Add html details option to canary hook + Use in npm plugin

### DIFF
--- a/docs/pages/writing-plugins.md
+++ b/docs/pages/writing-plugins.md
@@ -316,6 +316,11 @@ Ran after the package has been published.
 
 Used to publish a canary release. In this hook you get the semver bump and the unique canary postfix ID.
 
+You can either return a string value of just the version or an object containing the following which will be rendered within and HTML details element.
+
+- `newVersion` - The version published in the canary release or a header for the details element.
+- `details` - The body of the details element
+
 ```ts
 auto.hooks.canary.tapPromise(this.name, async (version, postFix) => {
   const lastRelease = await auto.git!.getLatestRelease();

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -83,8 +83,14 @@ interface ShipitInfo {
 }
 
 /** Make a HTML detail */
-const makeDetail = (summary: string, body: string) =>
-  `<details><summary>${summary}</summary>\n${body}\n</details>`;
+const makeDetail = (summary: string, body: string) => endent`
+  <details>
+    <summary>${summary}</summary>
+    <br />
+    
+    ${body}
+  </details>
+`;
 
 export interface IAutoHooks {
   /** Modify what is in the config. You must return the config in this hook. */
@@ -790,7 +796,7 @@ export default class Auto {
         '%v',
         !newVersion || newVersion.includes('\n')
           ? newVersion
-          : `\`${newVersion}\``
+          : `<code>${newVersion}</code>`
       );
 
       if (options.message !== 'false' && pr) {

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -82,6 +82,10 @@ interface ShipitInfo {
   context: ShipitContext;
 }
 
+/** Make a HTML detail */
+const makeDetail = (summary: string, body: string) =>
+  `<details><summary>${summary}</summary>\n${body}\n</details>`;
+
 export interface IAutoHooks {
   /** Modify what is in the config. You must return the config in this hook. */
   modifyConfig: SyncWaterfallHook<[IAutoConfig]>;
@@ -143,6 +147,12 @@ export interface IAutoHooks {
   canary: AsyncSeriesBailHook<
     [SEMVER, string],
     | string
+    | {
+        /** A summary to use in a details html element */
+        newVersion: string;
+        /** The details to use in a details html element */
+        details: string;
+      }
     | {
         /** Error when creating the canary release */
         error: string;
@@ -742,6 +752,7 @@ export default class Auto {
       calculateSemVerBump(labels, this.semVerLabels!, this.config) ||
       SEMVER.patch;
     let canaryVersion = '';
+    let newVersion = '';
 
     if (pr) {
       canaryVersion = `${canaryVersion}.${pr}`;
@@ -755,8 +766,6 @@ export default class Auto {
       canaryVersion = `${canaryVersion}.${await this.git.getSha(true)}`;
     }
 
-    let newVersion = '';
-
     if (options.dryRun) {
       this.logger.log.warn(
         `Published canary identifier would be: "-canary${canaryVersion}"`
@@ -765,7 +774,7 @@ export default class Auto {
       this.logger.verbose.info('Calling canary hook');
       const result = await this.hooks.canary.promise(version, canaryVersion);
 
-      if (typeof result === 'object') {
+      if (typeof result === 'object' && 'error' in result) {
         this.logger.log.warn(result.error);
         return;
       }
@@ -774,20 +783,26 @@ export default class Auto {
         return;
       }
 
-      newVersion = result;
-      const message =
-        options.message || '📦 Published PR as canary version: %v';
+      newVersion = typeof result === 'string' ? result : result.newVersion;
+      const messageHeader = (
+        options.message || '📦 Published PR as canary version: %v'
+      ).replace(
+        '%v',
+        !newVersion || newVersion.includes('\n')
+          ? newVersion
+          : `\`${newVersion}\``
+      );
 
-      if (message !== 'false' && pr) {
+      if (options.message !== 'false' && pr) {
+        const message =
+          typeof result === 'string'
+            ? messageHeader
+            : makeDetail(messageHeader, result.details);
+
         await this.prBody({
           pr: Number(pr),
           context: 'canary-version',
-          message: message.replace(
-            '%v',
-            !newVersion || newVersion.includes('\n')
-              ? newVersion
-              : `\`${newVersion}\``
-          )
+          message
         });
       }
 

--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -715,7 +715,8 @@ describe('canary', () => {
 
     const value = await hooks.canary.promise(Auto.SEMVER.patch, '');
     expect(exec.mock.calls[0][1]).toContain('lerna');
-    expect(value).toBe('1.2.3-canary.0');
+    // @ts-ignore
+    expect(value.newVersion).toBe('1.2.3-canary.0');
   });
 
   test('error when no canary release found', async () => {

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -612,7 +612,9 @@ export default class NPMPlugin implements IPlugin {
 
         return {
           newVersion: this.canaryScope
-            ? `Published under canary scope @${sanitizeScope(this.canaryScope)}`
+            ? `Published under canary scope @${sanitizeScope(
+                this.canaryScope
+              )}@${version}`
             : version,
           details: makeMonorepoInstallList(packageList)
         };

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -310,7 +310,7 @@ async function gitReset() {
 /** Make install instructions for multiple repos */
 const makeMonorepoInstallList = (packageList: string[]) =>
   [
-    'Test out this PR locally via:',
+    ':sparkles: Test out this PR locally via:\n',
     '```sh',
     ...packageList.map(p => `npm install ${p}`),
     '# or ',

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -612,7 +612,7 @@ export default class NPMPlugin implements IPlugin {
 
         return {
           newVersion: this.canaryScope
-            ? `Published under canary scope @${sanitizeScope(
+            ? `under canary scope @${sanitizeScope(
                 this.canaryScope
               )}@${version}`
             : version,


### PR DESCRIPTION
# What Changed

Adds a new possible return type to the `canary` hook. This return type will render in a HTML details element.

# Why

Provides a better install experience for canaries.

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.4.0-canary.898.11744.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.4.0-canary.898.11744.0
  npm install @auto-canary/core@9.4.0-canary.898.11744.0
  npm install @auto-canary/all-contributors@9.4.0-canary.898.11744.0
  npm install @auto-canary/chrome@9.4.0-canary.898.11744.0
  npm install @auto-canary/conventional-commits@9.4.0-canary.898.11744.0
  npm install @auto-canary/crates@9.4.0-canary.898.11744.0
  npm install @auto-canary/first-time-contributor@9.4.0-canary.898.11744.0
  npm install @auto-canary/git-tag@9.4.0-canary.898.11744.0
  npm install @auto-canary/jira@9.4.0-canary.898.11744.0
  npm install @auto-canary/maven@9.4.0-canary.898.11744.0
  npm install @auto-canary/npm@9.4.0-canary.898.11744.0
  npm install @auto-canary/omit-commits@9.4.0-canary.898.11744.0
  npm install @auto-canary/omit-release-notes@9.4.0-canary.898.11744.0
  npm install @auto-canary/released@9.4.0-canary.898.11744.0
  npm install @auto-canary/s3@9.4.0-canary.898.11744.0
  npm install @auto-canary/slack@9.4.0-canary.898.11744.0
  npm install @auto-canary/twitter@9.4.0-canary.898.11744.0
  npm install @auto-canary/upload-assets@9.4.0-canary.898.11744.0
  # or 
  yarn add @auto-canary/auto@9.4.0-canary.898.11744.0
  yarn add @auto-canary/core@9.4.0-canary.898.11744.0
  yarn add @auto-canary/all-contributors@9.4.0-canary.898.11744.0
  yarn add @auto-canary/chrome@9.4.0-canary.898.11744.0
  yarn add @auto-canary/conventional-commits@9.4.0-canary.898.11744.0
  yarn add @auto-canary/crates@9.4.0-canary.898.11744.0
  yarn add @auto-canary/first-time-contributor@9.4.0-canary.898.11744.0
  yarn add @auto-canary/git-tag@9.4.0-canary.898.11744.0
  yarn add @auto-canary/jira@9.4.0-canary.898.11744.0
  yarn add @auto-canary/maven@9.4.0-canary.898.11744.0
  yarn add @auto-canary/npm@9.4.0-canary.898.11744.0
  yarn add @auto-canary/omit-commits@9.4.0-canary.898.11744.0
  yarn add @auto-canary/omit-release-notes@9.4.0-canary.898.11744.0
  yarn add @auto-canary/released@9.4.0-canary.898.11744.0
  yarn add @auto-canary/s3@9.4.0-canary.898.11744.0
  yarn add @auto-canary/slack@9.4.0-canary.898.11744.0
  yarn add @auto-canary/twitter@9.4.0-canary.898.11744.0
  yarn add @auto-canary/upload-assets@9.4.0-canary.898.11744.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
