### PR TITLE
Make all-contributors plugin work for non-lerna packages again

### DIFF
--- a/plugins/all-contributors/__tests__/all-contributors.test.ts
+++ b/plugins/all-contributors/__tests__/all-contributors.test.ts
@@ -85,6 +85,36 @@ describe('All Contributors Plugin', () => {
     );
   });
 
+  test.only('should work for single package', async () => {
+    const releasedLabel = new AllContributors();
+    const autoHooks = makeHooks();
+    
+    mockRead('{ "contributors": [] }');
+    getLernaPackages.mockRejectedValueOnce(Promise.reject(new Error('test')));
+
+    releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto.Auto);
+
+    await autoHooks.afterAddToChangelog.promise({
+      bump: Auto.SEMVER.patch,
+      currentVersion: '0.0.0',
+      lastRelease: '0.0.0',
+      releaseNotes: '',
+      commits: [
+        {
+          subject: 'Do the thing',
+          hash: '123',
+          labels: [],
+          files: ['src/index.ts'],
+          authors: [{ username: 'Jeff', hash: '123' }]
+        }
+      ]
+    });
+
+    expect(exec.mock.calls[0][0]).toBe(
+      'npx all-contributors-cli add Jeff code'
+    );
+  });
+
   test('should find contributions from merge commit', async () => {
     const releasedLabel = new AllContributors();
     const autoHooks = makeHooks();

--- a/plugins/all-contributors/__tests__/all-contributors.test.ts
+++ b/plugins/all-contributors/__tests__/all-contributors.test.ts
@@ -85,7 +85,7 @@ describe('All Contributors Plugin', () => {
     );
   });
 
-  test.only('should work for single package', async () => {
+  test('should work for single package', async () => {
     const releasedLabel = new AllContributors();
     const autoHooks = makeHooks();
     


### PR DESCRIPTION
# What Changed

When I enable sub package changelogs for this plugin I broke it for non-lerna projects

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.12.1-canary.971.12685.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.12.1-canary.971.12685.0
  npm install @auto-canary/core@9.12.1-canary.971.12685.0
  npm install @auto-canary/all-contributors@9.12.1-canary.971.12685.0
  npm install @auto-canary/chrome@9.12.1-canary.971.12685.0
  npm install @auto-canary/conventional-commits@9.12.1-canary.971.12685.0
  npm install @auto-canary/crates@9.12.1-canary.971.12685.0
  npm install @auto-canary/first-time-contributor@9.12.1-canary.971.12685.0
  npm install @auto-canary/git-tag@9.12.1-canary.971.12685.0
  npm install @auto-canary/gradle@9.12.1-canary.971.12685.0
  npm install @auto-canary/jira@9.12.1-canary.971.12685.0
  npm install @auto-canary/maven@9.12.1-canary.971.12685.0
  npm install @auto-canary/npm@9.12.1-canary.971.12685.0
  npm install @auto-canary/omit-commits@9.12.1-canary.971.12685.0
  npm install @auto-canary/omit-release-notes@9.12.1-canary.971.12685.0
  npm install @auto-canary/released@9.12.1-canary.971.12685.0
  npm install @auto-canary/s3@9.12.1-canary.971.12685.0
  npm install @auto-canary/slack@9.12.1-canary.971.12685.0
  npm install @auto-canary/twitter@9.12.1-canary.971.12685.0
  npm install @auto-canary/upload-assets@9.12.1-canary.971.12685.0
  # or 
  yarn add @auto-canary/auto@9.12.1-canary.971.12685.0
  yarn add @auto-canary/core@9.12.1-canary.971.12685.0
  yarn add @auto-canary/all-contributors@9.12.1-canary.971.12685.0
  yarn add @auto-canary/chrome@9.12.1-canary.971.12685.0
  yarn add @auto-canary/conventional-commits@9.12.1-canary.971.12685.0
  yarn add @auto-canary/crates@9.12.1-canary.971.12685.0
  yarn add @auto-canary/first-time-contributor@9.12.1-canary.971.12685.0
  yarn add @auto-canary/git-tag@9.12.1-canary.971.12685.0
  yarn add @auto-canary/gradle@9.12.1-canary.971.12685.0
  yarn add @auto-canary/jira@9.12.1-canary.971.12685.0
  yarn add @auto-canary/maven@9.12.1-canary.971.12685.0
  yarn add @auto-canary/npm@9.12.1-canary.971.12685.0
  yarn add @auto-canary/omit-commits@9.12.1-canary.971.12685.0
  yarn add @auto-canary/omit-release-notes@9.12.1-canary.971.12685.0
  yarn add @auto-canary/released@9.12.1-canary.971.12685.0
  yarn add @auto-canary/s3@9.12.1-canary.971.12685.0
  yarn add @auto-canary/slack@9.12.1-canary.971.12685.0
  yarn add @auto-canary/twitter@9.12.1-canary.971.12685.0
  yarn add @auto-canary/upload-assets@9.12.1-canary.971.12685.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
