### PR TITLE
fix "Push to master" on next branch

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/changelog.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/changelog.test.ts.snap
@@ -71,6 +71,20 @@ exports[`generateReleaseNotes doesn't add additional release notes when there ar
 - Adam Dierkens (adam@dierkens.com)"
 `;
 
+exports[`generateReleaseNotes should add "Push to Next" 1`] = `
+"#### 🚀  Enhancement
+
+- First Feature [#1235](https://github.custom.com/foobar/auto/pull/1235) (adam@dierkens.com)
+
+#### ⚠️  Pushed to \`next\`
+
+- I was a push to master  (adam@dierkens.com)
+
+#### Authors: 1
+
+- Adam Dierkens (adam@dierkens.com)"
+`;
+
 exports[`generateReleaseNotes should add additional release notes 1`] = `
 "### Release Notes
 
@@ -169,7 +183,7 @@ exports[`generateReleaseNotes should include PR-less commits as patches 1`] = `
 
 - First Feature [#1235](https://github.custom.com/foobar/auto/pull/1235) (adam@dierkens.com)
 
-#### ⚠️  Pushed to master
+#### ⚠️  Pushed to \`master\`
 
 - I was a push to master  (adam@dierkens.com)
 
@@ -270,16 +284,6 @@ exports[`generateReleaseNotes should order the section major, minor, patch, then
 - Adam Dierkens (adam@dierkens.com)"
 `;
 
-exports[`generateReleaseNotes should prefer section with highest releaseType for PR with multiple labels 1`] = `
-"#### Minor Section
-
-- Some Feature [#1234](https://github.custom.com/foobar/auto/pull/1234) (adam@dierkens.com)
-
-#### Authors: 1
-
-- Adam Dierkens (adam@dierkens.com)"
-`;
-
 exports[`generateReleaseNotes should prefer section defined first in config for PR with multiple labels of same releaseType 1`] = `
 "#### Internal Section
 
@@ -292,6 +296,16 @@ exports[`generateReleaseNotes should prefer section defined first in config for 
 
 exports[`generateReleaseNotes should prefer section of default label for PR with multiple labels of same releaseType 1`] = `
 "#### 🚀  Enhancement
+
+- Some Feature [#1234](https://github.custom.com/foobar/auto/pull/1234) (adam@dierkens.com)
+
+#### Authors: 1
+
+- Adam Dierkens (adam@dierkens.com)"
+`;
+
+exports[`generateReleaseNotes should prefer section with highest releaseType for PR with multiple labels 1`] = `
+"#### Minor Section
 
 - Some Feature [#1234](https://github.custom.com/foobar/auto/pull/1234) (adam@dierkens.com)
 

--- a/packages/core/src/__tests__/__snapshots__/release.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/release.test.ts.snap
@@ -62,7 +62,7 @@ exports[`Release generateReleaseNotes should include PR-less commits 1`] = `
 
 - First Feature [#1235](https://github.com/web/site/pull/1235) (adam@dierkens.com)
 
-#### ⚠️  Pushed to master
+#### ⚠️  Pushed to \`master\`
 
 - I should be included  (adam@dierkens.com)
 
@@ -102,7 +102,7 @@ exports[`Release generateReleaseNotes should match rebased commits to PRs 1`] = 
 - Feature [#124](https://github.com/web/site/pull/124) (adam@dierkens.com)
 - I was rebased [#123](https://github.com/web/site/pull/123) (adam@dierkens.com)
 
-#### ⚠️  Pushed to master
+#### ⚠️  Pushed to \`master\`
 
 - I am a commit to master  (adam@dierkens.com)
 

--- a/packages/core/src/__tests__/changelog.test.ts
+++ b/packages/core/src/__tests__/changelog.test.ts
@@ -6,12 +6,16 @@ import { dummyLog } from '../utils/logger';
 
 import makeCommitFromMsg from './make-commit-from-msg';
 import SEMVER from '../semver';
+import { getCurrentBranch } from '../utils/get-current-branch';
+
+const currentBranchSpy = getCurrentBranch as jest.Mock;
+jest.mock('../utils/get-current-branch');
 
 const testOptions = (): IGenerateReleaseNotesOptions => ({
   owner: 'foobar',
   repo: 'auto',
   baseUrl: 'https://github.custom.com/foobar/auto',
-  labels: defaultLabels,
+  labels: [...defaultLabels],
   baseBranch: 'master',
   prereleaseBranches: ['next']
 });
@@ -24,7 +28,7 @@ describe('createUserLink', () => {
       owner: '',
       repo: '',
       baseUrl: 'https://github.custom.com/',
-      labels: defaultLabels,
+      labels: [...defaultLabels],
       baseBranch: 'master',
       prereleaseBranches: ['next']
     });
@@ -64,7 +68,7 @@ describe('createUserLink', () => {
       owner: '',
       repo: '',
       baseUrl: 'https://github.custom.com/',
-      labels: defaultLabels,
+      labels: [...defaultLabels],
       baseBranch: 'master',
       prereleaseBranches: ['next']
     });
@@ -331,6 +335,33 @@ describe('generateReleaseNotes', () => {
   });
 
   test('should include PR-less commits as patches', async () => {
+    const changelog = new Changelog(dummyLog(), testOptions());
+    changelog.loadDefaultHooks();
+
+    const commits = await logParse.normalizeCommits([
+      {
+        hash: '1',
+        files: [],
+        authorName: 'Adam Dierkens',
+        authorEmail: 'adam@dierkens.com',
+        subject: 'I was a push to master\n\n',
+        labels: ['pushToBaseBranch']
+      },
+      {
+        hash: '2',
+        files: [],
+        authorName: 'Adam Dierkens',
+        authorEmail: 'adam@dierkens.com',
+        subject: 'First Feature (#1235)',
+        labels: ['minor']
+      }
+    ]);
+
+    expect(await changelog.generateReleaseNotes(commits)).toMatchSnapshot();
+  });
+
+  test('should add "Push to Next"', async () => {
+    currentBranchSpy.mockReturnValueOnce('next')
     const changelog = new Changelog(dummyLog(), testOptions());
     changelog.loadDefaultHooks();
 

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -46,7 +46,7 @@ import execPromise from './utils/exec-promise';
 import loadPlugin, { IPlugin } from './utils/load-plugins';
 import createLog, { ILogger, setLogLevel } from './utils/logger';
 import { makeHooks } from './utils/make-hooks';
-import { execSync } from 'child_process';
+import { getCurrentBranch } from './utils/get-current-branch';
 import { buildSearchQuery, ISearchResult } from './match-sha-to-pr';
 import getRepository from './utils/get-repository';
 import {
@@ -273,31 +273,6 @@ export function determineNextVersion(
   return lte(next, currentVersion)
     ? inc(currentVersion, 'prerelease', tag) || 'prerelease'
     : next;
-}
-
-/** Get the current branch the git repo is set to */
-export function getCurrentBranch() {
-  const isPR = 'isPr' in env && env.isPr;
-  let branch: string | undefined;
-  // env-ci sets branch to target branch (ex: master) in some CI services.
-  // so we should make sure we aren't in a PR just to be safe
-
-  if (isPR && 'prBranch' in env) {
-    branch = env.prBranch;
-  } else {
-    branch = env.branch;
-  }
-
-  if (!branch) {
-    try {
-      branch = execSync('git symbolic-ref --short HEAD', {
-        encoding: 'utf8',
-        stdio: 'ignore'
-      });
-    } catch (error) {}
-  }
-
-  return branch;
 }
 
 /** Print the current version of "auto" */
@@ -1839,6 +1814,7 @@ export default class Auto {
 
 export * from './auto-args';
 export { default as InteractiveInit } from './init';
+export { getCurrentBranch } from './utils/get-current-branch';
 export { validatePluginConfiguration } from './validate-config';
 export { ILogger } from './utils/logger';
 export { IPlugin } from './utils/load-plugins';

--- a/packages/core/src/changelog.ts
+++ b/packages/core/src/changelog.ts
@@ -6,6 +6,7 @@ import { ICommitAuthor, IExtendedCommit } from './log-parse';
 import { ILabelDefinition } from './release';
 import { ILogger } from './utils/logger';
 import { makeChangelogHooks } from './utils/make-hooks';
+import { getCurrentBranch } from './utils/get-current-branch';
 import SEMVER from './semver';
 
 export interface IGenerateReleaseNotesOptions {
@@ -83,14 +84,23 @@ export default class Changelog {
     this.logger = logger;
     this.options = options;
     this.hooks = makeChangelogHooks();
+    const currentBranch = getCurrentBranch();
 
-    if (!this.options.labels.find(l => l.name === 'pushToBaseBranch'))
+    if (!this.options.labels.find(l => l.name === 'pushToBaseBranch')) {
+      // Either put the name of a prerelease branch or the base-branch in the changelog
+      const branch =
+        (currentBranch &&
+          options.prereleaseBranches.includes(currentBranch) &&
+          currentBranch) ||
+        options.baseBranch;
+
       this.options.labels.push({
         name: 'pushToBaseBranch',
-        changelogTitle: `⚠️  Pushed to ${options.baseBranch}`,
+        changelogTitle: `⚠️  Pushed to \`${branch}\``,
         description: 'N/A',
         releaseType: SEMVER.patch
       });
+    }
   }
 
   /** Load the default configuration */

--- a/packages/core/src/utils/get-current-branch.ts
+++ b/packages/core/src/utils/get-current-branch.ts
@@ -1,0 +1,29 @@
+import envCi from 'env-ci';
+import { execSync } from 'child_process';
+
+const env = envCi();
+
+/** Get the current branch the git repo is set to */
+export function getCurrentBranch() {
+  const isPR = 'isPr' in env && env.isPr;
+  let branch: string | undefined;
+  // env-ci sets branch to target branch (ex: master) in some CI services.
+  // so we should make sure we aren't in a PR just to be safe
+
+  if (isPR && 'prBranch' in env) {
+    branch = env.prBranch;
+  } else {
+    branch = env.branch;
+  }
+
+  if (!branch) {
+    try {
+      branch = execSync('git symbolic-ref --short HEAD', {
+        encoding: 'utf8',
+        stdio: 'ignore'
+      });
+    } catch (error) {}
+  }
+
+  return branch;
+}


### PR DESCRIPTION
# What Changed

see title

# Why

closes #823 

Todo:

- [x] Add tests


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.15.5-canary.1013.13183.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.15.5-canary.1013.13183.0
  npm install @auto-canary/core@9.15.5-canary.1013.13183.0
  npm install @auto-canary/all-contributors@9.15.5-canary.1013.13183.0
  npm install @auto-canary/chrome@9.15.5-canary.1013.13183.0
  npm install @auto-canary/conventional-commits@9.15.5-canary.1013.13183.0
  npm install @auto-canary/crates@9.15.5-canary.1013.13183.0
  npm install @auto-canary/first-time-contributor@9.15.5-canary.1013.13183.0
  npm install @auto-canary/git-tag@9.15.5-canary.1013.13183.0
  npm install @auto-canary/gradle@9.15.5-canary.1013.13183.0
  npm install @auto-canary/jira@9.15.5-canary.1013.13183.0
  npm install @auto-canary/maven@9.15.5-canary.1013.13183.0
  npm install @auto-canary/npm@9.15.5-canary.1013.13183.0
  npm install @auto-canary/omit-commits@9.15.5-canary.1013.13183.0
  npm install @auto-canary/omit-release-notes@9.15.5-canary.1013.13183.0
  npm install @auto-canary/released@9.15.5-canary.1013.13183.0
  npm install @auto-canary/s3@9.15.5-canary.1013.13183.0
  npm install @auto-canary/slack@9.15.5-canary.1013.13183.0
  npm install @auto-canary/twitter@9.15.5-canary.1013.13183.0
  npm install @auto-canary/upload-assets@9.15.5-canary.1013.13183.0
  # or 
  yarn add @auto-canary/auto@9.15.5-canary.1013.13183.0
  yarn add @auto-canary/core@9.15.5-canary.1013.13183.0
  yarn add @auto-canary/all-contributors@9.15.5-canary.1013.13183.0
  yarn add @auto-canary/chrome@9.15.5-canary.1013.13183.0
  yarn add @auto-canary/conventional-commits@9.15.5-canary.1013.13183.0
  yarn add @auto-canary/crates@9.15.5-canary.1013.13183.0
  yarn add @auto-canary/first-time-contributor@9.15.5-canary.1013.13183.0
  yarn add @auto-canary/git-tag@9.15.5-canary.1013.13183.0
  yarn add @auto-canary/gradle@9.15.5-canary.1013.13183.0
  yarn add @auto-canary/jira@9.15.5-canary.1013.13183.0
  yarn add @auto-canary/maven@9.15.5-canary.1013.13183.0
  yarn add @auto-canary/npm@9.15.5-canary.1013.13183.0
  yarn add @auto-canary/omit-commits@9.15.5-canary.1013.13183.0
  yarn add @auto-canary/omit-release-notes@9.15.5-canary.1013.13183.0
  yarn add @auto-canary/released@9.15.5-canary.1013.13183.0
  yarn add @auto-canary/s3@9.15.5-canary.1013.13183.0
  yarn add @auto-canary/slack@9.15.5-canary.1013.13183.0
  yarn add @auto-canary/twitter@9.15.5-canary.1013.13183.0
  yarn add @auto-canary/upload-assets@9.15.5-canary.1013.13183.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
