### PR TITLE
get node version in crash friendly way

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -521,8 +521,10 @@ export default class Auto {
       ${chalk.underline.white('Environment Information:')}
 
       "auto" version: v${getAutoVersion()}
-      "node" version: ${execSync('node --version', { encoding: 'utf8' }).trim()}
-      ${access['x-github-enterprise-version'] ? `GHE version:    v${access['x-github-enterprise-version']}\n`: '\n'}
+      "node" version: ${process.version.trim()}${
+        access['x-github-enterprise-version'] 
+          ? `GHE version:    v${access['x-github-enterprise-version']}\n`
+          : '\n'}
       ${chalk.underline.white('Project Information:')}
 
       ${logSuccess(noProject)} Repository:      ${repoLink}


### PR DESCRIPTION
# What Changed

see title

# Why

closes (hopefully) #959 


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.10.6-canary.960.12535.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.10.6-canary.960.12535.0
  npm install @auto-canary/core@9.10.6-canary.960.12535.0
  npm install @auto-canary/all-contributors@9.10.6-canary.960.12535.0
  npm install @auto-canary/chrome@9.10.6-canary.960.12535.0
  npm install @auto-canary/conventional-commits@9.10.6-canary.960.12535.0
  npm install @auto-canary/crates@9.10.6-canary.960.12535.0
  npm install @auto-canary/first-time-contributor@9.10.6-canary.960.12535.0
  npm install @auto-canary/git-tag@9.10.6-canary.960.12535.0
  npm install @auto-canary/gradle@9.10.6-canary.960.12535.0
  npm install @auto-canary/jira@9.10.6-canary.960.12535.0
  npm install @auto-canary/maven@9.10.6-canary.960.12535.0
  npm install @auto-canary/npm@9.10.6-canary.960.12535.0
  npm install @auto-canary/omit-commits@9.10.6-canary.960.12535.0
  npm install @auto-canary/omit-release-notes@9.10.6-canary.960.12535.0
  npm install @auto-canary/released@9.10.6-canary.960.12535.0
  npm install @auto-canary/s3@9.10.6-canary.960.12535.0
  npm install @auto-canary/slack@9.10.6-canary.960.12535.0
  npm install @auto-canary/twitter@9.10.6-canary.960.12535.0
  npm install @auto-canary/upload-assets@9.10.6-canary.960.12535.0
  # or 
  yarn add @auto-canary/auto@9.10.6-canary.960.12535.0
  yarn add @auto-canary/core@9.10.6-canary.960.12535.0
  yarn add @auto-canary/all-contributors@9.10.6-canary.960.12535.0
  yarn add @auto-canary/chrome@9.10.6-canary.960.12535.0
  yarn add @auto-canary/conventional-commits@9.10.6-canary.960.12535.0
  yarn add @auto-canary/crates@9.10.6-canary.960.12535.0
  yarn add @auto-canary/first-time-contributor@9.10.6-canary.960.12535.0
  yarn add @auto-canary/git-tag@9.10.6-canary.960.12535.0
  yarn add @auto-canary/gradle@9.10.6-canary.960.12535.0
  yarn add @auto-canary/jira@9.10.6-canary.960.12535.0
  yarn add @auto-canary/maven@9.10.6-canary.960.12535.0
  yarn add @auto-canary/npm@9.10.6-canary.960.12535.0
  yarn add @auto-canary/omit-commits@9.10.6-canary.960.12535.0
  yarn add @auto-canary/omit-release-notes@9.10.6-canary.960.12535.0
  yarn add @auto-canary/released@9.10.6-canary.960.12535.0
  yarn add @auto-canary/s3@9.10.6-canary.960.12535.0
  yarn add @auto-canary/slack@9.10.6-canary.960.12535.0
  yarn add @auto-canary/twitter@9.10.6-canary.960.12535.0
  yarn add @auto-canary/upload-assets@9.10.6-canary.960.12535.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
