### PR TITLE
Updated GitHub Action

### DIFF
--- a/docs/pages/build-platforms/github-actions.md
+++ b/docs/pages/build-platforms/github-actions.md
@@ -26,7 +26,7 @@ jobs:
         run: |
           git checkout ${GITHUB_REF:11} --
           git remote rm origin
-          git remote add origin https://$<your-github-user>:GITHUB_TOKEN@github.com/<project-owner>/<project-repo>
+          git remote add origin "https://x-access-token:$GH_TOKEN@github.com/<owner>/<repo>.git"
           git fetch origin --tags
           git branch --set-upstream-to origin/${GITHUB_REF:11} ${GITHUB_REF:11}
       - name: Use Node.js 12.x

--- a/docs/pages/build-platforms/github-actions.md
+++ b/docs/pages/build-platforms/github-actions.md
@@ -22,17 +22,22 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
     steps:
       - uses: actions/checkout@v1
+
       - name: Prepare repository
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git checkout ${GITHUB_REF:11} --
           git remote rm origin
           git remote add origin "https://x-access-token:$GH_TOKEN@github.com/<owner>/<repo>.git"
           git fetch origin --tags
           git branch --set-upstream-to origin/${GITHUB_REF:11} ${GITHUB_REF:11}
+
       - name: Use Node.js 12.x
         uses: actions/setup-node@v1
         with:
           node-version: 12.x
+
       - name: Cache node modules
         uses: actions/cache@v1
         with:
@@ -40,6 +45,7 @@ jobs:
           key: yarn-deps-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             yarn-deps-${{ hashFiles('yarn.lock') }}
+
       - name: Create Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/pages/build-platforms/github-actions.md
+++ b/docs/pages/build-platforms/github-actions.md
@@ -45,8 +45,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          yarn
-          yarn build 
+          yarn install --frozen-lockfile
+          yarn build
           npx auto shipit
 ```
 


### PR DESCRIPTION
# What Changed

I used https://intuit.github.io/auto/pages/build-platforms/github-actions.html nearly exactly, but still needed a couple tweaks to work successfully.

# Why

- `--frozen-lockfile` for deterministic installs.
- `x-access-token` to solve permissions issues.
- Added `\n` between `- uses`, because copy/paste merged a couple together. This caused GitHub to throw an error like _workflow contains uses and runs at the same time_ until I corrected the indentation from the copy/paste.

Todo:

- [x] Add docs
- [ ] Isn't `auto ` in `devDependencies`, so `npx` shouldn't be necessary?
