### PR TITLE
Add new command 'latest' for easier testing and more flexibility

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,7 @@
   - [auto changelog](pages/generated/changelog.md)
   - [auto release](pages/generated/release.md)
   - [auto shipit](pages/generated/shipit.md)
+  - [auto latest](pages/generated/latest.md)
   - [auto next](pages/generated/next.md)
   - [auto canary](pages/generated/canary.md)
 - [PR Interaction](pages/pr-interaction.md)

--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -414,7 +414,7 @@ export const commands: Command[] = [
     name: 'shipit',
     group: 'Release Commands',
     description: endent`
-      Run the full \`auto\` release pipeline. Detects if in a lerna project.
+      Context aware publishing.
 
       1. call from base branch -> latest version released (LATEST)
       2. call from prerelease branch -> prerelease version released (NEXT)
@@ -434,6 +434,15 @@ export const commands: Command[] = [
           'Make auto publish prerelease versions when merging to master. Only PRs merged with "release" label will generate a "latest" release. Only use this flag if you do not want to maintain a prerelease branch, and instead only want to use master.'
       }
     ]
+  },
+  {
+    name: 'latest',
+    group: 'Release Commands',
+    description: endent`
+      Run the full \`auto\` release pipeline. Force a release to latest and bypass \`shipit\` safeguards.
+    `,
+    examples: ['{green $} auto latest'],
+    options: [baseBranch, dryRun]
   },
   {
     name: 'canary',

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -74,6 +74,9 @@ export async function run(command: string, args: ApiOptions) {
       case 'shipit':
         await auto.shipit(args as IShipItOptions);
         break;
+      case 'latest':
+        await auto.latest(args as IShipItOptions);
+        break;
       case 'canary':
         await auto.canary(args as ICanaryOptions);
         break;

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1087,6 +1087,11 @@ export default class Auto {
     return { newVersion, commitsInRelease: commits, context: 'next' };
   }
 
+  /** Force a release to latest and bypass `shipit` safeguards. */
+  async latest(options: IShipItOptions = {}) {
+    await this.publishFullRelease(options)
+  }
+
   /**
    * Run the full workflow.
    *
@@ -1221,7 +1226,7 @@ export default class Auto {
     return result;
   }
 
-  /** On master: publish a new latest version */
+  /** Publish a new version with changelog, publish, and release */
   private async publishFullRelease(
     options: IShipItOptions & {
       /** Internal option to shipt from a certain tag or commit */


### PR DESCRIPTION
# What Changed

Add new top level command that bypasses `shipit`'s logic and always published to latest.

# Why

To enable people to test their CI setups a little better without hacks.

Todo:

- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.11.0-canary.968.12607.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.11.0-canary.968.12607.0
  npm install @auto-canary/core@9.11.0-canary.968.12607.0
  npm install @auto-canary/all-contributors@9.11.0-canary.968.12607.0
  npm install @auto-canary/chrome@9.11.0-canary.968.12607.0
  npm install @auto-canary/conventional-commits@9.11.0-canary.968.12607.0
  npm install @auto-canary/crates@9.11.0-canary.968.12607.0
  npm install @auto-canary/first-time-contributor@9.11.0-canary.968.12607.0
  npm install @auto-canary/git-tag@9.11.0-canary.968.12607.0
  npm install @auto-canary/gradle@9.11.0-canary.968.12607.0
  npm install @auto-canary/jira@9.11.0-canary.968.12607.0
  npm install @auto-canary/maven@9.11.0-canary.968.12607.0
  npm install @auto-canary/npm@9.11.0-canary.968.12607.0
  npm install @auto-canary/omit-commits@9.11.0-canary.968.12607.0
  npm install @auto-canary/omit-release-notes@9.11.0-canary.968.12607.0
  npm install @auto-canary/released@9.11.0-canary.968.12607.0
  npm install @auto-canary/s3@9.11.0-canary.968.12607.0
  npm install @auto-canary/slack@9.11.0-canary.968.12607.0
  npm install @auto-canary/twitter@9.11.0-canary.968.12607.0
  npm install @auto-canary/upload-assets@9.11.0-canary.968.12607.0
  # or 
  yarn add @auto-canary/auto@9.11.0-canary.968.12607.0
  yarn add @auto-canary/core@9.11.0-canary.968.12607.0
  yarn add @auto-canary/all-contributors@9.11.0-canary.968.12607.0
  yarn add @auto-canary/chrome@9.11.0-canary.968.12607.0
  yarn add @auto-canary/conventional-commits@9.11.0-canary.968.12607.0
  yarn add @auto-canary/crates@9.11.0-canary.968.12607.0
  yarn add @auto-canary/first-time-contributor@9.11.0-canary.968.12607.0
  yarn add @auto-canary/git-tag@9.11.0-canary.968.12607.0
  yarn add @auto-canary/gradle@9.11.0-canary.968.12607.0
  yarn add @auto-canary/jira@9.11.0-canary.968.12607.0
  yarn add @auto-canary/maven@9.11.0-canary.968.12607.0
  yarn add @auto-canary/npm@9.11.0-canary.968.12607.0
  yarn add @auto-canary/omit-commits@9.11.0-canary.968.12607.0
  yarn add @auto-canary/omit-release-notes@9.11.0-canary.968.12607.0
  yarn add @auto-canary/released@9.11.0-canary.968.12607.0
  yarn add @auto-canary/s3@9.11.0-canary.968.12607.0
  yarn add @auto-canary/slack@9.11.0-canary.968.12607.0
  yarn add @auto-canary/twitter@9.11.0-canary.968.12607.0
  yarn add @auto-canary/upload-assets@9.11.0-canary.968.12607.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
