### PR TITLE
Fix loading canary versions of official plugins

### DIFF
--- a/packages/core/src/utils/__tests__/load-plugin-canary.test.ts
+++ b/packages/core/src/utils/__tests__/load-plugin-canary.test.ts
@@ -1,0 +1,22 @@
+import loadPlugin from '../load-plugins';
+import { dummyLog } from '../logger';
+
+const logger = dummyLog();
+
+jest.mock(
+  '@auto-canary/baz',
+  () => ({
+    default: class {
+      name = 'baz';
+    }
+  }),
+  {
+    virtual: true
+  }
+);
+
+describe('loadPlugins', () => {
+  test('should load canary plugins', () => {
+    expect(loadPlugin(['baz', {}], logger)?.name).toBe('baz');
+  });
+});

--- a/packages/core/src/utils/load-plugins.ts
+++ b/packages/core/src/utils/load-plugins.ts
@@ -79,6 +79,11 @@ export default function loadPlugin(
     plugin = requirePlugin(path.join('@auto-it', pluginPath), logger);
   }
 
+  // Try importing canary version of plugin
+  if (!plugin) {
+    plugin = requirePlugin(path.join('@auto-canary', pluginPath), logger);
+  }
+
   // Try requiring a package
   if (
     !plugin &&


### PR DESCRIPTION
# What Changed

When we do the canary scope for canaries it would break your `.autorc` because it couldn't find any plugins.

# Why

partially addresses #1020 

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.15.10-canary.1021.13359.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.15.10-canary.1021.13359.0
  npm install @auto-canary/core@9.15.10-canary.1021.13359.0
  npm install @auto-canary/all-contributors@9.15.10-canary.1021.13359.0
  npm install @auto-canary/chrome@9.15.10-canary.1021.13359.0
  npm install @auto-canary/conventional-commits@9.15.10-canary.1021.13359.0
  npm install @auto-canary/crates@9.15.10-canary.1021.13359.0
  npm install @auto-canary/first-time-contributor@9.15.10-canary.1021.13359.0
  npm install @auto-canary/git-tag@9.15.10-canary.1021.13359.0
  npm install @auto-canary/gradle@9.15.10-canary.1021.13359.0
  npm install @auto-canary/jira@9.15.10-canary.1021.13359.0
  npm install @auto-canary/maven@9.15.10-canary.1021.13359.0
  npm install @auto-canary/npm@9.15.10-canary.1021.13359.0
  npm install @auto-canary/omit-commits@9.15.10-canary.1021.13359.0
  npm install @auto-canary/omit-release-notes@9.15.10-canary.1021.13359.0
  npm install @auto-canary/released@9.15.10-canary.1021.13359.0
  npm install @auto-canary/s3@9.15.10-canary.1021.13359.0
  npm install @auto-canary/slack@9.15.10-canary.1021.13359.0
  npm install @auto-canary/twitter@9.15.10-canary.1021.13359.0
  npm install @auto-canary/upload-assets@9.15.10-canary.1021.13359.0
  # or 
  yarn add @auto-canary/auto@9.15.10-canary.1021.13359.0
  yarn add @auto-canary/core@9.15.10-canary.1021.13359.0
  yarn add @auto-canary/all-contributors@9.15.10-canary.1021.13359.0
  yarn add @auto-canary/chrome@9.15.10-canary.1021.13359.0
  yarn add @auto-canary/conventional-commits@9.15.10-canary.1021.13359.0
  yarn add @auto-canary/crates@9.15.10-canary.1021.13359.0
  yarn add @auto-canary/first-time-contributor@9.15.10-canary.1021.13359.0
  yarn add @auto-canary/git-tag@9.15.10-canary.1021.13359.0
  yarn add @auto-canary/gradle@9.15.10-canary.1021.13359.0
  yarn add @auto-canary/jira@9.15.10-canary.1021.13359.0
  yarn add @auto-canary/maven@9.15.10-canary.1021.13359.0
  yarn add @auto-canary/npm@9.15.10-canary.1021.13359.0
  yarn add @auto-canary/omit-commits@9.15.10-canary.1021.13359.0
  yarn add @auto-canary/omit-release-notes@9.15.10-canary.1021.13359.0
  yarn add @auto-canary/released@9.15.10-canary.1021.13359.0
  yarn add @auto-canary/s3@9.15.10-canary.1021.13359.0
  yarn add @auto-canary/slack@9.15.10-canary.1021.13359.0
  yarn add @auto-canary/twitter@9.15.10-canary.1021.13359.0
  yarn add @auto-canary/upload-assets@9.15.10-canary.1021.13359.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
