### PR TITLE
fix case sensitive username bug and handle git errors

### DIFF
--- a/plugins/all-contributors/package.json
+++ b/plugins/all-contributors/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@auto-it/core": "link:../../packages/core",
     "anymatch": "^3.1.1",
+    "await-to-js": "^2.1.1",
     "tslib": "1.10.0"
   },
   "devDependencies": {

--- a/plugins/all-contributors/src/index.ts
+++ b/plugins/all-contributors/src/index.ts
@@ -8,6 +8,7 @@ import {
 import fs from 'fs';
 import path from 'path';
 import match from 'anymatch';
+import on from 'await-to-js';
 import { execSync } from 'child_process';
 import { IExtendedCommit } from '@auto-it/core/src/log-parse';
 
@@ -153,8 +154,8 @@ export default class AllContributorsPlugin implements IPlugin {
         if (changedFiles) {
           await execPromise('git', ['add', 'README.md']);
           await execPromise('git', ['add', '.all-contributorsrc']);
-          await execPromise('git', ['add', '**/README.md']);
-          await execPromise('git', ['add', '**/.all-contributorsrc']);
+          await on(execPromise('git', ['add', '**/README.md']));
+          await on(execPromise('git', ['add', '**/.all-contributorsrc']));
           await execPromise('git', [
             'commit',
             '--no-verify',
@@ -234,7 +235,8 @@ export default class AllContributorsPlugin implements IPlugin {
     Object.entries(authorContributions).forEach(([username, contributions]) => {
       const { contributions: old = [] } =
         config.contributors.find(
-          contributor => contributor.login === username
+          contributor =>
+            contributor.login.toLowerCase() === username.toLowerCase()
         ) || {};
       const hasNew = [...contributions].find(
         contribution => !old.includes(contribution)


### PR DESCRIPTION
# What Changed

Was running into an issue where the GItHub api returns only lowercase usernames which conflict with sometimes capitalized versions

# Why

This failed our last release


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.10.8-canary.967.12595.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.10.8-canary.967.12595.0
  npm install @auto-canary/core@9.10.8-canary.967.12595.0
  npm install @auto-canary/all-contributors@9.10.8-canary.967.12595.0
  npm install @auto-canary/chrome@9.10.8-canary.967.12595.0
  npm install @auto-canary/conventional-commits@9.10.8-canary.967.12595.0
  npm install @auto-canary/crates@9.10.8-canary.967.12595.0
  npm install @auto-canary/first-time-contributor@9.10.8-canary.967.12595.0
  npm install @auto-canary/git-tag@9.10.8-canary.967.12595.0
  npm install @auto-canary/gradle@9.10.8-canary.967.12595.0
  npm install @auto-canary/jira@9.10.8-canary.967.12595.0
  npm install @auto-canary/maven@9.10.8-canary.967.12595.0
  npm install @auto-canary/npm@9.10.8-canary.967.12595.0
  npm install @auto-canary/omit-commits@9.10.8-canary.967.12595.0
  npm install @auto-canary/omit-release-notes@9.10.8-canary.967.12595.0
  npm install @auto-canary/released@9.10.8-canary.967.12595.0
  npm install @auto-canary/s3@9.10.8-canary.967.12595.0
  npm install @auto-canary/slack@9.10.8-canary.967.12595.0
  npm install @auto-canary/twitter@9.10.8-canary.967.12595.0
  npm install @auto-canary/upload-assets@9.10.8-canary.967.12595.0
  # or 
  yarn add @auto-canary/auto@9.10.8-canary.967.12595.0
  yarn add @auto-canary/core@9.10.8-canary.967.12595.0
  yarn add @auto-canary/all-contributors@9.10.8-canary.967.12595.0
  yarn add @auto-canary/chrome@9.10.8-canary.967.12595.0
  yarn add @auto-canary/conventional-commits@9.10.8-canary.967.12595.0
  yarn add @auto-canary/crates@9.10.8-canary.967.12595.0
  yarn add @auto-canary/first-time-contributor@9.10.8-canary.967.12595.0
  yarn add @auto-canary/git-tag@9.10.8-canary.967.12595.0
  yarn add @auto-canary/gradle@9.10.8-canary.967.12595.0
  yarn add @auto-canary/jira@9.10.8-canary.967.12595.0
  yarn add @auto-canary/maven@9.10.8-canary.967.12595.0
  yarn add @auto-canary/npm@9.10.8-canary.967.12595.0
  yarn add @auto-canary/omit-commits@9.10.8-canary.967.12595.0
  yarn add @auto-canary/omit-release-notes@9.10.8-canary.967.12595.0
  yarn add @auto-canary/released@9.10.8-canary.967.12595.0
  yarn add @auto-canary/s3@9.10.8-canary.967.12595.0
  yarn add @auto-canary/slack@9.10.8-canary.967.12595.0
  yarn add @auto-canary/twitter@9.10.8-canary.967.12595.0
  yarn add @auto-canary/upload-assets@9.10.8-canary.967.12595.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
