### PR TITLE
better error message running release in repo w/o tags

### DIFF
--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -793,6 +793,23 @@ describe('Auto', () => {
   });
 
   describe('release', () => {
+    test('should exit when no tags found', async () => {
+      const auto = new Auto({ ...defaults, plugins: [] });
+      const exit = jest.fn();
+
+      // @ts-ignore
+      process.exit = exit;
+
+      auto.logger = dummyLog();
+      await auto.loadConfig();
+
+      auto.git!.getLatestRelease = () => Promise.resolve('');
+      auto.git!.getLatestTagInBranch = () => Promise.reject(new Error('No names found, cannot describe anything.'));
+
+      await auto.runRelease();
+      expect(exit).toHaveBeenCalled();
+    });
+
     test("doesn't try to overwrite releases", async () => {
       const auto = new Auto({ ...defaults, plugins: [] });
       auto.logger = dummyLog();

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1315,7 +1315,7 @@ export default class Auto {
 
           The "release" command creates GitHub releases for tags that have already been created in your repo.
           
-          If there are no tags there is nothing to release.
+          If there are no tags there is nothing to release. If you don't use "shipit" ensure you tag your releases with the new version number.
         `,
         '\n'
       );


### PR DESCRIPTION
# What Changed

Previously you would get an error like `No names found, cannot describe anything` when trying to call `auto release` without any local tags. The release command just make GitHub releases for tags, so without none it should do nothing.

# Why

It was a confusing error message.

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.8.1-canary.919.12031.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.8.1-canary.919.12031.0
  npm install @auto-canary/core@9.8.1-canary.919.12031.0
  npm install @auto-canary/all-contributors@9.8.1-canary.919.12031.0
  npm install @auto-canary/chrome@9.8.1-canary.919.12031.0
  npm install @auto-canary/conventional-commits@9.8.1-canary.919.12031.0
  npm install @auto-canary/crates@9.8.1-canary.919.12031.0
  npm install @auto-canary/first-time-contributor@9.8.1-canary.919.12031.0
  npm install @auto-canary/git-tag@9.8.1-canary.919.12031.0
  npm install @auto-canary/jira@9.8.1-canary.919.12031.0
  npm install @auto-canary/maven@9.8.1-canary.919.12031.0
  npm install @auto-canary/npm@9.8.1-canary.919.12031.0
  npm install @auto-canary/omit-commits@9.8.1-canary.919.12031.0
  npm install @auto-canary/omit-release-notes@9.8.1-canary.919.12031.0
  npm install @auto-canary/released@9.8.1-canary.919.12031.0
  npm install @auto-canary/s3@9.8.1-canary.919.12031.0
  npm install @auto-canary/slack@9.8.1-canary.919.12031.0
  npm install @auto-canary/twitter@9.8.1-canary.919.12031.0
  npm install @auto-canary/upload-assets@9.8.1-canary.919.12031.0
  # or 
  yarn add @auto-canary/auto@9.8.1-canary.919.12031.0
  yarn add @auto-canary/core@9.8.1-canary.919.12031.0
  yarn add @auto-canary/all-contributors@9.8.1-canary.919.12031.0
  yarn add @auto-canary/chrome@9.8.1-canary.919.12031.0
  yarn add @auto-canary/conventional-commits@9.8.1-canary.919.12031.0
  yarn add @auto-canary/crates@9.8.1-canary.919.12031.0
  yarn add @auto-canary/first-time-contributor@9.8.1-canary.919.12031.0
  yarn add @auto-canary/git-tag@9.8.1-canary.919.12031.0
  yarn add @auto-canary/jira@9.8.1-canary.919.12031.0
  yarn add @auto-canary/maven@9.8.1-canary.919.12031.0
  yarn add @auto-canary/npm@9.8.1-canary.919.12031.0
  yarn add @auto-canary/omit-commits@9.8.1-canary.919.12031.0
  yarn add @auto-canary/omit-release-notes@9.8.1-canary.919.12031.0
  yarn add @auto-canary/released@9.8.1-canary.919.12031.0
  yarn add @auto-canary/s3@9.8.1-canary.919.12031.0
  yarn add @auto-canary/slack@9.8.1-canary.919.12031.0
  yarn add @auto-canary/twitter@9.8.1-canary.919.12031.0
  yarn add @auto-canary/upload-assets@9.8.1-canary.919.12031.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
