### PR TITLE
Wrap version in code

### DIFF
--- a/plugins/released/__tests__/released-label.test.ts
+++ b/plugins/released/__tests__/released-label.test.ts
@@ -203,7 +203,7 @@ describe('release label plugin', () => {
 
     expect(comment).toHaveBeenCalledWith(
       expect.objectContaining({
-        message: ':rocket: PR was released in 1.0.0 :rocket:'
+        message: ':rocket: PR was released in `1.0.0` :rocket:'
       })
     );
   });
@@ -349,7 +349,7 @@ describe('release label plugin', () => {
     expect(comment).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
-        message: ':rocket: Issue was released in 1.0.0 :rocket:',
+        message: ':rocket: Issue was released in `1.0.0` :rocket:',
         pr: 420,
         context: 'released'
       })

--- a/plugins/released/src/index.ts
+++ b/plugins/released/src/index.ts
@@ -19,7 +19,7 @@ const defaultOptions = {
   label: 'released',
   prereleaseLabel: 'prerelease',
   lockIssues: false,
-  message: `:rocket: ${TYPE} was released in ${VERSION} :rocket:`
+  message: `:rocket: ${TYPE} was released in \`${VERSION}\` :rocket:`
 };
 
 const closeIssue = /(?:Close|Closes|Closed|Fix|Fixes|Fixed|Resolve|Resolves|Resolved)\s((?:#\d+(?:,\s)?)+)/gi;


### PR DESCRIPTION
# What Changed
> 🚀 PR was released in v0.5.1 🚀

becomes

> 🚀 PR was released in `v0.5.1` 🚀

# Why

Emojis without markdown is 😢 🐼.

Todo:

- [x] Add tests
