### PR TITLE
use different version commit message for independent projects

### DIFF
--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -806,7 +806,7 @@ describe('canary', () => {
       '--yes',
       '--no-push',
       '-m',
-      '"Bump version to: %s [skip ci]"',
+      '"Bump independent versions [skip ci]"',
       false
     ]);
   });

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -579,7 +579,9 @@ export default class NPMPlugin implements IPlugin {
           '--yes',
           '--no-push',
           '-m',
-          VERSION_COMMIT_MESSAGE,
+          isIndependent
+            ? '"Bump independent versions [skip ci]"'
+            : VERSION_COMMIT_MESSAGE,
           this.exact && '--exact',
           ...verboseArgs
         ]);


### PR DESCRIPTION
# What Changed

See title.

# Why

> Note that this placeholder interpolation only applies when using the default "fixed" versioning mode, as there is no "global" version to interpolate when versioning independently.

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.6.1-canary.915.11975.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.6.1-canary.915.11975.0
  npm install @auto-canary/core@9.6.1-canary.915.11975.0
  npm install @auto-canary/all-contributors@9.6.1-canary.915.11975.0
  npm install @auto-canary/chrome@9.6.1-canary.915.11975.0
  npm install @auto-canary/conventional-commits@9.6.1-canary.915.11975.0
  npm install @auto-canary/crates@9.6.1-canary.915.11975.0
  npm install @auto-canary/first-time-contributor@9.6.1-canary.915.11975.0
  npm install @auto-canary/git-tag@9.6.1-canary.915.11975.0
  npm install @auto-canary/jira@9.6.1-canary.915.11975.0
  npm install @auto-canary/maven@9.6.1-canary.915.11975.0
  npm install @auto-canary/npm@9.6.1-canary.915.11975.0
  npm install @auto-canary/omit-commits@9.6.1-canary.915.11975.0
  npm install @auto-canary/omit-release-notes@9.6.1-canary.915.11975.0
  npm install @auto-canary/released@9.6.1-canary.915.11975.0
  npm install @auto-canary/s3@9.6.1-canary.915.11975.0
  npm install @auto-canary/slack@9.6.1-canary.915.11975.0
  npm install @auto-canary/twitter@9.6.1-canary.915.11975.0
  npm install @auto-canary/upload-assets@9.6.1-canary.915.11975.0
  # or 
  yarn add @auto-canary/auto@9.6.1-canary.915.11975.0
  yarn add @auto-canary/core@9.6.1-canary.915.11975.0
  yarn add @auto-canary/all-contributors@9.6.1-canary.915.11975.0
  yarn add @auto-canary/chrome@9.6.1-canary.915.11975.0
  yarn add @auto-canary/conventional-commits@9.6.1-canary.915.11975.0
  yarn add @auto-canary/crates@9.6.1-canary.915.11975.0
  yarn add @auto-canary/first-time-contributor@9.6.1-canary.915.11975.0
  yarn add @auto-canary/git-tag@9.6.1-canary.915.11975.0
  yarn add @auto-canary/jira@9.6.1-canary.915.11975.0
  yarn add @auto-canary/maven@9.6.1-canary.915.11975.0
  yarn add @auto-canary/npm@9.6.1-canary.915.11975.0
  yarn add @auto-canary/omit-commits@9.6.1-canary.915.11975.0
  yarn add @auto-canary/omit-release-notes@9.6.1-canary.915.11975.0
  yarn add @auto-canary/released@9.6.1-canary.915.11975.0
  yarn add @auto-canary/s3@9.6.1-canary.915.11975.0
  yarn add @auto-canary/slack@9.6.1-canary.915.11975.0
  yarn add @auto-canary/twitter@9.6.1-canary.915.11975.0
  yarn add @auto-canary/upload-assets@9.6.1-canary.915.11975.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
