### PR TITLE
add scoped plugin support

### DIFF
--- a/docs/pages/plugins.md
+++ b/docs/pages/plugins.md
@@ -41,9 +41,14 @@ Unofficial plugins pulled from NPM should be named in the format `auto-plugin-PL
 
 That name is provided to auto to use that particular plugin.
 
-```json
+```jsonc
 {
-  "plugins": ["auto-plugin-my-cool-plugin", "some-package"]
+  "plugins": [
+    "auto-plugin-my-cool-plugin",
+    // or
+    "@my-scope/auto-plugin-my-cool-plugin",
+    "some-package"
+  ]
 }
 ```
 

--- a/packages/core/src/utils/load-plugins.ts
+++ b/packages/core/src/utils/load-plugins.ts
@@ -79,6 +79,11 @@ export default function loadPlugin(
     plugin = requirePlugin(path.join('@auto-it', pluginPath), logger);
   }
 
+  // Try requiring a package
+  if (!plugin && pluginPath.includes('auto-plugin-')) {
+    plugin = requirePlugin(pluginPath, logger);
+  }
+
   if (!plugin) {
     logger.log.warn(`Could not find plugin: ${pluginPath}`);
     return;


### PR DESCRIPTION
# What Changed

Plugins can now have a name like `@my-scope/auto-plugin-my-plugin`.

# Why

I like to publish things under scopes, including plugins

Todo:

- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.14.0-canary.991.12893.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.14.0-canary.991.12893.0
  npm install @auto-canary/core@9.14.0-canary.991.12893.0
  npm install @auto-canary/all-contributors@9.14.0-canary.991.12893.0
  npm install @auto-canary/chrome@9.14.0-canary.991.12893.0
  npm install @auto-canary/conventional-commits@9.14.0-canary.991.12893.0
  npm install @auto-canary/crates@9.14.0-canary.991.12893.0
  npm install @auto-canary/first-time-contributor@9.14.0-canary.991.12893.0
  npm install @auto-canary/git-tag@9.14.0-canary.991.12893.0
  npm install @auto-canary/gradle@9.14.0-canary.991.12893.0
  npm install @auto-canary/jira@9.14.0-canary.991.12893.0
  npm install @auto-canary/maven@9.14.0-canary.991.12893.0
  npm install @auto-canary/npm@9.14.0-canary.991.12893.0
  npm install @auto-canary/omit-commits@9.14.0-canary.991.12893.0
  npm install @auto-canary/omit-release-notes@9.14.0-canary.991.12893.0
  npm install @auto-canary/released@9.14.0-canary.991.12893.0
  npm install @auto-canary/s3@9.14.0-canary.991.12893.0
  npm install @auto-canary/slack@9.14.0-canary.991.12893.0
  npm install @auto-canary/twitter@9.14.0-canary.991.12893.0
  npm install @auto-canary/upload-assets@9.14.0-canary.991.12893.0
  # or 
  yarn add @auto-canary/auto@9.14.0-canary.991.12893.0
  yarn add @auto-canary/core@9.14.0-canary.991.12893.0
  yarn add @auto-canary/all-contributors@9.14.0-canary.991.12893.0
  yarn add @auto-canary/chrome@9.14.0-canary.991.12893.0
  yarn add @auto-canary/conventional-commits@9.14.0-canary.991.12893.0
  yarn add @auto-canary/crates@9.14.0-canary.991.12893.0
  yarn add @auto-canary/first-time-contributor@9.14.0-canary.991.12893.0
  yarn add @auto-canary/git-tag@9.14.0-canary.991.12893.0
  yarn add @auto-canary/gradle@9.14.0-canary.991.12893.0
  yarn add @auto-canary/jira@9.14.0-canary.991.12893.0
  yarn add @auto-canary/maven@9.14.0-canary.991.12893.0
  yarn add @auto-canary/npm@9.14.0-canary.991.12893.0
  yarn add @auto-canary/omit-commits@9.14.0-canary.991.12893.0
  yarn add @auto-canary/omit-release-notes@9.14.0-canary.991.12893.0
  yarn add @auto-canary/released@9.14.0-canary.991.12893.0
  yarn add @auto-canary/s3@9.14.0-canary.991.12893.0
  yarn add @auto-canary/slack@9.14.0-canary.991.12893.0
  yarn add @auto-canary/twitter@9.14.0-canary.991.12893.0
  yarn add @auto-canary/upload-assets@9.14.0-canary.991.12893.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
