### PR TITLE
filter out bots in first-time contributor plugins

### DIFF
--- a/packages/core/src/__tests__/make-commit-from-msg.ts
+++ b/packages/core/src/__tests__/make-commit-from-msg.ts
@@ -16,6 +16,8 @@ const makeCommitFromMsg = (
     username?: string;
     /** Packages effected by the commit */
     packages?: string[];
+    /** The type of user */
+    type?: 'Bot' | 'User';
     /** PR info for the commit */
     pullRequest?: {
       /** PR number attached to commit */
@@ -35,6 +37,7 @@ const makeCommitFromMsg = (
   files: options.files || [],
   authors: [
     {
+      type: options.type,
       name:
         options.name !== undefined && options.name !== null
           ? options.name

--- a/packages/core/src/log-parse.ts
+++ b/packages/core/src/log-parse.ts
@@ -10,6 +10,8 @@ export interface ICommitAuthor {
   username?: string;
   /** The commit this author created */
   hash?: string;
+  /** The type of user */
+  type?: 'Bot' | 'User' | string;
 }
 
 export interface IPullRequest {
@@ -25,31 +27,31 @@ export interface ICommit {
   /**
    *
    */
-hash: string;
+  hash: string;
   /**
    *
    */
-authorName?: string;
+  authorName?: string;
   /**
    *
    */
-authorEmail?: string;
+  authorEmail?: string;
   /**
    *
    */
-subject: string;
+  subject: string;
   /**
    *
    */
-rawBody?: string;
+  rawBody?: string;
   /**
    *
    */
-labels?: string[];
+  labels?: string[];
   /**
    *
    */
-files: string[];
+  files: string[];
 }
 
 export type IExtendedCommit = ICommit & {

--- a/plugins/first-time-contributor/__tests__/__snapshots__/first-time-contributor.test.ts.snap
+++ b/plugins/first-time-contributor/__tests__/__snapshots__/first-time-contributor.test.ts.snap
@@ -16,6 +16,8 @@ Thank you, Jeff123 ([@Jeff123](https://github.com/Jeff123)), for all your work!"
 ]
 `;
 
+exports[`First Time Contributor Plugin should exclude bots 1`] = `Array []`;
+
 exports[`First Time Contributor Plugin should include a username if it exists 1`] = `
 Array [
   ":tada: This release contains work from new contributors! :tada:

--- a/plugins/first-time-contributor/__tests__/first-time-contributor.test.ts
+++ b/plugins/first-time-contributor/__tests__/first-time-contributor.test.ts
@@ -135,4 +135,21 @@ describe('First Time Contributor Plugin', () => {
 
     expect(await hooks.addToBody.promise([], commits)).toMatchSnapshot();
   });
+
+  test('should exclude bots', async () => {
+    const hooks = setup();
+    const commits = [
+      makeCommitFromMsg('foo', {
+        username: 'jeff-the-snake',
+        name: 'jeff',
+        type: 'Bot'
+      })
+    ];
+
+    graphql.mockReturnValue({
+      search: { issueCount: 1 }
+    });
+
+    expect(await hooks.addToBody.promise([], commits)).toMatchSnapshot();
+  });
 });

--- a/plugins/first-time-contributor/src/index.ts
+++ b/plugins/first-time-contributor/src/index.ts
@@ -29,13 +29,14 @@ export default class FirstTimeContributorPlugin implements IPlugin {
           const newContributors = (
             await Promise.all(
               flatMap(commits, c => c.authors).map(async author => {
-                if (!author.username) {
+                if (!author.username || author.type === 'Bot') {
                   return;
                 }
 
+                // prettier-ignore
                 const prs = await auto.git?.graphql(`
                   {
-                    search(first: 2, type: ISSUE, query: "user:${auto.git?.options.owner} repo:${auto.git?.options.repo} author:${author.username} state:closed") {
+                    search(first: 2, type: ISSUE, query: "repo:${auto.git?.options.owner}/${auto.git?.options.repo} is:pr is:merged author:${author.username}") {
                       issueCount
                     }
                   }


### PR DESCRIPTION
# What Changed

see title

# Why

we don't need to thank renovate **that** much

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.10.7-canary.961.12548.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.10.7-canary.961.12548.0
  npm install @auto-canary/core@9.10.7-canary.961.12548.0
  npm install @auto-canary/all-contributors@9.10.7-canary.961.12548.0
  npm install @auto-canary/chrome@9.10.7-canary.961.12548.0
  npm install @auto-canary/conventional-commits@9.10.7-canary.961.12548.0
  npm install @auto-canary/crates@9.10.7-canary.961.12548.0
  npm install @auto-canary/first-time-contributor@9.10.7-canary.961.12548.0
  npm install @auto-canary/git-tag@9.10.7-canary.961.12548.0
  npm install @auto-canary/gradle@9.10.7-canary.961.12548.0
  npm install @auto-canary/jira@9.10.7-canary.961.12548.0
  npm install @auto-canary/maven@9.10.7-canary.961.12548.0
  npm install @auto-canary/npm@9.10.7-canary.961.12548.0
  npm install @auto-canary/omit-commits@9.10.7-canary.961.12548.0
  npm install @auto-canary/omit-release-notes@9.10.7-canary.961.12548.0
  npm install @auto-canary/released@9.10.7-canary.961.12548.0
  npm install @auto-canary/s3@9.10.7-canary.961.12548.0
  npm install @auto-canary/slack@9.10.7-canary.961.12548.0
  npm install @auto-canary/twitter@9.10.7-canary.961.12548.0
  npm install @auto-canary/upload-assets@9.10.7-canary.961.12548.0
  # or 
  yarn add @auto-canary/auto@9.10.7-canary.961.12548.0
  yarn add @auto-canary/core@9.10.7-canary.961.12548.0
  yarn add @auto-canary/all-contributors@9.10.7-canary.961.12548.0
  yarn add @auto-canary/chrome@9.10.7-canary.961.12548.0
  yarn add @auto-canary/conventional-commits@9.10.7-canary.961.12548.0
  yarn add @auto-canary/crates@9.10.7-canary.961.12548.0
  yarn add @auto-canary/first-time-contributor@9.10.7-canary.961.12548.0
  yarn add @auto-canary/git-tag@9.10.7-canary.961.12548.0
  yarn add @auto-canary/gradle@9.10.7-canary.961.12548.0
  yarn add @auto-canary/jira@9.10.7-canary.961.12548.0
  yarn add @auto-canary/maven@9.10.7-canary.961.12548.0
  yarn add @auto-canary/npm@9.10.7-canary.961.12548.0
  yarn add @auto-canary/omit-commits@9.10.7-canary.961.12548.0
  yarn add @auto-canary/omit-release-notes@9.10.7-canary.961.12548.0
  yarn add @auto-canary/released@9.10.7-canary.961.12548.0
  yarn add @auto-canary/s3@9.10.7-canary.961.12548.0
  yarn add @auto-canary/slack@9.10.7-canary.961.12548.0
  yarn add @auto-canary/twitter@9.10.7-canary.961.12548.0
  yarn add @auto-canary/upload-assets@9.10.7-canary.961.12548.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
