### PR TITLE
fix maven release creation

### DIFF
--- a/plugins/maven/__tests__/maven.test.ts
+++ b/plugins/maven/__tests__/maven.test.ts
@@ -20,7 +20,7 @@ describe('maven', () => {
     plugin.apply({
       hooks,
       logger: dummyLog(),
-      prefixRelease: r => r
+      prefixRelease: r => `v${r}`
     } as Auto.Auto);
   });
 
@@ -169,7 +169,7 @@ describe('maven', () => {
         </project>
       `);
 
-      expect(await hooks.getPreviousVersion.promise()).toBe('1.0.0');
+      expect(await hooks.getPreviousVersion.promise()).toBe('v1.0.0');
     });
 
     test('should throw when no version in pom.xml', async () => {

--- a/plugins/maven/src/index.ts
+++ b/plugins/maven/src/index.ts
@@ -114,8 +114,8 @@ export default class MavenPlugin implements IPlugin {
       return developer;
     });
 
-    auto.hooks.getPreviousVersion.tapPromise(this.name, () =>
-      getPreviousVersion(auto)
+    auto.hooks.getPreviousVersion.tapPromise(this.name, async () =>
+      auto.prefixRelease(await getPreviousVersion(auto))
     );
 
     auto.hooks.version.tapPromise(this.name, async version => {
@@ -138,7 +138,7 @@ export default class MavenPlugin implements IPlugin {
       await execPromise('mvn', [
         '-B',
         'release:prepare',
-        `-Dtag=v${newVersion}`,
+        `-Dtag=${auto.prefixRelease(newVersion)}`,
         `-DreleaseVersion=${newVersion}`,
         '-DpushChanges=false'
       ]);


### PR DESCRIPTION
# What Changed

Use `auto.prefixRelease` to correctly prefix the version for the release command.

# Why

closes #926 

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.8.4-canary.927.12102.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.8.4-canary.927.12102.0
  npm install @auto-canary/core@9.8.4-canary.927.12102.0
  npm install @auto-canary/all-contributors@9.8.4-canary.927.12102.0
  npm install @auto-canary/chrome@9.8.4-canary.927.12102.0
  npm install @auto-canary/conventional-commits@9.8.4-canary.927.12102.0
  npm install @auto-canary/crates@9.8.4-canary.927.12102.0
  npm install @auto-canary/first-time-contributor@9.8.4-canary.927.12102.0
  npm install @auto-canary/git-tag@9.8.4-canary.927.12102.0
  npm install @auto-canary/jira@9.8.4-canary.927.12102.0
  npm install @auto-canary/maven@9.8.4-canary.927.12102.0
  npm install @auto-canary/npm@9.8.4-canary.927.12102.0
  npm install @auto-canary/omit-commits@9.8.4-canary.927.12102.0
  npm install @auto-canary/omit-release-notes@9.8.4-canary.927.12102.0
  npm install @auto-canary/released@9.8.4-canary.927.12102.0
  npm install @auto-canary/s3@9.8.4-canary.927.12102.0
  npm install @auto-canary/slack@9.8.4-canary.927.12102.0
  npm install @auto-canary/twitter@9.8.4-canary.927.12102.0
  npm install @auto-canary/upload-assets@9.8.4-canary.927.12102.0
  # or 
  yarn add @auto-canary/auto@9.8.4-canary.927.12102.0
  yarn add @auto-canary/core@9.8.4-canary.927.12102.0
  yarn add @auto-canary/all-contributors@9.8.4-canary.927.12102.0
  yarn add @auto-canary/chrome@9.8.4-canary.927.12102.0
  yarn add @auto-canary/conventional-commits@9.8.4-canary.927.12102.0
  yarn add @auto-canary/crates@9.8.4-canary.927.12102.0
  yarn add @auto-canary/first-time-contributor@9.8.4-canary.927.12102.0
  yarn add @auto-canary/git-tag@9.8.4-canary.927.12102.0
  yarn add @auto-canary/jira@9.8.4-canary.927.12102.0
  yarn add @auto-canary/maven@9.8.4-canary.927.12102.0
  yarn add @auto-canary/npm@9.8.4-canary.927.12102.0
  yarn add @auto-canary/omit-commits@9.8.4-canary.927.12102.0
  yarn add @auto-canary/omit-release-notes@9.8.4-canary.927.12102.0
  yarn add @auto-canary/released@9.8.4-canary.927.12102.0
  yarn add @auto-canary/s3@9.8.4-canary.927.12102.0
  yarn add @auto-canary/slack@9.8.4-canary.927.12102.0
  yarn add @auto-canary/twitter@9.8.4-canary.927.12102.0
  yarn add @auto-canary/upload-assets@9.8.4-canary.927.12102.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
