### PR TITLE
determine if branch behind remote and exit before trying to publish

### DIFF
--- a/docs/pages/quick-merge.md
+++ b/docs/pages/quick-merge.md
@@ -1,12 +1,11 @@
 # Merging Quickly
 
-One major caveat of `auto` is that you need to be mindful of merging multiple PRs at once. You **must not** merge two PRs at once or you _will_ botch one of the releases.
+One caveat of `auto` is that you need to be mindful of merging multiple PRs at once. You **must not** merge a PR while another is publishing (ex: `lerna publish`). While this window is small, it exists and you should know about it.
 
-`auto` works by looking at the `git` tree to calculate the version bump then makes commits for the `CHANGELOG.md` and the new version. If you merge two PRs at once:
+`auto` works by looking at the `git` tree to calculate the version bump then makes commits for the `CHANGELOG.md` and the new version. If you merge a PR while another is publishing:
 
-1. one might pick up the others changes
-2. they might try to publish the same version number
-3. one will try to push over the other's changes and fail
+- they might try to publish the same version number
+- one will try to push over the other's changes and fail
 
 ::: message is-success
 If you ensure that the last build on master has finished you shouldn't run into any problems!

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -192,13 +192,12 @@ Global Options
 
 ## Merging Quickly
 
-One major caveat of `auto` is that you need to be mindful of merging multiple PRs at once. You must not merge two PRs at once or you will botch one of the releases.
+One caveat of `auto` is that you need to be mindful of merging multiple PRs at once. You **must not** merge a PR while another is publishing (ex: `lerna publish`). While this window is small, it exists and you should know about it.
 
-`auto` works by looking at the `git` tree to calculate the version bump then makes commits for the `CHANGELOG.md` and the new version. If you merge two PRs at once:
+`auto` works by looking at the `git` tree to calculate the version bump then makes commits for the `CHANGELOG.md` and the new version. If you merge a PR while another is publishing:
 
-1. one might pick up the others changes
-2. they might try to publish the same version number
-3. one will try to push over the other's changes and fail
+- they might try to publish the same version number
+- one will try to push over the other's changes and fail
 
 The one [exception](https://intuit.github.io/auto/pages/quick-merge.html#with-skip-release) to this rule with when merging a bunch of PRs with `skip-release` labels.
 

--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -1247,6 +1247,7 @@ describe('Auto', () => {
       auto.checkClean = () => Promise.resolve(true);
       auto.logger = dummyLog();
       await auto.loadConfig();
+      auto.remote = 'https://github.com/intuit/auto'
 
       // @ts-ignore
       auto.makeChangelog = () => Promise.resolve();

--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -1263,7 +1263,7 @@ describe('Auto', () => {
       expect(afterShipIt).toHaveBeenCalled();
     });
 
-    test('should not publish when no behind remote', async () => {
+    test('should not publish when behind remote', async () => {
       jest.spyOn(child, 'execSync').mockImplementation(command => {
         if (command.startsWith('git')) {
           throw new Error();

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -382,7 +382,6 @@ export default class Auto {
         ]);
         const [, remoteHead] = heads.match(/^(\w+)?/) || [];
 
-        console.log({remoteHead})
         if (remoteHead) {
           // This will throw if the branch is ahead of the current branch
           execSync(`git merge-base --is-ancestor ${remoteHead} HEAD`);

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -370,12 +370,10 @@ export default class Auto {
      * Determine if repo is behind HEAD of current branch. We do this in
      * the "afterVersion" hook so the check happens as late as possible.
      */
-    console.log(this.remote)
     this.hooks.afterVersion.tapPromise('Check remote for commits', async () => {
       // Credit from https://github.com/semantic-release/semantic-release/blob/b2b7b57fbd51af3fe25accdd6cd8499beb9005e5/lib/git.js#L179
       // `true` is the HEAD of the current local branch is the same as the HEAD of the remote branch, falsy otherwise.
       try {
-        console.log(this.remote)
         const heads = await execPromise('git', [
           'ls-remote',
           '--heads',

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -370,10 +370,12 @@ export default class Auto {
      * Determine if repo is behind HEAD of current branch. We do this in
      * the "afterVersion" hook so the check happens as late as possible.
      */
+    console.log(this.remote)
     this.hooks.afterVersion.tapPromise('Check remote for commits', async () => {
       // Credit from https://github.com/semantic-release/semantic-release/blob/b2b7b57fbd51af3fe25accdd6cd8499beb9005e5/lib/git.js#L179
       // `true` is the HEAD of the current local branch is the same as the HEAD of the remote branch, falsy otherwise.
       try {
+        console.log(this.remote)
         const heads = await execPromise('git', [
           'ls-remote',
           '--heads',

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -62,6 +62,7 @@ import {
   formatError
 } from './validate-config';
 import { omit } from './utils/omit';
+import { execSync } from 'child_process';
 
 const proxyUrl = process.env.https_proxy || process.env.http_proxy;
 const env = envCi();
@@ -396,6 +397,39 @@ export default class Auto {
           options.newVersion,
           options.isPrerelease
         );
+      }
+    });
+
+    /** 
+     * Determine if repo is behind HEAD of current branch. We do this in
+     * the "afterVersion" hook so the check happens as late as possible.
+     */
+    this.hooks.afterVersion.tapPromise('Check remote for commits', async () => {
+      // Credit from https://github.com/semantic-release/semantic-release/blob/b2b7b57fbd51af3fe25accdd6cd8499beb9005e5/lib/git.js#L179
+      // `true` is the HEAD of the current local branch is the same as the HEAD of the remote branch, falsy otherwise.
+      try {
+        const heads = await execPromise('git', [
+          'ls-remote',
+          '--heads',
+          this.remote,
+          getCurrentBranch()
+        ]);
+        const [, remoteHead] = heads.match(/^(\w+)?/) || [];
+
+        if (remoteHead) {
+          // This will throw if the branch is ahead of the current branch
+          execSync(`git merge-base --is-ancestor ${remoteHead} HEAD`);
+        }
+
+        this.logger.verbose.info(
+          'Current branch is up to date, proceeding with release'
+        );
+      } catch (error) {
+        // If we are behind or there is no match, exit and skip the release
+        this.logger.log.warn(
+          'Current commit is behind, skipping the release to avoid collisions.'
+        );
+        process.exit(0);
       }
     });
   }

--- a/plugins/git-tag/src/index.ts
+++ b/plugins/git-tag/src/index.ts
@@ -40,7 +40,6 @@ export default class GitTagPlugin implements IPlugin {
 
       const lastTag = await getTag();
       const newTag = inc(lastTag, version as ReleaseType);
-      const branch = getCurrentBranch() || '';
 
       if (!newTag) {
         auto.logger.log.info('No release found, doing nothing');
@@ -55,15 +54,6 @@ export default class GitTagPlugin implements IPlugin {
         prefixedTag,
         '-m',
         `"Update version to ${prefixedTag}"`
-      ]);
-
-      auto.logger.log.info(`Pushing new tag to GitHub: ${prefixedTag}`);
-      await execPromise('git', [
-        'push',
-        '--follow-tags',
-        '--set-upstream',
-        auto.remote,
-        branch || auto.baseBranch
       ]);
     });
 
@@ -98,5 +88,17 @@ export default class GitTagPlugin implements IPlugin {
 
       return preReleaseVersions;
     });
+
+    auto.hooks.publish.tapPromise(this.name, async () => {
+      auto.logger.log.info('Pushing new tag to GitHub');
+
+      await execPromise('git', [
+        'push',
+        '--follow-tags',
+        '--set-upstream',
+        auto.remote,
+        getCurrentBranch() || auto.baseBranch
+      ]);
+    })
   }
 }


### PR DESCRIPTION
# What Changed

Between the `version` and `publish` hooks we check `remote` to see if there are any new commits. If there are we abort the release, since we would not be able to push our commits onto the `baseBranch` without `--force` or rebasing.

# Why

This will help with the "Merging too quickly" problem. The only case it does not cover is where a publish takes a long time (for instance in a lerna monorepo) and a change is merged while this publish is running. The PR merged during publish will fail because of new commits on the remote.

closes #825 

Todo:

- [ ] Add tests


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.16.0-canary.1018.13286.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.16.0-canary.1018.13286.0
  npm install @auto-canary/core@9.16.0-canary.1018.13286.0
  npm install @auto-canary/all-contributors@9.16.0-canary.1018.13286.0
  npm install @auto-canary/chrome@9.16.0-canary.1018.13286.0
  npm install @auto-canary/conventional-commits@9.16.0-canary.1018.13286.0
  npm install @auto-canary/crates@9.16.0-canary.1018.13286.0
  npm install @auto-canary/first-time-contributor@9.16.0-canary.1018.13286.0
  npm install @auto-canary/git-tag@9.16.0-canary.1018.13286.0
  npm install @auto-canary/gradle@9.16.0-canary.1018.13286.0
  npm install @auto-canary/jira@9.16.0-canary.1018.13286.0
  npm install @auto-canary/maven@9.16.0-canary.1018.13286.0
  npm install @auto-canary/npm@9.16.0-canary.1018.13286.0
  npm install @auto-canary/omit-commits@9.16.0-canary.1018.13286.0
  npm install @auto-canary/omit-release-notes@9.16.0-canary.1018.13286.0
  npm install @auto-canary/released@9.16.0-canary.1018.13286.0
  npm install @auto-canary/s3@9.16.0-canary.1018.13286.0
  npm install @auto-canary/slack@9.16.0-canary.1018.13286.0
  npm install @auto-canary/twitter@9.16.0-canary.1018.13286.0
  npm install @auto-canary/upload-assets@9.16.0-canary.1018.13286.0
  # or 
  yarn add @auto-canary/auto@9.16.0-canary.1018.13286.0
  yarn add @auto-canary/core@9.16.0-canary.1018.13286.0
  yarn add @auto-canary/all-contributors@9.16.0-canary.1018.13286.0
  yarn add @auto-canary/chrome@9.16.0-canary.1018.13286.0
  yarn add @auto-canary/conventional-commits@9.16.0-canary.1018.13286.0
  yarn add @auto-canary/crates@9.16.0-canary.1018.13286.0
  yarn add @auto-canary/first-time-contributor@9.16.0-canary.1018.13286.0
  yarn add @auto-canary/git-tag@9.16.0-canary.1018.13286.0
  yarn add @auto-canary/gradle@9.16.0-canary.1018.13286.0
  yarn add @auto-canary/jira@9.16.0-canary.1018.13286.0
  yarn add @auto-canary/maven@9.16.0-canary.1018.13286.0
  yarn add @auto-canary/npm@9.16.0-canary.1018.13286.0
  yarn add @auto-canary/omit-commits@9.16.0-canary.1018.13286.0
  yarn add @auto-canary/omit-release-notes@9.16.0-canary.1018.13286.0
  yarn add @auto-canary/released@9.16.0-canary.1018.13286.0
  yarn add @auto-canary/s3@9.16.0-canary.1018.13286.0
  yarn add @auto-canary/slack@9.16.0-canary.1018.13286.0
  yarn add @auto-canary/twitter@9.16.0-canary.1018.13286.0
  yarn add @auto-canary/upload-assets@9.16.0-canary.1018.13286.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
