### PR TITLE
dont run git hooks when commiting the version for a single npm package

### DIFF
--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -391,6 +391,7 @@ describe('publish', () => {
     expect(exec).toHaveBeenCalledWith('npm', [
       'version',
       Auto.SEMVER.patch,
+      '--no-commit-hooks',
       '-m',
       '"Bump version to: %s [skip ci]"',
       '--loglevel',
@@ -419,6 +420,7 @@ describe('publish', () => {
     expect(exec).toHaveBeenCalledWith('npm', [
       'version',
       Auto.SEMVER.patch,
+      '--no-commit-hooks',
       '-m',
       '"Bump version to: %s [skip ci]"'
     ]);
@@ -575,6 +577,7 @@ describe('publish', () => {
     expect(exec).toHaveBeenCalledWith('npm', [
       'version',
       '1.0.1',
+      '--no-commit-hooks',
       '-m',
       '"Bump version to: %s [skip ci]"'
     ]);

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -617,6 +617,7 @@ export default class NPMPlugin implements IPlugin {
       await execPromise('npm', [
         'version',
         latestBump || version,
+        '--no-commit-hooks',
         '-m',
         VERSION_COMMIT_MESSAGE,
         ...verboseArgs


### PR DESCRIPTION
# What Changed

See title.

# Why

Git hooks could botch a release.

Todo:

- [x] Add tests
