### PR TITLE
fix GH_USER in jenkins documentation

### DIFF
--- a/docs/pages/build-platforms/jenkins.md
+++ b/docs/pages/build-platforms/jenkins.md
@@ -16,7 +16,7 @@ You must use some sort of step that implements `skip ci` functionality. Otherwis
 pipeline {
   environment {
     NPM_TOKEN = credentials('NPM_TOKEN')
-    GH_USER = credentials('GH_TOKEN')
+    GH_USER = credentials('GH_USER')
     GH_TOKEN = credentials('GH_TOKEN')
   }
   stages {


### PR DESCRIPTION
# What Changed
fixing `GH_USER` env  variable. should point to `credentials('GH_USER')`
 
# Why
fixing typo which was introduced via https://github.com/intuit/auto/pull/923
Todo:

- [ ] Add tests
- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.8.4-canary.925.12093.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.8.4-canary.925.12093.0
  npm install @auto-canary/core@9.8.4-canary.925.12093.0
  npm install @auto-canary/all-contributors@9.8.4-canary.925.12093.0
  npm install @auto-canary/chrome@9.8.4-canary.925.12093.0
  npm install @auto-canary/conventional-commits@9.8.4-canary.925.12093.0
  npm install @auto-canary/crates@9.8.4-canary.925.12093.0
  npm install @auto-canary/first-time-contributor@9.8.4-canary.925.12093.0
  npm install @auto-canary/git-tag@9.8.4-canary.925.12093.0
  npm install @auto-canary/jira@9.8.4-canary.925.12093.0
  npm install @auto-canary/maven@9.8.4-canary.925.12093.0
  npm install @auto-canary/npm@9.8.4-canary.925.12093.0
  npm install @auto-canary/omit-commits@9.8.4-canary.925.12093.0
  npm install @auto-canary/omit-release-notes@9.8.4-canary.925.12093.0
  npm install @auto-canary/released@9.8.4-canary.925.12093.0
  npm install @auto-canary/s3@9.8.4-canary.925.12093.0
  npm install @auto-canary/slack@9.8.4-canary.925.12093.0
  npm install @auto-canary/twitter@9.8.4-canary.925.12093.0
  npm install @auto-canary/upload-assets@9.8.4-canary.925.12093.0
  # or 
  yarn add @auto-canary/auto@9.8.4-canary.925.12093.0
  yarn add @auto-canary/core@9.8.4-canary.925.12093.0
  yarn add @auto-canary/all-contributors@9.8.4-canary.925.12093.0
  yarn add @auto-canary/chrome@9.8.4-canary.925.12093.0
  yarn add @auto-canary/conventional-commits@9.8.4-canary.925.12093.0
  yarn add @auto-canary/crates@9.8.4-canary.925.12093.0
  yarn add @auto-canary/first-time-contributor@9.8.4-canary.925.12093.0
  yarn add @auto-canary/git-tag@9.8.4-canary.925.12093.0
  yarn add @auto-canary/jira@9.8.4-canary.925.12093.0
  yarn add @auto-canary/maven@9.8.4-canary.925.12093.0
  yarn add @auto-canary/npm@9.8.4-canary.925.12093.0
  yarn add @auto-canary/omit-commits@9.8.4-canary.925.12093.0
  yarn add @auto-canary/omit-release-notes@9.8.4-canary.925.12093.0
  yarn add @auto-canary/released@9.8.4-canary.925.12093.0
  yarn add @auto-canary/s3@9.8.4-canary.925.12093.0
  yarn add @auto-canary/slack@9.8.4-canary.925.12093.0
  yarn add @auto-canary/twitter@9.8.4-canary.925.12093.0
  yarn add @auto-canary/upload-assets@9.8.4-canary.925.12093.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
