### PR TITLE
Fix manual git tagging

### DIFF
--- a/plugins/chrome/src/index.ts
+++ b/plugins/chrome/src/index.ts
@@ -147,7 +147,12 @@ export default class ChromeWebStorePlugin implements IPlugin {
         '--no-verify'
       ]);
 
-      await execPromise('git', ['tag', manifest.version]);
+      await execPromise('git', [
+        'tag',
+        manifest.version,
+        '-m',
+        `"Update version to ${manifest.version}"`
+      ]);
     });
 
     auto.hooks.publish.tapPromise(this.name, async () => {

--- a/plugins/git-tag/__tests__/git-tag.test.ts
+++ b/plugins/git-tag/__tests__/git-tag.test.ts
@@ -1,5 +1,6 @@
 import * as Auto from '@auto-it/core';
 import { makeHooks } from '@auto-it/core/dist/utils/make-hooks';
+import { dummyLog } from '@auto-it/core/dist/utils/logger';
 
 import GitTag from '../src';
 
@@ -13,6 +14,7 @@ const setup = (mockGit?: any) => {
   plugin.apply(({
     hooks,
     git: mockGit,
+    logger: dummyLog(),
     prefixRelease: (r: string) => r,
     config: { prereleaseBranches: ['next'] },
     getCurrentVersion: () => 'v1.0.0'

--- a/plugins/git-tag/__tests__/git-tag.test.ts
+++ b/plugins/git-tag/__tests__/git-tag.test.ts
@@ -69,7 +69,12 @@ describe('Git Tag Plugin', () => {
     test('should tag next version', async () => {
       const hooks = setup({ getLatestTagInBranch: () => 'v1.0.0' });
       await hooks.version.promise(Auto.SEMVER.patch);
-      expect(exec).toHaveBeenCalledWith('git', ['tag', '1.0.1']);
+      expect(exec).toHaveBeenCalledWith('git', [
+        'tag',
+        '1.0.1',
+        '-m',
+        '"Update version to 1.0.1"'
+      ]);
     });
   });
 
@@ -88,7 +93,12 @@ describe('Git Tag Plugin', () => {
 
       await hooks.next.promise([], Auto.SEMVER.patch);
 
-      expect(exec).toHaveBeenCalledWith('git', ['tag', '1.0.1-next.0']);
+      expect(exec).toHaveBeenCalledWith('git', [
+        'tag',
+        '1.0.1-next.0',
+        '-m',
+        '"Tag pre-release: 1.0.1-next.0"'
+      ]);
       expect(exec).toHaveBeenCalledWith('git', ['push', '--tags']);
     });
   });

--- a/plugins/git-tag/src/index.ts
+++ b/plugins/git-tag/src/index.ts
@@ -50,7 +50,12 @@ export default class GitTagPlugin implements IPlugin {
       const prefixedTag = auto.prefixRelease(newTag);
 
       auto.logger.log.info(`Tagging new tag: ${lastTag} => ${prefixedTag}`);
-      await execPromise('git', ['tag', prefixedTag]);
+      await execPromise('git', [
+        'tag',
+        prefixedTag,
+        '-m',
+        `"Update version to ${prefixedTag}"`
+      ]);
 
       auto.logger.log.info(`Pushing new tag to GitHub: ${prefixedTag}`);
       await execPromise('git', [

--- a/plugins/git-tag/src/index.ts
+++ b/plugins/git-tag/src/index.ts
@@ -88,7 +88,12 @@ export default class GitTagPlugin implements IPlugin {
         prereleaseBranch
       );
 
-      await execPromise('git', ['tag', prerelease]);
+      await execPromise('git', [
+        'tag',
+        prerelease,
+        '-m',
+        `"Tag pre-release: ${prerelease}"`
+      ]);
       await execPromise('git', ['push', '--tags']);
 
       return preReleaseVersions;

--- a/plugins/git-tag/src/index.ts
+++ b/plugins/git-tag/src/index.ts
@@ -19,7 +19,7 @@ export default class GitTagPlugin implements IPlugin {
       try {
         return await auto.git!.getLatestTagInBranch();
       } catch (error) {
-        return auto.prefixRelease('0.0.0')
+        return auto.prefixRelease('0.0.0');
       }
     }
 
@@ -43,10 +43,16 @@ export default class GitTagPlugin implements IPlugin {
       const branch = getCurrentBranch() || '';
 
       if (!newTag) {
+        auto.logger.log.info('No release found, doing nothing');
         return;
       }
 
-      await execPromise('git', ['tag', auto.prefixRelease(newTag)]);
+      const prefixedTag = auto.prefixRelease(newTag);
+
+      auto.logger.log.info(`Tagging new tag: ${lastTag} => ${prefixedTag}`);
+      await execPromise('git', ['tag', prefixedTag]);
+
+      auto.logger.log.info(`Pushing new tag to GitHub: ${prefixedTag}`);
       await execPromise('git', [
         'push',
         '--follow-tags',

--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -892,7 +892,12 @@ describe('next', () => {
       '1.2.4-next.0',
       '--no-git-tag-version'
     ]);
-    expect(exec).toHaveBeenCalledWith('git', ['tag', '1.2.4-next.0']);
+    expect(exec).toHaveBeenCalledWith('git', [
+      'tag',
+      '1.2.4-next.0',
+      '-m',
+      '"Update version to 1.2.4-next.0"'
+    ]);
     expect(exec).toHaveBeenCalledWith('git', ['push', '--tags']);
     expect(exec).toHaveBeenCalledWith('npm', ['publish', '--tag', 'next']);
   });

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -830,7 +830,12 @@ export default class NPMPlugin implements IPlugin {
         ]);
 
         const { version } = await loadPackageJson();
-        await execPromise('git', ['tag', auto.prefixRelease(version!)]);
+        await execPromise('git', [
+          'tag',
+          auto.prefixRelease(version!),
+          '-m',
+          `"Update version to ${version}"`
+        ]);
 
         await execPromise('npm', [
           'publish',


### PR DESCRIPTION
# What Changed

Anywhere that we manually tag a commit I added a message. This makes it an `annoted` tag that will get pushed with `--follow-tags`

# Why

Turns out that the `git-tag` plugin (and other plugins that manually tag) were never actually pushing the tag during `shipit`. This was covered by the fact that when making a new GitHub release a tag will be created if the one in the release doesn't exist. This PR makes sure that the tag is pushed.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.10.1-canary.930.12201.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.10.1-canary.930.12201.0
  npm install @auto-canary/core@9.10.1-canary.930.12201.0
  npm install @auto-canary/all-contributors@9.10.1-canary.930.12201.0
  npm install @auto-canary/chrome@9.10.1-canary.930.12201.0
  npm install @auto-canary/conventional-commits@9.10.1-canary.930.12201.0
  npm install @auto-canary/crates@9.10.1-canary.930.12201.0
  npm install @auto-canary/first-time-contributor@9.10.1-canary.930.12201.0
  npm install @auto-canary/git-tag@9.10.1-canary.930.12201.0
  npm install @auto-canary/gradle@9.10.1-canary.930.12201.0
  npm install @auto-canary/jira@9.10.1-canary.930.12201.0
  npm install @auto-canary/maven@9.10.1-canary.930.12201.0
  npm install @auto-canary/npm@9.10.1-canary.930.12201.0
  npm install @auto-canary/omit-commits@9.10.1-canary.930.12201.0
  npm install @auto-canary/omit-release-notes@9.10.1-canary.930.12201.0
  npm install @auto-canary/released@9.10.1-canary.930.12201.0
  npm install @auto-canary/s3@9.10.1-canary.930.12201.0
  npm install @auto-canary/slack@9.10.1-canary.930.12201.0
  npm install @auto-canary/twitter@9.10.1-canary.930.12201.0
  npm install @auto-canary/upload-assets@9.10.1-canary.930.12201.0
  # or 
  yarn add @auto-canary/auto@9.10.1-canary.930.12201.0
  yarn add @auto-canary/core@9.10.1-canary.930.12201.0
  yarn add @auto-canary/all-contributors@9.10.1-canary.930.12201.0
  yarn add @auto-canary/chrome@9.10.1-canary.930.12201.0
  yarn add @auto-canary/conventional-commits@9.10.1-canary.930.12201.0
  yarn add @auto-canary/crates@9.10.1-canary.930.12201.0
  yarn add @auto-canary/first-time-contributor@9.10.1-canary.930.12201.0
  yarn add @auto-canary/git-tag@9.10.1-canary.930.12201.0
  yarn add @auto-canary/gradle@9.10.1-canary.930.12201.0
  yarn add @auto-canary/jira@9.10.1-canary.930.12201.0
  yarn add @auto-canary/maven@9.10.1-canary.930.12201.0
  yarn add @auto-canary/npm@9.10.1-canary.930.12201.0
  yarn add @auto-canary/omit-commits@9.10.1-canary.930.12201.0
  yarn add @auto-canary/omit-release-notes@9.10.1-canary.930.12201.0
  yarn add @auto-canary/released@9.10.1-canary.930.12201.0
  yarn add @auto-canary/s3@9.10.1-canary.930.12201.0
  yarn add @auto-canary/slack@9.10.1-canary.930.12201.0
  yarn add @auto-canary/twitter@9.10.1-canary.930.12201.0
  yarn add @auto-canary/upload-assets@9.10.1-canary.930.12201.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
