### PR TITLE
add ability to store slack hook url in environment variable

### DIFF
--- a/plugins/slack/README.md
+++ b/plugins/slack/README.md
@@ -19,6 +19,7 @@ To use the plugin include it in your `.autorc`.
 ```json
 {
   "plugins": [
+    // or
     ["slack", { "url": "https://url-to-your-slack-hook.com" }],
     // or
     ["slack", "https://url-to-your-slack-hook.com"],
@@ -26,12 +27,14 @@ To use the plugin include it in your `.autorc`.
     [
       "slack",
       { "url": "https://url-to-your-slack-hook.com", "atTarget": "here" }
-    ]
+    ],
+    // Below: Uses slack hook set in process.env.SLACK_WEBHOOK_URL
+    "slack"
   ]
 }
 ```
 
-This URL should be to you webhook. If you require a token to post to a slack hook, make sure you have a `SLACK_TOKEN` variable available on your environment. This token will be added to eh URL as a query string parameter.
+This URL should be to you webhook. Store it in `SLACK_WEBHOOK_URL` for more security. If you require a token to post to a slack hook, make sure you have a `SLACK_TOKEN` variable available on your environment. This token will be added to eh URL as a query string parameter.
 
 ### Next
 

--- a/plugins/slack/__tests__/__snapshots__/slack.test.ts.snap
+++ b/plugins/slack/__tests__/__snapshots__/slack.test.ts.snap
@@ -2,6 +2,8 @@
 
 exports[`postToSlack should call slack api 1`] = `"{\\"text\\":\\"@channel: New release *<https://github.custom.com/adierkens/test/releases/tag/1.0.0|1.0.0>*\\\\n* My Notes*\\\\n• PR <google.com|some link>\\",\\"link_names\\":1}"`;
 
+exports[`postToSlack should call slack api in env var 1`] = `"{\\"text\\":\\"@channel: New release *<https://github.custom.com/adierkens/test/releases/tag/1.0.0|1.0.0>*\\\\n* My Notes*\\\\n• PR <google.com|some link>\\",\\"link_names\\":1}"`;
+
 exports[`postToSlack should call slack api with custom atTarget 1`] = `"{\\"text\\":\\"@here: New release *<https://github.custom.com/adierkens/test/releases/tag/1.0.0|1.0.0>*\\\\n* My Notes*\\\\n• PR <google.com|some link>\\",\\"link_names\\":1}"`;
 
 exports[`postToSlack should call slack api with minimal config 1`] = `"{\\"text\\":\\"@channel: New release *<https://github.custom.com/adierkens/test/releases/tag/1.0.0|1.0.0>*\\\\n* My Notes*\\\\n• PR <google.com|some link>\\",\\"link_names\\":1}"`;


### PR DESCRIPTION
# What Changed

Store slack token in `process.env` for security.

# Why

closes #830

Todo:

- [x] Add tests
- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.6.0-canary.912.11937.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.6.0-canary.912.11937.0
  npm install @auto-canary/core@9.6.0-canary.912.11937.0
  npm install @auto-canary/all-contributors@9.6.0-canary.912.11937.0
  npm install @auto-canary/chrome@9.6.0-canary.912.11937.0
  npm install @auto-canary/conventional-commits@9.6.0-canary.912.11937.0
  npm install @auto-canary/crates@9.6.0-canary.912.11937.0
  npm install @auto-canary/first-time-contributor@9.6.0-canary.912.11937.0
  npm install @auto-canary/git-tag@9.6.0-canary.912.11937.0
  npm install @auto-canary/jira@9.6.0-canary.912.11937.0
  npm install @auto-canary/maven@9.6.0-canary.912.11937.0
  npm install @auto-canary/npm@9.6.0-canary.912.11937.0
  npm install @auto-canary/omit-commits@9.6.0-canary.912.11937.0
  npm install @auto-canary/omit-release-notes@9.6.0-canary.912.11937.0
  npm install @auto-canary/released@9.6.0-canary.912.11937.0
  npm install @auto-canary/s3@9.6.0-canary.912.11937.0
  npm install @auto-canary/slack@9.6.0-canary.912.11937.0
  npm install @auto-canary/twitter@9.6.0-canary.912.11937.0
  npm install @auto-canary/upload-assets@9.6.0-canary.912.11937.0
  # or 
  yarn add @auto-canary/auto@9.6.0-canary.912.11937.0
  yarn add @auto-canary/core@9.6.0-canary.912.11937.0
  yarn add @auto-canary/all-contributors@9.6.0-canary.912.11937.0
  yarn add @auto-canary/chrome@9.6.0-canary.912.11937.0
  yarn add @auto-canary/conventional-commits@9.6.0-canary.912.11937.0
  yarn add @auto-canary/crates@9.6.0-canary.912.11937.0
  yarn add @auto-canary/first-time-contributor@9.6.0-canary.912.11937.0
  yarn add @auto-canary/git-tag@9.6.0-canary.912.11937.0
  yarn add @auto-canary/jira@9.6.0-canary.912.11937.0
  yarn add @auto-canary/maven@9.6.0-canary.912.11937.0
  yarn add @auto-canary/npm@9.6.0-canary.912.11937.0
  yarn add @auto-canary/omit-commits@9.6.0-canary.912.11937.0
  yarn add @auto-canary/omit-release-notes@9.6.0-canary.912.11937.0
  yarn add @auto-canary/released@9.6.0-canary.912.11937.0
  yarn add @auto-canary/s3@9.6.0-canary.912.11937.0
  yarn add @auto-canary/slack@9.6.0-canary.912.11937.0
  yarn add @auto-canary/twitter@9.6.0-canary.912.11937.0
  yarn add @auto-canary/upload-assets@9.6.0-canary.912.11937.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
