### PR TITLE
info: handle when there is no previous version

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -552,7 +552,9 @@ export default class Auto {
     const repo = (await this.getRepo(this.config!)) || {};
     const repoLink = link(`${repo.owner}/${repo.repo}`, project?.html_url!);
     const author = (await this.getGitUser()) || ({} as IAuthor);
-    const version = await this.getCurrentVersion(await this.git.getLatestRelease());
+    const version = await this.getCurrentVersion(
+      await this.git.getLatestRelease()
+    );
     const [err, latestRelease] = await on(this.git.getLatestReleaseInfo());
     const latestReleaseLink = latestRelease
       ? link(latestRelease.tag_name, latestRelease.html_url)
@@ -985,7 +987,7 @@ export default class Auto {
   // eslint-disable-next-line complexity
   async canary(args: ICanaryOptions = {}): Promise<ShipitInfo | undefined> {
     const options = { ...this.getCommandDefault('canary'), ...args };
-    
+
     if (!this.git || !this.release) {
       throw this.createErrorMessage();
     }
@@ -1103,7 +1105,7 @@ export default class Auto {
    */
   async next(args: INextOptions): Promise<ShipitInfo | undefined> {
     const options = { ...this.getCommandDefault('next'), ...args };
-    
+
     if (!this.git || !this.release) {
       throw this.createErrorMessage();
     }
@@ -1203,7 +1205,10 @@ export default class Auto {
    * 4. Create a release
    */
   async shipit(args: IShipItOptions = {}) {
-    const options: IShipItOptions = { ...this.getCommandDefault('shipit'), ...args };
+    const options: IShipItOptions = {
+      ...this.getCommandDefault('shipit'),
+      ...args
+    };
 
     if (!this.git || !this.release) {
       throw this.createErrorMessage();
@@ -1510,12 +1515,7 @@ export default class Auto {
   /** Make a release over a range of commits */
   private async makeRelease(args: IReleaseOptions = {}) {
     const options = { ...this.getCommandDefault('release'), ...args };
-    const {
-      dryRun,
-      from,
-      useVersion,
-      prerelease = false
-    } = options;
+    const { dryRun, from, useVersion, prerelease = false } = options;
 
     if (!this.release || !this.git) {
       throw this.createErrorMessage();

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -552,7 +552,7 @@ export default class Auto {
     const repo = (await this.getRepo(this.config!)) || {};
     const repoLink = link(`${repo.owner}/${repo.repo}`, project?.html_url!);
     const author = (await this.getGitUser()) || ({} as IAuthor);
-    const version = await this.hooks.getPreviousVersion.promise();
+    const version = await this.getCurrentVersion(await this.git.getLatestRelease());
     const [err, latestRelease] = await on(this.git.getLatestReleaseInfo());
     const latestReleaseLink = latestRelease
       ? link(latestRelease.tag_name, latestRelease.html_url)


### PR DESCRIPTION
# What Changed

see title.

# Why

closes #1014



<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.15.6-canary.1015.13205.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.15.6-canary.1015.13205.0
  npm install @auto-canary/core@9.15.6-canary.1015.13205.0
  npm install @auto-canary/all-contributors@9.15.6-canary.1015.13205.0
  npm install @auto-canary/chrome@9.15.6-canary.1015.13205.0
  npm install @auto-canary/conventional-commits@9.15.6-canary.1015.13205.0
  npm install @auto-canary/crates@9.15.6-canary.1015.13205.0
  npm install @auto-canary/first-time-contributor@9.15.6-canary.1015.13205.0
  npm install @auto-canary/git-tag@9.15.6-canary.1015.13205.0
  npm install @auto-canary/gradle@9.15.6-canary.1015.13205.0
  npm install @auto-canary/jira@9.15.6-canary.1015.13205.0
  npm install @auto-canary/maven@9.15.6-canary.1015.13205.0
  npm install @auto-canary/npm@9.15.6-canary.1015.13205.0
  npm install @auto-canary/omit-commits@9.15.6-canary.1015.13205.0
  npm install @auto-canary/omit-release-notes@9.15.6-canary.1015.13205.0
  npm install @auto-canary/released@9.15.6-canary.1015.13205.0
  npm install @auto-canary/s3@9.15.6-canary.1015.13205.0
  npm install @auto-canary/slack@9.15.6-canary.1015.13205.0
  npm install @auto-canary/twitter@9.15.6-canary.1015.13205.0
  npm install @auto-canary/upload-assets@9.15.6-canary.1015.13205.0
  # or 
  yarn add @auto-canary/auto@9.15.6-canary.1015.13205.0
  yarn add @auto-canary/core@9.15.6-canary.1015.13205.0
  yarn add @auto-canary/all-contributors@9.15.6-canary.1015.13205.0
  yarn add @auto-canary/chrome@9.15.6-canary.1015.13205.0
  yarn add @auto-canary/conventional-commits@9.15.6-canary.1015.13205.0
  yarn add @auto-canary/crates@9.15.6-canary.1015.13205.0
  yarn add @auto-canary/first-time-contributor@9.15.6-canary.1015.13205.0
  yarn add @auto-canary/git-tag@9.15.6-canary.1015.13205.0
  yarn add @auto-canary/gradle@9.15.6-canary.1015.13205.0
  yarn add @auto-canary/jira@9.15.6-canary.1015.13205.0
  yarn add @auto-canary/maven@9.15.6-canary.1015.13205.0
  yarn add @auto-canary/npm@9.15.6-canary.1015.13205.0
  yarn add @auto-canary/omit-commits@9.15.6-canary.1015.13205.0
  yarn add @auto-canary/omit-release-notes@9.15.6-canary.1015.13205.0
  yarn add @auto-canary/released@9.15.6-canary.1015.13205.0
  yarn add @auto-canary/s3@9.15.6-canary.1015.13205.0
  yarn add @auto-canary/slack@9.15.6-canary.1015.13205.0
  yarn add @auto-canary/twitter@9.15.6-canary.1015.13205.0
  yarn add @auto-canary/upload-assets@9.15.6-canary.1015.13205.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
