### PR TITLE
Don't release canary on skip-release by default, add force flag

### DIFF
--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -499,7 +499,8 @@ export const commands: AutoCommand[] = [
         type: Boolean,
         group: 'main',
         description:
-          'Force a canary release, even if the PR is marked to skip the release'
+          'Force a canary release, even if the PR is marked to skip the release',
+        config: true
       }
     ]
   },

--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -469,6 +469,7 @@ export const commands: AutoCommand[] = [
     `,
     examples: [
       '{green $} auto canary',
+      '{green $} auto canary --force',
       '{green $} auto canary --pr 123 --build 5',
       '{green $} auto canary --message "Install PR version: `yarn add -D my-project@%v`"',
       '{green $} auto canary --message false'
@@ -492,6 +493,13 @@ export const commands: AutoCommand[] = [
         description:
           "Message to comment on PR with. Defaults to 'Published PR with canary version: %v'. Pass false to disable the comment",
         config: true
+      },
+      {
+        name: 'force',
+        type: Boolean,
+        group: 'main',
+        description:
+          'Force a canary release, even if the PR is marked to skip the release'
       }
     ]
   },

--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -1135,7 +1135,7 @@ describe('Auto', () => {
       expect(canary).toHaveBeenCalledWith(SEMVER.patch, '.abcd');
     });
 
-    test('works when PR has "skip-release" label', async () => {
+    test('should not publish when is present "skip-release" label', async () => {
       const auto = new Auto({ ...defaults, plugins: [] });
       // @ts-ignore
       auto.checkClean = () => Promise.resolve(true);
@@ -1154,7 +1154,7 @@ describe('Auto', () => {
       auto.hooks.canary.tap('test', canary);
 
       await auto.canary();
-      expect(canary).toHaveBeenCalledWith(SEMVER.patch, '.abcd');
+      expect(canary).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/auto-args.ts
+++ b/packages/core/src/auto-args.ts
@@ -113,6 +113,8 @@ export interface ICanaryOptions {
   build?: number;
   /** The message used when attaching the canary version to a PR */
   message?: string | 'false';
+  /** Always deploy a canary, even if the PR is marked as skip release */
+  force?: boolean;
 }
 
 export interface INextOptions {

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1036,9 +1036,19 @@ export default class Auto {
     const from = (await this.git.shaExists('HEAD^')) ? 'HEAD^' : 'HEAD';
     const head = await this.release.getCommitsInRelease(from);
     const labels = head.map(commit => commit.labels);
-    const version =
-      calculateSemVerBump(labels, this.semVerLabels!, this.config) ||
-      SEMVER.patch;
+    const version = calculateSemVerBump(
+      labels,
+      this.semVerLabels!,
+      this.config
+    );
+
+    if (version === SEMVER.noVersion && !options.force) {
+      this.logger.log.info(
+        'Skipping canary release due to PR being specifying no release. Use `auto canary --force` to override this setting'
+      );
+      return;
+    }
+
     let canaryVersion = '';
     let newVersion = '';
 

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1007,6 +1007,7 @@ export default class Auto {
   }
 
   /** Create a canary (or test) version of the project */
+  // eslint-disable-next-line complexity
   async canary(args: ICanaryOptions = {}): Promise<ShipitInfo | undefined> {
     const options = { ...this.getCommandDefault('canary'), ...args };
     
@@ -1025,7 +1026,7 @@ export default class Auto {
       process.exit(1);
     }
 
-    // await this.checkClean();
+    await this.checkClean();
 
     let { pr, build } = await this.getPrEnvInfo();
     pr = options.pr ? String(options.pr) : pr;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -86,6 +86,7 @@ const globalOptions = t.partial({
   }),
   /** Options to pass to "auto canary" */
   canary: t.partial({
+    force: t.boolean,
     message: t.union([t.literal(false), t.string])
   }),
   /** Options to pass to "auto next" */


### PR DESCRIPTION
Fixes #962

# What Changed

Canaries now no longer publish for PRs that skip the release. A flag `--force` was added to the `canary` subcommand to make it always publish, regardless of label. 

# Why

Often times for things like docs updates or other trivial changes deploying a canary is extra noise that's unnecessary. 

# Open questions

1. Does `shipit` need to be updated with some sort of force flag?
2. Eslint complexity is over the limit on the `canary` function. Should I increase it or refactor that function to pull out some checks?
3. Did I miss updating things anywhere?
4. Should we invert this PR to make it where it releases by default but has a flag to skip canaries if skip release.  (i.e. `--respect-labels` or something)

Todo:

- [ ] Figure out how to handle eslint complexity failure
- [ ] Add tests
- [ ] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.15.4-canary.993.13171.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.15.4-canary.993.13171.0
  npm install @auto-canary/core@9.15.4-canary.993.13171.0
  npm install @auto-canary/all-contributors@9.15.4-canary.993.13171.0
  npm install @auto-canary/chrome@9.15.4-canary.993.13171.0
  npm install @auto-canary/conventional-commits@9.15.4-canary.993.13171.0
  npm install @auto-canary/crates@9.15.4-canary.993.13171.0
  npm install @auto-canary/first-time-contributor@9.15.4-canary.993.13171.0
  npm install @auto-canary/git-tag@9.15.4-canary.993.13171.0
  npm install @auto-canary/gradle@9.15.4-canary.993.13171.0
  npm install @auto-canary/jira@9.15.4-canary.993.13171.0
  npm install @auto-canary/maven@9.15.4-canary.993.13171.0
  npm install @auto-canary/npm@9.15.4-canary.993.13171.0
  npm install @auto-canary/omit-commits@9.15.4-canary.993.13171.0
  npm install @auto-canary/omit-release-notes@9.15.4-canary.993.13171.0
  npm install @auto-canary/released@9.15.4-canary.993.13171.0
  npm install @auto-canary/s3@9.15.4-canary.993.13171.0
  npm install @auto-canary/slack@9.15.4-canary.993.13171.0
  npm install @auto-canary/twitter@9.15.4-canary.993.13171.0
  npm install @auto-canary/upload-assets@9.15.4-canary.993.13171.0
  # or 
  yarn add @auto-canary/auto@9.15.4-canary.993.13171.0
  yarn add @auto-canary/core@9.15.4-canary.993.13171.0
  yarn add @auto-canary/all-contributors@9.15.4-canary.993.13171.0
  yarn add @auto-canary/chrome@9.15.4-canary.993.13171.0
  yarn add @auto-canary/conventional-commits@9.15.4-canary.993.13171.0
  yarn add @auto-canary/crates@9.15.4-canary.993.13171.0
  yarn add @auto-canary/first-time-contributor@9.15.4-canary.993.13171.0
  yarn add @auto-canary/git-tag@9.15.4-canary.993.13171.0
  yarn add @auto-canary/gradle@9.15.4-canary.993.13171.0
  yarn add @auto-canary/jira@9.15.4-canary.993.13171.0
  yarn add @auto-canary/maven@9.15.4-canary.993.13171.0
  yarn add @auto-canary/npm@9.15.4-canary.993.13171.0
  yarn add @auto-canary/omit-commits@9.15.4-canary.993.13171.0
  yarn add @auto-canary/omit-release-notes@9.15.4-canary.993.13171.0
  yarn add @auto-canary/released@9.15.4-canary.993.13171.0
  yarn add @auto-canary/s3@9.15.4-canary.993.13171.0
  yarn add @auto-canary/slack@9.15.4-canary.993.13171.0
  yarn add @auto-canary/twitter@9.15.4-canary.993.13171.0
  yarn add @auto-canary/upload-assets@9.15.4-canary.993.13171.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
