### PR TITLE
Independent releases

### DIFF
--- a/docs/pages/writing-plugins.md
+++ b/docs/pages/writing-plugins.md
@@ -155,21 +155,46 @@ auto.hooks.afterAddToChangelog.tap(
 
 #### afterRelease
 
-Ran after the `release` command has run. This async hooks gets the following arguments:
+Ran after the `release` command has run. This async hook gets the following arguments:
 
-- lastVersion - the version that existed prior to the current release
-- nextVersion - version that was just released
-- commits - the commits in the release
-- releaseNotes - generated release notes for the release
-- response - the response returned from making the release
+- `lastVersion` - the version that existed prior to the current release
+- `nextVersion` - version that was just released
+- `commits` - the commits in the release
+- `releaseNotes` - generated release notes for the release
+- `response` - the response returned from making the release
 
 ```ts
-auto.hooks.afterRelease.tap(
+auto.hooks.afterRelease.tapPromise(
   'MyPlugin',
   async ({ lastVersion, nextVersion, commits, releaseNotes, response }) => {
     // do something
   }
 );
+```
+
+#### makeRelease
+
+Ran when trying to make a release during the `release` command has run. This async hook gets the following arguments:
+
+- `dryRun` - Whether this is a dry run
+- `from` - Commit to start calculating the version from
+- `newVersion` - The version being released
+- `isPrerelease` - Whether the release being made is a prerelease
+- `fullReleaseNotes` - The generated release notes for all of the commits
+- `commits` - The commits included in the release
+
+```ts
+auto.hooks.makeRelease.tapPromise('MyPlugin', async options => {
+  if (!options.dryRun) {
+    this.logger.log.info(`Releasing ${options.newVersion} to GitHub.`);
+
+    return this.git!.publish(
+      options.fullReleaseNotes,
+      options.newVersion,
+      options.isPrerelease
+    );
+  }
+});
 ```
 
 #### afterShipIt

--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -816,7 +816,8 @@ describe('Auto', () => {
       auto.logger = dummyLog();
       await auto.loadConfig();
       auto.git!.getLatestRelease = () => Promise.resolve('1.2.3');
-      jest.spyOn(auto.git!, 'publish').mockImplementation();
+
+      jest.spyOn(auto.git!, 'publish').mockReturnValueOnce({} as any);
       jest
         .spyOn(auto.release!, 'generateReleaseNotes')
         .mockImplementation(() => Promise.resolve('releaseNotes'));
@@ -855,7 +856,7 @@ describe('Auto', () => {
       auto.git!.getPreviousTagInBranch = () => Promise.resolve('1.2.3');
       auto.git!.getLatestTagInBranch = () => Promise.resolve('1.2.4');
 
-      jest.spyOn(auto.git!, 'publish').mockImplementation();
+      jest.spyOn(auto.git!, 'publish').mockReturnValueOnce({} as any);
       jest
         .spyOn(auto.release!, 'generateReleaseNotes')
         .mockImplementation(() => Promise.resolve('releaseNotes'));
@@ -891,7 +892,8 @@ describe('Auto', () => {
       auto.logger = dummyLog();
       await auto.loadConfig();
       auto.git!.getLatestRelease = () => Promise.resolve('1.2.3');
-      jest.spyOn(auto.git!, 'publish').mockImplementation();
+
+      jest.spyOn(auto.git!, 'publish').mockReturnValueOnce({} as any);
       jest
         .spyOn(auto.release!, 'generateReleaseNotes')
         .mockImplementation(() => Promise.resolve('releaseNotes'));
@@ -929,7 +931,8 @@ describe('Auto', () => {
       auto.logger = dummyLog();
       await auto.loadConfig();
       auto.git!.getLatestRelease = () => Promise.resolve('1.2.3');
-      jest.spyOn(auto.git!, 'publish').mockImplementation();
+
+      jest.spyOn(auto.git!, 'publish').mockReturnValueOnce({} as any);
       jest
         .spyOn(auto.release!, 'generateReleaseNotes')
         .mockImplementation(() => Promise.resolve('releaseNotes'));

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -133,9 +133,31 @@ export interface IAutoHooks {
         /** The generated release notes for the commits */
         releaseNotes: string;
         /** The response from creating the new release. */
-        response?: Response<ReposCreateReleaseResponse>;
+        response?:
+          | Response<ReposCreateReleaseResponse>
+          | Response<ReposCreateReleaseResponse>[];
       }
     ]
+  >;
+  /** Override what happens when "releasing" code to a Github release */
+  makeRelease: AsyncSeriesBailHook<
+    [
+      {
+        /** Do not actually do anything */
+        dryRun?: boolean;
+        /** Commit to start calculating the version from */
+        from: string;
+        /** The version being released */
+        newVersion: string;
+        /** Whether the release being made is a prerelease */
+        isPrerelease?: boolean;
+        /** The generated release notes for the commits */
+        fullReleaseNotes: string;
+      }
+    ],
+    | Response<ReposCreateReleaseResponse>
+    | Response<ReposCreateReleaseResponse>[]
+    | void
   >;
   /** Get git author. Typically from a package distribution description file. */
   getAuthor: AsyncSeriesBailHook<[], IAuthorOptions | void>;
@@ -333,6 +355,30 @@ export default class Auto {
         }
       }
     );
+
+    this.hooks.makeRelease.tapPromise('Default', async options => {
+      if (options.dryRun) {
+        const bump = await this.getVersion({ from: options.from });
+
+        this.logger.log.info(
+          `Would have created a release on GitHub for version: ${inc(
+            options.newVersion,
+            bump as ReleaseType
+          )}`
+        );
+        this.logger.log.note(
+          'The above version would only get released if ran with "shipit" or a custom script that bumps the version using the "version" command'
+        );
+      } else {
+        this.logger.log.info(`Releasing ${options.newVersion} to GitHub.`);
+
+        return this.git!.publish(
+          options.fullReleaseNotes,
+          options.newVersion,
+          options.isPrerelease
+        );
+      }
+    });
 
     loadEnv();
 
@@ -1275,6 +1321,7 @@ export default class Auto {
 
     this.logger.log.info(`Using release notes:\n${releaseNotes}`);
 
+    // In a monorepo this just matches the last tag created during a publish
     const latestTag = await this.git.getLatestTagInBranch();
     const rawVersion =
       useVersion ||
@@ -1303,24 +1350,15 @@ export default class Auto {
       return;
     }
 
-    let release: Response<ReposCreateReleaseResponse> | undefined;
+    const release = await this.hooks.makeRelease.promise({
+      dryRun,
+      from: lastRelease,
+      isPrerelease,
+      newVersion,
+      fullReleaseNotes: releaseNotes
+    });
 
-    if (dryRun) {
-      const bump = await this.getVersion({ from });
-
-      this.logger.log.info(
-        `Would have created a release on GitHub for version: ${inc(
-          newVersion,
-          bump as ReleaseType
-        )}`
-      );
-      this.logger.log.note(
-        'The above version would only get released if ran with "shipit" or a custom script that bumps the version using the "version" command'
-      );
-    } else {
-      this.logger.log.info(`Releasing ${newVersion} to GitHub.`);
-      release = await this.git.publish(releaseNotes, newVersion, isPrerelease);
-
+    if (release) {
       await this.hooks.afterRelease.promise({
         lastRelease,
         newVersion,

--- a/packages/core/src/utils/make-hooks.ts
+++ b/packages/core/src/utils/make-hooks.ts
@@ -20,6 +20,7 @@ export const makeHooks = (): IAutoHooks => ({
   afterAddToChangelog: new AsyncSeriesHook(['context']),
   beforeCommitChangelog: new AsyncSeriesHook(['context']),
   afterShipIt: new AsyncParallelHook(['version', 'commits', 'context']),
+  makeRelease: new AsyncSeriesBailHook(['releaseInfo']),
   afterRelease: new AsyncParallelHook(['releaseInfo']),
   onCreateRelease: new SyncHook(['options']),
   onCreateChangelog: new SyncHook(['changelog', 'version']),

--- a/plugins/released/src/index.ts
+++ b/plugins/released/src/index.ts
@@ -86,14 +86,13 @@ export default class ReleasedLabelPlugin implements IPlugin {
           return;
         }
 
+        const isPrerelease = Array.isArray(response)
+          ? response.some(r => r?.data.prerelease)
+          : response?.data.prerelease;
+
         await Promise.all(
           commits.map(async commit =>
-            this.addReleased(
-              auto,
-              commit,
-              newVersion,
-              response?.data.prerelease
-            )
+            this.addReleased(auto, commit, newVersion, isPrerelease)
           )
         );
       }

--- a/plugins/twitter/src/index.ts
+++ b/plugins/twitter/src/index.ts
@@ -139,6 +139,10 @@ export default class TwitterPlugin implements IPlugin {
           return;
         }
 
+        const url = Array.isArray(response)
+          ? response.map(r => `- ${r.data.html_url}`).join('\n')
+          : response.data.html_url;
+
         await this.tweet(
           makeTweet({
             releaseNotes,
@@ -146,7 +150,7 @@ export default class TwitterPlugin implements IPlugin {
             versionBump,
             newVersion,
             repo: auto.git.options.repo,
-            url: response.data.html_url
+            url
           })
         );
       }


### PR DESCRIPTION
# What Changed

Previously GitHub releases for independent monorepo would put all the changes in whatever the last tag was. Now we put only the release notes for the package in a unique release for the package (+ anything done to the root).

# Release Notes

This PR adds a new hook for plugin developers.

`makeRelease` - This hook is called when `auto shipit` or `auto release` tries to make a release. If untapped auto will run the default behavior. Otherwise it is up to the plugin tapping the hook to call `auto.git.publish` to make releases on GitHub.

# Why

closes #656

Todo:

- [x] Add tests
- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.8.0-canary.916.12005.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.8.0-canary.916.12005.0
  npm install @auto-canary/core@9.8.0-canary.916.12005.0
  npm install @auto-canary/all-contributors@9.8.0-canary.916.12005.0
  npm install @auto-canary/chrome@9.8.0-canary.916.12005.0
  npm install @auto-canary/conventional-commits@9.8.0-canary.916.12005.0
  npm install @auto-canary/crates@9.8.0-canary.916.12005.0
  npm install @auto-canary/first-time-contributor@9.8.0-canary.916.12005.0
  npm install @auto-canary/git-tag@9.8.0-canary.916.12005.0
  npm install @auto-canary/jira@9.8.0-canary.916.12005.0
  npm install @auto-canary/maven@9.8.0-canary.916.12005.0
  npm install @auto-canary/npm@9.8.0-canary.916.12005.0
  npm install @auto-canary/omit-commits@9.8.0-canary.916.12005.0
  npm install @auto-canary/omit-release-notes@9.8.0-canary.916.12005.0
  npm install @auto-canary/released@9.8.0-canary.916.12005.0
  npm install @auto-canary/s3@9.8.0-canary.916.12005.0
  npm install @auto-canary/slack@9.8.0-canary.916.12005.0
  npm install @auto-canary/twitter@9.8.0-canary.916.12005.0
  npm install @auto-canary/upload-assets@9.8.0-canary.916.12005.0
  # or 
  yarn add @auto-canary/auto@9.8.0-canary.916.12005.0
  yarn add @auto-canary/core@9.8.0-canary.916.12005.0
  yarn add @auto-canary/all-contributors@9.8.0-canary.916.12005.0
  yarn add @auto-canary/chrome@9.8.0-canary.916.12005.0
  yarn add @auto-canary/conventional-commits@9.8.0-canary.916.12005.0
  yarn add @auto-canary/crates@9.8.0-canary.916.12005.0
  yarn add @auto-canary/first-time-contributor@9.8.0-canary.916.12005.0
  yarn add @auto-canary/git-tag@9.8.0-canary.916.12005.0
  yarn add @auto-canary/jira@9.8.0-canary.916.12005.0
  yarn add @auto-canary/maven@9.8.0-canary.916.12005.0
  yarn add @auto-canary/npm@9.8.0-canary.916.12005.0
  yarn add @auto-canary/omit-commits@9.8.0-canary.916.12005.0
  yarn add @auto-canary/omit-release-notes@9.8.0-canary.916.12005.0
  yarn add @auto-canary/released@9.8.0-canary.916.12005.0
  yarn add @auto-canary/s3@9.8.0-canary.916.12005.0
  yarn add @auto-canary/slack@9.8.0-canary.916.12005.0
  yarn add @auto-canary/twitter@9.8.0-canary.916.12005.0
  yarn add @auto-canary/upload-assets@9.8.0-canary.916.12005.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
