### PR TITLE
don't force publish canary/next for independent lerna projects

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -881,7 +881,7 @@ export default class Auto {
    * Comment on a PR. Only one comment will be present on the PR, Older comments are removed.
    * You can use the "context" option to multiple comments on a PR.
    *
-   * @param options - Options for the comment functionality
+   * @param args - Options for the comment functionality
    */
   async comment(args: ICommentOptions) {
     const options = { ...this.getCommandDefault('comment'), ...args };

--- a/plugins/npm/__tests__/__snapshots__/npm.test.ts.snap
+++ b/plugins/npm/__tests__/__snapshots__/npm.test.ts.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`canary dont force publish canaries 1`] = `
+Object {
+  "details": ":sparkles: Test out this PR locally via:
+
+\`\`\`sh
+npm install @foobar/lib@1.1.0.canary
+# or 
+yarn add @foobar/lib@1.1.0.canary
+\`\`\`",
+  "newVersion": "Canary Versions",
+}
+`;

--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -830,6 +830,48 @@ describe('canary', () => {
     ]);
   });
 
+  test('dont force publish canaries', async () => {
+    const plugin = new NPMPlugin();
+    const hooks = makeHooks();
+
+    plugin.apply({
+      config: { prereleaseBranches: ['next'] },
+      hooks,
+      remote: 'origin',
+      baseBranch: 'master',
+      logger: dummyLog(),
+      git: {
+        getLatestRelease: () => Promise.resolve('@foo/lib:1.1.0'),
+        getLatestTagInBranch: () => '1.2.3'
+      }
+    } as any);
+    existsSync.mockReturnValueOnce(true);
+    readFileSync.mockReturnValue('{ "version": "independent" }');
+
+    readResult = `
+      {
+        "name": "test"
+      }
+    `;
+
+    getLernaPackages.mockImplementation(async () =>
+      Promise.resolve([
+        {
+          path: 'path/to/package',
+          name: '@foobar/app',
+          version: '1.2.4'
+        },
+        {
+          path: 'path/to/package',
+          name: '@foobar/lib',
+          version: '1.1.0.canary'
+        }
+      ])
+    );
+
+    expect(await hooks.canary.promise(Auto.SEMVER.patch, '')).toMatchSnapshot()
+  });
+
   test('error when no canary release found - independent', async () => {
     const plugin = new NPMPlugin();
     const hooks = makeHooks();

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -701,7 +701,7 @@ export default class NPMPlugin implements IPlugin {
 
           return {
             newVersion: 'Canary Versions',
-            details: makeMonorepoInstallList(packageList)
+            details: makeMonorepoInstallList(packageList.filter(p => p.includes('canary')))
           };
         }
 

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -451,12 +451,12 @@ export default class NPMPlugin implements IPlugin {
       }
     });
 
-    auto.hooks.beforeShipIt.tap(this.name, async context => {
+    auto.hooks.beforeShipIt.tap(this.name, async () => {
       const isIndependent = getLernaJson().version === 'independent';
 
       // In independent mode it's possible that no changes to packages have been
       // made, so no release will be made.
-      if (isIndependent && context.releaseType === 'latest') {
+      if (isIndependent) {
         try {
           await execPromise('yarn', ['lerna', 'updated']);
         } catch (error) {
@@ -679,7 +679,7 @@ export default class NPMPlugin implements IPlugin {
           next,
           '--dist-tag',
           'canary',
-          '--force-publish', // you always want a canary version to publish
+          !isIndependent && '--force-publish',
           '--yes', // skip prompts,
           '--no-git-reset', // so we can get the version that just published
           '--no-git-tag-version', // no need to tag and commit,
@@ -802,7 +802,7 @@ export default class NPMPlugin implements IPlugin {
           prereleaseBranch,
           '--no-push',
           // you always want a next version to publish
-          '--force-publish',
+          !isIndependent && '--force-publish',
           // skip prompts
           '--yes',
           // do not add ^ to next versions, this can result in `npm i` resolving the wrong next version


### PR DESCRIPTION
# What Changed

In `lerna` independent projects it doesn't make sense to force publish all changes during canary/next. 

# Why

closes #815

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.15.3-canary.1012.13143.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.15.3-canary.1012.13143.0
  npm install @auto-canary/core@9.15.3-canary.1012.13143.0
  npm install @auto-canary/all-contributors@9.15.3-canary.1012.13143.0
  npm install @auto-canary/chrome@9.15.3-canary.1012.13143.0
  npm install @auto-canary/conventional-commits@9.15.3-canary.1012.13143.0
  npm install @auto-canary/crates@9.15.3-canary.1012.13143.0
  npm install @auto-canary/first-time-contributor@9.15.3-canary.1012.13143.0
  npm install @auto-canary/git-tag@9.15.3-canary.1012.13143.0
  npm install @auto-canary/gradle@9.15.3-canary.1012.13143.0
  npm install @auto-canary/jira@9.15.3-canary.1012.13143.0
  npm install @auto-canary/maven@9.15.3-canary.1012.13143.0
  npm install @auto-canary/npm@9.15.3-canary.1012.13143.0
  npm install @auto-canary/omit-commits@9.15.3-canary.1012.13143.0
  npm install @auto-canary/omit-release-notes@9.15.3-canary.1012.13143.0
  npm install @auto-canary/released@9.15.3-canary.1012.13143.0
  npm install @auto-canary/s3@9.15.3-canary.1012.13143.0
  npm install @auto-canary/slack@9.15.3-canary.1012.13143.0
  npm install @auto-canary/twitter@9.15.3-canary.1012.13143.0
  npm install @auto-canary/upload-assets@9.15.3-canary.1012.13143.0
  # or 
  yarn add @auto-canary/auto@9.15.3-canary.1012.13143.0
  yarn add @auto-canary/core@9.15.3-canary.1012.13143.0
  yarn add @auto-canary/all-contributors@9.15.3-canary.1012.13143.0
  yarn add @auto-canary/chrome@9.15.3-canary.1012.13143.0
  yarn add @auto-canary/conventional-commits@9.15.3-canary.1012.13143.0
  yarn add @auto-canary/crates@9.15.3-canary.1012.13143.0
  yarn add @auto-canary/first-time-contributor@9.15.3-canary.1012.13143.0
  yarn add @auto-canary/git-tag@9.15.3-canary.1012.13143.0
  yarn add @auto-canary/gradle@9.15.3-canary.1012.13143.0
  yarn add @auto-canary/jira@9.15.3-canary.1012.13143.0
  yarn add @auto-canary/maven@9.15.3-canary.1012.13143.0
  yarn add @auto-canary/npm@9.15.3-canary.1012.13143.0
  yarn add @auto-canary/omit-commits@9.15.3-canary.1012.13143.0
  yarn add @auto-canary/omit-release-notes@9.15.3-canary.1012.13143.0
  yarn add @auto-canary/released@9.15.3-canary.1012.13143.0
  yarn add @auto-canary/s3@9.15.3-canary.1012.13143.0
  yarn add @auto-canary/slack@9.15.3-canary.1012.13143.0
  yarn add @auto-canary/twitter@9.15.3-canary.1012.13143.0
  yarn add @auto-canary/upload-assets@9.15.3-canary.1012.13143.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
