### PR TITLE
fix plugin loading from absolute windows paths

### DIFF
--- a/packages/core/src/utils/__tests__/load-plugin-windows.test.ts
+++ b/packages/core/src/utils/__tests__/load-plugin-windows.test.ts
@@ -1,0 +1,24 @@
+import loadPlugin from '../load-plugins';
+import { dummyLog } from '../logger';
+
+const logger = dummyLog();
+
+jest.mock(
+  'C:\\plugins\\filter-non-pull-request.js',
+  () => ({
+    default: class {
+      name = 'foo';
+    }
+  }),
+  {
+    virtual: true
+  }
+);
+
+describe('loadPlugins', () => {
+  test('should load official plugins', () => {
+    expect(
+      loadPlugin(['C:\\plugins\\filter-non-pull-request.js', {}], logger)?.name
+    ).toBe('foo');
+  });
+});

--- a/packages/core/src/utils/load-plugins.ts
+++ b/packages/core/src/utils/load-plugins.ts
@@ -34,6 +34,11 @@ export default function loadPlugin(
   [pluginPath, options]: [string, any],
   logger: ILogger
 ): IPlugin | undefined {
+  const isLocal =
+    pluginPath.startsWith('.') ||
+    pluginPath.startsWith('/') ||
+    pluginPath.match(/^[A-Z]:\\/); // Support for windows paths
+
   let plugin:
     | IPluginConstructor
     | {
@@ -43,12 +48,12 @@ export default function loadPlugin(
     | undefined;
 
   // Try requiring a path
-  if (pluginPath.startsWith('.') || pluginPath.startsWith('/')) {
+  if (isLocal) {
     plugin = requirePlugin(pluginPath, logger);
   }
 
   // Try requiring a path from cwd
-  if (!plugin && (pluginPath.startsWith('.') || pluginPath.startsWith('/'))) {
+  if (!plugin && isLocal) {
     const localPath = path.join(process.cwd(), pluginPath);
     plugin = requirePlugin(localPath, logger);
 


### PR DESCRIPTION
# What Changed

Handle paths like `C:\foo\plugin.js`

# Why

closes #1020 

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.15.10-canary.1022.13366.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.15.10-canary.1022.13366.0
  npm install @auto-canary/core@9.15.10-canary.1022.13366.0
  npm install @auto-canary/all-contributors@9.15.10-canary.1022.13366.0
  npm install @auto-canary/chrome@9.15.10-canary.1022.13366.0
  npm install @auto-canary/conventional-commits@9.15.10-canary.1022.13366.0
  npm install @auto-canary/crates@9.15.10-canary.1022.13366.0
  npm install @auto-canary/first-time-contributor@9.15.10-canary.1022.13366.0
  npm install @auto-canary/git-tag@9.15.10-canary.1022.13366.0
  npm install @auto-canary/gradle@9.15.10-canary.1022.13366.0
  npm install @auto-canary/jira@9.15.10-canary.1022.13366.0
  npm install @auto-canary/maven@9.15.10-canary.1022.13366.0
  npm install @auto-canary/npm@9.15.10-canary.1022.13366.0
  npm install @auto-canary/omit-commits@9.15.10-canary.1022.13366.0
  npm install @auto-canary/omit-release-notes@9.15.10-canary.1022.13366.0
  npm install @auto-canary/released@9.15.10-canary.1022.13366.0
  npm install @auto-canary/s3@9.15.10-canary.1022.13366.0
  npm install @auto-canary/slack@9.15.10-canary.1022.13366.0
  npm install @auto-canary/twitter@9.15.10-canary.1022.13366.0
  npm install @auto-canary/upload-assets@9.15.10-canary.1022.13366.0
  # or 
  yarn add @auto-canary/auto@9.15.10-canary.1022.13366.0
  yarn add @auto-canary/core@9.15.10-canary.1022.13366.0
  yarn add @auto-canary/all-contributors@9.15.10-canary.1022.13366.0
  yarn add @auto-canary/chrome@9.15.10-canary.1022.13366.0
  yarn add @auto-canary/conventional-commits@9.15.10-canary.1022.13366.0
  yarn add @auto-canary/crates@9.15.10-canary.1022.13366.0
  yarn add @auto-canary/first-time-contributor@9.15.10-canary.1022.13366.0
  yarn add @auto-canary/git-tag@9.15.10-canary.1022.13366.0
  yarn add @auto-canary/gradle@9.15.10-canary.1022.13366.0
  yarn add @auto-canary/jira@9.15.10-canary.1022.13366.0
  yarn add @auto-canary/maven@9.15.10-canary.1022.13366.0
  yarn add @auto-canary/npm@9.15.10-canary.1022.13366.0
  yarn add @auto-canary/omit-commits@9.15.10-canary.1022.13366.0
  yarn add @auto-canary/omit-release-notes@9.15.10-canary.1022.13366.0
  yarn add @auto-canary/released@9.15.10-canary.1022.13366.0
  yarn add @auto-canary/s3@9.15.10-canary.1022.13366.0
  yarn add @auto-canary/slack@9.15.10-canary.1022.13366.0
  yarn add @auto-canary/twitter@9.15.10-canary.1022.13366.0
  yarn add @auto-canary/upload-assets@9.15.10-canary.1022.13366.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
