### PR TITLE
Adding proxyagent to graphql

### DIFF
--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -438,6 +438,7 @@ export default class Git {
 
     const data = await graphql(query, {
       baseUrl: this.graphqlBaseUrl,
+      agent: this.options.agent,
       headers: {
         authorization: `token ${this.options.token}`
       }

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -104,9 +104,9 @@ export default class Git {
       .plugin(throttling);
     this.github = new GitHub({
       baseUrl: this.baseUrl,
-      agent: this.options.agent,
       auth: this.options.token,
       previews: ['symmetra-preview'],
+      request: { agent: this.options.agent },
       throttle: {
         onRateLimit: (retryAfter: number, opts: ThrottleOpts) => {
           this.logger.log.warn(
@@ -438,7 +438,7 @@ export default class Git {
 
     const data = await graphql(query, {
       baseUrl: this.graphqlBaseUrl,
-      agent: this.options.agent,
+      request: { agent: this.options.agent },
       headers: {
         authorization: `token ${this.options.token}`
       }


### PR DESCRIPTION
# What Changed

Added proxy agent while call graphql

# Why

Graphql api call is failing if github is behind the firewall.

closes #964

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.10.8-canary.963.12580.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.10.8-canary.963.12580.0
  npm install @auto-canary/core@9.10.8-canary.963.12580.0
  npm install @auto-canary/all-contributors@9.10.8-canary.963.12580.0
  npm install @auto-canary/chrome@9.10.8-canary.963.12580.0
  npm install @auto-canary/conventional-commits@9.10.8-canary.963.12580.0
  npm install @auto-canary/crates@9.10.8-canary.963.12580.0
  npm install @auto-canary/first-time-contributor@9.10.8-canary.963.12580.0
  npm install @auto-canary/git-tag@9.10.8-canary.963.12580.0
  npm install @auto-canary/gradle@9.10.8-canary.963.12580.0
  npm install @auto-canary/jira@9.10.8-canary.963.12580.0
  npm install @auto-canary/maven@9.10.8-canary.963.12580.0
  npm install @auto-canary/npm@9.10.8-canary.963.12580.0
  npm install @auto-canary/omit-commits@9.10.8-canary.963.12580.0
  npm install @auto-canary/omit-release-notes@9.10.8-canary.963.12580.0
  npm install @auto-canary/released@9.10.8-canary.963.12580.0
  npm install @auto-canary/s3@9.10.8-canary.963.12580.0
  npm install @auto-canary/slack@9.10.8-canary.963.12580.0
  npm install @auto-canary/twitter@9.10.8-canary.963.12580.0
  npm install @auto-canary/upload-assets@9.10.8-canary.963.12580.0
  # or 
  yarn add @auto-canary/auto@9.10.8-canary.963.12580.0
  yarn add @auto-canary/core@9.10.8-canary.963.12580.0
  yarn add @auto-canary/all-contributors@9.10.8-canary.963.12580.0
  yarn add @auto-canary/chrome@9.10.8-canary.963.12580.0
  yarn add @auto-canary/conventional-commits@9.10.8-canary.963.12580.0
  yarn add @auto-canary/crates@9.10.8-canary.963.12580.0
  yarn add @auto-canary/first-time-contributor@9.10.8-canary.963.12580.0
  yarn add @auto-canary/git-tag@9.10.8-canary.963.12580.0
  yarn add @auto-canary/gradle@9.10.8-canary.963.12580.0
  yarn add @auto-canary/jira@9.10.8-canary.963.12580.0
  yarn add @auto-canary/maven@9.10.8-canary.963.12580.0
  yarn add @auto-canary/npm@9.10.8-canary.963.12580.0
  yarn add @auto-canary/omit-commits@9.10.8-canary.963.12580.0
  yarn add @auto-canary/omit-release-notes@9.10.8-canary.963.12580.0
  yarn add @auto-canary/released@9.10.8-canary.963.12580.0
  yarn add @auto-canary/s3@9.10.8-canary.963.12580.0
  yarn add @auto-canary/slack@9.10.8-canary.963.12580.0
  yarn add @auto-canary/twitter@9.10.8-canary.963.12580.0
  yarn add @auto-canary/upload-assets@9.10.8-canary.963.12580.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
