### PR TITLE
add fallback for when --is-ancestor fails

### DIFF
--- a/packages/core/src/release.ts
+++ b/packages/core/src/release.ts
@@ -379,26 +379,32 @@ export default class Release {
 
     const logParse = await this.createLogParse();
     const commits = (await logParse.normalizeCommits(gitlog)).filter(commit => {
-      // 0 exit code means that the commit is an ancestor of "from"
-      // and should not be released
-      const released =
-        execSync(
-          `git merge-base --is-ancestor ${commit.hash} ${from}; echo $?`,
-          {
-            encoding: 'utf8'
-          }
-        ).trim() === '0';
+      try {
+        // 0 exit code means that the commit is an ancestor of "from"
+        // and should not be released
+        const released =
+          execSync(
+            `git merge-base --is-ancestor ${commit.hash} ${from}; echo $?`,
+            {
+              encoding: 'utf8'
+            }
+          ).trim() === '0';
 
-      if (released) {
-        this.logger.verbose.warn(
-          `Commit already released omitting: "${commit.hash.slice(
-            0,
-            8
-          )}" with message "${commit.subject}"`
-        );
+        if (released) {
+          this.logger.verbose.warn(
+            `Commit already released omitting: "${commit.hash.slice(
+              0,
+              8
+            )}" with message "${commit.subject}"`
+          );
+        }
+
+        return !released;
+      } catch (error) {
+        this.logger.verbose.warn(error)
+        // If an error happens include the commit to be safe.
+        return true;
       }
-
-      return !released;
     });
 
     this.logger.veryVerbose.info('Added labels to commits:\n', commits);


### PR DESCRIPTION
# What Changed

see title

# Why

fixes #973 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.13.1-canary.989.12868.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.13.1-canary.989.12868.0
  npm install @auto-canary/core@9.13.1-canary.989.12868.0
  npm install @auto-canary/all-contributors@9.13.1-canary.989.12868.0
  npm install @auto-canary/chrome@9.13.1-canary.989.12868.0
  npm install @auto-canary/conventional-commits@9.13.1-canary.989.12868.0
  npm install @auto-canary/crates@9.13.1-canary.989.12868.0
  npm install @auto-canary/first-time-contributor@9.13.1-canary.989.12868.0
  npm install @auto-canary/git-tag@9.13.1-canary.989.12868.0
  npm install @auto-canary/gradle@9.13.1-canary.989.12868.0
  npm install @auto-canary/jira@9.13.1-canary.989.12868.0
  npm install @auto-canary/maven@9.13.1-canary.989.12868.0
  npm install @auto-canary/npm@9.13.1-canary.989.12868.0
  npm install @auto-canary/omit-commits@9.13.1-canary.989.12868.0
  npm install @auto-canary/omit-release-notes@9.13.1-canary.989.12868.0
  npm install @auto-canary/released@9.13.1-canary.989.12868.0
  npm install @auto-canary/s3@9.13.1-canary.989.12868.0
  npm install @auto-canary/slack@9.13.1-canary.989.12868.0
  npm install @auto-canary/twitter@9.13.1-canary.989.12868.0
  npm install @auto-canary/upload-assets@9.13.1-canary.989.12868.0
  # or 
  yarn add @auto-canary/auto@9.13.1-canary.989.12868.0
  yarn add @auto-canary/core@9.13.1-canary.989.12868.0
  yarn add @auto-canary/all-contributors@9.13.1-canary.989.12868.0
  yarn add @auto-canary/chrome@9.13.1-canary.989.12868.0
  yarn add @auto-canary/conventional-commits@9.13.1-canary.989.12868.0
  yarn add @auto-canary/crates@9.13.1-canary.989.12868.0
  yarn add @auto-canary/first-time-contributor@9.13.1-canary.989.12868.0
  yarn add @auto-canary/git-tag@9.13.1-canary.989.12868.0
  yarn add @auto-canary/gradle@9.13.1-canary.989.12868.0
  yarn add @auto-canary/jira@9.13.1-canary.989.12868.0
  yarn add @auto-canary/maven@9.13.1-canary.989.12868.0
  yarn add @auto-canary/npm@9.13.1-canary.989.12868.0
  yarn add @auto-canary/omit-commits@9.13.1-canary.989.12868.0
  yarn add @auto-canary/omit-release-notes@9.13.1-canary.989.12868.0
  yarn add @auto-canary/released@9.13.1-canary.989.12868.0
  yarn add @auto-canary/s3@9.13.1-canary.989.12868.0
  yarn add @auto-canary/slack@9.13.1-canary.989.12868.0
  yarn add @auto-canary/twitter@9.13.1-canary.989.12868.0
  yarn add @auto-canary/upload-assets@9.13.1-canary.989.12868.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
