### PR TITLE
Default Config When running shipit

### DIFF
--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -29,7 +29,7 @@ export async function run(command: string, args: ApiOptions) {
       return;
     }
 
-    const config = await auto.loadConfig();
+    await auto.loadConfig();
 
     if (args.verbose || command === 'info') {
       const { hasError } = await auto.info();
@@ -43,51 +43,45 @@ export async function run(command: string, args: ApiOptions) {
       }
     }
 
-    const commandConfig = config[command as keyof typeof config];
-    const allArgs = {
-      ...(typeof commandConfig === 'object' ? commandConfig : {}),
-      ...args
-    };
-
     switch (command) {
       case 'create-labels':
-        await auto.createLabels(allArgs as ICreateLabelsOptions);
+        await auto.createLabels(args as ICreateLabelsOptions);
         break;
       case 'label':
-        await auto.label(allArgs as ILabelOptions);
+        await auto.label(args as ILabelOptions);
         break;
       case 'pr-check':
-        await auto.prCheck(allArgs as IPRCheckOptions);
+        await auto.prCheck(args as IPRCheckOptions);
         break;
       case 'pr-status':
-        await auto.prStatus(allArgs as IPRStatusOptions);
+        await auto.prStatus(args as IPRStatusOptions);
         break;
       case 'comment':
-        await auto.comment(allArgs as ICommentOptions);
+        await auto.comment(args as ICommentOptions);
         break;
       case 'pr-body':
-        await auto.prBody(allArgs as IPRBodyOptions);
+        await auto.prBody(args as IPRBodyOptions);
         break;
       case 'version':
-        await auto.version(allArgs as IVersionOptions);
+        await auto.version(args as IVersionOptions);
         break;
       case 'changelog':
-        await auto.changelog(allArgs as IChangelogOptions);
+        await auto.changelog(args as IChangelogOptions);
         break;
       case 'release':
-        await auto.runRelease(allArgs as IReleaseOptions);
+        await auto.runRelease(args as IReleaseOptions);
         break;
       case 'shipit':
-        await auto.shipit(allArgs as IShipItOptions);
+        await auto.shipit(args as IShipItOptions);
         break;
       case 'latest':
-        await auto.latest(allArgs as IShipItOptions);
+        await auto.latest(args as IShipItOptions);
         break;
       case 'canary':
-        await auto.canary(allArgs as ICanaryOptions);
+        await auto.canary(args as ICanaryOptions);
         break;
       case 'next':
-        await auto.next(allArgs as INextOptions);
+        await auto.next(args as INextOptions);
         break;
       default:
         throw new Error(`idk what i'm doing.`);


### PR DESCRIPTION
# What Changed

only get default config in command that allow it, enables shipit to easily use sub-commands configs

# Why

The default config was only being applied at the command level. meaning if shipit ran a sub-command the default config would be ignored. 

To fix this I moved applying the default config to core only on commands that allow configuration.

Todo:

- [ ] Add tests
- [ ] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.15.1-canary.1000.13013.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.15.1-canary.1000.13013.0
  npm install @auto-canary/core@9.15.1-canary.1000.13013.0
  npm install @auto-canary/all-contributors@9.15.1-canary.1000.13013.0
  npm install @auto-canary/chrome@9.15.1-canary.1000.13013.0
  npm install @auto-canary/conventional-commits@9.15.1-canary.1000.13013.0
  npm install @auto-canary/crates@9.15.1-canary.1000.13013.0
  npm install @auto-canary/first-time-contributor@9.15.1-canary.1000.13013.0
  npm install @auto-canary/git-tag@9.15.1-canary.1000.13013.0
  npm install @auto-canary/gradle@9.15.1-canary.1000.13013.0
  npm install @auto-canary/jira@9.15.1-canary.1000.13013.0
  npm install @auto-canary/maven@9.15.1-canary.1000.13013.0
  npm install @auto-canary/npm@9.15.1-canary.1000.13013.0
  npm install @auto-canary/omit-commits@9.15.1-canary.1000.13013.0
  npm install @auto-canary/omit-release-notes@9.15.1-canary.1000.13013.0
  npm install @auto-canary/released@9.15.1-canary.1000.13013.0
  npm install @auto-canary/s3@9.15.1-canary.1000.13013.0
  npm install @auto-canary/slack@9.15.1-canary.1000.13013.0
  npm install @auto-canary/twitter@9.15.1-canary.1000.13013.0
  npm install @auto-canary/upload-assets@9.15.1-canary.1000.13013.0
  # or 
  yarn add @auto-canary/auto@9.15.1-canary.1000.13013.0
  yarn add @auto-canary/core@9.15.1-canary.1000.13013.0
  yarn add @auto-canary/all-contributors@9.15.1-canary.1000.13013.0
  yarn add @auto-canary/chrome@9.15.1-canary.1000.13013.0
  yarn add @auto-canary/conventional-commits@9.15.1-canary.1000.13013.0
  yarn add @auto-canary/crates@9.15.1-canary.1000.13013.0
  yarn add @auto-canary/first-time-contributor@9.15.1-canary.1000.13013.0
  yarn add @auto-canary/git-tag@9.15.1-canary.1000.13013.0
  yarn add @auto-canary/gradle@9.15.1-canary.1000.13013.0
  yarn add @auto-canary/jira@9.15.1-canary.1000.13013.0
  yarn add @auto-canary/maven@9.15.1-canary.1000.13013.0
  yarn add @auto-canary/npm@9.15.1-canary.1000.13013.0
  yarn add @auto-canary/omit-commits@9.15.1-canary.1000.13013.0
  yarn add @auto-canary/omit-release-notes@9.15.1-canary.1000.13013.0
  yarn add @auto-canary/released@9.15.1-canary.1000.13013.0
  yarn add @auto-canary/s3@9.15.1-canary.1000.13013.0
  yarn add @auto-canary/slack@9.15.1-canary.1000.13013.0
  yarn add @auto-canary/twitter@9.15.1-canary.1000.13013.0
  yarn add @auto-canary/upload-assets@9.15.1-canary.1000.13013.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
