### PR TITLE
move ICommit to "core" to fix external plugin TS build errors

### DIFF
--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import { retry } from '@octokit/plugin-retry';
 import { throttling } from '@octokit/plugin-throttling';
 import Octokit from '@octokit/rest';
-import gitlogNode, { ICommit } from 'gitlog';
+import gitlogNode from 'gitlog';
 import HttpsProxyAgent from 'https-proxy-agent';
 import tinyColor from 'tinycolor2';
 import { promisify } from 'util';
@@ -16,6 +16,7 @@ import { ILabelDefinition } from './release';
 import execPromise from './utils/exec-promise';
 import { dummyLog, ILogger } from './utils/logger';
 import { gt } from 'semver';
+import { ICommit } from './log-parse';
 
 const gitlog = promisify(gitlogNode);
 
@@ -306,7 +307,7 @@ export default class Git {
   @memoize()
   async getGitLog(start: string, end = 'HEAD'): Promise<ICommit[]> {
     try {
-      const log = await gitlog({
+      const log = await gitlog<ICommit>({
         repo: process.cwd(),
         number: Number.MAX_SAFE_INTEGER,
         fields: ['hash', 'authorName', 'authorEmail', 'rawBody'],

--- a/packages/core/src/log-parse.ts
+++ b/packages/core/src/log-parse.ts
@@ -1,4 +1,3 @@
-import { ICommit } from 'gitlog';
 import { AsyncSeriesBailHook, AsyncSeriesWaterfallHook } from 'tapable';
 import { makeLogParseHooks } from './utils/make-hooks';
 
@@ -20,6 +19,37 @@ export interface IPullRequest {
   base?: string;
   /** The body of the PR (opening comment) */
   body?: string;
+}
+
+export interface ICommit {
+  /**
+   *
+   */
+hash: string;
+  /**
+   *
+   */
+authorName?: string;
+  /**
+   *
+   */
+authorEmail?: string;
+  /**
+   *
+   */
+subject: string;
+  /**
+   *
+   */
+rawBody?: string;
+  /**
+   *
+   */
+labels?: string[];
+  /**
+   *
+   */
+files: string[];
 }
 
 export type IExtendedCommit = ICommit & {

--- a/typings/gitlog.d.ts
+++ b/typings/gitlog.d.ts
@@ -1,26 +1,34 @@
 declare module 'gitlog' {
-  export interface ICommit {
-    hash: string;
-    authorName?: string;
-    authorEmail?: string;
-    subject: string;
-    rawBody?: string;
-    labels?: string[];
-    files: string[];
-  }
-
   interface IGitlogOptions {
-    repo: string;
-    fields: string[];
-    branch: string;
-    number: number;
-    execOptions: {
-      maxBuffer: number;
+    /**
+     *
+     */
+repo: string;
+    /**
+     *
+     */
+fields: string[];
+    /**
+     *
+     */
+branch: string;
+    /**
+     *
+     */
+number: number;
+    /**
+     *
+     */
+execOptions: {
+      /**
+       *
+       */
+maxBuffer: number;
     };
   }
 
-  export default function gitlog(
+  export default function gitlog<T>(
     options: IGitlogOptions,
-    callback: (err: Error, res: ICommit[]) => void
+    callback: (err: Error, res: T[]) => void
   ): void;
 }


### PR DESCRIPTION
# What Changed

Move an interface from a `.d.ts` file for an untyped package to `core`.

# Why

![Screen Shot 2020-01-30 at 9 56 29 AM](https://user-images.githubusercontent.com/1192452/73476300-ce87cf00-4346-11ea-8cea-2da6746d0391.png)


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.8.3-canary.921.12060.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.8.3-canary.921.12060.0
  npm install @auto-canary/core@9.8.3-canary.921.12060.0
  npm install @auto-canary/all-contributors@9.8.3-canary.921.12060.0
  npm install @auto-canary/chrome@9.8.3-canary.921.12060.0
  npm install @auto-canary/conventional-commits@9.8.3-canary.921.12060.0
  npm install @auto-canary/crates@9.8.3-canary.921.12060.0
  npm install @auto-canary/first-time-contributor@9.8.3-canary.921.12060.0
  npm install @auto-canary/git-tag@9.8.3-canary.921.12060.0
  npm install @auto-canary/jira@9.8.3-canary.921.12060.0
  npm install @auto-canary/maven@9.8.3-canary.921.12060.0
  npm install @auto-canary/npm@9.8.3-canary.921.12060.0
  npm install @auto-canary/omit-commits@9.8.3-canary.921.12060.0
  npm install @auto-canary/omit-release-notes@9.8.3-canary.921.12060.0
  npm install @auto-canary/released@9.8.3-canary.921.12060.0
  npm install @auto-canary/s3@9.8.3-canary.921.12060.0
  npm install @auto-canary/slack@9.8.3-canary.921.12060.0
  npm install @auto-canary/twitter@9.8.3-canary.921.12060.0
  npm install @auto-canary/upload-assets@9.8.3-canary.921.12060.0
  # or 
  yarn add @auto-canary/auto@9.8.3-canary.921.12060.0
  yarn add @auto-canary/core@9.8.3-canary.921.12060.0
  yarn add @auto-canary/all-contributors@9.8.3-canary.921.12060.0
  yarn add @auto-canary/chrome@9.8.3-canary.921.12060.0
  yarn add @auto-canary/conventional-commits@9.8.3-canary.921.12060.0
  yarn add @auto-canary/crates@9.8.3-canary.921.12060.0
  yarn add @auto-canary/first-time-contributor@9.8.3-canary.921.12060.0
  yarn add @auto-canary/git-tag@9.8.3-canary.921.12060.0
  yarn add @auto-canary/jira@9.8.3-canary.921.12060.0
  yarn add @auto-canary/maven@9.8.3-canary.921.12060.0
  yarn add @auto-canary/npm@9.8.3-canary.921.12060.0
  yarn add @auto-canary/omit-commits@9.8.3-canary.921.12060.0
  yarn add @auto-canary/omit-release-notes@9.8.3-canary.921.12060.0
  yarn add @auto-canary/released@9.8.3-canary.921.12060.0
  yarn add @auto-canary/s3@9.8.3-canary.921.12060.0
  yarn add @auto-canary/slack@9.8.3-canary.921.12060.0
  yarn add @auto-canary/twitter@9.8.3-canary.921.12060.0
  yarn add @auto-canary/upload-assets@9.8.3-canary.921.12060.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
