### PR TITLE
ensure remote can be pushed to

### DIFF
--- a/docs/pages/build-platforms/github-actions.md
+++ b/docs/pages/build-platforms/github-actions.md
@@ -23,16 +23,6 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Prepare repository
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: |
-          git checkout ${GITHUB_REF:11} --
-          git remote rm origin
-          git remote add origin "https://x-access-token:$GH_TOKEN@github.com/<owner>/<repo>.git"
-          git fetch origin --tags
-          git branch --set-upstream-to origin/${GITHUB_REF:11} ${GITHUB_REF:11}
-
       - name: Use Node.js 12.x
         uses: actions/setup-node@v1
         with:

--- a/docs/pages/build-platforms/jenkins.md
+++ b/docs/pages/build-platforms/jenkins.md
@@ -32,16 +32,6 @@ pipeline {
         }
       }
     }
-    stage('Auth') {
-      steps {
-        sh '''
-          echo "https://${GH_USER}:${GH_TOKEN}@github.com" >> /tmp/gitcredfile
-          git config --global user.name "Andrew Lisowski"
-          git config --global user.email "lisowski54@gmail.com"
-          git config --global credential.helper "store --file=/tmp/gitcredfile"
-        '''
-      }
-    }
     stage('Install') {
       steps {
         sh 'yarn install --frozen-lockfile'

--- a/docs/pages/build-platforms/travis.md
+++ b/docs/pages/build-platforms/travis.md
@@ -20,14 +20,6 @@ script:
   - yarn test
   - yarn build
 
-before_deploy:
-  - git config --local user.name "${GIT_NAME}"
-  - git config --local user.email "${GIT_EMAIL}"
-  - git remote rm origin
-  - git remote add origin https://${GH_TOKEN}@github.com/hipstersmoothie/my-test-project
-  - git fetch origin --tags
-  - git checkout master
-  - git branch --set-upstream-to origin/master master
 deploy:
   skip_cleanup: true
   provider: script

--- a/docs/pages/build-platforms/travis.md
+++ b/docs/pages/build-platforms/travis.md
@@ -5,7 +5,7 @@ The following config declares the `deploy` job that run on all branches. The job
 - a new `latest` version from `master`
 - a `canary` build from a pull request (if your package manager plugin implements them)
 
-**`.circleci/config.yml`**
+**`.travis.yml`**
 
 ```yaml
 language: node_js

--- a/docs/pages/writing-plugins.md
+++ b/docs/pages/writing-plugins.md
@@ -329,7 +329,7 @@ auto.hooks.publish.tapPromise('NPM', async (version: SEMVER) => {
     'push',
     '--follow-tags',
     '--set-upstream',
-    'origin',
+    auto.remote,
     '$branch'
   ]);
 });
@@ -632,7 +632,7 @@ export default class NPMPlugin {
         'push',
         '--follow-tags',
         '--set-upstream',
-        'origin',
+        auto.remote,
         '$branch'
       ]);
     });

--- a/packages/core/src/__tests__/auto-canary-local.test.ts
+++ b/packages/core/src/__tests__/auto-canary-local.test.ts
@@ -12,6 +12,24 @@ const defaults = {
   token: 'XXXX'
 };
 
+jest.mock('@octokit/rest', () => {
+  const Octokit = class MockOctokit {
+    static plugin = () => Octokit;
+
+    authenticate = () => undefined;
+
+    repos = {
+      get: jest.fn().mockReturnValue({})
+    }
+
+    hook = {
+      error: () => undefined
+    };
+  };
+
+  return { Octokit };
+});
+
 test('shipit should publish canary in locally when not on master', async () => {
   const auto = new Auto({ ...defaults, plugins: [] });
   auto.logger = dummyLog();

--- a/packages/core/src/__tests__/auto-comment.test.ts
+++ b/packages/core/src/__tests__/auto-comment.test.ts
@@ -9,6 +9,24 @@ const defaults = {
   token: 'XXXX'
 };
 
+jest.mock('@octokit/rest', () => {
+  const Octokit = class MockOctokit {
+    static plugin = () => Octokit;
+
+    authenticate = () => undefined;
+
+    repos = {
+      get: jest.fn().mockReturnValue({})
+    }
+
+    hook = {
+      error: () => undefined
+    };
+  };
+
+  return { Octokit };
+});
+
 describe('comment', () => {
   test('should find PR number from CI', async () => {
     const auto = new Auto(defaults);

--- a/packages/core/src/__tests__/auto-in-pr-ci.test.ts
+++ b/packages/core/src/__tests__/auto-in-pr-ci.test.ts
@@ -18,6 +18,24 @@ const defaults = {
   token: 'XXXX'
 };
 
+jest.mock('@octokit/rest', () => {
+  const Octokit = class MockOctokit {
+    static plugin = () => Octokit;
+
+    authenticate = () => undefined;
+
+    repos = {
+      get: jest.fn().mockReturnValue({})
+    }
+
+    hook = {
+      error: () => undefined
+    };
+  };
+
+  return { Octokit };
+});
+
 describe('canary in ci', () => {
   test('calls the canary hook with the canary version', async () => {
     const auto = new Auto({ ...defaults, plugins: [] });

--- a/packages/core/src/__tests__/auto-make-changelog.test.ts
+++ b/packages/core/src/__tests__/auto-make-changelog.test.ts
@@ -11,7 +11,7 @@ jest
 const importMock = jest.fn();
 jest.mock('import-cwd', () => (path: string) => importMock(path));
 jest.mock('env-ci', () => () => ({ isCi: false, branch: 'master' }));
-jest.mock('../utils/exec-promise', () => () => '');
+jest.mock('../utils/exec-promise', () => () => Promise.resolve(''));
 
 const defaults = {
   owner: 'foo',
@@ -35,6 +35,10 @@ jest.mock('@octokit/rest', () => {
     search = {
       issuesAndPullRequests: () => ({ data: { items: [] } })
     };
+
+    repos = {
+      get: jest.fn().mockReturnValue(Promise.resolve({}))
+    }
 
     hook = {
       error: () => undefined

--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -46,6 +46,10 @@ jest.mock('@octokit/rest', () => {
       issuesAndPullRequests: () => ({ data: { items: [] } })
     };
 
+    repos = {
+      get: jest.fn().mockReturnValue({})
+    };
+
     hook = {
       error: () => undefined
     };

--- a/packages/core/src/__tests__/remote.test.ts
+++ b/packages/core/src/__tests__/remote.test.ts
@@ -1,0 +1,117 @@
+import Auto from '../auto';
+import { dummyLog } from '../utils/logger';
+
+const defaultRemote = 'git@github.foo.com'
+const defaults = {
+  owner: 'foo',
+  repo: 'bar',
+  token: 'XXXX'
+};
+
+const reposGet = jest.fn();
+
+jest.mock('@octokit/rest', () => {
+  const Octokit = class MockOctokit {
+    static plugin = () => Octokit;
+
+    authenticate = () => undefined;
+
+    repos = {
+      get: reposGet
+    };
+
+    hook = {
+      error: () => undefined
+    };
+  };
+
+  return { Octokit };
+});
+
+const execSpy = jest.fn();
+// @ts-ignore
+jest.mock('../utils/exec-promise.ts', () => (...args) => execSpy(...args));
+
+
+describe('remote parsing', () => {
+  test('should fall back to origin when no git', async () => {
+    const auto = new Auto(defaults);
+    auto.logger = dummyLog();
+
+    execSpy.mockReturnValue(Promise.resolve())
+
+    // @ts-ignore
+    expect(await auto.getRemote()).toBe('origin');
+  });
+
+
+  test('should fall back to configured remote when no git', async () => {
+    const auto = new Auto(defaults);
+    auto.logger = dummyLog();
+
+    execSpy.mockReturnValue(Promise.resolve(defaultRemote))
+
+    // @ts-ignore
+    expect(await auto.getRemote()).toBe(defaultRemote);
+  });
+
+  test('should fall back to configured remote', async () => {
+    const auto = new Auto(defaults);
+    auto.logger = dummyLog();
+
+    execSpy.mockReturnValue(Promise.resolve(defaultRemote))
+    auto.git = {
+      getProject: () => {},
+      verifyAuth: () => false
+    } as any
+
+    // @ts-ignore
+    expect(await auto.getRemote()).toBe(defaultRemote);
+  });
+
+  test('use html_url when authed', async () => {
+    const html_url = 'https://my.repo'
+    const auto = new Auto(defaults);
+    auto.logger = dummyLog();
+
+    execSpy.mockReturnValue(Promise.resolve(defaultRemote))
+    auto.git = {
+      getProject: () => ({ html_url }),
+      verifyAuth: () => true
+    } as any
+
+    // @ts-ignore
+    expect(await auto.getRemote()).toBe(html_url);
+  });
+
+  test('use fall back to default when not authed', async () => {
+    const html_url = 'https://my.repo'
+    const auto = new Auto(defaults);
+    auto.logger = dummyLog();
+
+    execSpy.mockReturnValue(Promise.resolve(defaultRemote))
+    auto.git = {
+      getProject: () => ({ html_url }),
+      verifyAuth: () => false
+    } as any
+
+    // @ts-ignore
+    expect(await auto.getRemote()).toBe(defaultRemote);
+  });
+
+  test('add token to url if html doesn\'t auth', async () => {
+    const html_url = 'https://my.repo'
+    const auto = new Auto(defaults);
+    process.env.GH_TOKEN = 'XXXX'
+    auto.logger = dummyLog();
+
+    execSpy.mockReturnValue(Promise.resolve(defaultRemote))
+    auto.git = {
+      getProject: () => ({ html_url }),
+      verifyAuth: (url: string) => url !== html_url
+    } as any
+
+    // @ts-ignore
+    expect(await auto.getRemote()).toBe("https://XXXX@my.repo/");
+  });
+});

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -135,6 +135,19 @@ export default class Git {
     });
   }
 
+  /** Verify the write access authorization to remote repository with push dry-run. */
+  async verifyAuth(url: string) {
+    try {
+      await execPromise(
+        'git',
+        ['push', '--dry-run', '--no-verify', url, `HEAD:${this.options.baseBranch}`, '-q']
+      );
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
+
   /** Get the "Latest Release" from GitHub */
   @memoize()
   async getLatestReleaseInfo() {

--- a/plugins/chrome/src/index.ts
+++ b/plugins/chrome/src/index.ts
@@ -171,7 +171,7 @@ export default class ChromeWebStorePlugin implements IPlugin {
         'push',
         '--follow-tags',
         '--set-upstream',
-        'origin',
+        auto.remote,
         auto.baseBranch
       ]);
     });

--- a/plugins/crates/__tests__/crates.test.ts
+++ b/plugins/crates/__tests__/crates.test.ts
@@ -221,6 +221,7 @@ describe('CratesPlugin', () => {
         plugin.apply({
           hooks,
           logger: dummyLog(),
+          remote: 'origin',
           baseBranch: 'master'
         } as Auto.Auto);
         await hooks.publish.promise(Auto.SEMVER.patch);

--- a/plugins/crates/src/index.ts
+++ b/plugins/crates/src/index.ts
@@ -110,7 +110,7 @@ export default class CratesPlugin implements IPlugin {
         'push',
         '--follow-tags',
         '--set-upstream',
-        'origin',
+        auto.remote,
         auto.baseBranch
       ]);
       auto.logger.log.info('Push complete');

--- a/plugins/git-tag/__tests__/git-tag.test.ts
+++ b/plugins/git-tag/__tests__/git-tag.test.ts
@@ -14,6 +14,7 @@ const setup = (mockGit?: any) => {
   plugin.apply(({
     hooks,
     git: mockGit,
+    remote: 'origin',
     logger: dummyLog(),
     prefixRelease: (r: string) => r,
     config: { prereleaseBranches: ['next'] },
@@ -99,7 +100,7 @@ describe('Git Tag Plugin', () => {
         '-m',
         '"Tag pre-release: 1.0.1-next.0"'
       ]);
-      expect(exec).toHaveBeenCalledWith('git', ['push', '--tags']);
+      expect(exec).toHaveBeenCalledWith('git', ['push', 'origin', '--tags']);
     });
   });
 });

--- a/plugins/git-tag/src/index.ts
+++ b/plugins/git-tag/src/index.ts
@@ -62,7 +62,7 @@ export default class GitTagPlugin implements IPlugin {
         'push',
         '--follow-tags',
         '--set-upstream',
-        'origin',
+        auto.remote,
         branch || auto.baseBranch
       ]);
     });
@@ -94,7 +94,7 @@ export default class GitTagPlugin implements IPlugin {
         '-m',
         `"Tag pre-release: ${prerelease}"`
       ]);
-      await execPromise('git', ['push', '--tags']);
+      await execPromise('git', ['push', auto.remote, '--tags']);
 
       return preReleaseVersions;
     });

--- a/plugins/gradle/src/index.ts
+++ b/plugins/gradle/src/index.ts
@@ -114,7 +114,7 @@ export default class GradleReleasePluginPlugin implements IPlugin {
         'push',
         '--follow-tags',
         '--set-upstream',
-        'origin',
+        auto.remote,
         auto.baseBranch
       ]);
     });

--- a/plugins/maven/src/index.ts
+++ b/plugins/maven/src/index.ts
@@ -156,7 +156,7 @@ export default class MavenPlugin implements IPlugin {
         'push',
         '--follow-tags',
         '--set-upstream',
-        'origin',
+        auto.remote,
         auto.baseBranch
       ]);
 
@@ -174,7 +174,7 @@ export default class MavenPlugin implements IPlugin {
       // prepare for next development iteration
       await execPromise('git', ['reset', '--hard', 'dev-snapshot']);
       await execPromise('git', ['branch', '-d', 'dev-snapshot']);
-      await execPromise('git', ['push', 'origin', auto.baseBranch]);
+      await execPromise('git', ['push', auto.remote, auto.baseBranch]);
     });
   }
 }

--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -163,6 +163,7 @@ describe('getAuthor', () => {
     plugin.apply({
       config: { prereleaseBranches: ['next'] },
       hooks,
+      remote: 'origin',
       baseBranch: 'master',
       logger: dummyLog()
     } as Auto.Auto);
@@ -182,6 +183,7 @@ describe('getAuthor', () => {
     plugin.apply({
       config: { prereleaseBranches: ['next'] },
       hooks,
+      remote: 'origin',
       baseBranch: 'master',
       logger: dummyLog()
     } as Auto.Auto);
@@ -208,6 +210,7 @@ describe('getAuthor', () => {
     plugin.apply({
       config: { prereleaseBranches: ['next'] },
       hooks,
+      remote: 'origin',
       baseBranch: 'master',
       logger: dummyLog()
     } as Auto.Auto);
@@ -233,6 +236,7 @@ describe('getRepository', () => {
     plugin.apply({
       config: { prereleaseBranches: ['next'] },
       hooks,
+      remote: 'origin',
       baseBranch: 'master',
       logger: dummyLog()
     } as Auto.Auto);
@@ -264,6 +268,7 @@ describe('getPreviousVersion', () => {
     plugin.apply({
       config: { prereleaseBranches: ['next'] },
       hooks,
+      remote: 'origin',
       baseBranch: 'master',
       logger: dummyLog(),
       prefixRelease: str => str
@@ -286,6 +291,7 @@ describe('getPreviousVersion', () => {
     plugin.apply({
       config: { prereleaseBranches: ['next'] },
       hooks,
+      remote: 'origin',
       baseBranch: 'master',
       logger: dummyLog(),
       prefixRelease: str => str
@@ -309,6 +315,7 @@ describe('getPreviousVersion', () => {
     plugin.apply({
       config: { prereleaseBranches: ['next'] },
       hooks,
+      remote: 'origin',
       baseBranch: 'master',
       logger: dummyLog(),
       prefixRelease: str => str
@@ -342,6 +349,7 @@ describe('getPreviousVersion', () => {
     plugin.apply({
       config: { prereleaseBranches: ['next'] },
       hooks,
+      remote: 'origin',
       baseBranch: 'master',
       logger: dummyLog(),
       prefixRelease: str => str
@@ -377,6 +385,7 @@ describe('publish', () => {
     plugin.apply({
       config: { prereleaseBranches: ['next'] },
       hooks,
+      remote: 'origin',
       baseBranch: 'master',
       logger
     } as Auto.Auto);
@@ -406,6 +415,7 @@ describe('publish', () => {
     plugin.apply({
       config: { prereleaseBranches: ['next'] },
       hooks,
+      remote: 'origin',
       baseBranch: 'master',
       logger: dummyLog()
     } as Auto.Auto);
@@ -433,6 +443,7 @@ describe('publish', () => {
     plugin.apply({
       config: { prereleaseBranches: ['next'] },
       hooks,
+      remote: 'origin',
       baseBranch: 'master',
       logger: dummyLog()
     } as Auto.Auto);
@@ -468,6 +479,7 @@ describe('publish', () => {
     plugin.apply({
       config: { prereleaseBranches: ['next'] },
       hooks,
+      remote: 'origin',
       baseBranch: 'master',
       logger: dummyLog()
     } as Auto.Auto);
@@ -503,6 +515,7 @@ describe('publish', () => {
     plugin.apply({
       config: { prereleaseBranches: ['next'] },
       hooks,
+      remote: 'origin',
       baseBranch: 'master',
       logger: dummyLog()
     } as Auto.Auto);
@@ -538,6 +551,7 @@ describe('publish', () => {
     plugin.apply({
       config: { prereleaseBranches: ['next'] },
       hooks,
+      remote: 'origin',
       baseBranch: 'master',
       logger: dummyLog()
     } as Auto.Auto);
@@ -560,6 +574,7 @@ describe('publish', () => {
     plugin.apply({
       config: { prereleaseBranches: ['next'] },
       hooks,
+      remote: 'origin',
       baseBranch: 'master',
       logger: dummyLog()
     } as Auto.Auto);
@@ -590,6 +605,7 @@ describe('publish', () => {
     plugin.apply({
       config: { prereleaseBranches: ['next'] },
       hooks,
+      remote: 'origin',
       baseBranch: 'master',
       logger: dummyLog()
     } as Auto.Auto);
@@ -626,6 +642,7 @@ describe('publish', () => {
     plugin.apply({
       config: { prereleaseBranches: ['next'] },
       hooks,
+      remote: 'origin',
       baseBranch: 'master',
       logger: dummyLog()
     } as Auto.Auto);
@@ -654,6 +671,7 @@ describe('canary', () => {
     plugin.apply(({
       config: { prereleaseBranches: ['next'] },
       hooks,
+      remote: 'origin',
       baseBranch: 'master',
       logger: dummyLog(),
       getCurrentVersion: () => '1.2.3',
@@ -681,6 +699,7 @@ describe('canary', () => {
     plugin.apply({
       config: { prereleaseBranches: ['next'] },
       hooks,
+      remote: 'origin',
       baseBranch: 'master',
       logger: dummyLog(),
       git: {
@@ -724,6 +743,7 @@ describe('canary', () => {
     plugin.apply({
       config: { prereleaseBranches: ['next'] },
       hooks,
+      remote: 'origin',
       baseBranch: 'master',
       logger: dummyLog(),
       git: {
@@ -767,6 +787,7 @@ describe('canary', () => {
     plugin.apply({
       config: { prereleaseBranches: ['next'] },
       hooks,
+      remote: 'origin',
       baseBranch: 'master',
       logger: dummyLog()
     } as Auto.Auto);
@@ -816,6 +837,7 @@ describe('canary', () => {
     plugin.apply({
       config: { prereleaseBranches: ['next'] },
       hooks,
+      remote: 'origin',
       baseBranch: 'master',
       logger: dummyLog(),
       git: {
@@ -866,6 +888,7 @@ describe('next', () => {
     plugin.apply(({
       config: { prereleaseBranches: ['next'] },
       hooks,
+      remote: 'origin',
       baseBranch: 'master',
       logger: dummyLog(),
       getCurrentVersion: () => '1.2.3',
@@ -898,7 +921,7 @@ describe('next', () => {
       '-m',
       '"Update version to 1.2.4-next.0"'
     ]);
-    expect(exec).toHaveBeenCalledWith('git', ['push', '--tags']);
+    expect(exec).toHaveBeenCalledWith('git', ['push', 'origin', '--tags']);
     expect(exec).toHaveBeenCalledWith('npm', ['publish', '--tag', 'next']);
   });
 
@@ -915,6 +938,7 @@ describe('next', () => {
     plugin.apply(({
       config: { prereleaseBranches: ['next'] },
       hooks,
+      remote: 'origin',
       baseBranch: 'master',
       logger: dummyLog(),
       getCurrentVersion: () => '1.2.3',
@@ -933,7 +957,7 @@ describe('next', () => {
       'npx',
       expect.arrayContaining(['lerna', 'publish', '1.2.4-next.0'])
     );
-    expect(exec).toHaveBeenCalledWith('git', ['push', '--tags']);
+    expect(exec).toHaveBeenCalledWith('git', ['push', 'origin', '--tags']);
   });
 
   test('works in monorepo - independent', async () => {
@@ -949,6 +973,7 @@ describe('next', () => {
     plugin.apply(({
       config: { prereleaseBranches: ['next'] },
       hooks,
+      remote: 'origin',
       baseBranch: 'master',
       logger: dummyLog(),
       prefixRelease: (v: string) => v,
@@ -967,7 +992,7 @@ describe('next', () => {
       'npx',
       expect.arrayContaining(['lerna', 'publish', 'prerelease'])
     );
-    expect(exec).toHaveBeenCalledWith('git', ['push', '--tags']);
+    expect(exec).toHaveBeenCalledWith('git', ['push', 'origin', '--tags']);
   });
 });
 
@@ -987,6 +1012,7 @@ describe('makeRelease', () => {
     plugin.apply({
       config: { prereleaseBranches: ['next'] },
       hooks,
+      remote: 'origin',
       baseBranch: 'master',
       logger: dummyLog(),
       prefixRelease: str => str,

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -848,7 +848,7 @@ export default class NPMPlugin implements IPlugin {
         preReleaseVersions.push(auto.prefixRelease(version!));
       }
 
-      await execPromise('git', ['push', '--tags']);
+      await execPromise('git', ['push', auto.remote, '--tags']);
       return preReleaseVersions;
     });
 
@@ -897,7 +897,7 @@ export default class NPMPlugin implements IPlugin {
         'push',
         '--follow-tags',
         '--set-upstream',
-        'origin',
+        auto.remote,
         branch || auto.baseBranch
       ]);
       auto.logger.verbose.info('Successfully published repo');


### PR DESCRIPTION
# What Changed

Make sure we can push to the remote 

# Why

This will make it so you don't have to configure known hosts for `auto` and will not have to fuss with the remote url + tokens at all.

Todo:

- [ ] Add tests
- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.12.0-canary.969.12658.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.12.0-canary.969.12658.0
  npm install @auto-canary/core@9.12.0-canary.969.12658.0
  npm install @auto-canary/all-contributors@9.12.0-canary.969.12658.0
  npm install @auto-canary/chrome@9.12.0-canary.969.12658.0
  npm install @auto-canary/conventional-commits@9.12.0-canary.969.12658.0
  npm install @auto-canary/crates@9.12.0-canary.969.12658.0
  npm install @auto-canary/first-time-contributor@9.12.0-canary.969.12658.0
  npm install @auto-canary/git-tag@9.12.0-canary.969.12658.0
  npm install @auto-canary/gradle@9.12.0-canary.969.12658.0
  npm install @auto-canary/jira@9.12.0-canary.969.12658.0
  npm install @auto-canary/maven@9.12.0-canary.969.12658.0
  npm install @auto-canary/npm@9.12.0-canary.969.12658.0
  npm install @auto-canary/omit-commits@9.12.0-canary.969.12658.0
  npm install @auto-canary/omit-release-notes@9.12.0-canary.969.12658.0
  npm install @auto-canary/released@9.12.0-canary.969.12658.0
  npm install @auto-canary/s3@9.12.0-canary.969.12658.0
  npm install @auto-canary/slack@9.12.0-canary.969.12658.0
  npm install @auto-canary/twitter@9.12.0-canary.969.12658.0
  npm install @auto-canary/upload-assets@9.12.0-canary.969.12658.0
  # or 
  yarn add @auto-canary/auto@9.12.0-canary.969.12658.0
  yarn add @auto-canary/core@9.12.0-canary.969.12658.0
  yarn add @auto-canary/all-contributors@9.12.0-canary.969.12658.0
  yarn add @auto-canary/chrome@9.12.0-canary.969.12658.0
  yarn add @auto-canary/conventional-commits@9.12.0-canary.969.12658.0
  yarn add @auto-canary/crates@9.12.0-canary.969.12658.0
  yarn add @auto-canary/first-time-contributor@9.12.0-canary.969.12658.0
  yarn add @auto-canary/git-tag@9.12.0-canary.969.12658.0
  yarn add @auto-canary/gradle@9.12.0-canary.969.12658.0
  yarn add @auto-canary/jira@9.12.0-canary.969.12658.0
  yarn add @auto-canary/maven@9.12.0-canary.969.12658.0
  yarn add @auto-canary/npm@9.12.0-canary.969.12658.0
  yarn add @auto-canary/omit-commits@9.12.0-canary.969.12658.0
  yarn add @auto-canary/omit-release-notes@9.12.0-canary.969.12658.0
  yarn add @auto-canary/released@9.12.0-canary.969.12658.0
  yarn add @auto-canary/s3@9.12.0-canary.969.12658.0
  yarn add @auto-canary/slack@9.12.0-canary.969.12658.0
  yarn add @auto-canary/twitter@9.12.0-canary.969.12658.0
  yarn add @auto-canary/upload-assets@9.12.0-canary.969.12658.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
