### PR TITLE
enhance BeforeShipit hook to include the type of release that will be made

### DIFF
--- a/docs/pages/writing-plugins.md
+++ b/docs/pages/writing-plugins.md
@@ -101,8 +101,12 @@ auto.hooks.modifyConfig.tap('test', config => {
 
 Happens before `shipit` is run. This is a great way to throw an error if a token or key is not present.
 
+Context Object:
+
+- `releaseType` (`latest` | `old` | `next` | `canary`) - The type of release `shipit` will attempt to make.
+
 ```ts
-auto.hooks.beforeRun.tapPromise('NPM', async config => {
+auto.hooks.beforeRun.tapPromise('NPM', async context => {
   if (!process.env.NPM_TOKEN) {
     throw new Error('NPM Token is needed for the NPM plugin!');
   }
@@ -542,7 +546,7 @@ class MyPlugin implements IPlugin {
         variable: 'MY_TOKEN',
         message: `This is a very important secret`
       }
-    ])
+    ]);
   }
 }
 ```

--- a/packages/core/src/utils/make-hooks.ts
+++ b/packages/core/src/utils/make-hooks.ts
@@ -16,7 +16,7 @@ import { InteractiveInitHooks } from '../init';
 export const makeHooks = (): IAutoHooks => ({
   beforeRun: new SyncHook(['config']),
   modifyConfig: new SyncWaterfallHook(['config']),
-  beforeShipIt: new SyncHook(),
+  beforeShipIt: new AsyncSeriesHook(['context']),
   afterAddToChangelog: new AsyncSeriesHook(['context']),
   beforeCommitChangelog: new AsyncSeriesHook(['context']),
   afterShipIt: new AsyncParallelHook(['version', 'commits', 'context']),

--- a/plugins/crates/__tests__/crates.test.ts
+++ b/plugins/crates/__tests__/crates.test.ts
@@ -151,9 +151,9 @@ describe('CratesPlugin', () => {
         const hooks = makeHooks();
         plugin.apply({ hooks, logger: dummyLog() } as Auto.Auto);
 
-        await expect(hooks.beforeShipIt.promise()).rejects.toThrow(
-          'Cargo token is needed for the Crates plugin'
-        );
+        await expect(
+          hooks.beforeShipIt.promise({ releaseType: 'canary' })
+        ).rejects.toThrow('Cargo token is needed for the Crates plugin');
       });
 
       test('does not throw error if Cargo creds', async () => {
@@ -162,7 +162,9 @@ describe('CratesPlugin', () => {
         const hooks = makeHooks();
         plugin.apply({ hooks, logger: dummyLog() } as Auto.Auto);
 
-        await expect(hooks.beforeShipIt.promise()).resolves.not.toThrow();
+        await expect(
+          hooks.beforeShipIt.promise({ releaseType: 'canary' })
+        ).resolves.not.toThrow();
       });
     });
 


### PR DESCRIPTION
# What Changed

Run beforeShipit a little later to include releaseType, but not later than anything actually happening

# Why

This greatly enhances what you can do with this hook. Incoming PR will abort releases for lerna independant projects that do not generate a release.

Todo:

- [ ] Add tests
- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.7.0-canary.913.11958.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.7.0-canary.913.11958.0
  npm install @auto-canary/core@9.7.0-canary.913.11958.0
  npm install @auto-canary/all-contributors@9.7.0-canary.913.11958.0
  npm install @auto-canary/chrome@9.7.0-canary.913.11958.0
  npm install @auto-canary/conventional-commits@9.7.0-canary.913.11958.0
  npm install @auto-canary/crates@9.7.0-canary.913.11958.0
  npm install @auto-canary/first-time-contributor@9.7.0-canary.913.11958.0
  npm install @auto-canary/git-tag@9.7.0-canary.913.11958.0
  npm install @auto-canary/jira@9.7.0-canary.913.11958.0
  npm install @auto-canary/maven@9.7.0-canary.913.11958.0
  npm install @auto-canary/npm@9.7.0-canary.913.11958.0
  npm install @auto-canary/omit-commits@9.7.0-canary.913.11958.0
  npm install @auto-canary/omit-release-notes@9.7.0-canary.913.11958.0
  npm install @auto-canary/released@9.7.0-canary.913.11958.0
  npm install @auto-canary/s3@9.7.0-canary.913.11958.0
  npm install @auto-canary/slack@9.7.0-canary.913.11958.0
  npm install @auto-canary/twitter@9.7.0-canary.913.11958.0
  npm install @auto-canary/upload-assets@9.7.0-canary.913.11958.0
  # or 
  yarn add @auto-canary/auto@9.7.0-canary.913.11958.0
  yarn add @auto-canary/core@9.7.0-canary.913.11958.0
  yarn add @auto-canary/all-contributors@9.7.0-canary.913.11958.0
  yarn add @auto-canary/chrome@9.7.0-canary.913.11958.0
  yarn add @auto-canary/conventional-commits@9.7.0-canary.913.11958.0
  yarn add @auto-canary/crates@9.7.0-canary.913.11958.0
  yarn add @auto-canary/first-time-contributor@9.7.0-canary.913.11958.0
  yarn add @auto-canary/git-tag@9.7.0-canary.913.11958.0
  yarn add @auto-canary/jira@9.7.0-canary.913.11958.0
  yarn add @auto-canary/maven@9.7.0-canary.913.11958.0
  yarn add @auto-canary/npm@9.7.0-canary.913.11958.0
  yarn add @auto-canary/omit-commits@9.7.0-canary.913.11958.0
  yarn add @auto-canary/omit-release-notes@9.7.0-canary.913.11958.0
  yarn add @auto-canary/released@9.7.0-canary.913.11958.0
  yarn add @auto-canary/s3@9.7.0-canary.913.11958.0
  yarn add @auto-canary/slack@9.7.0-canary.913.11958.0
  yarn add @auto-canary/twitter@9.7.0-canary.913.11958.0
  yarn add @auto-canary/upload-assets@9.7.0-canary.913.11958.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
