### PR TITLE
Respect PR label when conventional commit message is present

### DIFF
--- a/plugins/conventional-commits/src/index.ts
+++ b/plugins/conventional-commits/src/index.ts
@@ -1,6 +1,6 @@
 import { applyPlugins, mappers, parse } from 'parse-commit-message';
 
-import { Auto, IPlugin, VersionLabel } from '@auto-it/core';
+import { Auto, IPlugin, VersionLabel, SEMVER } from '@auto-it/core';
 
 /**
  * Parse conventional commit messages and use them to
@@ -26,8 +26,20 @@ export default class ConventionalCommitsPlugin implements IPlugin {
           const incrementLabel = auto.semVerLabels.get(
             conventionalCommit.increment as VersionLabel
           );
+          const allSemVerLabels = [
+            auto.semVerLabels.get(SEMVER.major),
+            auto.semVerLabels.get(SEMVER.minor),
+            auto.semVerLabels.get(SEMVER.patch)
+          ].reduce<string[]>(
+            (acc, labels) => (labels ? [...acc, ...labels] : acc),
+            []
+          );
 
-          if (conventionalCommit.header && incrementLabel) {
+          if (
+            conventionalCommit.header &&
+            incrementLabel &&
+            !commit.labels.some(l => allSemVerLabels.includes(l))
+          ) {
             commit.labels = [...commit.labels, ...incrementLabel];
           }
         } catch (error) {


### PR DESCRIPTION
# What Changed

Fix bug where the PR label could be overridden by commit message. In `auto` the labels are the source of truth.

# Why

closes #462

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.15.2-canary.1001.13025.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.15.2-canary.1001.13025.0
  npm install @auto-canary/core@9.15.2-canary.1001.13025.0
  npm install @auto-canary/all-contributors@9.15.2-canary.1001.13025.0
  npm install @auto-canary/chrome@9.15.2-canary.1001.13025.0
  npm install @auto-canary/conventional-commits@9.15.2-canary.1001.13025.0
  npm install @auto-canary/crates@9.15.2-canary.1001.13025.0
  npm install @auto-canary/first-time-contributor@9.15.2-canary.1001.13025.0
  npm install @auto-canary/git-tag@9.15.2-canary.1001.13025.0
  npm install @auto-canary/gradle@9.15.2-canary.1001.13025.0
  npm install @auto-canary/jira@9.15.2-canary.1001.13025.0
  npm install @auto-canary/maven@9.15.2-canary.1001.13025.0
  npm install @auto-canary/npm@9.15.2-canary.1001.13025.0
  npm install @auto-canary/omit-commits@9.15.2-canary.1001.13025.0
  npm install @auto-canary/omit-release-notes@9.15.2-canary.1001.13025.0
  npm install @auto-canary/released@9.15.2-canary.1001.13025.0
  npm install @auto-canary/s3@9.15.2-canary.1001.13025.0
  npm install @auto-canary/slack@9.15.2-canary.1001.13025.0
  npm install @auto-canary/twitter@9.15.2-canary.1001.13025.0
  npm install @auto-canary/upload-assets@9.15.2-canary.1001.13025.0
  # or 
  yarn add @auto-canary/auto@9.15.2-canary.1001.13025.0
  yarn add @auto-canary/core@9.15.2-canary.1001.13025.0
  yarn add @auto-canary/all-contributors@9.15.2-canary.1001.13025.0
  yarn add @auto-canary/chrome@9.15.2-canary.1001.13025.0
  yarn add @auto-canary/conventional-commits@9.15.2-canary.1001.13025.0
  yarn add @auto-canary/crates@9.15.2-canary.1001.13025.0
  yarn add @auto-canary/first-time-contributor@9.15.2-canary.1001.13025.0
  yarn add @auto-canary/git-tag@9.15.2-canary.1001.13025.0
  yarn add @auto-canary/gradle@9.15.2-canary.1001.13025.0
  yarn add @auto-canary/jira@9.15.2-canary.1001.13025.0
  yarn add @auto-canary/maven@9.15.2-canary.1001.13025.0
  yarn add @auto-canary/npm@9.15.2-canary.1001.13025.0
  yarn add @auto-canary/omit-commits@9.15.2-canary.1001.13025.0
  yarn add @auto-canary/omit-release-notes@9.15.2-canary.1001.13025.0
  yarn add @auto-canary/released@9.15.2-canary.1001.13025.0
  yarn add @auto-canary/s3@9.15.2-canary.1001.13025.0
  yarn add @auto-canary/slack@9.15.2-canary.1001.13025.0
  yarn add @auto-canary/twitter@9.15.2-canary.1001.13025.0
  yarn add @auto-canary/upload-assets@9.15.2-canary.1001.13025.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
