### PR TITLE
Overhaul "auto init" experience + make it pluggable

### DIFF
--- a/docs/pages/getting-started.md
+++ b/docs/pages/getting-started.md
@@ -48,7 +48,13 @@ Getting started with `auto` is super easy.
 
 ### 1. Initialize Options
 
-Initialize all options and configure label text. If this is not run then `auto` will use the default configuration. This command will produce and `.autorc`, this contains advanced configuration and might not be needed.
+Initialize the bare minimum options and a few other optional things.
+This will set you up locally but you will still have to configure environment variables in your CI. 
+
+- Override default labels
+- Add additional labels
+- Add plugins
+- Creates an .env file for local testing
 
 ### 2. Environment Variables
 

--- a/docs/pages/writing-plugins.md
+++ b/docs/pages/writing-plugins.md
@@ -532,6 +532,7 @@ class MyPlugin implements IPlugin {
 #### createEnv
 
 Add environment variables to get from the user
+
 ```ts
 class MyPlugin implements IPlugin {
   init(initializer: InteractiveInit) {

--- a/docs/pages/writing-plugins.md
+++ b/docs/pages/writing-plugins.md
@@ -483,6 +483,69 @@ auto.hooks.onCreateLogParse.tapPromise('Stars', changelog =>
 );
 ```
 
+### Init Hooks
+
+#### writeRcFile
+
+Override where/how the rc file is written.
+
+```ts
+class MyPlugin implements IPlugin {
+  init(initializer: InteractiveInit) {
+    initializer.hooks.writeRcFile.tapPromise('Example', async rc => {
+      // write the file somewhere other than .autorc
+      return filename;
+    });
+  }
+}
+```
+
+#### getRepo
+
+Get or verify the repo information.
+
+#### getAuthor - init
+
+Get or verify the author information.
+
+#### configurePlugin
+
+Run extra configuration for a plugin. Here is where to display prompts to the user.
+
+```ts
+class MyPlugin implements IPlugin {
+  init(initializer: InteractiveInit) {
+    initializer.hooks.configurePlugin.tapPromise('Example', async name => {
+      if (name === 'my-plugins') {
+        return [
+          name,
+          {
+            // extra config options
+          }
+        ];
+      }
+    });
+  }
+}
+```
+
+#### createEnv
+
+Add environment variables to get from the user
+```ts
+class MyPlugin implements IPlugin {
+  init(initializer: InteractiveInit) {
+    initializer.hooks.createEnv.tap('Example', vars => [
+      ...vars,
+      {
+        variable: 'MY_TOKEN',
+        message: `This is a very important secret`
+      }
+    ])
+  }
+}
+```
+
 ## Example Plugin - NPM (simple)
 
 To create a plugin simply make a class with an `apply` method and tap into the hooks you need.

--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -12,7 +12,6 @@ import {
   IChangelogOptions,
   ICommentOptions,
   ICreateLabelsOptions,
-  IInitOptions,
   ILabelOptions,
   IPRBodyOptions,
   IPRCheckOptions,
@@ -24,7 +23,6 @@ import {
 
 export type Flags =
   | keyof GlobalOptions
-  | keyof IInitOptions
   | keyof ICreateLabelsOptions
   | keyof ILabelOptions
   | keyof IPRCheckOptions
@@ -179,18 +177,8 @@ export const commands: Command[] = [
   {
     name: 'init',
     group: 'Setup Command',
-    description: 'Interactive setup for most configurable options',
-    examples: ['{green $} auto init'],
-    options: [
-      {
-        name: 'only-labels',
-        type: Boolean,
-        group: 'main',
-        description:
-          'Only run init for the labels. As most other options are for advanced users'
-      },
-      dryRun
-    ]
+    description: 'Interactive setup for minimum working configuration.',
+    examples: ['{green $} auto init']
   },
   {
     name: 'create-labels',

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -6,7 +6,6 @@ import Auto, {
   IChangelogOptions,
   ICommentOptions,
   ICreateLabelsOptions,
-  IInitOptions,
   ILabelOptions,
   IPRBodyOptions,
   IPRCheckOptions,
@@ -23,7 +22,7 @@ export async function run(command: string, args: ApiOptions) {
 
   switch (command) {
     case 'init':
-      await auto.init(args as IInitOptions);
+      await auto.init();
       break;
     case 'create-labels':
       await auto.loadConfig();

--- a/packages/core/src/auto-args.ts
+++ b/packages/core/src/auto-args.ts
@@ -17,13 +17,6 @@ export interface ILogOptions {
   verbose?: boolean | boolean[];
 }
 
-export interface IInitOptions {
-  /** Only show prompts for creating labels */
-  onlyLabels?: boolean;
-  /** Do not actually do anything */
-  dryRun?: boolean;
-}
-
 export interface ICreateLabelsOptions {
   /** Do not actually do anything */
   dryRun?: boolean;
@@ -156,7 +149,6 @@ export type GlobalOptions = {
 
 export type ApiOptions = GlobalOptions &
   (
-    | IInitOptions
     | ICreateLabelsOptions
     | ILabelOptions
     | IPRCheckOptions

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -21,7 +21,6 @@ import {
   IChangelogOptions,
   ICommentOptions,
   ICreateLabelsOptions,
-  IInitOptions,
   ILabelOptions,
   IPRCheckOptions,
   IPRStatusOptions,
@@ -34,7 +33,7 @@ import Changelog from './changelog';
 import { preVersionMap } from './semver';
 import Config from './config';
 import Git, { IGitOptions, IPRInfo } from './git';
-import init from './init';
+import InteractiveInit from './init';
 import LogParse, { IExtendedCommit } from './log-parse';
 import Release, {
   getVersionMap,
@@ -139,9 +138,15 @@ export interface IAutoHooks {
   getRepository: AsyncSeriesBailHook<[], (IRepoOptions & TestingToken) | void>;
   /** Tap into the things the Release class makes. This isn't the same as `auto release`, but the main class that does most of the work. */
   onCreateRelease: SyncHook<[Release]>;
-  /** This is where you hook into the LogParse's hooks. This hook is exposed for convenience on during `this.hooks.onCreateRelease` and at the root `this.hooks` */
+  /**
+   * This is where you hook into the LogParse's hooks.
+   * This hook is exposed for convenience during `this.hooks.onCreateRelease` and at the root `this.hooks`
+   */
   onCreateLogParse: SyncHook<[LogParse]>;
-  /** This is where you hook into the changelog's hooks.  This hook is exposed for convenience on during `this.hooks.onCreateRelease` and at the root `this.hooks` */
+  /**
+   * This is where you hook into the changelog's hooks.
+   * This hook is exposed for convenience during `this.hooks.onCreateRelease` and at the root `this.hooks`
+   */
   onCreateChangelog: SyncHook<[Changelog, SEMVER | undefined]>;
   /** Version the package. This is a good opportunity to `git tag` the release also.  */
   version: AsyncParallelHook<[SEMVER]>;
@@ -374,11 +379,10 @@ export default class Auto {
     this.hooks.onCreateRelease.call(this.release);
   }
 
-  /**
-   * Interactive prompt for initializing an .autorc
-   */
-  async init(options: IInitOptions = {}) {
-    await init(options, this.logger);
+  /** Interactive prompt for initializing an .autorc */ 
+  async init() {
+    const init = new InteractiveInit(this);
+    await init.run();
   }
 
   /** Determine if the repo is currently in a prerelease branch */
@@ -1470,6 +1474,7 @@ If a command fails manually run:
 // Plugin Utils
 
 export * from './auto-args';
+export { default as InteractiveInit } from './init';
 export { ILogger } from './utils/logger';
 export { IPlugin } from './utils/load-plugins';
 export { default as Auto } from './auto';

--- a/packages/core/src/init.ts
+++ b/packages/core/src/init.ts
@@ -2,246 +2,476 @@
 
 import endent from 'endent';
 import { prompt } from 'enquirer';
-import * as fs from 'fs';
-import * as path from 'path';
-import { promisify } from 'util';
+import { AsyncSeriesBailHook, AsyncSeriesWaterfallHook } from 'tapable';
 
-import { IInitOptions } from './auto-args';
-import { ILabelDefinition, defaultLabels } from './release';
+import { makeInteractiveInitHooks } from './utils/make-hooks';
+import { defaultLabels, ILabelDefinition } from './release';
+import SEMVER from './semver';
+import loadPlugin from './utils/load-plugins';
 import { ILogger } from './utils/logger';
+import { readFileSync, writeFileSync } from 'fs';
 
-const writeFile = promisify(fs.writeFile);
+// const writeFile = promisify(fs.writeFile);
 
-/** Determine if any value is an object */
-const isObject = <T>(value: T) => typeof value === 'object' && value !== null;
+interface Confirmation {
+  /** Whether the user confirmed the question */
+  confirmed: boolean;
+}
 
-/** Get all of the basic options for running "auto" */
-async function getFlags() {
-  return prompt([
-    {
-      type: 'input',
-      name: 'repo',
-      message:
-        'GitHub Project Repository (press enter to use package definition)'
-    },
-    {
-      type: 'input',
-      name: 'owner',
-      message: 'GitHub Project Owner (press enter to use package definition)'
-    },
-    {
-      type: 'confirm',
-      name: 'noVersionPrefix',
-      message: 'Use the version as the tag without the `v` prefix?',
-      initial: 'no'
-    },
-    {
-      type: 'input',
-      name: 'githubApi',
-      message: 'GitHub API to use (press enter to use public)'
-    },
-    {
-      type: 'input',
-      name: 'githubGraphqlApi',
-      message:
-        'GitHub Graphql API base path to use (press enter to use githubApi)'
-    },
-    {
-      type: 'input',
-      name: 'baseBranch',
-      message:
-        'Branch to treat as the "master" branch (press enter to use "master")'
-    },
-    {
-      type: 'confirm',
-      name: 'onlyPublishWithReleaseLabel',
-      message: 'Only bump version if `release` label is on pull request',
-      initial: 'no'
-    },
-    {
-      type: 'input',
-      name: 'name',
-      message:
-        'Git name to commit and release with (press enter to use package definition)'
-    },
-    {
-      type: 'input',
-      name: 'email',
-      message:
-        'Git email to commit with (press enter to use package definition)'
-    }
-  ]);
+interface InputResponse<T = 'string'> {
+  /** he value of the input prompt */
+  value: T;
+}
+
+interface RepoInformation {
+  /** The repo of to publish, might be set in package manager file. */
+  repo: string;
+  /** The owner of the repo to publish, might be set in package manager file. */
+  owner: string;
+}
+
+interface AuthorInformation {
+  /** The name of the author to make commits with */
+  name: string;
+  /** The email of the author to make commits with */
+  email: string;
+}
+
+interface GithubApis {
+  /** The github api to interact with */
+  githubApi?: string;
+  /** The github graphql api to interact with */
+  githubGraphqlApi?: string;
+}
+
+type PluginConfig = [string, any] | string;
+
+export type AutoRc = Partial<
+  RepoInformation & GithubApis & AuthorInformation
+> & {
+  /** Only bump version if `release` label is on pull request */
+  onlyPublishWithReleaseLabel?: boolean;
+  /** Labels that power auto */
+  labels?: ILabelDefinition[];
+  /** Configured auto plugins */
+  plugins?: PluginConfig[];
+};
+
+export interface InteractiveInitHooks {
+  /** Override where/how the rc file is written */
+  writeRcFile: AsyncSeriesBailHook<[AutoRc], string | void>;
+  /** Get or verify the repo information */
+  getRepo: AsyncSeriesBailHook<[], RepoInformation | true | void>;
+  /** Get or verify the author information */
+  getAuthor: AsyncSeriesBailHook<[], AuthorInformation | true | void>;
+  /** Run extra configuration for a plugin */
+  configurePlugin: AsyncSeriesBailHook<[string], PluginConfig | void>;
+  /** Add environment variables to get from the user */
+  createEnv: AsyncSeriesWaterfallHook<
+    [
+      {
+        /** The name of the env var */
+        variable: string;
+        /** The message to ask the user for the the env var */
+        message: string;
+      }[]
+    ]
+  >;
 }
 
 /** Get label configuration from the user. */
-async function getCustomLabels(onlyLabels = false) {
-  const useCustomChangelogTitles: {
-    /** The result of the prompt */
-    value: boolean;
-  } = onlyLabels
-    ? { value: onlyLabels }
-    : await prompt({
-        type: 'confirm',
-        name: 'value',
-        message: 'Would you like to use custom labels?',
-        initial: 'no'
-      });
-
-  let customLabels = {};
-
-  if (useCustomChangelogTitles.value) {
-    let i = 0;
-
-    while (defaultLabels[i]) {
-      const label = defaultLabels[i++];
-      const response = await prompt({
-        type: 'snippet',
-        name: 'value',
-        message: `Customize the ${label.name} label:`,
-        initial: label,
-        // @ts-ignore
-        template:
-          label.name === 'release' || label.name === 'skip-release'
-            ? endent`
-                label:  #{name}
-                desc:   #{description}
-              `
-            : endent`
-                label:  #{name}
-                title:  #{title}
-                desc:   #{description}
-              `
-      });
-
-      const { name, title, description } = response.value.values;
-      const newLabel: Partial<ILabelDefinition> = {};
-
-      if (name !== label.name) {
-        newLabel.name = name;
-      }
-
-      if (name !== label.changelogTitle) {
-        newLabel.changelogTitle = title;
-      }
-
-      if (name !== label.description) {
-        newLabel.description = description;
-      }
-
-      if (Object.keys(newLabel).length === 1 && newLabel.name) {
-        customLabels = {
-          ...customLabels,
-          [label.name]: name
-        };
-      } else if (Object.keys(newLabel).length !== 0) {
-        customLabels = {
-          ...customLabels,
-          [label.name]: newLabel
-        };
-      }
-    }
+async function getLabel(label?: ILabelDefinition) {
+  interface LabelResponse {
+    /** Response value */
+    value: {
+      /** Snippet values */
+      values: [ILabelDefinition];
+    };
   }
 
-  let getAnotherTitle: {
-    /** The result of the prompt */
-    value?: boolean;
-  } = await prompt({
-    type: 'confirm',
+  const response = await prompt<LabelResponse>({
+    type: 'snippet',
     name: 'value',
-    message: 'Would you like to add additional labels?',
+    message: label ? `Edit "${label.name}" label:` : 'Add a label:',
+    // @ts-ignore
+    template: label
+      ? endent`{
+          name: #{name:${label.name}},
+          ${
+            label.changelogTitle
+              ? `changelogTitle: #{changelogTitle:${label.changelogTitle}},`
+              : ''
+          }
+          description: #{description:${label.description}},
+          releaseType: #{releaseType:${label.releaseType}}
+        }`
+      : endent`{
+          name: #{name},
+          changelogTitle: #{changelogTitle},
+          description: #{description},
+          releaseType: #{releaseType}
+        }`,
+    validate: (state: {
+      /** The result of the prompt */
+      values: ILabelDefinition;
+    }) => {
+      if (!state.values.name) {
+        return 'name is required for new label';
+      }
+
+      const releaseTypes = [
+        SEMVER.major,
+        SEMVER.minor,
+        SEMVER.patch,
+        'none',
+        'skip',
+        'release'
+      ];
+
+      if (
+        state.values.releaseType &&
+        !releaseTypes.includes(state.values.releaseType)
+      ) {
+        return `Release type can only be one of the following: ${releaseTypes.join(
+          ', '
+        )}`;
+      }
+
+      return true;
+    }
+  });
+
+  const {
+    name,
+    changelogTitle,
+    description,
+    releaseType
+  } = response.value.values;
+  return { name, changelogTitle, description, releaseType };
+}
+
+/** Get any custom labels from the user */
+async function getAdditionalLabels() {
+  const labels: ILabelDefinition[] = [];
+
+  let addLabels = await prompt<Confirmation>({
+    type: 'confirm',
+    name: 'confirmed',
+    message: 'Would you like to add more labels?',
     initial: 'no'
   });
 
-  while (getAnotherTitle.value) {
-    const response = await prompt({
-      type: 'snippet',
-      name: 'value',
-      message: 'Add another label:',
-      // @ts-ignore
-      template: endent`
-        label:  #{name}
-        title:  #{title}
-        desc:   #{description}
-      `,
-      validate: (state: {
-        /** The result of the prompt */
-        values: {
-          /** Name of the label */
-          name?: string;
-          /** Changelog title of the label */
-          changelogTitle?: string;
-          /** Description of the label */
-          description?: string;
-        };
-      }) => {
-        if (!state.values.name) {
-          return 'Label is required for new label';
-        }
+  while (addLabels.confirmed) {
+    labels.push(await getLabel());
 
-        if (!state.values.changelogTitle) {
-          return 'Title is required for new label';
-        }
-
-        if (!state.values.description) {
-          return 'Description is required for new label';
-        }
-
-        return true;
-      }
-    });
-
-    const { name, title, description } = response.value.values;
-
-    customLabels = {
-      ...customLabels,
-      [name]: { name, title, description }
-    };
-
-    getAnotherTitle = await prompt({
+    addLabels = await prompt<Confirmation>({
       type: 'confirm',
-      name: 'value',
-      message: 'Would you like to add another?',
+      name: 'confirmed',
+      message: 'Would you like to add another label?',
       initial: 'no'
     });
   }
 
-  return customLabels;
+  return labels;
 }
 
-/** Run the interactive initialization prompt */
-export default async function init(
-  { onlyLabels, dryRun }: IInitOptions,
-  logger: ILogger
-) {
-  const flags = onlyLabels ? {} : await getFlags();
-  const labels = await getCustomLabels(onlyLabels);
-  const autoRc = Object.entries({
-    ...flags,
-    labels
-  }).reduce((all, [key, value]) => {
-    if (
-      value === '' ||
-      value === false ||
-      (isObject(value) && Object.keys(value).length === 0)
-    ) {
-      return all;
-    }
+/** Get default label overrides */
+async function getCustomizedDefaultLabels() {
+  const labels: ILabelDefinition[] = [];
+  const addLabels = await prompt<Confirmation>({
+    type: 'confirm',
+    name: 'confirmed',
+    message: 'Would you like to use customize the default labels?',
+    initial: 'no'
+  });
 
-    return {
-      ...all,
-      [key]: value
-    };
-  }, {} as { [key: string]: number | {} | boolean });
+  if (addLabels.confirmed) {
+    await defaultLabels.reduce(async (last, defaultLabel) => {
+      await last;
+      const newLabel = await getLabel(defaultLabel);
 
-  if (Object.keys(autoRc).length === 0) {
+      if (JSON.stringify(newLabel) !== JSON.stringify(defaultLabel)) {
+        labels.push({ ...newLabel, overwrite: true });
+      }
+    }, Promise.resolve());
+  }
+
+  return labels;
+}
+
+/** Get the plugins the user wants to use */
+async function getPlugins() {
+  const releasePlugins = {
+    'Chrome Web Store': 'chrome',
+    'Rust Crate': 'crates',
+    'Git Tag': 'git-tag',
+    'npm Package': 'npm',
+    Maven: 'maven'
+  };
+
+  const releasePlugin = await prompt<InputResponse>({
+    type: 'select',
+    name: 'value',
+    required: true,
+    message:
+      'What package manager plugin would you like to publish your project with?',
+    choices: Object.keys(releasePlugins)
+  });
+
+  const featurePlugin = await prompt<InputResponse<string[]>>({
+    type: 'multiselect',
+    name: 'value',
+    required: true,
+    message: 'What other plugins would you like to use?',
+    choices: [
+      {
+        name: 'all-contributors',
+        message:
+          'All Contributors - Automatically add contributors as changelogs are produced'
+      },
+      {
+        name: 'conventional-commits',
+        message: 'Conventional Commits - Parse conventional commit messages'
+      },
+      {
+        name: 'first-time-contributor',
+        message:
+          'First Time Contributor - Thank first time contributors for their work right in your release notes'
+      },
+      {
+        name: 'jira',
+        message: 'Jira - Include Jira story information'
+      },
+      {
+        name: 'released',
+        message: 'Released - Mark PRs as released'
+      },
+      {
+        name: 'slack',
+        message: 'Slack - Post your release notes to a slack channel'
+      },
+      {
+        name: 'twitter',
+        message: 'Twitter - Post tweets after a release is made'
+      }
+    ]
+  });
+
+  return [
+    releasePlugins[releasePlugin.value as keyof typeof releasePlugins],
+    ...featurePlugin.value
+  ];
+}
+
+/** Get env vars, create .env file, add to .gitignore */
+async function createEnv(hook: InteractiveInitHooks['createEnv']) {
+  let currentEnv: string;
+
+  try {
+    currentEnv = readFileSync('.env', { encoding: 'utf8' });
+  } catch (error) {
+    currentEnv = '';
+  }
+
+  const env = (await hook.promise([])).filter(
+    envVar => !currentEnv.includes(envVar.variable)
+  );
+
+  if (env.length === 0) {
     return;
   }
 
-  const jsonString = JSON.stringify(autoRc, undefined, 2);
+  const shouldCreateEnv = await prompt<Confirmation>({
+    type: 'confirm',
+    name: 'confirmed',
+    message:
+      'Would you like to create an .env file? This makes it easy to test and use auto locally.',
+    initial: 'yes'
+  });
 
-  if (dryRun) {
-    logger.log.note(`Initialization options would be:\n${jsonString}`);
-  } else {
-    await writeFile(path.join(process.cwd(), '.autorc'), jsonString);
+  if (!shouldCreateEnv.confirmed) {
+    return;
+  }
+
+  // Get user input for each variable
+  await env.reduce(async (last, envVar) => {
+    await last;
+
+    const token = await prompt<InputResponse>({
+      type: 'input',
+      name: 'value',
+      message: envVar.message,
+      required: true
+    });
+
+    currentEnv += `${envVar.variable}=${token.value}\n`;
+  }, Promise.resolve());
+
+  writeFileSync('.env', currentEnv);
+
+  let gitIgnore: string;
+
+  try {
+    gitIgnore = readFileSync('.env', { encoding: 'utf8' });
+  } catch (error) {
+    gitIgnore = '';
+  }
+
+  // Add env to gitignore if not already there
+  if (!gitIgnore.includes('.env')) {
+    writeFileSync('.env', gitIgnore ? `${gitIgnore}\n.env` : '.env');
+  }
+}
+
+/**
+ * Parse the gitlog for commits that are PRs and attach their labels.
+ * This class can also be tapped into via plugin to parse commits
+ * in other ways (ex: conventional-commits)
+ */
+export default class InteractiveInit {
+  /** Plugin entry points */
+  hooks: InteractiveInitHooks;
+  /** The logger for the initializer */
+  logger: ILogger;
+
+  /** Initialize the the init prompter and tap the default functionality  */
+  constructor(options: {
+    /** The logger for the initializer */
+    logger: ILogger;
+  }) {
+    this.hooks = makeInteractiveInitHooks();
+    this.logger = options.logger;
+  }
+
+  /** Run a prompt to get the author information */
+  async getAuthorInformation() {
+    const response = await prompt({
+      type: 'snippet',
+      name: 'author',
+      message: `What git user would you like to make commits with?`,
+      required: true,
+      // @ts-ignore
+      template: endent`
+        Name:   #{name} 
+        Email:  #{email}`
+    });
+
+    return response.author.values as AuthorInformation;
+  }
+
+  /** Run a prompt to get the repo information */
+  async getRepoInformation() {
+    const response = await prompt({
+      type: 'snippet',
+      name: 'repoInfo',
+      message: `What GitHub project you would like to publish?`,
+      required: true,
+      // @ts-ignore
+      template: endent`#{owner}/#{repo}`
+    });
+
+    return response.repoInfo.values as RepoInformation;
+  }
+
+  /** Load the default behavior */
+  private tapDefaults() {
+    this.hooks.getRepo.tapPromise('Init Default', this.getRepoInformation);
+    this.hooks.getAuthor.tapPromise('Init Default', this.getAuthorInformation);
+    this.hooks.createEnv.tap('Init Default', vars => [
+      ...vars,
+      {
+        variable: 'GH_TOKEN',
+        message: `Enter a personal access token for the GitHub API https://github.com/settings/tokens/new`
+      }
+    ]);
+    this.hooks.writeRcFile.tap('Init Default', rc => {
+      const filename = '.autorc';
+      writeFileSync(filename, JSON.stringify(rc, null, 2));
+      return filename;
+    });
+  }
+
+  /** Run the initialization. */
+  async run() {
+    let autoRc: Partial<AutoRc> = {};
+
+    const plugins: string[] = await getPlugins();
+
+    if (plugins) {
+      plugins
+        .map(name => loadPlugin([name, {}], this.logger))
+        .forEach(plugin => {
+          if (plugin?.init) {
+            plugin.init(this);
+          }
+        });
+
+      autoRc.plugins = await plugins.reduce(async (last, plugin) => {
+        return [
+          ...(await last),
+          (await this.hooks.configurePlugin.promise(plugin)) || plugin
+        ];
+      }, Promise.resolve([] as PluginConfig[]));
+    }
+
+    this.tapDefaults();
+    const repoInfo = await this.hooks.getRepo.promise();
+
+    if (typeof repoInfo === 'object') {
+      autoRc = { ...autoRc, ...repoInfo };
+    }
+
+    const author = await this.hooks.getAuthor.promise();
+
+    if (typeof author === 'object') {
+      autoRc = { ...autoRc, ...author };
+    }
+
+    const onlyPublishWithReleaseLabel = await prompt<Confirmation>({
+      type: 'confirm',
+      name: 'confirmed',
+      message: 'Only make releases if "release" label is on pull request?',
+      initial: 'no'
+    });
+
+    if (onlyPublishWithReleaseLabel.confirmed) {
+      autoRc = { ...autoRc, onlyPublishWithReleaseLabel: true };
+    }
+
+    const isEnterprise = await prompt<Confirmation>({
+      type: 'confirm',
+      name: 'confirmed',
+      message: 'Are you using an enterprise instance of GitHub?',
+      initial: 'no'
+    });
+
+    if (isEnterprise.confirmed) {
+      const response = await prompt({
+        type: 'snippet',
+        name: 'repoInfo',
+        message: `What are the api URLs for your GitHub enterprise instance?`,
+        required: true,
+        // @ts-ignore
+        template: endent`
+          GitHub API:  #{githubApi}
+          Graphql API: #{githubGraphqlApi}`
+      });
+
+      autoRc = { ...autoRc, ...response.repoInfo.values };
+    }
+
+    await createEnv(this.hooks.createEnv);
+
+    const newLabels = [
+      ...(await getCustomizedDefaultLabels()),
+      ...(await getAdditionalLabels())
+    ];
+
+    if (newLabels.length > 0) {
+      autoRc.labels = [...(autoRc.labels || []), ...newLabels];
+    }
+
+    const file = await this.hooks.writeRcFile.promise(autoRc);
+    this.logger.log.success(`Wrote configuration to: ${file}`);
   }
 }

--- a/packages/core/src/init.ts
+++ b/packages/core/src/init.ts
@@ -44,6 +44,7 @@ interface GithubApis {
   githubGraphqlApi?: string;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type PluginConfig = [string, any] | string;
 
 export type AutoRc = Partial<

--- a/packages/core/src/init.ts
+++ b/packages/core/src/init.ts
@@ -59,7 +59,7 @@ export type AutoRc = Partial<
 
 export interface InteractiveInitHooks {
   /** Override where/how the rc file is written */
-  writeRcFile: AsyncSeriesBailHook<[AutoRc], string | void>;
+  writeRcFile: AsyncSeriesBailHook<[AutoRc], true | void>;
   /** Get or verify the repo information */
   getRepo: AsyncSeriesBailHook<[], RepoInformation | true | void>;
   /** Get or verify the author information */
@@ -387,7 +387,7 @@ export default class InteractiveInit {
     this.hooks.writeRcFile.tap('Init Default', rc => {
       const filename = '.autorc';
       writeFileSync(filename, JSON.stringify(rc, null, 2));
-      return filename;
+      this.logger.log.success(`Wrote configuration to: ${filename}`);
     });
   }
 
@@ -471,7 +471,14 @@ export default class InteractiveInit {
       autoRc.labels = [...(autoRc.labels || []), ...newLabels];
     }
 
-    const file = await this.hooks.writeRcFile.promise(autoRc);
-    this.logger.log.success(`Wrote configuration to: ${file}`);
+    await this.hooks.writeRcFile.promise(autoRc);
+
+    this.logger.log.note(endent`
+      Next steps:
+      
+        - Run "auto create-labels" to create your labels on GitHub
+        - Add your environment variables to your CI builds
+        - Add "auto shipit" at the end of you build/release process\n
+    `);
   }
 }

--- a/packages/core/src/utils/load-plugins.ts
+++ b/packages/core/src/utils/load-plugins.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import Auto from '../auto';
 import { ILogger } from './logger';
 import tryRequire from './try-require';
+import InteractiveInit from '../init';
 
 export type IPluginConstructor = new (options?: any) => IPlugin;
 
@@ -11,6 +12,8 @@ export type IPluginConstructor = new (options?: any) => IPlugin;
 export interface IPlugin {
   /** The name to identify the plugin by */
   name: string;
+  /** Called when running `auto init`. gives plugin ability to add custom init experience. */
+  init?(initializer: InteractiveInit): void;
   /** Called when registering the plugin with auto */
   apply(auto: Auto): void;
 }

--- a/packages/core/src/utils/make-hooks.ts
+++ b/packages/core/src/utils/make-hooks.ts
@@ -10,6 +10,7 @@ import { IAutoHooks } from '../auto';
 import { IChangelogHooks } from '../changelog';
 import { ILogParseHooks } from '../log-parse';
 import { IReleaseHooks } from '../release';
+import { InteractiveInitHooks } from '../init';
 
 /** Make the hooks for "auto" */
 export const makeHooks = (): IAutoHooks => ({
@@ -45,6 +46,15 @@ export const makeReleaseHooks = (): IReleaseHooks => ({
 export const makeLogParseHooks = (): ILogParseHooks => ({
   parseCommit: new AsyncSeriesWaterfallHook(['commit']),
   omitCommit: new AsyncSeriesBailHook(['commit'])
+});
+
+/** Make the hooks for "InteractiveInit" */
+export const makeInteractiveInitHooks = (): InteractiveInitHooks => ({
+  writeRcFile: new AsyncSeriesBailHook(['rcFile']),
+  getRepo: new AsyncSeriesBailHook([]),
+  getAuthor: new AsyncSeriesBailHook([]),
+  createEnv: new AsyncSeriesWaterfallHook(['vars']),
+  configurePlugin: new AsyncSeriesBailHook(['pluginName'])
 });
 
 /** Make the hooks for "Changelog" */

--- a/plugins/jira/src/index.ts
+++ b/plugins/jira/src/index.ts
@@ -1,11 +1,17 @@
 import join from 'url-join';
+import {prompt} from 'enquirer'
 
-import { Auto, IPlugin } from '@auto-it/core';
+import { Auto, IPlugin, InteractiveInit } from '@auto-it/core';
 import { IExtendedCommit } from '@auto-it/core/dist/log-parse';
 
 interface IJiraPluginOptions {
   /** Url to a hosted JIRA instance */
   url: string;
+}
+
+interface InputResponse<T = 'string'> {
+  /** he value of the input prompt */
+  value: T;
 }
 
 interface IJiraCommit extends IExtendedCommit {
@@ -59,6 +65,21 @@ export default class JiraPlugin implements IPlugin {
   /** Initialize the plugin with it's options */
   constructor(options: IJiraPluginOptions | string) {
     this.options = typeof options === 'string' ? { url: options } : options;
+  }
+
+  init(initializer: InteractiveInit) {
+    initializer.hooks.configurePlugin.tapPromise(this.name, async (name) => {
+      if (name === 'jira') {
+        const url = await prompt<InputResponse>({
+          type: 'input',
+          name: 'value',
+          message: 'What is the root url of your Jira instance?',
+          required: true
+        });
+
+        return ['jira', url.value]
+      }
+    })
   }
 
   /** Tap into auto plugin points. */

--- a/plugins/jira/src/index.ts
+++ b/plugins/jira/src/index.ts
@@ -67,6 +67,7 @@ export default class JiraPlugin implements IPlugin {
     this.options = typeof options === 'string' ? { url: options } : options;
   }
 
+  /** Custom initialization for this plugin */
   init(initializer: InteractiveInit) {
     initializer.hooks.configurePlugin.tapPromise(this.name, async (name) => {
       if (name === 'jira') {

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -406,15 +406,15 @@ export default class NPMPlugin implements IPlugin {
         initializer.logger.log.warn(
           'Found auto configuration in package.json. Doing nothing.'
         );
-        process.exit();
+      } else {
+        await writeFile(
+          'package.json',
+          JSON.stringify({ ...packageJson, auto: rc }, null, 2)
+        );
+        initializer.logger.log.success('Wrote configuration to package.json');
       }
 
-      const filename = 'package.json';
-      await writeFile(
-        filename,
-        JSON.stringify({ ...packageJson, auto: rc }, null, 2)
-      );
-      return filename;
+      return true;
     });
   }
 

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -356,6 +356,7 @@ export default class NPMPlugin implements IPlugin {
     return getLernaPackages();
   }
 
+  /** Custom initialization for this plugin */
   init(initializer: InteractiveInit) {
     initializer.hooks.createEnv.tap(this.name, vars => [
       ...vars,
@@ -398,6 +399,7 @@ export default class NPMPlugin implements IPlugin {
     initializer.hooks.writeRcFile.tapPromise(this.name, async rc => {
       const packageJson = await loadPackageJson();
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       if ((packageJson as any).auto) {
         initializer.logger.log.note(
           'Would have wrote configuration:\n',

--- a/plugins/slack/src/index.ts
+++ b/plugins/slack/src/index.ts
@@ -1,7 +1,13 @@
 import { githubToSlack } from '@atomist/slack-messages';
-import { Auto, IPlugin, getCurrentBranch } from '@auto-it/core';
+import { Auto, IPlugin, getCurrentBranch, InteractiveInit } from '@auto-it/core';
 import fetch from 'node-fetch';
 import join from 'url-join';
+import {prompt} from 'enquirer'
+
+interface InputResponse<T = 'string'> {
+  /** he value of the input prompt */
+  value: T;
+}
 
 /** Transform markdown into slack friendly text */
 const sanitizeMarkdown = (markdown: string) =>
@@ -47,6 +53,21 @@ export default class SlackPlugin implements IPlugin {
           : false
       };
     }
+  }
+
+  init(initializer: InteractiveInit) {
+    initializer.hooks.configurePlugin.tapPromise(this.name, async (name) => {
+      if (name === 'slack') {
+        const url = await prompt<InputResponse>({
+          type: 'input',
+          name: 'value',
+          message: 'What is the root url of your slack hook?',
+          required: true
+        });
+
+        return ['slack', url.value]
+      }
+    })
   }
 
   /** Tap into auto plugin points. */

--- a/plugins/slack/src/index.ts
+++ b/plugins/slack/src/index.ts
@@ -55,6 +55,7 @@ export default class SlackPlugin implements IPlugin {
     }
   }
 
+  /** Custom initialization for this plugin */
   init(initializer: InteractiveInit) {
     initializer.hooks.configurePlugin.tapPromise(this.name, async (name) => {
       if (name === 'slack') {


### PR DESCRIPTION
# What Changed

Previously the init command kinda sucked. Now it is a bit smarter and 

- creates and .env file
- only prompts for some config if it needs it
- detects old config
- add and mildly configure some plugins
- Whole process is built around tappable and is completely customizeable for plugin authors

The easiest way to start using auto is now:

```sh
# Install
yarn add -D auto
# Interactive configuration initialization
yarn auto init
# Create labels on GitHub
yarn auto create-labels
# Should now be set up enough to run
yarn auto shipit
# Other than this the user should also set their env vars in their CI
```

# Why

closes #271

Todo:

- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.5.0-canary.901.11924.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.5.0-canary.901.11924.0
  npm install @auto-canary/core@9.5.0-canary.901.11924.0
  npm install @auto-canary/all-contributors@9.5.0-canary.901.11924.0
  npm install @auto-canary/chrome@9.5.0-canary.901.11924.0
  npm install @auto-canary/conventional-commits@9.5.0-canary.901.11924.0
  npm install @auto-canary/crates@9.5.0-canary.901.11924.0
  npm install @auto-canary/first-time-contributor@9.5.0-canary.901.11924.0
  npm install @auto-canary/git-tag@9.5.0-canary.901.11924.0
  npm install @auto-canary/jira@9.5.0-canary.901.11924.0
  npm install @auto-canary/maven@9.5.0-canary.901.11924.0
  npm install @auto-canary/npm@9.5.0-canary.901.11924.0
  npm install @auto-canary/omit-commits@9.5.0-canary.901.11924.0
  npm install @auto-canary/omit-release-notes@9.5.0-canary.901.11924.0
  npm install @auto-canary/released@9.5.0-canary.901.11924.0
  npm install @auto-canary/s3@9.5.0-canary.901.11924.0
  npm install @auto-canary/slack@9.5.0-canary.901.11924.0
  npm install @auto-canary/twitter@9.5.0-canary.901.11924.0
  npm install @auto-canary/upload-assets@9.5.0-canary.901.11924.0
  # or 
  yarn add @auto-canary/auto@9.5.0-canary.901.11924.0
  yarn add @auto-canary/core@9.5.0-canary.901.11924.0
  yarn add @auto-canary/all-contributors@9.5.0-canary.901.11924.0
  yarn add @auto-canary/chrome@9.5.0-canary.901.11924.0
  yarn add @auto-canary/conventional-commits@9.5.0-canary.901.11924.0
  yarn add @auto-canary/crates@9.5.0-canary.901.11924.0
  yarn add @auto-canary/first-time-contributor@9.5.0-canary.901.11924.0
  yarn add @auto-canary/git-tag@9.5.0-canary.901.11924.0
  yarn add @auto-canary/jira@9.5.0-canary.901.11924.0
  yarn add @auto-canary/maven@9.5.0-canary.901.11924.0
  yarn add @auto-canary/npm@9.5.0-canary.901.11924.0
  yarn add @auto-canary/omit-commits@9.5.0-canary.901.11924.0
  yarn add @auto-canary/omit-release-notes@9.5.0-canary.901.11924.0
  yarn add @auto-canary/released@9.5.0-canary.901.11924.0
  yarn add @auto-canary/s3@9.5.0-canary.901.11924.0
  yarn add @auto-canary/slack@9.5.0-canary.901.11924.0
  yarn add @auto-canary/twitter@9.5.0-canary.901.11924.0
  yarn add @auto-canary/upload-assets@9.5.0-canary.901.11924.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
