### PR TITLE
fix: gradle readme use jsonc syntax highlighting

### DIFF
--- a/plugins/gradle/README.md
+++ b/plugins/gradle/README.md
@@ -14,7 +14,7 @@ yarn add -D @auto-it/gradle
 
 ## Usage
 
-```json
+```jsonc
 {
   "plugins": [
     [


### PR DESCRIPTION
# What Changed

Change gradle plugin README to use correct languange syntax highlighting for the `.autorc` file

# Why

Easier to look at


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.10.8-canary.965.12569.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.10.8-canary.965.12569.0
  npm install @auto-canary/core@9.10.8-canary.965.12569.0
  npm install @auto-canary/all-contributors@9.10.8-canary.965.12569.0
  npm install @auto-canary/chrome@9.10.8-canary.965.12569.0
  npm install @auto-canary/conventional-commits@9.10.8-canary.965.12569.0
  npm install @auto-canary/crates@9.10.8-canary.965.12569.0
  npm install @auto-canary/first-time-contributor@9.10.8-canary.965.12569.0
  npm install @auto-canary/git-tag@9.10.8-canary.965.12569.0
  npm install @auto-canary/gradle@9.10.8-canary.965.12569.0
  npm install @auto-canary/jira@9.10.8-canary.965.12569.0
  npm install @auto-canary/maven@9.10.8-canary.965.12569.0
  npm install @auto-canary/npm@9.10.8-canary.965.12569.0
  npm install @auto-canary/omit-commits@9.10.8-canary.965.12569.0
  npm install @auto-canary/omit-release-notes@9.10.8-canary.965.12569.0
  npm install @auto-canary/released@9.10.8-canary.965.12569.0
  npm install @auto-canary/s3@9.10.8-canary.965.12569.0
  npm install @auto-canary/slack@9.10.8-canary.965.12569.0
  npm install @auto-canary/twitter@9.10.8-canary.965.12569.0
  npm install @auto-canary/upload-assets@9.10.8-canary.965.12569.0
  # or 
  yarn add @auto-canary/auto@9.10.8-canary.965.12569.0
  yarn add @auto-canary/core@9.10.8-canary.965.12569.0
  yarn add @auto-canary/all-contributors@9.10.8-canary.965.12569.0
  yarn add @auto-canary/chrome@9.10.8-canary.965.12569.0
  yarn add @auto-canary/conventional-commits@9.10.8-canary.965.12569.0
  yarn add @auto-canary/crates@9.10.8-canary.965.12569.0
  yarn add @auto-canary/first-time-contributor@9.10.8-canary.965.12569.0
  yarn add @auto-canary/git-tag@9.10.8-canary.965.12569.0
  yarn add @auto-canary/gradle@9.10.8-canary.965.12569.0
  yarn add @auto-canary/jira@9.10.8-canary.965.12569.0
  yarn add @auto-canary/maven@9.10.8-canary.965.12569.0
  yarn add @auto-canary/npm@9.10.8-canary.965.12569.0
  yarn add @auto-canary/omit-commits@9.10.8-canary.965.12569.0
  yarn add @auto-canary/omit-release-notes@9.10.8-canary.965.12569.0
  yarn add @auto-canary/released@9.10.8-canary.965.12569.0
  yarn add @auto-canary/s3@9.10.8-canary.965.12569.0
  yarn add @auto-canary/slack@9.10.8-canary.965.12569.0
  yarn add @auto-canary/twitter@9.10.8-canary.965.12569.0
  yarn add @auto-canary/upload-assets@9.10.8-canary.965.12569.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
