### PR TITLE
test for ancestor in windows friendly way

### DIFF
--- a/packages/core/src/__tests__/release.test.ts
+++ b/packages/core/src/__tests__/release.test.ts
@@ -379,9 +379,11 @@ describe('Release', () => {
           })
         ])
       );
-      exec.mockReturnValueOnce('1');
       exec.mockReturnValueOnce('0');
-
+      exec.mockImplementationOnce(() => {
+        throw new Error();
+      });
+      
       expect(await gh.getCommits('12345', '1234')).toMatchSnapshot();
     });
 

--- a/packages/core/src/release.ts
+++ b/packages/core/src/release.ts
@@ -378,14 +378,14 @@ export default class Release {
         released = false;
       } catch (error) {
         // --is-ancestor returned false so the commit is **before** "from"
-        // so do no release this commit again
+        // so do not release this commit again
         released = true;
       }
 
       if (released) {
         const shortHash = commit.hash.slice(0, 8);
         this.logger.verbose.warn(
-          `Commit already released omitting: "${shortHash}": "${commit.subject}"`
+          `Commit already released, omitting: ${shortHash}: "${commit.subject}"`
         );
       }
 

--- a/packages/core/src/release.ts
+++ b/packages/core/src/release.ts
@@ -367,37 +367,29 @@ export default class Release {
 
     const logParse = await this.createLogParse();
     const commits = (await logParse.normalizeCommits(gitlog)).filter(commit => {
+      let released: boolean;
+
       try {
-        let released: boolean;
-
-        try {
-          // This determines:         Is this commit an ancestor of this commit
-          //                                       ↓                ↓	
-          execSync(`git merge-base --is-ancestor ${from} ${commit.hash}`, {
-            encoding: 'utf8'
-          });
-          released = false;
-        } catch (error) {
-          // --is-ancestor returned false so the commit is **before** "from"
-          // so do no release this commit again
-          released = true;
-        }
-
-        if (released) {
-          this.logger.verbose.warn(
-            `Commit already released omitting: "${commit.hash.slice(
-              0,
-              8
-            )}" with message "${commit.subject}"`
-          );
-        }
-
-        return !released;
+        // This determines:         Is this commit an ancestor of this commit?
+        //                                       ↓                ↓
+        execSync(`git merge-base --is-ancestor ${from} ${commit.hash}`, {
+          encoding: 'utf8'
+        });
+        released = false;
       } catch (error) {
-        this.logger.verbose.warn(error);
-        // If an error happens include the commit to be safe.
-        return true;
+        // --is-ancestor returned false so the commit is **before** "from"
+        // so do no release this commit again
+        released = true;
       }
+
+      if (released) {
+        const shortHash = commit.hash.slice(0, 8);
+        this.logger.verbose.warn(
+          `Commit already released omitting: "${shortHash}": "${commit.subject}"`
+        );
+      }
+
+      return !released;
     });
 
     this.logger.veryVerbose.info('Added labels to commits:\n', commits);

--- a/packages/core/src/release.ts
+++ b/packages/core/src/release.ts
@@ -371,8 +371,8 @@ export default class Release {
         let released: boolean;
 
         try {
-          // 0 exit code means that "from" is an ancestor of the commit
-          // and should be released
+          // This determines:         Is this commit an ancestor of this commit
+          //                                       ↓                ↓	
           execSync(`git merge-base --is-ancestor ${from} ${commit.hash}`, {
             encoding: 'utf8'
           });


### PR DESCRIPTION
# What Changed

The whole `; echo$?` part was not windows (or human) friendly enough. Changed it to a `try/catch`

# Why

closes #973 

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.15.9-canary.1019.13328.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.15.9-canary.1019.13328.0
  npm install @auto-canary/core@9.15.9-canary.1019.13328.0
  npm install @auto-canary/all-contributors@9.15.9-canary.1019.13328.0
  npm install @auto-canary/chrome@9.15.9-canary.1019.13328.0
  npm install @auto-canary/conventional-commits@9.15.9-canary.1019.13328.0
  npm install @auto-canary/crates@9.15.9-canary.1019.13328.0
  npm install @auto-canary/first-time-contributor@9.15.9-canary.1019.13328.0
  npm install @auto-canary/git-tag@9.15.9-canary.1019.13328.0
  npm install @auto-canary/gradle@9.15.9-canary.1019.13328.0
  npm install @auto-canary/jira@9.15.9-canary.1019.13328.0
  npm install @auto-canary/maven@9.15.9-canary.1019.13328.0
  npm install @auto-canary/npm@9.15.9-canary.1019.13328.0
  npm install @auto-canary/omit-commits@9.15.9-canary.1019.13328.0
  npm install @auto-canary/omit-release-notes@9.15.9-canary.1019.13328.0
  npm install @auto-canary/released@9.15.9-canary.1019.13328.0
  npm install @auto-canary/s3@9.15.9-canary.1019.13328.0
  npm install @auto-canary/slack@9.15.9-canary.1019.13328.0
  npm install @auto-canary/twitter@9.15.9-canary.1019.13328.0
  npm install @auto-canary/upload-assets@9.15.9-canary.1019.13328.0
  # or 
  yarn add @auto-canary/auto@9.15.9-canary.1019.13328.0
  yarn add @auto-canary/core@9.15.9-canary.1019.13328.0
  yarn add @auto-canary/all-contributors@9.15.9-canary.1019.13328.0
  yarn add @auto-canary/chrome@9.15.9-canary.1019.13328.0
  yarn add @auto-canary/conventional-commits@9.15.9-canary.1019.13328.0
  yarn add @auto-canary/crates@9.15.9-canary.1019.13328.0
  yarn add @auto-canary/first-time-contributor@9.15.9-canary.1019.13328.0
  yarn add @auto-canary/git-tag@9.15.9-canary.1019.13328.0
  yarn add @auto-canary/gradle@9.15.9-canary.1019.13328.0
  yarn add @auto-canary/jira@9.15.9-canary.1019.13328.0
  yarn add @auto-canary/maven@9.15.9-canary.1019.13328.0
  yarn add @auto-canary/npm@9.15.9-canary.1019.13328.0
  yarn add @auto-canary/omit-commits@9.15.9-canary.1019.13328.0
  yarn add @auto-canary/omit-release-notes@9.15.9-canary.1019.13328.0
  yarn add @auto-canary/released@9.15.9-canary.1019.13328.0
  yarn add @auto-canary/s3@9.15.9-canary.1019.13328.0
  yarn add @auto-canary/slack@9.15.9-canary.1019.13328.0
  yarn add @auto-canary/twitter@9.15.9-canary.1019.13328.0
  yarn add @auto-canary/upload-assets@9.15.9-canary.1019.13328.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
