### PR TITLE
add support for snapshot version in the gradle plugin

### DIFF
--- a/plugins/gradle/README.md
+++ b/plugins/gradle/README.md
@@ -18,13 +18,18 @@ yarn add -D @auto-it/gradle
 {
   "plugins": [
     [
-      "gradle", {
+      "gradle",
+      {
         // An optional gradle binary cmd/path relative to your project
         // @default /usr/bin/gradle
         "gradleCommand": "./gradlew",
 
-        // An optional properties file where the gradle release plugin will read/write versions from.to.
+        // An optional properties file where shared properties can be read/written from.to.
         // @default ./gradle.properties
+        "gradlePropertiesFile": "./gradle.properties",
+
+        // An optional properties file where the version can be read/written from.to.
+        // @default ${gradlePropertiesFile}
         "versionFile": "./gradle.properties",
 
         // An optional gradle argument list -- IE any gradle option allowed for the version
@@ -65,7 +70,7 @@ release {
 
 You will also need all of the following configuration blocks for all parts of `auto` to function:
 
-1. Version defined inside `versionFile`
+1. Version defined inside `gradlePropertiesFile` or `versionFile`
 
 ```java-properties
 version=1.0.0

--- a/plugins/gradle/README.md
+++ b/plugins/gradle/README.md
@@ -70,7 +70,7 @@ release {
 
 You will also need all of the following configuration blocks for all parts of `auto` to function:
 
-1. Version defined inside `gradlePropertiesFile` or `versionFile`
+1. Version defined inside `versionFile`
 
 ```java-properties
 version=1.0.0

--- a/plugins/gradle/__tests__/gradle.test.ts
+++ b/plugins/gradle/__tests__/gradle.test.ts
@@ -8,12 +8,14 @@ import GradleReleasePlugin, {
   getProperties
 } from '../src';
 
-const mockRead = (result: string) =>
+const mockRead = (version: string) =>
   jest
     .spyOn(fs, 'readFile')
     // @ts-ignore
-    .mockReturnValueOnce(result);
+    .mockReturnValueOnce(version);
 
+const mockVersionProperties = (version: string, properties = '') =>
+  mockRead(version).mockReturnValueOnce(properties);
 describe('Gradle Plugin', () => {
   let hooks: Auto.IAutoHooks;
   const options: IGradleReleasePluginPluginOptions = {};
@@ -46,25 +48,7 @@ describe('Gradle Plugin', () => {
 
   describe('version', () => {
     test('should version release - patch version', async () => {
-      mockRead('version=1.0.0');
-      const spy = jest.fn();
-      jest.spyOn(Auto, 'execPromise').mockImplementation(spy);
-
-      await hooks.version.promise(Auto.SEMVER.patch);
-
-      expect(spy).toHaveBeenCalledWith(expect.stringMatching('gradle'), [
-        'release',
-        '-Prelease.useAutomaticVersion=true',
-        '-Prelease.releaseVersion=1.0.0',
-        '-Prelease.newVersion=1.0.1',
-        '-x createReleaseTag',
-        '-x preTagCommit',
-        '-x commitNewVersion'
-      ]);
-    });
-
-    test('should version release - version not found in properties', async () => {
-      mockRead('').mockReturnValueOnce('version=1.0.0');
+      mockVersionProperties('version=1.0.0');
       const spy = jest.fn();
       jest.spyOn(Auto, 'execPromise').mockImplementation(spy);
 
@@ -82,7 +66,7 @@ describe('Gradle Plugin', () => {
     });
 
     test('should version release - major version', async () => {
-      mockRead('version=1.0.0');
+      mockVersionProperties('version=1.0.0');
       const spy = jest.fn();
       jest.spyOn(Auto, 'execPromise').mockImplementation(spy);
 
@@ -100,7 +84,7 @@ describe('Gradle Plugin', () => {
     });
 
     test('should version release - minor version', async () => {
-      mockRead('version=1.1.0');
+      mockVersionProperties('version=1.1.0');
       const spy = jest.fn();
       jest.spyOn(Auto, 'execPromise').mockImplementation(spy);
 
@@ -118,7 +102,7 @@ describe('Gradle Plugin', () => {
     });
 
     test('should version release - patch w/ default snapshot', async () => {
-      mockRead('version=1.0.0-SNAPSHOT');
+      mockVersionProperties('version=1.0.0-SNAPSHOT');
       const spy = jest.fn();
       jest.spyOn(Auto, 'execPromise').mockImplementation(spy);
 
@@ -136,10 +120,7 @@ describe('Gradle Plugin', () => {
     });
 
     test('should version release - patch w/ custom snapshot', async () => {
-      mockRead(`
-        version=1.0.0.SNAP
-        snapshotSuffix=.SNAP
-      `);
+      mockVersionProperties('version=1.0.0.SNAP', 'snapshotSuffix=.SNAP');
       const spy = jest.fn();
       jest.spyOn(Auto, 'execPromise').mockImplementation(spy);
 
@@ -157,9 +138,7 @@ describe('Gradle Plugin', () => {
     });
 
     test('should version release - patch w/ custom snapshot in seperate files', async () => {
-      mockRead('snapshotSuffix=.SNAP').mockReturnValueOnce(
-        'version=1.0.0.SNAP'
-      );
+      mockVersionProperties('version=1.0.0.SNAP', 'snapshotSuffix=.SNAP');
       const spy = jest.fn();
       jest.spyOn(Auto, 'execPromise').mockImplementation(spy);
 
@@ -177,10 +156,7 @@ describe('Gradle Plugin', () => {
     });
 
     test('should version release - patch w/ custom snapshot regardless', async () => {
-      mockRead(`
-        version=1.0.0
-        snapshotSuffix=.SNAP
-      `);
+      mockVersionProperties('version=1.0.0', 'snapshotSuffix=.SNAP');
       const spy = jest.fn();
       jest.spyOn(Auto, 'execPromise').mockImplementation(spy);
 
@@ -214,7 +190,7 @@ describe('Gradle Plugin - Custom Command', () => {
 
   describe('version', () => {
     test('should version release - patch version - with custom gradle command', async () => {
-      mockRead('version=1.0.0');
+      mockVersionProperties('version=1.0.0');
       const spy = jest.fn();
       jest.spyOn(Auto, 'execPromise').mockImplementation(spy);
 

--- a/plugins/gradle/__tests__/gradle.test.ts
+++ b/plugins/gradle/__tests__/gradle.test.ts
@@ -16,6 +16,7 @@ const mockRead = (version: string) =>
 
 const mockVersionProperties = (version: string, properties = '') =>
   mockRead(version).mockReturnValueOnce(properties);
+
 describe('Gradle Plugin', () => {
   let hooks: Auto.IAutoHooks;
   const options: IGradleReleasePluginPluginOptions = {};

--- a/plugins/gradle/__tests__/gradle.test.ts
+++ b/plugins/gradle/__tests__/gradle.test.ts
@@ -3,7 +3,10 @@ import fs from 'fs-extra';
 import * as Auto from '@auto-it/core';
 import { dummyLog } from '@auto-it/core/dist/utils/logger';
 import { makeHooks } from '@auto-it/core/dist/utils/make-hooks';
-import GradleReleasePlugin, { IGradleReleasePluginPluginOptions } from '../src';
+import GradleReleasePlugin, {
+  IGradleReleasePluginPluginOptions,
+  readPropertiesFile
+} from '../src';
 
 const mockRead = (result: string) =>
   jest
@@ -36,7 +39,7 @@ describe('Gradle Plugin', () => {
 
     test('should throw when no version.json', async () => {
       await expect(hooks.getPreviousVersion.promise()).rejects.toThrowError(
-        'No version was found inside version-file.'
+        'Config file not found.'
       );
     });
   });
@@ -49,18 +52,15 @@ describe('Gradle Plugin', () => {
 
       await hooks.version.promise(Auto.SEMVER.patch);
 
-      expect(spy).toHaveBeenCalledWith(
-        expect.stringMatching('gradle'),
-        [
-          'release',
-          '-Prelease.useAutomaticVersion=true',
-          '-Prelease.releaseVersion=1.0.0',
-          '-Prelease.newVersion=1.0.1',
-          '-x createReleaseTag',
-          '-x preTagCommit',
-          '-x commitNewVersion'
-        ]
-      );
+      expect(spy).toHaveBeenCalledWith(expect.stringMatching('gradle'), [
+        'release',
+        '-Prelease.useAutomaticVersion=true',
+        '-Prelease.releaseVersion=1.0.0',
+        '-Prelease.newVersion=1.0.1',
+        '-x createReleaseTag',
+        '-x preTagCommit',
+        '-x commitNewVersion'
+      ]);
     });
 
     test('should version release - major version', async () => {
@@ -70,18 +70,15 @@ describe('Gradle Plugin', () => {
 
       await hooks.version.promise(Auto.SEMVER.major);
 
-      expect(spy).toHaveBeenCalledWith(
-        expect.stringMatching('gradle'),
-        [
-          'release',
-          '-Prelease.useAutomaticVersion=true',
-          '-Prelease.releaseVersion=1.0.0',
-          '-Prelease.newVersion=2.0.0',
-          '-x createReleaseTag',
-          '-x preTagCommit',
-          '-x commitNewVersion'
-        ]
-      );
+      expect(spy).toHaveBeenCalledWith(expect.stringMatching('gradle'), [
+        'release',
+        '-Prelease.useAutomaticVersion=true',
+        '-Prelease.releaseVersion=1.0.0',
+        '-Prelease.newVersion=2.0.0',
+        '-x createReleaseTag',
+        '-x preTagCommit',
+        '-x commitNewVersion'
+      ]);
     });
 
     test('should version release - minor version', async () => {
@@ -91,18 +88,72 @@ describe('Gradle Plugin', () => {
 
       await hooks.version.promise(Auto.SEMVER.minor);
 
-      expect(spy).toHaveBeenCalledWith(
-        expect.stringMatching('gradle'),
-        [
-          'release',
-          '-Prelease.useAutomaticVersion=true',
-          '-Prelease.releaseVersion=1.1.0',
-          '-Prelease.newVersion=1.2.0',
-          '-x createReleaseTag',
-          '-x preTagCommit',
-          '-x commitNewVersion'
-        ]
-      );
+      expect(spy).toHaveBeenCalledWith(expect.stringMatching('gradle'), [
+        'release',
+        '-Prelease.useAutomaticVersion=true',
+        '-Prelease.releaseVersion=1.1.0',
+        '-Prelease.newVersion=1.2.0',
+        '-x createReleaseTag',
+        '-x preTagCommit',
+        '-x commitNewVersion'
+      ]);
+    });
+
+    test('should read version from version file if not in properties file', async () => {
+      mockRead('').mockReturnValueOnce('version=1.0.0');
+      const spy = jest.fn();
+      jest.spyOn(Auto, 'execPromise').mockImplementation(spy);
+
+      await hooks.version.promise(Auto.SEMVER.patch);
+
+      expect(spy).toHaveBeenCalledWith(expect.stringMatching('gradle'), [
+        'release',
+        '-Prelease.useAutomaticVersion=true',
+        '-Prelease.releaseVersion=1.0.0',
+        '-Prelease.newVersion=1.0.1',
+        '-x createReleaseTag',
+        '-x preTagCommit',
+        '-x commitNewVersion'
+      ]);
+    });
+
+    test('should version release - minor w/ default snapshot', async () => {
+      mockRead('version=1.0.0-SNAPSHOT');
+      const spy = jest.fn();
+      jest.spyOn(Auto, 'execPromise').mockImplementation(spy);
+
+      await hooks.version.promise(Auto.SEMVER.patch);
+
+      expect(spy).toHaveBeenCalledWith(expect.stringMatching('gradle'), [
+        'release',
+        '-Prelease.useAutomaticVersion=true',
+        '-Prelease.releaseVersion=1.0.0',
+        '-Prelease.newVersion=1.0.1-SNAPSHOT',
+        '-x createReleaseTag',
+        '-x preTagCommit',
+        '-x commitNewVersion'
+      ]);
+    });
+
+    test('should version release - minor w/ custom snapshot', async () => {
+      mockRead(`
+        version=1.0.0.SNAP
+        snapshotSuffix=.SNAP
+      `);
+      const spy = jest.fn();
+      jest.spyOn(Auto, 'execPromise').mockImplementation(spy);
+
+      await hooks.version.promise(Auto.SEMVER.patch);
+
+      expect(spy).toHaveBeenCalledWith(expect.stringMatching('gradle'), [
+        'release',
+        '-Prelease.useAutomaticVersion=true',
+        '-Prelease.releaseVersion=1.0.0',
+        '-Prelease.newVersion=1.0.1.SNAP',
+        '-x createReleaseTag',
+        '-x preTagCommit',
+        '-x commitNewVersion'
+      ]);
     });
   });
 });
@@ -128,18 +179,41 @@ describe('Gradle Plugin - Custom Command', () => {
 
       await hooks.version.promise(Auto.SEMVER.patch);
 
-      expect(spy).toHaveBeenCalledWith(
-        expect.stringMatching('gradlew'),
-        [
-          'release',
-          '-Prelease.useAutomaticVersion=true',
-          '-Prelease.releaseVersion=1.0.0',
-          '-Prelease.newVersion=1.0.1',
-          '-x createReleaseTag',
-          '-x preTagCommit',
-          '-x commitNewVersion',
-          '-P prop=val'
-        ]
+      expect(spy).toHaveBeenCalledWith(expect.stringMatching('gradlew'), [
+        'release',
+        '-Prelease.useAutomaticVersion=true',
+        '-Prelease.releaseVersion=1.0.0',
+        '-Prelease.newVersion=1.0.1',
+        '-x createReleaseTag',
+        '-x preTagCommit',
+        '-x commitNewVersion',
+        '-P prop=val'
+      ]);
+    });
+  });
+});
+
+describe('readPropertiesFile', () => {
+  describe('readPropertiesFile', () => {
+    test('should read properties from file', async () => {
+      mockRead(`
+        version=1.0.0
+        snapshotSuffix=-SNAPSHOT
+      `);
+      expect(await readPropertiesFile('')).toStrictEqual({
+        version: '1.0.0',
+        snapshotSuffix: '-SNAPSHOT'
+      });
+    });
+
+    test('should read nothing from empty file', async () => {
+      mockRead('');
+      expect(await readPropertiesFile('')).toStrictEqual({});
+    });
+
+    test('should throw when no gradle.properties', async () => {
+      await expect(readPropertiesFile('')).rejects.toThrowError(
+        'Config file not found.'
       );
     });
   });

--- a/plugins/gradle/__tests__/gradle.test.ts
+++ b/plugins/gradle/__tests__/gradle.test.ts
@@ -5,7 +5,7 @@ import { dummyLog } from '@auto-it/core/dist/utils/logger';
 import { makeHooks } from '@auto-it/core/dist/utils/make-hooks';
 import GradleReleasePlugin, {
   IGradleReleasePluginPluginOptions,
-  readPropertiesFile
+  getProperties
 } from '../src';
 
 const mockRead = (result: string) =>
@@ -39,7 +39,7 @@ describe('Gradle Plugin', () => {
 
     test('should throw when no version.json', async () => {
       await expect(hooks.getPreviousVersion.promise()).rejects.toThrowError(
-        'Config file not found.'
+        'Properties-file not found.'
       );
     });
   });
@@ -47,6 +47,24 @@ describe('Gradle Plugin', () => {
   describe('version', () => {
     test('should version release - patch version', async () => {
       mockRead('version=1.0.0');
+      const spy = jest.fn();
+      jest.spyOn(Auto, 'execPromise').mockImplementation(spy);
+
+      await hooks.version.promise(Auto.SEMVER.patch);
+
+      expect(spy).toHaveBeenCalledWith(expect.stringMatching('gradle'), [
+        'release',
+        '-Prelease.useAutomaticVersion=true',
+        '-Prelease.releaseVersion=1.0.0',
+        '-Prelease.newVersion=1.0.1',
+        '-x createReleaseTag',
+        '-x preTagCommit',
+        '-x commitNewVersion'
+      ]);
+    });
+
+    test('should version release - version not found in properties', async () => {
+      mockRead('').mockReturnValueOnce('version=1.0.0');
       const spy = jest.fn();
       jest.spyOn(Auto, 'execPromise').mockImplementation(spy);
 
@@ -99,25 +117,7 @@ describe('Gradle Plugin', () => {
       ]);
     });
 
-    test('should read version from version file if not in properties file', async () => {
-      mockRead('').mockReturnValueOnce('version=1.0.0');
-      const spy = jest.fn();
-      jest.spyOn(Auto, 'execPromise').mockImplementation(spy);
-
-      await hooks.version.promise(Auto.SEMVER.patch);
-
-      expect(spy).toHaveBeenCalledWith(expect.stringMatching('gradle'), [
-        'release',
-        '-Prelease.useAutomaticVersion=true',
-        '-Prelease.releaseVersion=1.0.0',
-        '-Prelease.newVersion=1.0.1',
-        '-x createReleaseTag',
-        '-x preTagCommit',
-        '-x commitNewVersion'
-      ]);
-    });
-
-    test('should version release - minor w/ default snapshot', async () => {
+    test('should version release - patch w/ default snapshot', async () => {
       mockRead('version=1.0.0-SNAPSHOT');
       const spy = jest.fn();
       jest.spyOn(Auto, 'execPromise').mockImplementation(spy);
@@ -135,9 +135,50 @@ describe('Gradle Plugin', () => {
       ]);
     });
 
-    test('should version release - minor w/ custom snapshot', async () => {
+    test('should version release - patch w/ custom snapshot', async () => {
       mockRead(`
         version=1.0.0.SNAP
+        snapshotSuffix=.SNAP
+      `);
+      const spy = jest.fn();
+      jest.spyOn(Auto, 'execPromise').mockImplementation(spy);
+
+      await hooks.version.promise(Auto.SEMVER.patch);
+
+      expect(spy).toHaveBeenCalledWith(expect.stringMatching('gradle'), [
+        'release',
+        '-Prelease.useAutomaticVersion=true',
+        '-Prelease.releaseVersion=1.0.0',
+        '-Prelease.newVersion=1.0.1.SNAP',
+        '-x createReleaseTag',
+        '-x preTagCommit',
+        '-x commitNewVersion'
+      ]);
+    });
+
+    test('should version release - patch w/ custom snapshot in seperate files', async () => {
+      mockRead('snapshotSuffix=.SNAP').mockReturnValueOnce(
+        'version=1.0.0.SNAP'
+      );
+      const spy = jest.fn();
+      jest.spyOn(Auto, 'execPromise').mockImplementation(spy);
+
+      await hooks.version.promise(Auto.SEMVER.patch);
+
+      expect(spy).toHaveBeenCalledWith(expect.stringMatching('gradle'), [
+        'release',
+        '-Prelease.useAutomaticVersion=true',
+        '-Prelease.releaseVersion=1.0.0',
+        '-Prelease.newVersion=1.0.1.SNAP',
+        '-x createReleaseTag',
+        '-x preTagCommit',
+        '-x commitNewVersion'
+      ]);
+    });
+
+    test('should version release - patch w/ custom snapshot regardless', async () => {
+      mockRead(`
+        version=1.0.0
         snapshotSuffix=.SNAP
       `);
       const spy = jest.fn();
@@ -193,28 +234,26 @@ describe('Gradle Plugin - Custom Command', () => {
   });
 });
 
-describe('readPropertiesFile', () => {
-  describe('readPropertiesFile', () => {
-    test('should read properties from file', async () => {
-      mockRead(`
-        version=1.0.0
-        snapshotSuffix=-SNAPSHOT
-      `);
-      expect(await readPropertiesFile('')).toStrictEqual({
-        version: '1.0.0',
-        snapshotSuffix: '-SNAPSHOT'
-      });
+describe('getProperties', () => {
+  test('should read properties from file', async () => {
+    mockRead(`
+      version=1.0.0
+      snapshotSuffix=-SNAPSHOT
+    `);
+    expect(await getProperties('')).toStrictEqual({
+      version: '1.0.0',
+      snapshotSuffix: '-SNAPSHOT'
     });
+  });
 
-    test('should read nothing from empty file', async () => {
-      mockRead('');
-      expect(await readPropertiesFile('')).toStrictEqual({});
-    });
+  test('should read nothing from empty file', async () => {
+    mockRead('');
+    expect(await getProperties('')).toStrictEqual({});
+  });
 
-    test('should throw when no gradle.properties', async () => {
-      await expect(readPropertiesFile('')).rejects.toThrowError(
-        'Config file not found.'
-      );
-    });
+  test('should throw when no gradle.properties', async () => {
+    await expect(getProperties('')).rejects.toThrowError(
+      'Properties-file not found.'
+    );
   });
 });

--- a/plugins/gradle/src/index.ts
+++ b/plugins/gradle/src/index.ts
@@ -109,14 +109,13 @@ export default class GradleReleasePluginPlugin implements IPlugin {
     });
 
     auto.hooks.version.tapPromise(this.name, async (version: string) => {
-      let {
-        snapshotSuffix = '',
-        version: previousVersion
-      } = await getProperties(this.options.gradlePropertiesFile);
-      if (!previousVersion) {
-        previousVersion = await getPreviousVersion(this.options.versionFile);
-      }
+      const previousVersion = await getPreviousVersion(
+        this.options.versionFile
+      );
 
+      let { snapshotSuffix = '' } = await getProperties(
+        this.options.gradlePropertiesFile
+      );
       if (!snapshotSuffix && previousVersion.endsWith(defaultSnapshotSuffix)) {
         snapshotSuffix = defaultSnapshotSuffix;
       }


### PR DESCRIPTION
# What Changed

* new gradle properties file config option to read additional properties from
* versions file falls back to gradle properties file if not defined

# Why

* snapshot support for jvm libraries is a common build practice

Todo:

- [x] Add tests
- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.11.1-canary.970.12641.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.11.1-canary.970.12641.0
  npm install @auto-canary/core@9.11.1-canary.970.12641.0
  npm install @auto-canary/all-contributors@9.11.1-canary.970.12641.0
  npm install @auto-canary/chrome@9.11.1-canary.970.12641.0
  npm install @auto-canary/conventional-commits@9.11.1-canary.970.12641.0
  npm install @auto-canary/crates@9.11.1-canary.970.12641.0
  npm install @auto-canary/first-time-contributor@9.11.1-canary.970.12641.0
  npm install @auto-canary/git-tag@9.11.1-canary.970.12641.0
  npm install @auto-canary/gradle@9.11.1-canary.970.12641.0
  npm install @auto-canary/jira@9.11.1-canary.970.12641.0
  npm install @auto-canary/maven@9.11.1-canary.970.12641.0
  npm install @auto-canary/npm@9.11.1-canary.970.12641.0
  npm install @auto-canary/omit-commits@9.11.1-canary.970.12641.0
  npm install @auto-canary/omit-release-notes@9.11.1-canary.970.12641.0
  npm install @auto-canary/released@9.11.1-canary.970.12641.0
  npm install @auto-canary/s3@9.11.1-canary.970.12641.0
  npm install @auto-canary/slack@9.11.1-canary.970.12641.0
  npm install @auto-canary/twitter@9.11.1-canary.970.12641.0
  npm install @auto-canary/upload-assets@9.11.1-canary.970.12641.0
  # or 
  yarn add @auto-canary/auto@9.11.1-canary.970.12641.0
  yarn add @auto-canary/core@9.11.1-canary.970.12641.0
  yarn add @auto-canary/all-contributors@9.11.1-canary.970.12641.0
  yarn add @auto-canary/chrome@9.11.1-canary.970.12641.0
  yarn add @auto-canary/conventional-commits@9.11.1-canary.970.12641.0
  yarn add @auto-canary/crates@9.11.1-canary.970.12641.0
  yarn add @auto-canary/first-time-contributor@9.11.1-canary.970.12641.0
  yarn add @auto-canary/git-tag@9.11.1-canary.970.12641.0
  yarn add @auto-canary/gradle@9.11.1-canary.970.12641.0
  yarn add @auto-canary/jira@9.11.1-canary.970.12641.0
  yarn add @auto-canary/maven@9.11.1-canary.970.12641.0
  yarn add @auto-canary/npm@9.11.1-canary.970.12641.0
  yarn add @auto-canary/omit-commits@9.11.1-canary.970.12641.0
  yarn add @auto-canary/omit-release-notes@9.11.1-canary.970.12641.0
  yarn add @auto-canary/released@9.11.1-canary.970.12641.0
  yarn add @auto-canary/s3@9.11.1-canary.970.12641.0
  yarn add @auto-canary/slack@9.11.1-canary.970.12641.0
  yarn add @auto-canary/twitter@9.11.1-canary.970.12641.0
  yarn add @auto-canary/upload-assets@9.11.1-canary.970.12641.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
