### PR TITLE
add scoped plugin support

### DIFF
--- a/docs/pages/plugins.md
+++ b/docs/pages/plugins.md
@@ -41,9 +41,14 @@ Unofficial plugins pulled from NPM should be named in the format `auto-plugin-PL
 
 That name is provided to auto to use that particular plugin.
 
-```json
+```jsonc
 {
-  "plugins": ["auto-plugin-my-cool-plugin", "some-package"]
+  "plugins": [
+    "auto-plugin-my-cool-plugin",
+    // or
+    "@my-scope/auto-plugin-my-cool-plugin",
+    "some-package"
+  ]
 }
 ```
 

--- a/packages/core/src/utils/__tests__/load-plugin.test.ts
+++ b/packages/core/src/utils/__tests__/load-plugin.test.ts
@@ -4,8 +4,56 @@ import { dummyLog } from '../logger';
 
 const logger = dummyLog();
 
+jest.mock(
+  'auto-plugin-foo',
+  () => ({
+    default: class {
+      name = 'foo';
+    }
+  }),
+  {
+    virtual: true
+  }
+);
+jest.mock(
+  '@my-scope/auto-plugin-bar',
+  () => ({
+    default: class {
+      name = 'bar';
+    }
+  }),
+  { virtual: true }
+);
+jest.mock(
+  '@auto-it/baz',
+  () => ({
+    default: class {
+      name = 'baz';
+    }
+  }),
+  {
+    virtual: true
+  }
+);
+
 describe('loadPlugins', () => {
-  test('should require custom plugins -- fallback to cwd', async () => {
+  test('should load official plugins', () => {
+    expect(loadPlugin(['baz', {}], logger)?.name).toBe('baz');
+    expect(loadPlugin(['@auto-it/baz', {}], logger)?.name).toBe('baz');
+  });
+
+  test('should load community plugins', () => {
+    expect(loadPlugin(['foo', {}], logger)?.name).toBe('foo');
+    expect(loadPlugin(['auto-plugin-foo', {}], logger)?.name).toBe('foo');
+  });
+
+  test('should load scoped plugins', () => {
+    expect(
+      loadPlugin(['@my-scope/auto-plugin-bar', {}], logger)?.name
+    ).toBe('bar');
+  });
+
+  test('should require custom plugins -- fallback to cwd', () => {
     expect(
       loadPlugin([path.join(__dirname, './test-plugin.ts'), {}], logger)
     ).toStrictEqual(
@@ -16,7 +64,7 @@ describe('loadPlugins', () => {
     );
   });
 
-  test('should require custom plugins -- surface errors', async () => {
+  test('should require custom plugins -- surface errors', () => {
     expect(() =>
       loadPlugin(
         [path.join(__dirname, './test-plugin-malformed.js'), {}],
@@ -25,7 +73,7 @@ describe('loadPlugins', () => {
     ).toThrow();
   });
 
-  test('should load config', async () => {
+  test('should load config', () => {
     expect(
       loadPlugin(
         [path.join(__dirname, './test-plugin.ts'), 'do the thing'],

--- a/packages/core/src/utils/load-plugins.ts
+++ b/packages/core/src/utils/load-plugins.ts
@@ -79,6 +79,16 @@ export default function loadPlugin(
     plugin = requirePlugin(path.join('@auto-it', pluginPath), logger);
   }
 
+  // Try requiring a package
+  if (
+    !plugin &&
+    (pluginPath.includes('/auto-plugin-') ||
+      pluginPath.startsWith('auto-plugin-') ||
+      pluginPath.startsWith('@auto-it'))
+  ) {
+    plugin = requirePlugin(pluginPath, logger);
+  }
+
   if (!plugin) {
     logger.log.warn(`Could not find plugin: ${pluginPath}`);
     return;


### PR DESCRIPTION
# What Changed

Plugins can now have a name like `@my-scope/auto-plugin-my-plugin`.

I also fixed a bug where providing the full names of plugins would result in them not loading

**Before:**

❌ `@auto-it/npm`

❌ `auto-plugin-my-plugin`

❌ `@my-scope/auto-plugin-my-plugin`

**After:**

✅  `@auto-it/npm`

✅  `auto-plugin-my-plugin`

✅  `@my-scope/auto-plugin-my-plugin`


# Why

I like to publish things under scopes, including plugins
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.14.0-canary.992.12898.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.14.0-canary.992.12898.0
  npm install @auto-canary/core@9.14.0-canary.992.12898.0
  npm install @auto-canary/all-contributors@9.14.0-canary.992.12898.0
  npm install @auto-canary/chrome@9.14.0-canary.992.12898.0
  npm install @auto-canary/conventional-commits@9.14.0-canary.992.12898.0
  npm install @auto-canary/crates@9.14.0-canary.992.12898.0
  npm install @auto-canary/first-time-contributor@9.14.0-canary.992.12898.0
  npm install @auto-canary/git-tag@9.14.0-canary.992.12898.0
  npm install @auto-canary/gradle@9.14.0-canary.992.12898.0
  npm install @auto-canary/jira@9.14.0-canary.992.12898.0
  npm install @auto-canary/maven@9.14.0-canary.992.12898.0
  npm install @auto-canary/npm@9.14.0-canary.992.12898.0
  npm install @auto-canary/omit-commits@9.14.0-canary.992.12898.0
  npm install @auto-canary/omit-release-notes@9.14.0-canary.992.12898.0
  npm install @auto-canary/released@9.14.0-canary.992.12898.0
  npm install @auto-canary/s3@9.14.0-canary.992.12898.0
  npm install @auto-canary/slack@9.14.0-canary.992.12898.0
  npm install @auto-canary/twitter@9.14.0-canary.992.12898.0
  npm install @auto-canary/upload-assets@9.14.0-canary.992.12898.0
  # or 
  yarn add @auto-canary/auto@9.14.0-canary.992.12898.0
  yarn add @auto-canary/core@9.14.0-canary.992.12898.0
  yarn add @auto-canary/all-contributors@9.14.0-canary.992.12898.0
  yarn add @auto-canary/chrome@9.14.0-canary.992.12898.0
  yarn add @auto-canary/conventional-commits@9.14.0-canary.992.12898.0
  yarn add @auto-canary/crates@9.14.0-canary.992.12898.0
  yarn add @auto-canary/first-time-contributor@9.14.0-canary.992.12898.0
  yarn add @auto-canary/git-tag@9.14.0-canary.992.12898.0
  yarn add @auto-canary/gradle@9.14.0-canary.992.12898.0
  yarn add @auto-canary/jira@9.14.0-canary.992.12898.0
  yarn add @auto-canary/maven@9.14.0-canary.992.12898.0
  yarn add @auto-canary/npm@9.14.0-canary.992.12898.0
  yarn add @auto-canary/omit-commits@9.14.0-canary.992.12898.0
  yarn add @auto-canary/omit-release-notes@9.14.0-canary.992.12898.0
  yarn add @auto-canary/released@9.14.0-canary.992.12898.0
  yarn add @auto-canary/s3@9.14.0-canary.992.12898.0
  yarn add @auto-canary/slack@9.14.0-canary.992.12898.0
  yarn add @auto-canary/twitter@9.14.0-canary.992.12898.0
  yarn add @auto-canary/upload-assets@9.14.0-canary.992.12898.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
