### PR TITLE
create-labels: handle repos with large amounts of labels

### DIFF
--- a/packages/core/src/__tests__/git.test.ts
+++ b/packages/core/src/__tests__/git.test.ts
@@ -46,7 +46,7 @@ jest.mock('@octokit/rest', () => {
       updateComment,
       listComments,
       deleteComment,
-      listLabelsForRepo,
+      listLabelsForRepo: { endpoint: listLabelsForRepo },
       createLabel,
       updateLabel,
       addLabels,
@@ -581,9 +581,9 @@ describe('github', () => {
     test('return labels', async () => {
       const gh = new Git(options);
 
-      listLabelsForRepo.mockReturnValueOnce({
-        data: [{ name: 'first label' }, { name: 'second label' }]
-      });
+      paginate.mockReturnValueOnce(
+        Promise.resolve([{ name: 'first label' }, { name: 'second label' }])
+      );
 
       expect(await gh.getProjectLabels()).toStrictEqual([
         'first label',

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -290,14 +290,17 @@ export default class Git {
     };
 
     try {
-      const labels = await this.github.issues.listLabelsForRepo(args);
+      const labels: Octokit.IssuesListLabelsForRepoResponse = await this.github.paginate(
+        this.github.issues.listLabelsForRepo.endpoint(args)
+      );
+
       this.logger.veryVerbose.info(
         'Got response for "getProjectLabels":\n',
         labels
       );
-      this.logger.verbose.info('Found labels on project:\n', labels.data);
+      this.logger.verbose.info('Found labels on project:\n', labels);
 
-      return labels.data.map(l => l.name);
+      return labels.map(l => l.name);
     } catch (e) {
       throw new GitAPIError('getProjectLabels', args, e);
     }


### PR DESCRIPTION
# What Changed

correctly handle cases with repo that have more than 20 labels

# Why

`HttpError: Validation Failed: {"resource":"Label","code":"already_exists","field":"name"}`

Todo:

- [x] Add tests
- [x] Add docs
