### PR TITLE
Gradle Release Plugin

### DIFF
--- a/plugins/gradle/README.md
+++ b/plugins/gradle/README.md
@@ -1,6 +1,6 @@
-# Gradle Release Plugin Plugin
+# Gradle Plugin
 
-A plugin that calls gradle with versioning information.
+Release a Java project using [gradle](https://gradle.org/).
 
 ## Installation
 
@@ -17,8 +17,51 @@ yarn add -D @auto-it/gradle
 ```json
 {
   "plugins": [
-    ["gradle"]
+    [
+      "gradle", {
+        // An optional gradle binary cmd/path relative to your project
+        // @default /usr/bin/gradle
+        "gradleCommand": "./gradlew",
+        // An optional gradle argument list -- IE any gradle option allowed for the version
+        // of gradle you're using
+        // @default []
+        "gradleOptions": ["-P someProp=someVal"]
+      }
+    ]
     // other plugins
   ]
 }
+```
+
+## Maven Project Configuration
+
+Your project must be using the gradle release plugin. Make sure the the latest `gradle-release-plugin` is in your `build.gradle`.
+
+```groovy
+import java.util.regex.Matcher
+
+plugins {
+  id "org.sonarqube" version "2.7.1"
+  id 'net.researchgate.release' version '2.6.0' // gradle release plugin
+}
+
+task build {}
+build.dependsOn('app:build')
+build.dependsOn('app:assembleRelease')
+
+release {
+    failOnCommitNeeded = false
+    buildTasks = ['build']
+    versionPatterns = [
+        /(\d+)([^\d]*$)/: { Matcher m, Project p -> m.replaceAll("${(m[0][1] as int) + 1}${m[0][2]}")}
+    ]
+....
+```
+
+You will also need all of the following configuration blocks for all parts of `auto` to function:
+
+1. Version
+
+```java-properties
+version=1.0.0
 ```

--- a/plugins/gradle/README.md
+++ b/plugins/gradle/README.md
@@ -22,6 +22,11 @@ yarn add -D @auto-it/gradle
         // An optional gradle binary cmd/path relative to your project
         // @default /usr/bin/gradle
         "gradleCommand": "./gradlew",
+
+        // An optional properties file where the gradle release plugin will read/write versions from.to.
+        // @default ./gradle.properties
+        "versionFile": "./gradle.properties",
+
         // An optional gradle argument list -- IE any gradle option allowed for the version
         // of gradle you're using
         // @default []
@@ -60,7 +65,7 @@ release {
 
 You will also need all of the following configuration blocks for all parts of `auto` to function:
 
-1. Version
+1. Version defined inside `versionFile`
 
 ```java-properties
 version=1.0.0

--- a/plugins/gradle/README.md
+++ b/plugins/gradle/README.md
@@ -1,0 +1,24 @@
+# Gradle Release Plugin Plugin
+
+A plugin that calls gradle with versioning information.
+
+## Installation
+
+This plugin is not included with the `auto` CLI installed via NPM. To install:
+
+```sh
+npm i --save-dev @auto-it/gradle
+# or
+yarn add -D @auto-it/gradle
+```
+
+## Usage
+
+```json
+{
+  "plugins": [
+    ["gradle"]
+    // other plugins
+  ]
+}
+```

--- a/plugins/gradle/README.md
+++ b/plugins/gradle/README.md
@@ -33,7 +33,7 @@ yarn add -D @auto-it/gradle
 }
 ```
 
-## Maven Project Configuration
+## Gradle Project Configuration
 
 Your project must be using the gradle release plugin. Make sure the the latest `gradle-release-plugin` is in your `build.gradle`.
 

--- a/plugins/gradle/__tests__/gradle-release-plugin.test.ts
+++ b/plugins/gradle/__tests__/gradle-release-plugin.test.ts
@@ -106,3 +106,41 @@ describe('Gradle Release Plugin Plugin', () => {
     });
   });
 });
+
+describe('Gradle Release Plugin Plugin - Custom Command', () => {
+  let hooks: Auto.IAutoHooks;
+  const options: IGradleReleasePluginPluginOptions = {
+    gradleCommand: './gradlew',
+    gradleOptions: ['-P prop=val']
+  };
+
+  beforeEach(() => {
+    const plugin = new GradleReleasePlugin(options);
+    hooks = makeHooks();
+    plugin.apply({ hooks, logger: dummyLog() } as Auto.Auto);
+  });
+
+  describe('version', () => {
+    test('should version release - patch version - with custom gradle command', async () => {
+      mockRead('version=1.0.0');
+      const spy = jest.fn();
+      jest.spyOn(Auto, 'execPromise').mockImplementation(spy);
+
+      await hooks.version.promise(Auto.SEMVER.patch);
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringMatching('gradlew'),
+        [
+          'release',
+          '-Prelease.useAutomaticVersion=true',
+          '-Prelease.releaseVersion=1.0.0',
+          '-Prelease.newVersion=1.0.1',
+          '-x createReleaseTag',
+          '-x preTagCommit',
+          '-x commitNewVersion',
+          '-P prop=val'
+        ]
+      );
+    });
+  });
+});

--- a/plugins/gradle/__tests__/gradle-release-plugin.test.ts
+++ b/plugins/gradle/__tests__/gradle-release-plugin.test.ts
@@ -1,0 +1,108 @@
+import fs from 'fs-extra';
+
+import * as Auto from '@auto-it/core';
+import { dummyLog } from '@auto-it/core/dist/utils/logger';
+import { makeHooks } from '@auto-it/core/dist/utils/make-hooks';
+import GradleReleasePlugin, { IGradleReleasePluginPluginOptions } from '../src';
+
+const mockRead = (result: string) =>
+  jest
+    .spyOn(fs, 'readFile')
+    // @ts-ignore
+    .mockReturnValueOnce(result);
+
+describe('Gradle Release Plugin Plugin', () => {
+  let hooks: Auto.IAutoHooks;
+  const options: IGradleReleasePluginPluginOptions = {};
+
+  beforeEach(() => {
+    const plugin = new GradleReleasePlugin(options);
+    hooks = makeHooks();
+    plugin.apply({ hooks, logger: dummyLog() } as Auto.Auto);
+  });
+
+  describe('getPreviousVersion', () => {
+    test('should get previous version from version.json', async () => {
+      mockRead('version=1.0.0');
+      expect(await hooks.getPreviousVersion.promise()).toBe('1.0.0');
+    });
+
+    test('should throw when no in version.json', async () => {
+      mockRead('');
+      await expect(hooks.getPreviousVersion.promise()).rejects.toThrowError(
+        'No version was found inside version-file.'
+      );
+    });
+
+    test('should throw when no version.json', async () => {
+      await expect(hooks.getPreviousVersion.promise()).rejects.toThrowError(
+        'No version was found inside version-file.'
+      );
+    });
+  });
+
+  describe('version', () => {
+    test('should version release - patch version', async () => {
+      mockRead('version=1.0.0');
+      const spy = jest.fn();
+      jest.spyOn(Auto, 'execPromise').mockImplementation(spy);
+
+      await hooks.version.promise(Auto.SEMVER.patch);
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringMatching('gradle'),
+        [
+          'release',
+          '-Prelease.useAutomaticVersion=true',
+          '-Prelease.releaseVersion=1.0.0',
+          '-Prelease.newVersion=1.0.1',
+          '-x createReleaseTag',
+          '-x preTagCommit',
+          '-x commitNewVersion'
+        ]
+      );
+    });
+
+    test('should version release - major version', async () => {
+      mockRead('version=1.0.0');
+      const spy = jest.fn();
+      jest.spyOn(Auto, 'execPromise').mockImplementation(spy);
+
+      await hooks.version.promise(Auto.SEMVER.major);
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringMatching('gradle'),
+        [
+          'release',
+          '-Prelease.useAutomaticVersion=true',
+          '-Prelease.releaseVersion=1.0.0',
+          '-Prelease.newVersion=2.0.0',
+          '-x createReleaseTag',
+          '-x preTagCommit',
+          '-x commitNewVersion'
+        ]
+      );
+    });
+
+    test('should version release - minor version', async () => {
+      mockRead('version=1.1.0');
+      const spy = jest.fn();
+      jest.spyOn(Auto, 'execPromise').mockImplementation(spy);
+
+      await hooks.version.promise(Auto.SEMVER.minor);
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringMatching('gradle'),
+        [
+          'release',
+          '-Prelease.useAutomaticVersion=true',
+          '-Prelease.releaseVersion=1.1.0',
+          '-Prelease.newVersion=1.2.0',
+          '-x createReleaseTag',
+          '-x preTagCommit',
+          '-x commitNewVersion'
+        ]
+      );
+    });
+  });
+});

--- a/plugins/gradle/__tests__/gradle.test.ts
+++ b/plugins/gradle/__tests__/gradle.test.ts
@@ -11,7 +11,7 @@ const mockRead = (result: string) =>
     // @ts-ignore
     .mockReturnValueOnce(result);
 
-describe('Gradle Release Plugin Plugin', () => {
+describe('Gradle Plugin', () => {
   let hooks: Auto.IAutoHooks;
   const options: IGradleReleasePluginPluginOptions = {};
 
@@ -107,7 +107,7 @@ describe('Gradle Release Plugin Plugin', () => {
   });
 });
 
-describe('Gradle Release Plugin Plugin - Custom Command', () => {
+describe('Gradle Plugin - Custom Command', () => {
   let hooks: Auto.IAutoHooks;
   const options: IGradleReleasePluginPluginOptions = {
     gradleCommand: './gradlew',

--- a/plugins/gradle/package.json
+++ b/plugins/gradle/package.json
@@ -2,7 +2,7 @@
   "name": "@auto-it/gradle",
   "version": "7.16.3",
   "main": "dist/index.js",
-  "description": "A pluging that calls gradle-release-plugin with versioning information.",
+  "description": "A plugin that calls gradle-release-plugin with versioning information.",
   "author": {
     "name": "Brandon Miller",
     "email": "unknownerror404@gmail.com"

--- a/plugins/gradle/package.json
+++ b/plugins/gradle/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@auto-it/gradle",
+  "version": "7.16.3",
+  "main": "dist/index.js",
+  "description": "A pluging that calls gradle-release-plugin with versioning information.",
+  "author": {
+    "name": "Andrew Lisowski",
+    "email": "lisowski54@gmail.com"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/intuit/auto"
+  },
+  "files": [
+    "dist"
+  ],
+  "keywords": [
+    "automation",
+    "semantic",
+    "release",
+    "github",
+    "labels",
+    "automated",
+    "continuos integration",
+    "changelog"
+  ],
+  "scripts": {
+    "build": "tsc -b",
+    "start": "npm run build -- -w",
+    "lint": "eslint src --ext .ts",
+    "test": "jest --maxWorkers=2 --config ../../package.json"
+  },
+  "dependencies": {
+    "@auto-it/core": "link:../../packages/core",
+    "dot-properties": "^0.3.2",
+    "fs-extra": "^8.1.0",
+    "tslib": "1.10.0"
+  },
+  "devDependencies": {
+    "@types/fs-extra": "^8.0.1"
+  }
+}

--- a/plugins/gradle/package.json
+++ b/plugins/gradle/package.json
@@ -4,8 +4,8 @@
   "main": "dist/index.js",
   "description": "A pluging that calls gradle-release-plugin with versioning information.",
   "author": {
-    "name": "Andrew Lisowski",
-    "email": "lisowski54@gmail.com"
+    "name": "Brandon Miller",
+    "email": "unknownerror404@gmail.com"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/plugins/gradle/src/index.ts
+++ b/plugins/gradle/src/index.ts
@@ -1,0 +1,129 @@
+import { Auto, IPlugin, execPromise } from '@auto-it/core';
+import { IExtendedCommit } from '@auto-it/core/src/log-parse';
+
+import path from 'path';
+import fs from 'fs-extra';
+import { inc, ReleaseType } from 'semver';
+import { parse } from 'dot-properties';
+
+/** Global functions for usage in module */
+const logPrefix = '[Gradle-Release-Plugin]';
+
+export interface IGradleReleasePluginPluginOptions {
+  /** The file that contains the version string in it. */
+  versionFile?: string;
+
+  /** The command to build the project with */
+  gradleCommand?: string;
+
+  /** A list of gradle command customizations to pass to gradle */
+  gradleOptions?: Array<string>;
+}
+
+/** getPre does this */
+async function getPreviousVersion(path: string): Promise<string> {
+  try {
+    const data = await fs.readFile(path, 'utf-8');
+    const { version } = parse(data);
+
+    if (version) {
+      return version;
+    }
+  } catch (error) {}
+
+  throw new Error('No version was found inside version-file.');
+}
+
+/**  */
+export default class GradleReleasePluginPlugin implements IPlugin {
+  /** The name of the plugin */
+  name = 'Gradle Release Plugin';
+
+  /** The options of the plugin */
+  readonly options: IGradleReleasePluginPluginOptions;
+
+  /** Previous Version */
+  previousVersion = '';
+
+  /** Version to Release */
+  newVersion = '';
+
+  /** Initialize the plugin with it's options */
+  constructor(options: IGradleReleasePluginPluginOptions) {
+    this.options = {
+      versionFile: options?.versionFile
+        ? path.join(process.cwd(), options.versionFile)
+        : path.join(process.cwd(), './gradle.properties'),
+      gradleCommand: options?.gradleCommand
+        ? path.join(process.cwd(), options.gradleCommand)
+        : '/usr/bin/gradle',
+      gradleOptions: options?.gradleOptions || []
+    };
+  }
+
+  /** Tap into auto plugin points. */
+  apply(auto: Auto) {
+    auto.hooks.beforeRun.tap(this.name, () => {
+      auto.logger.log.warn(`${logPrefix} BeforeRun`);
+      // validation
+      if (!fs.existsSync(this.options.versionFile || '')) {
+        auto.logger.log.warn(
+          `${logPrefix} The version-file does not exist on disk.`
+        );
+      }
+    });
+
+    auto.hooks.onCreateLogParse.tap(this.name, logParse => {
+      logParse.hooks.omitCommit.tap(this.name, (commit: IExtendedCommit) => {
+        if (commit.subject.includes('[Gradle Release Plugin]')) {
+          return true;
+        }
+      });
+    });
+
+    auto.hooks.getPreviousVersion.tapPromise(this.name, () => {
+      return getPreviousVersion(this.options.versionFile || '');
+    });
+
+    auto.hooks.version.tapPromise(this.name, async (version: string) => {
+      this.previousVersion = await getPreviousVersion(
+        this.options.versionFile || ''
+      );
+      this.newVersion = inc(this.previousVersion, version as ReleaseType) || '';
+      if (!this.newVersion) {
+        throw new Error(
+          `Could not increment previous version: ${this.previousVersion}`
+        );
+      }
+
+      // coerce
+      const gradleCommand: string = this.options.gradleCommand || '';
+
+      await execPromise(gradleCommand, [
+        'release',
+        '-Prelease.useAutomaticVersion=true',
+        `-Prelease.releaseVersion=${this.previousVersion}`,
+        `-Prelease.newVersion=${this.newVersion}`,
+        '-x createReleaseTag',
+        '-x preTagCommit',
+        '-x commitNewVersion'
+      ]);
+
+      await execPromise('git', ['add', 'gradle.properties']);
+      await execPromise('git', [
+        'commit',
+        '-m',
+        `"Bump version to: ${this.newVersion} [skip ci]"`,
+        '--no-verify'
+      ]);
+
+      await execPromise('git', [
+        'push',
+        '--follow-tags',
+        '--set-upstream',
+        'origin',
+        auto.baseBranch
+      ]);
+    });
+  }
+}

--- a/plugins/gradle/src/index.ts
+++ b/plugins/gradle/src/index.ts
@@ -97,7 +97,8 @@ export default class GradleReleasePluginPlugin implements IPlugin {
       }
 
       // coerce
-      const gradleCommand: string = this.options.gradleCommand || '';
+      const gradleCommand: string = this.options.gradleCommand || ''
+      const gradleOptions = this.options.gradleOptions || []
 
       await execPromise(gradleCommand, [
         'release',
@@ -106,7 +107,8 @@ export default class GradleReleasePluginPlugin implements IPlugin {
         `-Prelease.newVersion=${this.newVersion}`,
         '-x createReleaseTag',
         '-x preTagCommit',
-        '-x commitNewVersion'
+        '-x commitNewVersion',
+        ...gradleOptions
       ]);
 
       await execPromise('git', ['add', 'gradle.properties']);

--- a/plugins/gradle/tsconfig.json
+++ b/plugins/gradle/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*", "../../typings/**/*"],
+
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+
+  "references": [
+    {
+      "path": "../../packages/core"
+    }
+  ]
+}

--- a/typings/dot-properties.d.ts
+++ b/typings/dot-properties.d.ts
@@ -1,0 +1,3 @@
+declare module 'dot-properties' {
+  export function parse(file: string): { version?: string };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,7 +8,7 @@
   integrity sha512-m2OzlTDbhvzK4hgswH9Lx0cdpq1AntXu53Klz5RGkFfuoDvKsnlU7tmtVfNWtUiP0zZbGtrb/BZYH7aB6TRnMA==
 
 "@auto-it/core@link:packages/core":
-  version "9.4.1"
+  version "9.8.1"
   dependencies:
     "@octokit/core" "2.2.0"
     "@octokit/graphql" "4.3.1"
@@ -37,7 +37,7 @@
     url-join "^4.0.0"
 
 "@auto-it/npm@link:plugins/npm":
-  version "9.4.1"
+  version "9.8.1"
   dependencies:
     "@auto-it/core" "link:packages/core"
     env-ci "^5.0.1"
@@ -52,7 +52,7 @@
     user-home "^2.0.0"
 
 "@auto-it/released@link:plugins/released":
-  version "9.4.1"
+  version "9.8.1"
   dependencies:
     "@auto-it/core" "link:packages/core"
     deepmerge "^4.0.0"
@@ -2542,6 +2542,13 @@
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
+
+"@types/fs-extra@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-8.0.1.tgz#a2378d6e7e8afea1564e44aafa2e207dadf77686"
+  integrity sha512-J00cVDALmi/hJOYsunyT52Hva5TnJeKP5yd1r+mH/ZU0mbYZflR0Z5kw5kITtKTRYMhm1JMClOFYdHnQszEvqw==
+  dependencies:
+    "@types/node" "*"
 
 "@types/glob@^7.1.1":
   version "7.1.1"
@@ -5875,6 +5882,11 @@ dot-prop@^4.1.0, dot-prop@^4.1.1, dot-prop@^4.2.0:
   integrity sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==
   dependencies:
     is-obj "^1.0.0"
+
+dot-properties@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/dot-properties/-/dot-properties-0.3.2.tgz#aa3efa3c8ca4343701eeac697b17dd426a7c8e40"
+  integrity sha512-1JmMpYEOP4ASJPlAejX3IOVErPyZ1Dqfqiy3jxgOk/9xPgoOWS6p5EHWETgWsIrG0VcIA4Tzyu0zBFzyj9oe7Q==
 
 dotenv@*, dotenv@^8.0.0:
   version "8.2.0"


### PR DESCRIPTION
# What Changed

Added new capability to build Gradle projects using The Gradle Release Plugin.

# Why

So that we could build Gradle Projects that support

Todo:

- [X] Add tests
- [X] Add docs
