### PR TITLE
npm: respect subPackageChangelogs false

### DIFF
--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -352,7 +352,10 @@ export default class NPMPlugin implements IPlugin {
   constructor(config: INpmConfig = {}) {
     this.exact = Boolean(config.exact);
     this.renderMonorepoChangelog = true;
-    this.subPackageChangelogs = config.subPackageChangelogs || true;
+    this.subPackageChangelogs =
+      typeof config.subPackageChangelogs === 'boolean'
+        ? config.subPackageChangelogs
+        : true;
     this.setRcToken =
       typeof config.setRcToken === 'boolean' ? config.setRcToken : true;
     this.forcePublish =
@@ -701,7 +704,9 @@ export default class NPMPlugin implements IPlugin {
 
           return {
             newVersion: 'Canary Versions',
-            details: makeMonorepoInstallList(packageList.filter(p => p.includes('canary')))
+            details: makeMonorepoInstallList(
+              packageList.filter(p => p.includes('canary'))
+            )
           };
         }
 


### PR DESCRIPTION
# What Changed

If `subPackageChangelogs` was false we would ignore it. New we don't

Todo:

- [x] Add tests


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.16.1-canary.1025.13435.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.16.1-canary.1025.13435.0
  npm install @auto-canary/core@9.16.1-canary.1025.13435.0
  npm install @auto-canary/all-contributors@9.16.1-canary.1025.13435.0
  npm install @auto-canary/chrome@9.16.1-canary.1025.13435.0
  npm install @auto-canary/conventional-commits@9.16.1-canary.1025.13435.0
  npm install @auto-canary/crates@9.16.1-canary.1025.13435.0
  npm install @auto-canary/first-time-contributor@9.16.1-canary.1025.13435.0
  npm install @auto-canary/git-tag@9.16.1-canary.1025.13435.0
  npm install @auto-canary/gradle@9.16.1-canary.1025.13435.0
  npm install @auto-canary/jira@9.16.1-canary.1025.13435.0
  npm install @auto-canary/maven@9.16.1-canary.1025.13435.0
  npm install @auto-canary/npm@9.16.1-canary.1025.13435.0
  npm install @auto-canary/omit-commits@9.16.1-canary.1025.13435.0
  npm install @auto-canary/omit-release-notes@9.16.1-canary.1025.13435.0
  npm install @auto-canary/released@9.16.1-canary.1025.13435.0
  npm install @auto-canary/s3@9.16.1-canary.1025.13435.0
  npm install @auto-canary/slack@9.16.1-canary.1025.13435.0
  npm install @auto-canary/twitter@9.16.1-canary.1025.13435.0
  npm install @auto-canary/upload-assets@9.16.1-canary.1025.13435.0
  # or 
  yarn add @auto-canary/auto@9.16.1-canary.1025.13435.0
  yarn add @auto-canary/core@9.16.1-canary.1025.13435.0
  yarn add @auto-canary/all-contributors@9.16.1-canary.1025.13435.0
  yarn add @auto-canary/chrome@9.16.1-canary.1025.13435.0
  yarn add @auto-canary/conventional-commits@9.16.1-canary.1025.13435.0
  yarn add @auto-canary/crates@9.16.1-canary.1025.13435.0
  yarn add @auto-canary/first-time-contributor@9.16.1-canary.1025.13435.0
  yarn add @auto-canary/git-tag@9.16.1-canary.1025.13435.0
  yarn add @auto-canary/gradle@9.16.1-canary.1025.13435.0
  yarn add @auto-canary/jira@9.16.1-canary.1025.13435.0
  yarn add @auto-canary/maven@9.16.1-canary.1025.13435.0
  yarn add @auto-canary/npm@9.16.1-canary.1025.13435.0
  yarn add @auto-canary/omit-commits@9.16.1-canary.1025.13435.0
  yarn add @auto-canary/omit-release-notes@9.16.1-canary.1025.13435.0
  yarn add @auto-canary/released@9.16.1-canary.1025.13435.0
  yarn add @auto-canary/s3@9.16.1-canary.1025.13435.0
  yarn add @auto-canary/slack@9.16.1-canary.1025.13435.0
  yarn add @auto-canary/twitter@9.16.1-canary.1025.13435.0
  yarn add @auto-canary/upload-assets@9.16.1-canary.1025.13435.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
