### PR TITLE
add fallback to get lerna json

### DIFF
--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -314,12 +314,12 @@ describe('getPreviousVersion', () => {
       prefixRelease: str => str
     } as Auto.Auto);
 
-    readResult = `
+    readFileSync.mockReturnValueOnce(`
       {
         "name": "test",
         "version": "2.0.0"
       }
-    `;
+    `);
     expect(await hooks.getPreviousVersion.promise()).toBe('2.0.0');
   });
 
@@ -330,12 +330,12 @@ describe('getPreviousVersion', () => {
     // isMonorepo
     existsSync.mockReturnValueOnce(true);
     monorepoPackages.mockReturnValueOnce(monorepoPackagesResult);
-    readResult = `
+    readFileSync.mockReturnValueOnce(`
       {
         "name": "test",
         "version": "0.0.1"
       }
-    `;
+    `);
     // published version of test package
     exec.mockReturnValueOnce('0.1.2');
 

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -22,7 +22,7 @@ import { gt, gte, inc, ReleaseType } from 'semver';
 
 import getConfigFromPackageJson from './package-config';
 import setTokenOnCI from './set-npm-token';
-import { loadPackageJson, readFile, writeFile } from './utils';
+import { loadPackageJson, writeFile } from './utils';
 
 const { isCi } = envCi();
 const VERSION_COMMIT_MESSAGE = '"Bump version to: %s [skip ci]"';
@@ -200,7 +200,13 @@ interface INpmConfig {
 }
 
 /** Parse the lerna.json file. */
-const getLernaJson = () => JSON.parse(fs.readFileSync('lerna.json', 'utf8'));
+const getLernaJson = () => {
+  try {
+    return JSON.parse(fs.readFileSync('lerna.json', 'utf8'));
+  } catch (error) {
+    return {};
+  }
+};
 
 /** Render a list of string in markdown */
 const markdownList = (lines: string[]) =>
@@ -214,8 +220,7 @@ async function getPreviousVersion(auto: Auto, prereleaseBranch: string) {
     auto.logger.veryVerbose.info(
       'Using monorepo to calculate previous release'
     );
-    const monorepoVersion = JSON.parse(await readFile('lerna.json', 'utf-8'))
-      .version;
+    const monorepoVersion = getLernaJson().version;
 
     if (monorepoVersion === 'independent') {
       previousVersion =


### PR DESCRIPTION
# What Changed

Ensure getting lerna.json doesn't kill process

# Why

Got a random 


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.8.2-canary.920.12048.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.8.2-canary.920.12048.0
  npm install @auto-canary/core@9.8.2-canary.920.12048.0
  npm install @auto-canary/all-contributors@9.8.2-canary.920.12048.0
  npm install @auto-canary/chrome@9.8.2-canary.920.12048.0
  npm install @auto-canary/conventional-commits@9.8.2-canary.920.12048.0
  npm install @auto-canary/crates@9.8.2-canary.920.12048.0
  npm install @auto-canary/first-time-contributor@9.8.2-canary.920.12048.0
  npm install @auto-canary/git-tag@9.8.2-canary.920.12048.0
  npm install @auto-canary/jira@9.8.2-canary.920.12048.0
  npm install @auto-canary/maven@9.8.2-canary.920.12048.0
  npm install @auto-canary/npm@9.8.2-canary.920.12048.0
  npm install @auto-canary/omit-commits@9.8.2-canary.920.12048.0
  npm install @auto-canary/omit-release-notes@9.8.2-canary.920.12048.0
  npm install @auto-canary/released@9.8.2-canary.920.12048.0
  npm install @auto-canary/s3@9.8.2-canary.920.12048.0
  npm install @auto-canary/slack@9.8.2-canary.920.12048.0
  npm install @auto-canary/twitter@9.8.2-canary.920.12048.0
  npm install @auto-canary/upload-assets@9.8.2-canary.920.12048.0
  # or 
  yarn add @auto-canary/auto@9.8.2-canary.920.12048.0
  yarn add @auto-canary/core@9.8.2-canary.920.12048.0
  yarn add @auto-canary/all-contributors@9.8.2-canary.920.12048.0
  yarn add @auto-canary/chrome@9.8.2-canary.920.12048.0
  yarn add @auto-canary/conventional-commits@9.8.2-canary.920.12048.0
  yarn add @auto-canary/crates@9.8.2-canary.920.12048.0
  yarn add @auto-canary/first-time-contributor@9.8.2-canary.920.12048.0
  yarn add @auto-canary/git-tag@9.8.2-canary.920.12048.0
  yarn add @auto-canary/jira@9.8.2-canary.920.12048.0
  yarn add @auto-canary/maven@9.8.2-canary.920.12048.0
  yarn add @auto-canary/npm@9.8.2-canary.920.12048.0
  yarn add @auto-canary/omit-commits@9.8.2-canary.920.12048.0
  yarn add @auto-canary/omit-release-notes@9.8.2-canary.920.12048.0
  yarn add @auto-canary/released@9.8.2-canary.920.12048.0
  yarn add @auto-canary/s3@9.8.2-canary.920.12048.0
  yarn add @auto-canary/slack@9.8.2-canary.920.12048.0
  yarn add @auto-canary/twitter@9.8.2-canary.920.12048.0
  yarn add @auto-canary/upload-assets@9.8.2-canary.920.12048.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
