### PR TITLE
Changelog formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # v9.16.0 (Thu Mar 05 2020)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `auto`, `@auto-it/core`, `@auto-it/git-tag`
   - determine if branch behind remote and exit before trying to publish [#1018](https://github.com/intuit/auto/pull/1018) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 🏠  Internal
+#### 🏠 Internal
 
 - `@auto-it/core`
   - fix tests [#1024](https://github.com/intuit/auto/pull/1024) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -18,7 +18,7 @@
 
 # v9.15.11 (Thu Mar 05 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - fix plugin loading from absolute windows paths [#1022](https://github.com/intuit/auto/pull/1022) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -31,7 +31,7 @@
 
 # v9.15.10 (Thu Mar 05 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - Fix loading canary versions of official plugins [#1021](https://github.com/intuit/auto/pull/1021) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -44,7 +44,7 @@
 
 # v9.15.9 (Thu Mar 05 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - test for ancestor in windows friendly way [#1019](https://github.com/intuit/auto/pull/1019) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -57,7 +57,7 @@
 
 # v9.15.8 (Tue Mar 03 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `auto`
   - set license on CLI [#1017](https://github.com/intuit/auto/pull/1017) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -70,7 +70,7 @@
 
 # v9.15.7 (Tue Mar 03 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `auto`, `@auto-it/core`, `@auto-it/all-contributors`, `@auto-it/chrome`, `@auto-it/conventional-commits`, `@auto-it/crates`, `@auto-it/first-time-contributor`, `@auto-it/git-tag`, `@auto-it/gradle`, `@auto-it/jira`, `@auto-it/maven`, `@auto-it/npm`, `@auto-it/omit-commits`, `@auto-it/omit-release-notes`, `@auto-it/released`, `@auto-it/s3`, `@auto-it/slack`, `@auto-it/twitter`, `@auto-it/upload-assets`
   - add license to all sub-packages [#1016](https://github.com/intuit/auto/pull/1016) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -83,7 +83,7 @@
 
 # v9.15.6 (Tue Mar 03 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - info: handle when there is no previous version [#1015](https://github.com/intuit/auto/pull/1015) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -96,7 +96,7 @@
 
 # v9.15.5 (Tue Mar 03 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - fix "Push to master" on next branch [#1013](https://github.com/intuit/auto/pull/1013) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -109,7 +109,7 @@
 
 # v9.15.4 (Mon Mar 02 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `auto`, `@auto-it/core`
   - Don't release canary on skip-release by default, add force flag [#993](https://github.com/intuit/auto/pull/993) ([@hipstersmoothie](https://github.com/hipstersmoothie) [@zephraph](https://github.com/zephraph))
@@ -123,7 +123,7 @@
 
 # v9.15.3 (Mon Mar 02 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`, `@auto-it/npm`
   - don't force publish canary/next for independent lerna projects [#1012](https://github.com/intuit/auto/pull/1012) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -151,7 +151,7 @@
 
 # v9.15.2 (Sun Mar 01 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/conventional-commits`
   - Respect PR label when conventional commit message is present [#1001](https://github.com/intuit/auto/pull/1001) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -164,7 +164,7 @@
 
 # v9.15.1 (Sun Mar 01 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `auto`, `@auto-it/core`
   - Default Config When running shipit [#1000](https://github.com/intuit/auto/pull/1000) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -181,13 +181,13 @@
 
 _From #998_
 
-Configs are now fully validated including plugins 🎉 
+Configs are now fully validated including plugins 🎉
 
 <img width="1171" alt="Screen Shot 2020-02-29 at 10 19 01 PM" src="https://user-images.githubusercontent.com/1192452/75620907-b8864d80-5b42-11ea-84e0-15292696185d.png">
 
-###  🚀 Command Configuration  🚀 
+### 🚀 Command Configuration 🚀
 
-With the inclusion of configuration validation we decided to restrict valid root level keys to only options that are shared between commands. All of these options are called out in the [`.autorc` docs](https://intuit.github.io/auto/pages/autorc.html). 
+With the inclusion of configuration validation we decided to restrict valid root level keys to only options that are shared between commands. All of these options are called out in the [`.autorc` docs](https://intuit.github.io/auto/pages/autorc.html).
 
 But for some commands it still makes sense to configure flag permanently in the `.autorc`. For those commands you can now supply defaults for flags using the following format.
 
@@ -205,16 +205,16 @@ Please refer to each command's documentation to see which options are configurab
 
 ### New Hook
 
-For plugins configuration validation a new hook `validateConfiguration` was added for plugins to tap into and report configuration errors.  [Read more](https://intuit.github.io/auto/pages/writing-plugins.html#validateconfig)
+For plugins configuration validation a new hook `validateConfiguration` was added for plugins to tap into and report configuration errors. [Read more](https://intuit.github.io/auto/pages/writing-plugins.html#validateconfig)
 
 ---
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `auto`, `@auto-it/core`, `@auto-it/all-contributors`, `@auto-it/chrome`, `@auto-it/conventional-commits`, `@auto-it/crates`, `@auto-it/git-tag`, `@auto-it/gradle`, `@auto-it/jira`, `@auto-it/maven`, `@auto-it/npm`, `@auto-it/omit-commits`, `@auto-it/omit-release-notes`, `@auto-it/released`, `@auto-it/s3`, `@auto-it/slack`, `@auto-it/twitter`, `@auto-it/upload-assets`
   - Config Validation + Command Defaults [#998](https://github.com/intuit/auto/pull/998) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - Add @unknownerror404 as a contributor [#997](https://github.com/intuit/auto/pull/997) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -226,7 +226,7 @@ For plugins configuration validation a new hook `validateConfiguration` was adde
 
 # v9.14.0 (Tue Feb 25 2020)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `@auto-it/core`
   - add scoped plugin support [#992](https://github.com/intuit/auto/pull/992) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -239,12 +239,12 @@ For plugins configuration validation a new hook `validateConfiguration` was adde
 
 # v9.13.1 (Mon Feb 24 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - add fallback for when --is-ancestor fails [#989](https://github.com/intuit/auto/pull/989) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - Better Travis Docs [#990](https://github.com/intuit/auto/pull/990) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -271,17 +271,17 @@ For plugins configuration validation a new hook `validateConfiguration` was adde
 
 # v9.13.0 (Sat Feb 22 2020)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `auto`, `@auto-it/core`, `@auto-it/all-contributors`, `@auto-it/npm`
   - When parsing owner/repo fallback to parsing 'origin' [#975](https://github.com/intuit/auto/pull/975) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - add git version to 'auto info' output [#977](https://github.com/intuit/auto/pull/977) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - Update bug_report.md [#974](https://github.com/intuit/auto/pull/974) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -293,7 +293,7 @@ For plugins configuration validation a new hook `validateConfiguration` was adde
 
 # v9.12.1 (Sat Feb 22 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `auto`, `@auto-it/npm`
   - add warning about using npm plugin with noVersionPrefix [#972](https://github.com/intuit/auto/pull/972) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -308,7 +308,7 @@ For plugins configuration validation a new hook `validateConfiguration` was adde
 
 # v9.12.0 (Fri Feb 21 2020)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `@auto-it/core`, `@auto-it/chrome`, `@auto-it/crates`, `@auto-it/git-tag`, `@auto-it/gradle`, `@auto-it/maven`, `@auto-it/npm`
   - ensure remote can be pushed to [#969](https://github.com/intuit/auto/pull/969) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -321,7 +321,7 @@ For plugins configuration validation a new hook `validateConfiguration` was adde
 
 # v9.11.0 (Fri Feb 21 2020)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `auto`, `@auto-it/core`
   - Add new command 'latest' for easier testing and more flexibility [#968](https://github.com/intuit/auto/pull/968) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -338,14 +338,14 @@ For plugins configuration validation a new hook `validateConfiguration` was adde
 
 Thank you, Jeremiah Zucker ([@sugarmanz](https://github.com/sugarmanz)), for all your work!
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/all-contributors`
   - fix case sensitive username bug and handle git errors [#967](https://github.com/intuit/auto/pull/967) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - `@auto-it/core`
   - Adding proxyagent to graphql [#963](https://github.com/intuit/auto/pull/963) ([@YogiKhan](https://github.com/YogiKhan) [@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - `@auto-it/gradle`
   - fix: gradle readme use jsonc syntax highlighting [#965](https://github.com/intuit/auto/pull/965) ([@sugarmanz](https://github.com/sugarmanz))
@@ -360,7 +360,7 @@ Thank you, Jeremiah Zucker ([@sugarmanz](https://github.com/sugarmanz)), for all
 
 # v9.10.7 (Tue Feb 18 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`, `@auto-it/first-time-contributor`
   - filter out bots in first-time contributor plugins [#961](https://github.com/intuit/auto/pull/961) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -377,12 +377,12 @@ Thank you, Jeremiah Zucker ([@sugarmanz](https://github.com/sugarmanz)), for all
 
 Thank you, null[@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]), for all your work!
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - get node version in crash friendly way [#960](https://github.com/intuit/auto/pull/960) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - add clearer docs around github token permissions [#958](https://github.com/intuit/auto/pull/958) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Add gradle to root readme [#957](https://github.com/intuit/auto/pull/957) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -415,7 +415,7 @@ Thank you, null[@dependabot-preview[bot]](https://github.com/dependabot-preview[
 
 Thank you, null[@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]), for all your work!
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Add gradle to tsconfig. [#946](https://github.com/intuit/auto/pull/946) (brandon_miller3@intuit.com [@unknownerror404](https://github.com/unknownerror404))
 
@@ -445,7 +445,7 @@ Thank you, null[@dependabot-preview[bot]](https://github.com/dependabot-preview[
 
 # v9.10.4 (Thu Feb 06 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `auto`, `@auto-it/core`
   - Run `auto info` when any command is run with --verbose [#934](https://github.com/intuit/auto/pull/934) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -458,7 +458,7 @@ Thank you, null[@dependabot-preview[bot]](https://github.com/dependabot-preview[
 
 # v9.10.3 (Thu Feb 06 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - add info about token permission [#933](https://github.com/intuit/auto/pull/933) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -471,7 +471,7 @@ Thank you, null[@dependabot-preview[bot]](https://github.com/dependabot-preview[
 
 # v9.10.2 (Thu Feb 06 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - create-labels: handle repos with large amounts of labels [#932](https://github.com/intuit/auto/pull/932) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -484,7 +484,7 @@ Thank you, null[@dependabot-preview[bot]](https://github.com/dependabot-preview[
 
 # v9.10.1 (Thu Feb 06 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/chrome`, `@auto-it/git-tag`, `@auto-it/npm`
   - Fix manual git tagging [#930](https://github.com/intuit/auto/pull/930) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -497,7 +497,7 @@ Thank you, null[@dependabot-preview[bot]](https://github.com/dependabot-preview[
 
 # v9.10.0 (Thu Feb 06 2020)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `auto`, `@auto-it/core`, `@auto-it/maven`
   - add "info" command [#931](https://github.com/intuit/auto/pull/931) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -510,12 +510,12 @@ Thank you, null[@dependabot-preview[bot]](https://github.com/dependabot-preview[
 
 # v9.9.1 (Tue Feb 04 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/npm`
   - dont run git hooks when commiting the version for a single npm package [#929](https://github.com/intuit/auto/pull/929) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - Add gradle plugin to docs website [#928](https://github.com/intuit/auto/pull/928) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -531,7 +531,7 @@ Thank you, null[@dependabot-preview[bot]](https://github.com/dependabot-preview[
 
 Thank you, Brandon Miller ([@unknownerror404](https://github.com/unknownerror404)), for all your work!
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `@auto-it/gradle`
   - Gradle Release Plugin [#924](https://github.com/intuit/auto/pull/924) (brandon_miller3@intuit.com [@unknownerror404](https://github.com/unknownerror404))
@@ -545,13 +545,13 @@ Thank you, Brandon Miller ([@unknownerror404](https://github.com/unknownerror404
 
 # v9.8.4 (Fri Jan 31 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - fix GH_USER in jenkins documentation [#925](https://github.com/intuit/auto/pull/925) (navjot_cheema@intuit.com [@ncheema](https://github.com/ncheema))
 - `@auto-it/maven`
   - fix maven release creation [#927](https://github.com/intuit/auto/pull/927) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - `@auto-it/maven`
   - Update maven and jenkins documentation (resolves #922) [#923](https://github.com/intuit/auto/pull/923) (navjot_cheema@intuit.com [@ncheema](https://github.com/ncheema))
@@ -566,7 +566,7 @@ Thank you, Brandon Miller ([@unknownerror404](https://github.com/unknownerror404
 
 # v9.8.3 (Thu Jan 30 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - move ICommit to "core" to fix external plugin TS build errors [#921](https://github.com/intuit/auto/pull/921) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -579,7 +579,7 @@ Thank you, Brandon Miller ([@unknownerror404](https://github.com/unknownerror404
 
 # v9.8.2 (Thu Jan 30 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/npm`
   - add fallback to get lerna json [#920](https://github.com/intuit/auto/pull/920) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -592,7 +592,7 @@ Thank you, Brandon Miller ([@unknownerror404](https://github.com/unknownerror404
 
 # v9.8.1 (Wed Jan 29 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - better error message running release in repo w/o tags [#919](https://github.com/intuit/auto/pull/919) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -615,7 +615,7 @@ This PR adds a new hook for plugin developers.
 
 ---
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `@auto-it/core`, `@auto-it/npm`, `@auto-it/released`, `@auto-it/twitter`, `@auto-it/upload-assets`
   - Independent releases [#916](https://github.com/intuit/auto/pull/916) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -628,12 +628,12 @@ This PR adds a new hook for plugin developers.
 
 # v9.7.0 (Mon Jan 27 2020)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `@auto-it/core`, `@auto-it/crates`
   - enhance BeforeShipit hook to include the type of release that will be made [#913](https://github.com/intuit/auto/pull/913) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/npm`
   - abort release if lerna reports no unchanged packages [#914](https://github.com/intuit/auto/pull/914) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -648,7 +648,7 @@ This PR adds a new hook for plugin developers.
 
 # v9.6.0 (Mon Jan 27 2020)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `@auto-it/slack`
   - add ability to store slack hook url in environment variable [#912](https://github.com/intuit/auto/pull/912) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -665,7 +665,7 @@ This PR adds a new hook for plugin developers.
 
 Thank you, null[@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]), for all your work!
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `auto`, `@auto-it/core`, `@auto-it/jira`, `@auto-it/npm`, `@auto-it/slack`
   - Overhaul "auto init" experience + make it pluggable [#901](https://github.com/intuit/auto/pull/901) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -695,12 +695,12 @@ Thank you, null[@dependabot-preview[bot]](https://github.com/dependabot-preview[
 
 # v9.4.1 (Sat Jan 25 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/released`
   - Wrap version in code [#900](https://github.com/intuit/auto/pull/900) ([@ericclemmons](https://github.com/ericclemmons))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - Updated GitHub Action [#899](https://github.com/intuit/auto/pull/899) ([@ericclemmons](https://github.com/ericclemmons))
 
@@ -712,7 +712,7 @@ Thank you, null[@dependabot-preview[bot]](https://github.com/dependabot-preview[
 
 # v9.4.0 (Sat Jan 25 2020)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `@auto-it/core`, `@auto-it/npm`
   - Add html details option to canary hook + Use in npm plugin [#898](https://github.com/intuit/auto/pull/898) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -725,7 +725,7 @@ Thank you, null[@dependabot-preview[bot]](https://github.com/dependabot-preview[
 
 # v9.3.4 (Sat Jan 25 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - add better messaging when pr number cannot be detected [#896](https://github.com/intuit/auto/pull/896) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -738,12 +738,12 @@ Thank you, null[@dependabot-preview[bot]](https://github.com/dependabot-preview[
 
 # v9.3.3 (Fri Jan 24 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - Add 📦 emoji to canary PR message to make it more noticeable [#897](https://github.com/intuit/auto/pull/897) ([@ericclemmons](https://github.com/ericclemmons))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - `@auto-it/all-contributors`
   - Explicitly add npm & yarn step for all-contributors [#895](https://github.com/intuit/auto/pull/895) ([@ericclemmons](https://github.com/ericclemmons))
@@ -756,7 +756,7 @@ Thank you, null[@dependabot-preview[bot]](https://github.com/dependabot-preview[
 
 # v9.3.2 (Fri Jan 24 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`, `@auto-it/npm`
   - Fix private package previous version calculation + Improve dry run messaging [#894](https://github.com/intuit/auto/pull/894) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -769,7 +769,7 @@ Thank you, null[@dependabot-preview[bot]](https://github.com/dependabot-preview[
 
 # v9.3.1 (Fri Jan 24 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - Surface plugin syntax errors to user [#892](https://github.com/intuit/auto/pull/892) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -782,7 +782,7 @@ Thank you, null[@dependabot-preview[bot]](https://github.com/dependabot-preview[
 
 # v9.3.0 (Fri Jan 24 2020)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `@auto-it/npm`
   - add ability to publish exact versions in monorepo [#891](https://github.com/intuit/auto/pull/891) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -795,7 +795,7 @@ Thank you, null[@dependabot-preview[bot]](https://github.com/dependabot-preview[
 
 # v9.2.3 (Fri Jan 24 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/first-time-contributor`
   - determine first time contributor by using PR count instead of git history [#890](https://github.com/intuit/auto/pull/890) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -812,7 +812,7 @@ Thank you, null[@dependabot-preview[bot]](https://github.com/dependabot-preview[
 
 Thank you, Hannes Güdelhöfer ([@reckter](https://github.com/reckter)), for all your work!
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - Fix error on empty pr body [#889](https://github.com/intuit/auto/pull/889) ([@reckter](https://github.com/reckter))
@@ -825,7 +825,7 @@ Thank you, Hannes Güdelhöfer ([@reckter](https://github.com/reckter)), for all
 
 # v9.2.1 (Fri Jan 24 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `auto`, `@auto-it/core`, `@auto-it/git-tag`
   - fallback to 0.0.0 in git-tag plugin with no previous releases [#888](https://github.com/intuit/auto/pull/888) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -838,7 +838,7 @@ Thank you, Hannes Güdelhöfer ([@reckter](https://github.com/reckter)), for all
 
 # v9.2.0 (Thu Jan 23 2020)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `@auto-it/core`, `@auto-it/all-contributors`, `@auto-it/npm`
   - Add ability to manage sub-package contributor lists [#887](https://github.com/intuit/auto/pull/887) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -851,7 +851,7 @@ Thank you, Hannes Güdelhöfer ([@reckter](https://github.com/reckter)), for all
 
 # v9.1.3 (Thu Jan 23 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/npm`
   - Fix commiting sub-package changelogs [#885](https://github.com/intuit/auto/pull/885) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -864,7 +864,7 @@ Thank you, Hannes Güdelhöfer ([@reckter](https://github.com/reckter)), for all
 
 # v9.1.2 (Thu Jan 23 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - fix omitting renovate release notes when a user manually rebases the renovate PR [#884](https://github.com/intuit/auto/pull/884) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -877,12 +877,12 @@ Thank you, Hannes Güdelhöfer ([@reckter](https://github.com/reckter)), for all
 
 # v9.1.1 (Thu Jan 23 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - Fix onlyPublishWithReleaseLabel w/o labels [#883](https://github.com/intuit/auto/pull/883) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - `@auto-it/chrome`, `@auto-it/maven`
   - add clearer docs around creating GH_TOKEN [#882](https://github.com/intuit/auto/pull/882) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -895,7 +895,7 @@ Thank you, Hannes Güdelhöfer ([@reckter](https://github.com/reckter)), for all
 
 # v9.1.0 (Tue Jan 21 2020)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `@auto-it/core`
   - canary: try to match commit to PR if not found in env [#812](https://github.com/intuit/auto/pull/812) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -925,7 +925,7 @@ Thank you, Hannes Güdelhöfer ([@reckter](https://github.com/reckter)), for all
 
 # v9.0.2 (Tue Jan 14 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/all-contributors`
   - Fix running all-contributors when not installed [#871](https://github.com/intuit/auto/pull/871) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -938,7 +938,7 @@ Thank you, Hannes Güdelhöfer ([@reckter](https://github.com/reckter)), for all
 
 # v9.0.1 (Mon Jan 13 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - handle PR numbers that don't exist in repo/fork [#870](https://github.com/intuit/auto/pull/870) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -951,12 +951,12 @@ Thank you, Hannes Güdelhöfer ([@reckter](https://github.com/reckter)), for all
 
 # v9.0.0 (Mon Jan 13 2020)
 
-#### 💥  Breaking Change
+#### 💥 Breaking Change
 
 - `auto`
   - require Node.js >=10.x [#869](https://github.com/intuit/auto/pull/869) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/npm`
   - match npm behavior for scoped packages [#868](https://github.com/intuit/auto/pull/868) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -994,12 +994,12 @@ Thank you, Hannes Güdelhöfer ([@reckter](https://github.com/reckter)), for all
 
 # v8.8.0 (Thu Jan 02 2020)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `@auto-it/slack`
   - fix: prevent slack from default publishing on prerelease branches [#829](https://github.com/intuit/auto/pull/829) ([@Aghassi](https://github.com/Aghassi))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - docs: fixed incorrect afterRelease hook object [#842](https://github.com/intuit/auto/pull/842) ([@Aghassi](https://github.com/Aghassi))
 - `@auto-it/core`
@@ -1028,7 +1028,7 @@ Thank you, Hannes Güdelhöfer ([@reckter](https://github.com/reckter)), for all
 
 # v8.7.3 (Fri Dec 20 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - next: check origin head instead of local branch for tags [#827](https://github.com/intuit/auto/pull/827) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -1041,7 +1041,7 @@ Thank you, Hannes Güdelhöfer ([@reckter](https://github.com/reckter)), for all
 
 # v8.7.2 (Fri Dec 20 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - find the last greatest tag to help with botched releases [#826](https://github.com/intuit/auto/pull/826) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -1054,7 +1054,7 @@ Thank you, Hannes Güdelhöfer ([@reckter](https://github.com/reckter)), for all
 
 # v8.7.1 (Thu Dec 19 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`, `@auto-it/npm`
   - Add more logs for next release calculation [#824](https://github.com/intuit/auto/pull/824) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -1067,7 +1067,7 @@ Thank you, Hannes Güdelhöfer ([@reckter](https://github.com/reckter)), for all
 
 # v8.7.0 (Thu Dec 19 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `@auto-it/core`
   - add context of what type of release was made during shipit [#821](https://github.com/intuit/auto/pull/821) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -1080,7 +1080,7 @@ Thank you, Hannes Güdelhöfer ([@reckter](https://github.com/reckter)), for all
 
 # v8.6.3 (Thu Dec 19 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`, `@auto-it/git-tag`, `@auto-it/npm`, `@auto-it/released`
   - determine next version using by omitting tags from master [#820](https://github.com/intuit/auto/pull/820) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -1093,7 +1093,7 @@ Thank you, Hannes Güdelhöfer ([@reckter](https://github.com/reckter)), for all
 
 # v8.6.2 (Wed Dec 18 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - only access auto login if it all exists [#819](https://github.com/intuit/auto/pull/819) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -1106,12 +1106,12 @@ Thank you, Hannes Güdelhöfer ([@reckter](https://github.com/reckter)), for all
 
 # v8.6.1 (Wed Dec 18 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - canary hook can return void to not bail [#817](https://github.com/intuit/auto/pull/817) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - update docs to show JS plugins and how to use versionBranches [#816](https://github.com/intuit/auto/pull/816) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -1123,7 +1123,7 @@ Thank you, Hannes Güdelhöfer ([@reckter](https://github.com/reckter)), for all
 
 # v8.5.0 (Tue Dec 17 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `auto`, `@auto-it/core`, `@auto-it/all-contributors`, `@auto-it/chrome`, `@auto-it/conventional-commits`, `@auto-it/crates`, `@auto-it/first-time-contributor`, `@auto-it/git-tag`, `@auto-it/jira`, `@auto-it/maven`, `@auto-it/npm`, `@auto-it/omit-commits`, `@auto-it/omit-release-notes`, `@auto-it/released`, `@auto-it/s3`, `@auto-it/slack`, `@auto-it/twitter`, `@auto-it/upload-assets`
   - Version branches [#814](https://github.com/intuit/auto/pull/814) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -1136,7 +1136,7 @@ Thank you, Hannes Güdelhöfer ([@reckter](https://github.com/reckter)), for all
 
 # v8.4.1 (Mon Dec 16 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `auto`, `@auto-it/npm`
   - alias the canary scope [#813](https://github.com/intuit/auto/pull/813) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -1149,7 +1149,7 @@ Thank you, Hannes Güdelhöfer ([@reckter](https://github.com/reckter)), for all
 
 # v8.4.0 (Mon Dec 16 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `@auto-it/core`
   - version: detect prerelease branch [#811](https://github.com/intuit/auto/pull/811) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -1162,7 +1162,7 @@ Thank you, Hannes Güdelhöfer ([@reckter](https://github.com/reckter)), for all
 
 # v8.3.0 (Mon Dec 16 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `@auto-it/core`, `@auto-it/git-tag`, `@auto-it/npm`
   - release: detect prerelease branch + be smarter about commit range [#810](https://github.com/intuit/auto/pull/810) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -1191,12 +1191,12 @@ Thank you, Hannes Güdelhöfer ([@reckter](https://github.com/reckter)), for all
 
 # v8.2.0 (Sun Dec 15 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `auto`, `@auto-it/core`
   - release: add flag to publish prerelease [#800](https://github.com/intuit/auto/pull/800) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - Slight improvements to label configuration docs [#799](https://github.com/intuit/auto/pull/799) ([@bnigh](https://github.com/bnigh))
 
@@ -1213,7 +1213,7 @@ Thank you, Hannes Güdelhöfer ([@reckter](https://github.com/reckter)), for all
 
 # v8.1.3 (Sat Dec 14 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`, `@auto-it/jira`, `@auto-it/npm`
   - omit next branch PR Title from being in release notes [#796](https://github.com/intuit/auto/pull/796) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -1226,7 +1226,7 @@ Thank you, Hannes Güdelhöfer ([@reckter](https://github.com/reckter)), for all
 
 # v8.1.2 (Sat Dec 14 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - Fix `none` releases: they were not handling extra labels [#797](https://github.com/intuit/auto/pull/797) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -1239,7 +1239,7 @@ Thank you, Hannes Güdelhöfer ([@reckter](https://github.com/reckter)), for all
 
 # v8.1.1 (Sat Dec 14 2019)
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - `@auto-it/npm`
   - add diagrams [#795](https://github.com/intuit/auto/pull/795) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -1252,23 +1252,23 @@ Thank you, Hannes Güdelhöfer ([@reckter](https://github.com/reckter)), for all
 
 # v8.1.0 (Sat Dec 14 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `@auto-it/npm`
   - add canaryScope option for more secure PR builds [#792](https://github.com/intuit/auto/pull/792) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - fix bug where merging a none would skip previously meged semver bump [#794](https://github.com/intuit/auto/pull/794) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 🏠  Internal
+#### 🏠 Internal
 
 - add context [#790](https://github.com/intuit/auto/pull/790) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - `@auto-it/npm`
   - V8.1 [#793](https://github.com/intuit/auto/pull/793) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - docs(publishing): add period after sentence [#788](https://github.com/intuit/auto/pull/788) ([@bmuenzenmeyer](https://github.com/bmuenzenmeyer))
 
@@ -1291,7 +1291,7 @@ _From #758_
 
 _From #751_
 
-Label configuration just got a whole lot simpler 🎉 
+Label configuration just got a whole lot simpler 🎉
 
 1. Labels can now only be supplied as an array of label objects.
 
@@ -1300,7 +1300,7 @@ Label configuration just got a whole lot simpler 🎉
   "labels": [
     { "releaseType": "major", "name": "Version: Major" },
     { "releaseType": "minor", "name": "Version: Minor" },
-    { "releaseType": "patch", "name": "Version: Patch" },
+    { "releaseType": "patch", "name": "Version: Patch" }
   ]
 }
 ```
@@ -1309,9 +1309,7 @@ Label configuration just got a whole lot simpler 🎉
 
 ```json
 {
-  "labels": [
-    { "releaseType": "skip", "name": "NO!" }
-  ]
+  "labels": [{ "releaseType": "skip", "name": "NO!" }]
 }
 ```
 
@@ -1320,7 +1318,7 @@ Label configuration just got a whole lot simpler 🎉
 ```json
 {
   "labels": [
-    { "releaseType": "major", "name": "Version: Major", "overwrite": true },
+    { "releaseType": "major", "name": "Version: Major", "overwrite": true }
   ]
 }
 ```
@@ -1329,9 +1327,7 @@ Label configuration just got a whole lot simpler 🎉
 
 ```json
 {
-  "labels": [
-    { "releaseType": "none", "name": "documentation" },
-  ]
+  "labels": [{ "releaseType": "none", "name": "documentation" }]
 }
 ```
 
@@ -1339,15 +1335,13 @@ Label configuration just got a whole lot simpler 🎉
 
 ```json
 {
-  "labels": [
-    { "changelogTitle": "New Docs Yo!", "name": "documentation" },
-  ]
+  "labels": [{ "changelogTitle": "New Docs Yo!", "name": "documentation" }]
 }
 ```
 
 ---
 
-#### 💥  Breaking Change
+#### 💥 Breaking Change
 
 - `auto`, `@auto-it/core`, `@auto-it/all-contributors`, `@auto-it/chrome`, `@auto-it/conventional-commits`, `@auto-it/crates`, `@auto-it/first-time-contributor`, `@auto-it/git-tag`, `@auto-it/jira`, `@auto-it/maven`, `@auto-it/npm`, `@auto-it/released`, `@auto-it/s3`, `@auto-it/slack`, `@auto-it/twitter`, `@auto-it/upload-assets`
   - Release v8 [#758](https://github.com/intuit/auto/pull/758) ([@hipstersmoothie](https://github.com/hipstersmoothie) [@adierkens](https://github.com/adierkens))
@@ -1362,7 +1356,7 @@ Label configuration just got a whole lot simpler 🎉
 - `@auto-it/core`, `@auto-it/released`
   - remove old use of prerelease label + add prerelease label to released plugin [#729](https://github.com/intuit/auto/pull/729) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `@auto-it/core`
   - add release notes to prerelease PRs [#777](https://github.com/intuit/auto/pull/777) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -1383,7 +1377,7 @@ Label configuration just got a whole lot simpler 🎉
 - `auto`, `@auto-it/core`, `@auto-it/npm`
   - Add ability for "next" branch publishing [#726](https://github.com/intuit/auto/pull/726) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`, `@auto-it/all-contributors`, `@auto-it/npm`
   - only grant contributions for work in commit [#786](https://github.com/intuit/auto/pull/786) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -1406,7 +1400,7 @@ Label configuration just got a whole lot simpler 🎉
 - `@auto-it/core`
   - must set git user before publishing so we know we can commit [#727](https://github.com/intuit/auto/pull/727) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 🏠  Internal
+#### 🏠 Internal
 
 - reset monorepo version for next branch [#769](https://github.com/intuit/auto/pull/769) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - `@auto-it/core`, `@auto-it/git-tag`, `@auto-it/npm`, `@auto-it/s3`
@@ -1414,7 +1408,7 @@ Label configuration just got a whole lot simpler 🎉
 - `@auto-it/upload-assets`
   - More resilient test case [#772](https://github.com/intuit/auto/pull/772) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - `@auto-it/conventional-commits`
   - Update README to include required npm plugin [#776](https://github.com/intuit/auto/pull/776) ([@sarah-vanderlaan](https://github.com/sarah-vanderlaan))
@@ -1449,12 +1443,12 @@ Label configuration just got a whole lot simpler 🎉
 
 # v7.17.0 (Fri Dec 06 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `@auto-it/all-contributors`
   - add more defaults to all-contributors plugin [#756](https://github.com/intuit/auto/pull/756) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - docs(introduction): fix typo [#755](https://github.com/intuit/auto/pull/755) ([@bmuenzenmeyer](https://github.com/bmuenzenmeyer))
 - fix docs build issue [#753](https://github.com/intuit/auto/pull/753) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -1503,12 +1497,12 @@ Label configuration just got a whole lot simpler 🎉
 
 # v7.16.3 (Mon Nov 18 2019)
 
-#### 🏠  Internal
+#### 🏠 Internal
 
 - `@auto-it/core`, `@auto-it/maven`, `@auto-it/npm`, `@auto-it/released`
   - Upgrade to Typescript 3.7 [#711](https://github.com/intuit/auto/pull/711) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - force docs publish [#700](https://github.com/intuit/auto/pull/700) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - `auto`
@@ -1538,7 +1532,7 @@ Label configuration just got a whole lot simpler 🎉
 
 # v7.16.2 (Thu Nov 14 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/npm`
   - More flexible monorepo publishing [#698](https://github.com/intuit/auto/pull/698) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -1551,7 +1545,7 @@ Label configuration just got a whole lot simpler 🎉
 
 # v7.16.1 (Thu Nov 14 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/npm`
   - match behavior between lerna and npm when pushing git tags [#697](https://github.com/intuit/auto/pull/697) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -1564,11 +1558,11 @@ Label configuration just got a whole lot simpler 🎉
 
 # v7.16.0 (Thu Nov 14 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - automatically update brew formula [#694](https://github.com/intuit/auto/pull/694) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - correct grammar [#696](https://github.com/intuit/auto/pull/696) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - correct docs [#695](https://github.com/intuit/auto/pull/695) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -1581,7 +1575,7 @@ Label configuration just got a whole lot simpler 🎉
 
 # v7.15.2 (Thu Nov 14 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/npm`
   - Fixed string interpolation on Lerna version bump [#693](https://github.com/intuit/auto/pull/693) ([@jrnail23](https://github.com/jrnail23))
@@ -1594,12 +1588,12 @@ Label configuration just got a whole lot simpler 🎉
 
 # v7.15.1 (Wed Nov 13 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - add logs for where plugins were found [#691](https://github.com/intuit/auto/pull/691) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - add non-npm docs [#679](https://github.com/intuit/auto/pull/679) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - add jenkins usage [#690](https://github.com/intuit/auto/pull/690) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -1616,7 +1610,7 @@ Label configuration just got a whole lot simpler 🎉
 
 # v7.15.0 (Tue Nov 12 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `auto`, `@auto-it/core`, `@auto-it/git-tag`, `@auto-it/npm`
   - Default to `git-tag` plugin when run from binary [#684](https://github.com/intuit/auto/pull/684) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -1629,7 +1623,7 @@ Label configuration just got a whole lot simpler 🎉
 
 # v7.14.1 (Tue Nov 12 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/all-contributors`
   - Fix bug where 'all-contributors' plugin wasn't picking up changes [#683](https://github.com/intuit/auto/pull/683) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -1642,12 +1636,12 @@ Label configuration just got a whole lot simpler 🎉
 
 # v7.14.0 (Tue Nov 12 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `@auto-it/core`
-  - detect PR number when running  "auto label" without "--pr" [#682](https://github.com/intuit/auto/pull/682) ([@hipstersmoothie](https://github.com/hipstersmoothie))
+  - detect PR number when running "auto label" without "--pr" [#682](https://github.com/intuit/auto/pull/682) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - `auto`
   - Rewrite README Issue #666 [#680](https://github.com/intuit/auto/pull/680) ([@karenclo](https://github.com/karenclo) [@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -1661,12 +1655,12 @@ Label configuration just got a whole lot simpler 🎉
 
 # v7.13.3 (Tue Nov 12 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - warn when canary not implemented [#678](https://github.com/intuit/auto/pull/678) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 🏠  Internal
+#### 🏠 Internal
 
 - must trust github for docs to publish [#667](https://github.com/intuit/auto/pull/667) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -1693,16 +1687,16 @@ Label configuration just got a whole lot simpler 🎉
 
 # v7.13.2 (Sun Nov 10 2019)
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - clarify plugin docs [#664](https://github.com/intuit/auto/pull/664) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - `auto`, `@auto-it/core`, `@auto-it/all-contributors`, `@auto-it/chrome`, `@auto-it/conventional-commits`, `@auto-it/crates`, `@auto-it/first-time-contributor`, `@auto-it/git-tag`, `@auto-it/jira`, `@auto-it/maven`, `@auto-it/npm`, `@auto-it/omit-commits`, `@auto-it/omit-release-notes`, `@auto-it/released`, `@auto-it/s3`, `@auto-it/slack`, `@auto-it/twitter`, `@auto-it/upload-assets`
   - Add JSDoc comment to most everything [#665](https://github.com/intuit/auto/pull/665) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### ⚠️  Pushed to master
+#### ⚠️ Pushed to master
 
-- skip ci when updating gh-pages  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- set git user  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- skip ci when updating gh-pages ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- set git user ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -1712,7 +1706,7 @@ Label configuration just got a whole lot simpler 🎉
 
 # v7.13.1 (Thu Nov 07 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/npm`
   - Fix GitHub Release's release notes for monorepo during shipit [#663](https://github.com/intuit/auto/pull/663) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -1725,7 +1719,7 @@ Label configuration just got a whole lot simpler 🎉
 
 # v7.13.0 (Thu Nov 07 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `@auto-it/core`, `@auto-it/all-contributors`, `@auto-it/npm`
   - NPM: manage a changelog for each sub-package in monorepo [#658](https://github.com/intuit/auto/pull/658) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -1738,7 +1732,7 @@ Label configuration just got a whole lot simpler 🎉
 
 # v7.12.9 (Thu Nov 07 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - Fix wrong author in changelog [#661](https://github.com/intuit/auto/pull/661) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -1751,7 +1745,7 @@ Label configuration just got a whole lot simpler 🎉
 
 # v7.12.8 (Thu Nov 07 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/first-time-contributor`
   - Fix multiple first-time-contributor thank you [#660](https://github.com/intuit/auto/pull/660) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -1764,7 +1758,7 @@ Label configuration just got a whole lot simpler 🎉
 
 # v7.12.7 (Thu Nov 07 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/released`
   - Fix creating old changelogs [#659](https://github.com/intuit/auto/pull/659) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -1795,18 +1789,18 @@ Label configuration just got a whole lot simpler 🎉
 
 # v7.12.5 (Tue Nov 05 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - fix issue with latest enterprise compat plugin [#655](https://github.com/intuit/auto/pull/655) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - `@auto-it/core`
   - Update changelog to include prs without labels when using custom patch label [#640](https://github.com/intuit/auto/pull/640) ([@bnigh](https://github.com/bnigh))
 
-#### 🏠  Internal
+#### 🏠 Internal
 
 - more reliable docs publish [#642](https://github.com/intuit/auto/pull/642) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - Adds documentation for using auto with no plugins [#641](https://github.com/intuit/auto/pull/641) ([@athityakumar](https://github.com/athityakumar))
 
@@ -1824,12 +1818,12 @@ Label configuration just got a whole lot simpler 🎉
 
 Thank you, Athitya Kumar ([@athityakumar](https://github.com/athityakumar)), for all your work!
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - Update changelog to include prs without labels when using custom patch label [#640](https://github.com/intuit/auto/pull/640) ([@bnigh](https://github.com/bnigh))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - Adds documentation for using auto with no plugins [#641](https://github.com/intuit/auto/pull/641) ([@athityakumar](https://github.com/athityakumar))
 
@@ -1842,7 +1836,7 @@ Thank you, Athitya Kumar ([@athityakumar](https://github.com/athityakumar)), for
 
 # v7.12.4 (Tue Oct 29 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/released`
   - Update released plugin message creation to replace all tokens [#638](https://github.com/intuit/auto/pull/638) ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
@@ -1870,7 +1864,7 @@ Thank you, Athitya Kumar ([@athityakumar](https://github.com/athityakumar)), for
 
 # v7.12.3 (Thu Oct 24 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`, `@auto-it/first-time-contributor`
   - better error messaging when tags aren't present [#626](https://github.com/intuit/auto/pull/626) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -1887,7 +1881,7 @@ Thank you, Athitya Kumar ([@athityakumar](https://github.com/athityakumar)), for
 
 Thank you, Rocio Montes ([@roxiomontes](https://github.com/roxiomontes)), for all your work!
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - adding Auto svg logo [#625](https://github.com/intuit/auto/pull/625) ([@roxiomontes](https://github.com/roxiomontes))
 
@@ -1899,7 +1893,7 @@ Thank you, Rocio Montes ([@roxiomontes](https://github.com/roxiomontes)), for al
 
 # v7.12.1 (Wed Oct 23 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/chrome`, `@auto-it/crates`, `@auto-it/git-tag`, `@auto-it/maven`, `@auto-it/npm`
   - Fix windows git refspec problem [#613](https://github.com/intuit/auto/pull/613) ([@adierkens](https://github.com/adierkens))
@@ -1926,12 +1920,12 @@ A new hook is available to plugin developers. the `afterAddToChangelog` enables 
 
 ---
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `@auto-it/core`, `@auto-it/all-contributors`
   - New Plugin: All contributors [#612](https://github.com/intuit/auto/pull/612) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - Move git-tag to "Package Manager Plugins" [#611](https://github.com/intuit/auto/pull/611) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -1957,7 +1951,7 @@ A new hook is available to plugin developers. the `afterAddToChangelog` enables 
 
 # v7.11.0 (Fri Oct 18 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `@auto-it/core`, `@auto-it/chrome`, `@auto-it/git-tag`, `@auto-it/npm`, `@auto-it/omit-commits`, `@auto-it/omit-release-notes`, `@auto-it/s3`, `@auto-it/twitter`
   - New Plugin: Amazon S3 [#466](https://github.com/intuit/auto/pull/466) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -1995,15 +1989,15 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 ---
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `@auto-it/core`, `@auto-it/crates`, `@auto-it/first-time-contributor`
   - New Plugin: "first-time-contributor" [#610](https://github.com/intuit/auto/pull/610) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### ⚠️  Pushed to master
+#### ⚠️ Pushed to master
 
 - `@auto-it/first-time-contributor`
-  - fix build  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+  - fix build ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -2013,7 +2007,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.9.2 (Thu Oct 17 2019)
 
-#### 🏠  Internal
+#### 🏠 Internal
 
 - `auto`
   - Switch to command-line-application and command-line-docs [#585](https://github.com/intuit/auto/pull/585) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -2026,12 +2020,12 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.9.1 (Thu Oct 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - only add hash to canary version if no pr or build detected [#609](https://github.com/intuit/auto/pull/609) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - `@auto-it/crates`, `@auto-it/maven`
   - fix install names in readmes [#608](https://github.com/intuit/auto/pull/608) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -2044,12 +2038,12 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.9.0 (Wed Oct 16 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `@auto-it/crates`
   - Crates (Rust language) plugin [#587](https://github.com/intuit/auto/pull/587) ([@Celeo](https://github.com/Celeo) [@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 🏠  Internal
+#### 🏠 Internal
 
 - update plugin template [#606](https://github.com/intuit/auto/pull/606) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - `auto`, `@auto-it/core`, `@auto-it/chrome`, `@auto-it/conventional-commits`, `@auto-it/git-tag`, `@auto-it/jira`, `@auto-it/maven`, `@auto-it/npm`, `@auto-it/omit-commits`, `@auto-it/omit-release-notes`, `@auto-it/released`, `@auto-it/slack`, `@auto-it/twitter`, `@auto-it/upload-assets`
@@ -2057,7 +2051,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 - `auto`, `@auto-it/core`, `@auto-it/chrome`, `@auto-it/conventional-commits`, `@auto-it/git-tag`, `@auto-it/jira`, `@auto-it/maven`, `@auto-it/npm`, `@auto-it/omit-commits`, `@auto-it/omit-release-notes`, `@auto-it/released`, `@auto-it/slack`, `@auto-it/twitter`, `@auto-it/upload-assets`
   - Update Tooling [#605](https://github.com/intuit/auto/pull/605) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - update README.md [#586](https://github.com/intuit/auto/pull/586) ([@Celeo](https://github.com/Celeo))
 
@@ -2091,7 +2085,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.8.0 (Fri Oct 04 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `@auto-it/core`
   - proxy support in auto [#584](https://github.com/intuit/auto/pull/584) (ykhandelwal@intuit.com [@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -2105,7 +2099,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.7.0 (Thu Oct 03 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `auto`, `@auto-it/core`
   - Ability to edit comments [#583](https://github.com/intuit/auto/pull/583) (alex_sutedja@intuit.com [@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -2131,7 +2125,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.6.2 (Mon Sep 30 2019)
 
-#### 🏠  Internal
+#### 🏠 Internal
 
 - `@auto-it/core`
   - Update Octokit [#574](https://github.com/intuit/auto/pull/574) ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]) [@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -2145,7 +2139,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.6.1 (Fri Sep 27 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/jira`
   - Fix jira plugin regex [#572](https://github.com/intuit/auto/pull/572) (velu_ganapathy@intuit.com [@vganapat](https://github.com/vganapat))
@@ -2170,7 +2164,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.6.0 (Thu Sep 12 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `auto`, `@auto-it/core`
   - Add 'from' option for version command [#561](https://github.com/intuit/auto/pull/561) ([@bnigh](https://github.com/bnigh))
@@ -2183,7 +2177,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.5.0 (Thu Sep 12 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `auto`, `@auto-it/core`
   - Add 'from' option for release command [#552](https://github.com/intuit/auto/pull/552) ([@bnigh](https://github.com/bnigh))
@@ -2196,7 +2190,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.4.5 (Mon Sep 09 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - Canary: fallback to first commit if now tags exist [#560](https://github.com/intuit/auto/pull/560) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -2218,7 +2212,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.4.4 (Tue Sep 03 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/npm`
   - Fix setting npm token with a URL that doesn't end in / [#551](https://github.com/intuit/auto/pull/551) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -2241,7 +2235,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.4.3 (Mon Sep 02 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/npm`
   - set-token: handle when no name in root package.json [#549](https://github.com/intuit/auto/pull/549) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -2254,7 +2248,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.4.2 (Mon Sep 02 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - label creation is case insensitive [#548](https://github.com/intuit/auto/pull/548) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -2267,7 +2261,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.4.1 (Sun Sep 01 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - Fix create-labels bug [#542](https://github.com/intuit/auto/pull/542) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -2280,7 +2274,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.4.0 (Sat Aug 31 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `@auto-it/core`, `@auto-it/conventional-commits`
   - add ability for configured labels to be an array [#540](https://github.com/intuit/auto/pull/540) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -2293,7 +2287,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.3.6 (Wed Aug 28 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`, `@auto-it/released`
   - omit commit+prs that: aren't found in repo, are issues, or have the "released" label [#538](https://github.com/intuit/auto/pull/538) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -2311,7 +2305,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.3.5 (Wed Aug 28 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - Ensure the release doesn't fail if a PR doesn't exist [#537](https://github.com/intuit/auto/pull/537) ([@zephraph](https://github.com/zephraph))
@@ -2324,7 +2318,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.3.4 (Mon Aug 26 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - Fix PRs with non-configured labels being omitted from changelogs [#533](https://github.com/intuit/auto/pull/533) ([@bnigh](https://github.com/bnigh))
@@ -2337,7 +2331,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.3.3 (Mon Aug 26 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - Improve Author Reporting [#531](https://github.com/intuit/auto/pull/531) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -2372,7 +2366,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.3.2 (Sat Aug 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - attach sha to canary version if no (pr || build) [#519](https://github.com/intuit/auto/pull/519) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -2385,7 +2379,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.3.1 (Fri Aug 16 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - add extra logs [#517](https://github.com/intuit/auto/pull/517) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -2408,7 +2402,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.3.0 (Thu Aug 15 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `auto`, `@auto-it/chrome`, `@auto-it/conventional-commits`, `@auto-it/git-tag`, `@auto-it/jira`, `@auto-it/maven`, `@auto-it/npm`, `@auto-it/omit-commits`, `@auto-it/omit-release-notes`, `@auto-it/released`, `@auto-it/slack`, `@auto-it/twitter`, `@auto-it/upload-assets`
   - Add Maven Plugin [#510](https://github.com/intuit/auto/pull/510) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -2436,16 +2430,16 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.2.3 (Mon Jul 29 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - fix logging error in pr-check [#497](https://github.com/intuit/auto/pull/497) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 🏠  Internal
+#### 🏠 Internal
 
 - change to dependabot [#495](https://github.com/intuit/auto/pull/495) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - fix docs [#496](https://github.com/intuit/auto/pull/496) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -2466,11 +2460,11 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.2.2 (Wed Jul 24 2019)
 
-#### 🏠  Internal
+#### 🏠 Internal
 
 - Remove pr semver check [#479](https://github.com/intuit/auto/pull/479) ([@zephraph](https://github.com/zephraph))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - Fix links in docs [#486](https://github.com/intuit/auto/pull/486) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Update README.md [#485](https://github.com/intuit/auto/pull/485) ([@RichieRunner](https://github.com/RichieRunner))
@@ -2485,7 +2479,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.2.1 (Tue Jul 09 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - Rework plugin importing logic [#480](https://github.com/intuit/auto/pull/480) ([@zephraph](https://github.com/zephraph))
@@ -2500,7 +2494,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.2.0 (Thu Jul 04 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `@auto-it/slack`
   - feat(slack): add custom slack at targets [#475](https://github.com/intuit/auto/pull/475) ([@hello-woof](https://github.com/hello-woof))
@@ -2513,7 +2507,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.1.4 (Wed Jul 03 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - Add a little extra error handling around plugin loading [#474](https://github.com/intuit/auto/pull/474) ([@zephraph](https://github.com/zephraph))
@@ -2526,7 +2520,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.1.3 (Sat Jun 29 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/git-tag`
   - Fix wording on Git tag plugin [#469](https://github.com/intuit/auto/pull/469) ([@zephraph](https://github.com/zephraph))
@@ -2539,7 +2533,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.1.2 (Tue Jun 18 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/slack`
   - Slack Plugin: fix tag link [#464](https://github.com/intuit/auto/pull/464) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -2552,7 +2546,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.1.1 (Mon Jun 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/conventional-commits`
   - Conventional Commits Plugin: fix looping issue [#461](https://github.com/intuit/auto/pull/461) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -2565,7 +2559,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.1.0 (Fri Jun 14 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `@auto-it/core`, `@auto-it/git-tag`
   - Git tag Plugin [#460](https://github.com/intuit/auto/pull/460) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -2578,7 +2572,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.0.13 (Mon Jun 10 2019)
 
-#### 🏠  Internal
+#### 🏠 Internal
 
 - `@auto-it/core`, `@auto-it/upload-assets`
   - update octokit [#459](https://github.com/intuit/auto/pull/459) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -2591,7 +2585,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.0.12 (Sat Jun 08 2019)
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - Update AutoChangeLog with Typo Fixes [#457](https://github.com/intuit/auto/pull/457) ([@jdfalko](https://github.com/jdfalko))
 
@@ -2603,7 +2597,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.0.11 (Thu Jun 06 2019)
 
-#### 🏠  Internal
+#### 🏠 Internal
 
 - Bump handlebars from 4.1.0 to 4.1.2 [#453](https://github.com/intuit/auto/pull/453) ([@dependabot[bot]](https://github.com/dependabot[bot]))
 
@@ -2615,7 +2609,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.0.10 (Thu Jun 06 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/npm`
   - NPM Plugin: fix canary versions [#456](https://github.com/intuit/auto/pull/456) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -2628,7 +2622,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.0.9 (Thu Jun 06 2019)
 
-#### 🏠  Internal
+#### 🏠 Internal
 
 - Bump js-yaml from 3.12.0 to 3.13.1 [#454](https://github.com/intuit/auto/pull/454) ([@dependabot[bot]](https://github.com/dependabot[bot]))
 
@@ -2640,7 +2634,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.0.8 (Thu Jun 06 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`, `@auto-it/npm`
   - Independant Canary version reporting + Whitespace in pr-body [#455](https://github.com/intuit/auto/pull/455) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -2653,7 +2647,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.0.7 (Thu May 30 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - Changelog bugs [#452](https://github.com/intuit/auto/pull/452) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -2666,7 +2660,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.0.6 (Thu May 30 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`, `@auto-it/jira`, `@auto-it/npm`, `@auto-it/omit-release-notes`
   - Lerna independent mode bugs [#451](https://github.com/intuit/auto/pull/451) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -2679,12 +2673,12 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.0.5 (Thu May 30 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - Respect author in config [#450](https://github.com/intuit/auto/pull/450) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - Get docs publishing [#448](https://github.com/intuit/auto/pull/448) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -2701,12 +2695,12 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.0.4 (Mon May 20 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/npm`
   - stop using --canary flag in npm package [#446](https://github.com/intuit/auto/pull/446) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - Update README.md [#445](https://github.com/intuit/auto/pull/445) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -2718,7 +2712,7 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.0.3 (Mon May 20 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - fall back to normal require for npx and global usage [#444](https://github.com/intuit/auto/pull/444) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -2731,12 +2725,12 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.0.2 (Sun May 19 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - Remove bin entry from core [#441](https://github.com/intuit/auto/pull/441) ([@zephraph](https://github.com/zephraph))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - Fix conventional commits link [#439](https://github.com/intuit/auto/pull/439) ([@zephraph](https://github.com/zephraph))
 
@@ -2748,12 +2742,12 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
 
 # v7.0.1 (Sat May 18 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - `@auto-it/core`
   - fix changelog indentation [#438](https://github.com/intuit/auto/pull/438) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 🏠  Internal
+#### 🏠 Internal
 
 - `auto`
   - fix bundle step, must gzip correct folder [#437](https://github.com/intuit/auto/pull/437) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -2773,12 +2767,15 @@ auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
     old `afterRelease`
 
 ```js
-auto.hooks.afterRelease.tap('MyPlugin', async (version, commits, releaseNotes) => {
-// do something
-});
+auto.hooks.afterRelease.tap(
+  'MyPlugin',
+  async (version, commits, releaseNotes) => {
+    // do something
+  }
+);
 ```
 
-new  `afterRelease`
+new `afterRelease`
 
 ```js
 auto.hooks.afterRelease.tap( 'MyPlugin', async ({ version, commits, releaseNotes, response }) => {
@@ -2792,7 +2789,7 @@ _From #408_
 
 ```json
 {
-"jira": "https://url-to-jira"
+  "jira": "https://url-to-jira"
 }
 ```
 
@@ -2800,11 +2797,11 @@ this should be changed to:
 
 ```json
 {
-"plugins": [
-["jira", { "url": "https://url-to-jira" }],
-// or
-["jira", "https://url-to-jira"]
-]
+  "plugins": [
+    ["jira", { "url": "https://url-to-jira" }],
+    // or
+    ["jira", "https://url-to-jira"]
+  ]
 }
 ```
 
@@ -2844,7 +2841,7 @@ _From #407_
 
 ```json
 {
-"slack": "https://url-to-slack"
+  "slack": "https://url-to-slack"
 }
 ```
 
@@ -2852,17 +2849,17 @@ this should be changed to:
 
 ```json
 {
-"plugins": [
-["slack", { "url": "https://url-to-your-slack-hook.com" }],
-// or
-["slack", "https://url-to-your-slack-hook.com"]
-]
+  "plugins": [
+    ["slack", { "url": "https://url-to-your-slack-hook.com" }],
+    // or
+    ["slack", "https://url-to-your-slack-hook.com"]
+  ]
 }
 ```
 
 ---
 
-#### 💥  Breaking Change
+#### 💥 Breaking Change
 
 - Factor out filter accounts plugin [#409](https://github.com/intuit/auto/pull/409) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Move jira functionality to plugin [#408](https://github.com/intuit/auto/pull/408) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -2882,7 +2879,7 @@ this should be changed to:
 - `auto`, `@auto-it/core`, `@auto-it/chrome`, `@auto-it/conventional-commits`, `@auto-it/jira`, `@auto-it/npm`, `@auto-it/released`, `@auto-it/slack`
   - Restructure to Monorepo [#410](https://github.com/intuit/auto/pull/410) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `@auto-it/core`, `@auto-it/omit-commits`, `@auto-it/omit-release-notes`
   - new hook: omit prs from release notes + add omit-release-notes plugin [#427](https://github.com/intuit/auto/pull/427) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -2893,28 +2890,28 @@ this should be changed to:
 - `auto`, `@auto-it/core`
   - Bundle `auto` for all major platforms [#418](https://github.com/intuit/auto/pull/418) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add docs about omitReleaseNotes  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- run the correct command  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- start  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add docs about omitReleaseNotes ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- run the correct command ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- start ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - `auto`, `@auto-it/core`
   - fix bundling plugin issue [#435](https://github.com/intuit/auto/pull/435) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - `@auto-it/core`, `@auto-it/npm`
   - Various Bug Fixes [#434](https://github.com/intuit/auto/pull/434) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - `@auto-it/core`, `@auto-it/upload-assets`
-  - rename ghub to github  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+  - rename ghub to github ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - `@auto-it/omit-commits`
-  - fix build  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+  - fix build ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - `@auto-it/core`
   - fix problem where pr-body would only match after two were rendered [#431](https://github.com/intuit/auto/pull/431) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - `@auto-it/npm`
   - Parse monorepo packages outside of `packages` directory [#411](https://github.com/intuit/auto/pull/411) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Update docs/pages/plugins.md
 
-Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+Co-Authored-By: Justin Bennett <zephraph@gmail.com> ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 🏠  Internal
+#### 🏠 Internal
 
 - Add monorepo plugin create command [#430](https://github.com/intuit/auto/pull/430) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - `auto`, `@auto-it/core`, `@auto-it/released`
@@ -2935,7 +2932,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v6.5.1 (Mon May 13 2019)
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - typo [#405](https://github.com/intuit/auto/pull/405) ([@zephraph](https://github.com/zephraph))
 
@@ -2947,7 +2944,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v6.5.0 (Fri May 10 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - Add --delete to `comment` and `pr-body` [#403](https://github.com/intuit/auto/pull/403) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -2959,11 +2956,11 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v6.4.1 (Fri May 10 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - fix jira PR titles without additional subject [#404](https://github.com/intuit/auto/pull/404) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - update docs for canary [#402](https://github.com/intuit/auto/pull/402) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -2975,7 +2972,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v6.4.0 (Thu May 09 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - update canary to update pr body when there is a pr [#401](https://github.com/intuit/auto/pull/401) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -2992,7 +2989,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v6.3.5 (Thu May 09 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - lerna no-force-publish release conflict [#399](https://github.com/intuit/auto/pull/399) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3004,7 +3001,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v6.3.4 (Thu May 09 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - conventional-commit plugin: should omit PR merge commits when a commit in the PR has CC commit message [#395](https://github.com/intuit/auto/pull/395) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3020,7 +3017,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v6.3.3 (Thu May 09 2019)
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - Fix grammar in getting started documentation [#396](https://github.com/intuit/auto/pull/396) ([@djpowers](https://github.com/djpowers))
 
@@ -3032,11 +3029,11 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v6.3.1 (Wed May 08 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - ensure major minor and patch get to changelog in that order [#392](https://github.com/intuit/auto/pull/392) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - add page for conventional-commits plugin [#393](https://github.com/intuit/auto/pull/393) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3048,7 +3045,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v6.3.0 (Wed May 08 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - Release notes [#380](https://github.com/intuit/auto/pull/380) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3060,9 +3057,9 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v6.2.6 (Wed May 08 2019)
 
-#### ⚠️  Pushed to master
+#### ⚠️ Pushed to master
 
-- add better logs when setting git user  ([@lisowski54@gmail.com](https://github.com/lisowski54@gmail.com))
+- add better logs when setting git user ([@lisowski54@gmail.com](https://github.com/lisowski54@gmail.com))
 
 #### Authors: 1
 
@@ -3072,7 +3069,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v6.2.5 (Wed May 08 2019)
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - Fix typo in introduction documentation [#391](https://github.com/intuit/auto/pull/391) ([@djpowers](https://github.com/djpowers))
 
@@ -3084,7 +3081,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v6.2.4 (Wed May 08 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - remove getGitHubToken function [#386](https://github.com/intuit/auto/pull/386) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3096,7 +3093,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v6.2.3 (Wed May 08 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - use correct variable in pr-body success message [#389](https://github.com/intuit/auto/pull/389) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3108,7 +3105,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v6.2.2 (Tue May 07 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - must await posting to the PR body [#388](https://github.com/intuit/auto/pull/388) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3120,7 +3117,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v6.2.1 (Tue May 07 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - split off useless hash from version [#387](https://github.com/intuit/auto/pull/387) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3136,7 +3133,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v6.2.0 (Tue May 07 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - Error on uncommited files when before running canary + version [#384](https://github.com/intuit/auto/pull/384) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3148,7 +3145,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v6.1.1 (Tue May 07 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Correct reported lerna independent version [#383](https://github.com/intuit/auto/pull/383) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3160,7 +3157,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v6.1.0 (Tue May 07 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - add `auto pr-body` to add info to pr bodies + canary posts to body instead of comment [#379](https://github.com/intuit/auto/pull/379) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3172,7 +3169,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v6.0.2 (Mon May 06 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - report back correct versions when running canary [#378](https://github.com/intuit/auto/pull/378) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3184,7 +3181,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v6.0.1 (Mon May 06 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Better get by username/email error handling [#377](https://github.com/intuit/auto/pull/377) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3196,11 +3193,11 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v6.0.0 (Mon May 06 2019)
 
-#### 💥  Breaking Change
+#### 💥 Breaking Change
 
 - Restrict config type [#374](https://github.com/intuit/auto/pull/374) ([@zephraph](https://github.com/zephraph))
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - Support Lerna Independent mode [#373](https://github.com/intuit/auto/pull/373) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3217,7 +3214,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v5.0.1 (Sat May 04 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - shipit will publish a canary locally when not on master [#371](https://github.com/intuit/auto/pull/371) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3229,16 +3226,16 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v5.0.0 (Sat May 04 2019)
 
-#### 💥  Breaking Change
+#### 💥 Breaking Change
 
 - Calling `shipit` in PR in CI creates canary release [#351](https://github.com/intuit/auto/pull/351) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Configure base-branch + pushToMaster => pushToBaseBranch [#357](https://github.com/intuit/auto/pull/357) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 🏠  Internal
+#### 🏠 Internal
 
 - skip releases for greenkeeper + make special changelog section [#366](https://github.com/intuit/auto/pull/366) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - add blog [#368](https://github.com/intuit/auto/pull/368) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3250,7 +3247,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.15.5 (Fri May 03 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - fix bug when tying to publish canary for PR with skip-release label [#367](https://github.com/intuit/auto/pull/367) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3262,7 +3259,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.15.4 (Fri May 03 2019)
 
-#### 🏠  Internal
+#### 🏠 Internal
 
 - remove accidental log [#365](https://github.com/intuit/auto/pull/365) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Update @types/node to the latest version 🚀 [#364](https://github.com/intuit/auto/pull/364) ([@greenkeeper[bot]](https://github.com/greenkeeper[bot]))
@@ -3276,7 +3273,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.15.3 (Fri May 03 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Override any env var set in the .env [#362](https://github.com/intuit/auto/pull/362) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3288,7 +3285,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.15.2 (Fri May 03 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - make logLevel available on the logger [#363](https://github.com/intuit/auto/pull/363) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3300,7 +3297,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.15.1 (Fri May 03 2019)
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - update docs [#361](https://github.com/intuit/auto/pull/361) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3312,7 +3309,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.15.0 (Fri May 03 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - when canary is run locally it uses the commits SHA instead of PR + Build [#360](https://github.com/intuit/auto/pull/360) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3324,7 +3321,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.14.1 (Fri May 03 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - changelog includes any commit that has a PR parsed from the commit message [#359](https://github.com/intuit/auto/pull/359) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3336,7 +3333,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.14.0 (Thu May 02 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - enable loglevel silly for npm/lerna when in verbose or veryVerbose mode [#356](https://github.com/intuit/auto/pull/356) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3348,7 +3345,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.13.2 (Thu May 02 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - increase buffer for situations when user has a LOT of unpublished work [#354](https://github.com/intuit/auto/pull/354) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3360,13 +3357,11 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.13.1 (Thu May 02 2019)
 
-
-
 ---
 
 # v4.13.0 (Thu May 02 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - add forcePublish config option to npm plugin [#352](https://github.com/intuit/auto/pull/352) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3378,7 +3373,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.12.0 (Wed May 01 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - canary command [#349](https://github.com/intuit/auto/pull/349) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3390,11 +3385,11 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.11.0 (Wed May 01 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - Graphql url config [#350](https://github.com/intuit/auto/pull/350) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 🏠  Internal
+#### 🏠 Internal
 
 - Update node-fetch to the latest version 🚀 [#347](https://github.com/intuit/auto/pull/347) ([@greenkeeper[bot]](https://github.com/greenkeeper[bot]))
 
@@ -3407,7 +3402,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.10.0 (Wed May 01 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - comment, pr, and pr-check detect PR number in CI [#348](https://github.com/intuit/auto/pull/348) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3419,7 +3414,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.9.4 (Sat Apr 27 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Throw an error if extended config fails to load [#344](https://github.com/intuit/auto/pull/344) ([@zephraph](https://github.com/zephraph))
 
@@ -3431,11 +3426,11 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.9.3 (Sat Apr 27 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - fix bug when no labels exist [#343](https://github.com/intuit/auto/pull/343) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 🏠  Internal
+#### 🏠 Internal
 
 - Update import-cwd to the latest version 🚀 [#342](https://github.com/intuit/auto/pull/342) ([@greenkeeper[bot]](https://github.com/greenkeeper[bot]))
 
@@ -3448,11 +3443,11 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.9.2 (Sat Apr 27 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - use graphql to get around search rate limits [#340](https://github.com/intuit/auto/pull/340) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 🏠  Internal
+#### 🏠 Internal
 
 - Update node-fetch to the latest version 🚀 [#339](https://github.com/intuit/auto/pull/339) ([@greenkeeper[bot]](https://github.com/greenkeeper[bot]))
 - Update @types/node-fetch to the latest version 🚀 [#336](https://github.com/intuit/auto/pull/336) ([@greenkeeper[bot]](https://github.com/greenkeeper[bot]))
@@ -3466,7 +3461,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.9.1 (Fri Apr 26 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Adjust rate limiting retries from 3 to 5 [#338](https://github.com/intuit/auto/pull/338) ([@zephraph](https://github.com/zephraph))
 
@@ -3478,11 +3473,11 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.9.0 (Thu Apr 25 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - Add throttling, retry octokit plugins [#335](https://github.com/intuit/auto/pull/335) ([@zephraph](https://github.com/zephraph))
 
-#### 🏠  Internal
+#### 🏠 Internal
 
 - Update @hutson/set-npm-auth-token-for-ci to the latest version 🚀 [#330](https://github.com/intuit/auto/pull/330) ([@greenkeeper[bot]](https://github.com/greenkeeper[bot]))
 - Update husky to the latest version 🚀 [#333](https://github.com/intuit/auto/pull/333) ([@greenkeeper[bot]](https://github.com/greenkeeper[bot]))
@@ -3496,7 +3491,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.8.17 (Mon Apr 15 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - use old addLabels praram because of bug in new one [#329](https://github.com/intuit/auto/pull/329) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3508,12 +3503,12 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.8.15 (Mon Apr 15 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - update command line args [#328](https://github.com/intuit/auto/pull/328) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Octokit [#325](https://github.com/intuit/auto/pull/325) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 🏠  Internal
+#### 🏠 Internal
 
 - update node types [#326](https://github.com/intuit/auto/pull/326) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - update ts-jest [#327](https://github.com/intuit/auto/pull/327) ([@hipstersmoothie](https://github.com/hipstersmoothie))
@@ -3528,7 +3523,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.8.14 (Fri Apr 05 2019)
 
-#### 🏠  Internal
+#### 🏠 Internal
 
 - Update registry-url to the latest version 🚀 [#323](https://github.com/intuit/auto/pull/323) ([@greenkeeper[bot]](https://github.com/greenkeeper[bot]))
 - Update @types/semver to the latest version 🚀 [#321](https://github.com/intuit/auto/pull/321) ([@greenkeeper[bot]](https://github.com/greenkeeper[bot]))
@@ -3539,7 +3534,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 - Update @types/node-fetch to the latest version 🚀 [#309](https://github.com/intuit/auto/pull/309) ([@greenkeeper[bot]](https://github.com/greenkeeper[bot]))
 - Update tslint-xo to the latest version 🚀 [#312](https://github.com/intuit/auto/pull/312) ([@greenkeeper[bot]](https://github.com/greenkeeper[bot]))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - Fix issue with warning wrapping section [#322](https://github.com/intuit/auto/pull/322) ([@zephraph](https://github.com/zephraph))
 
@@ -3552,7 +3547,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.8.13 (Wed Mar 20 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - only add users once to changelog [#311](https://github.com/intuit/auto/pull/311) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3564,11 +3559,11 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.8.12 (Wed Mar 20 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - last ditch search for related PRs [#310](https://github.com/intuit/auto/pull/310) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - fix typo in docs [#307](https://github.com/intuit/auto/pull/307) ([@solon](https://github.com/solon))
 
@@ -3581,7 +3576,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.8.11 (Thu Mar 14 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Remove auth in error responses if it's present [#297](https://github.com/intuit/auto/pull/297) ([@zephraph](https://github.com/zephraph))
 
@@ -3593,12 +3588,12 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.8.10 (Wed Mar 13 2019)
 
-#### 🏠  Internal
+#### 🏠 Internal
 
 - update deps [#306](https://github.com/intuit/auto/pull/306) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Update @types/node to the latest version 🚀 [#303](https://github.com/intuit/auto/pull/303) ([@greenkeeper[bot]](https://github.com/greenkeeper[bot]))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - fixing a typo [#302](https://github.com/intuit/auto/pull/302) ([@GGonryun](https://github.com/GGonryun))
 
@@ -3612,7 +3607,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.8.9 (Mon Mar 04 2019)
 
-#### 🏠  Internal
+#### 🏠 Internal
 
 - update deps [#300](https://github.com/intuit/auto/pull/300) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Update tslint-xo to the latest version 🚀 [#298](https://github.com/intuit/auto/pull/298) ([@greenkeeper[bot]](https://github.com/greenkeeper[bot]))
@@ -3628,7 +3623,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.8.8 (Fri Feb 15 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Fix the formatting for slack messages [#292](https://github.com/intuit/auto/pull/292) ([@adierkens](https://github.com/adierkens))
 
@@ -3640,7 +3635,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.8.7 (Fri Feb 15 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Fix Promise issue when creating changelog [#293](https://github.com/intuit/auto/pull/293) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3652,7 +3647,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.8.6 (Wed Feb 13 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - check if released label has already been added [#290](https://github.com/intuit/auto/pull/290) (hipstersmoothie@users.noreply.github.com)
 
@@ -3664,7 +3659,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.8.5 (Wed Feb 13 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - released plugin respects dry run flag [#289](https://github.com/intuit/auto/pull/289) (hipstersmoothie@users.noreply.github.com)
 
@@ -3676,11 +3671,11 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.8.4 (Wed Feb 13 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - ShipIt - Get Slack URL from config [#288](https://github.com/intuit/auto/pull/288) (hipstersmoothie@users.noreply.github.com)
 
-#### 🏠  Internal
+#### 🏠 Internal
 
 - Update @types/node to the latest version 🚀 [#287](https://github.com/intuit/auto/pull/287) ([@greenkeeper[bot]](https://github.com/greenkeeper[bot]) [@hipstersmoothie](https://github.com/hipstersmoothie))
 - Update @types/node-fetch to the latest version 🚀 [#286](https://github.com/intuit/auto/pull/286) ([@greenkeeper[bot]](https://github.com/greenkeeper[bot]))
@@ -3697,7 +3692,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.8.3 (Wed Feb 06 2019)
 
-#### 🏠  Internal
+#### 🏠 Internal
 
 - Update all-contributors-cli to the latest version 🚀 [#284](https://github.com/intuit/auto/pull/284) ([@greenkeeper[bot]](https://github.com/greenkeeper[bot]))
 
@@ -3709,7 +3704,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.8.2 (Wed Feb 06 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Update @types/jest to the latest version 🚀 [#282](https://github.com/intuit/auto/pull/282) ([@greenkeeper[bot]](https://github.com/greenkeeper[bot]))
 
@@ -3721,7 +3716,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.8.1 (Thu Jan 31 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - ensure that setRcToken is respected [#279](https://github.com/intuit/auto/pull/279) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3733,7 +3728,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.8.0 (Thu Jan 31 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - NPM Plugin: Allow user to turn off setting RC token [#278](https://github.com/intuit/auto/pull/278) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3745,7 +3740,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.7.5 (Wed Jan 30 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - run git status in verbose mode for lerna [#277](https://github.com/intuit/auto/pull/277) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3757,7 +3752,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.7.4 (Wed Jan 30 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - add more logging for lerna debugging [#276](https://github.com/intuit/auto/pull/276) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3769,7 +3764,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.7.3 (Tue Jan 29 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - don't run commmit hooks. match npm version bahvior [#275](https://github.com/intuit/auto/pull/275) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3781,7 +3776,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.7.2 (Mon Jan 28 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - can't warn here or else `version` will fail [#274](https://github.com/intuit/auto/pull/274) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3793,7 +3788,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.7.1 (Sat Jan 26 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Update dependencies to enable Greenkeeper 🌴 [#273](https://github.com/intuit/auto/pull/273) ([@greenkeeper[bot]](https://github.com/greenkeeper[bot]) [@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3806,7 +3801,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.7.0 (Fri Jan 25 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - `create-labels` update labels when the exist [#272](https://github.com/intuit/auto/pull/272) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3818,7 +3813,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.6.0 (Fri Jan 25 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - modifyConfig hook [#270](https://github.com/intuit/auto/pull/270) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3830,7 +3825,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.5.3 (Fri Jan 25 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Custom labels still resolve changelog titles [#269](https://github.com/intuit/auto/pull/269) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3842,7 +3837,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.5.2 (Fri Jan 25 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - pushes to master should only include title in changelog [#267](https://github.com/intuit/auto/pull/267) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3854,7 +3849,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.5.1 (Fri Jan 25 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - add addLabel enterprise compat [#265](https://github.com/intuit/auto/pull/265) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3866,7 +3861,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.5.0 (Fri Jan 25 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - afterRelease hook [#264](https://github.com/intuit/auto/pull/264) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3878,7 +3873,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.4.4 (Fri Jan 25 2019)
 
-#### 🏠  Internal
+#### 🏠 Internal
 
 - remove .only [#261](https://github.com/intuit/auto/pull/261) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3890,7 +3885,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.4.3 (Fri Jan 25 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - load extends config from path [#260](https://github.com/intuit/auto/pull/260) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3902,7 +3897,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.4.2 (Fri Jan 25 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - release plugin: do nothing when skip-release present [#259](https://github.com/intuit/auto/pull/259) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3914,11 +3909,11 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.4.1 (Thu Jan 24 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Better config debug [#257](https://github.com/intuit/auto/pull/257) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 📝  Documentation
+#### 📝 Documentation
 
 - Add clarity to a few of the docs [#255](https://github.com/intuit/auto/pull/255) ([@zephraph](https://github.com/zephraph))
 
@@ -3931,7 +3926,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.4.0 (Thu Jan 24 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - Released plugin: add released label to issue too [#253](https://github.com/intuit/auto/pull/253) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3943,7 +3938,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.3.0 (Thu Jan 24 2019)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - Released Plugin: lock merged issues [#252](https://github.com/intuit/auto/pull/252) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3955,7 +3950,7 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.2.2 (Thu Jan 24 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Released Plugin: add context to comments so they don't override other comments [#251](https://github.com/intuit/auto/pull/251) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
@@ -3967,9 +3962,9 @@ Co-Authored-By: Justin Bennett <zephraph@gmail.com>  ([@hipstersmoothie](https:/
 
 # v4.2.1 (Thu Jan 24 2019)
 
-#### ⚠️  Pushed to master
+#### ⚠️ Pushed to master
 
-- quick rename  ([@lisowski54@gmail.com](https://github.com/lisowski54@gmail.com))
+- quick rename ([@lisowski54@gmail.com](https://github.com/lisowski54@gmail.com))
 
 #### Authors: 1
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,8 +1,8 @@
 # v9.15.8 (Tue Mar 03 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- set license on CLI  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- set license on CLI ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -12,9 +12,9 @@
 
 # v9.15.7 (Tue Mar 03 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- update --help output in cli readme  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- update --help output in cli readme ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -24,10 +24,10 @@
 
 # v9.15.4 (Mon Mar 02 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- make --force configurable in the .autorc  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Don't release canary on skip-release by default, add force flag  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- make --force configurable in the .autorc ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Don't release canary on skip-release by default, add force flag ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -37,15 +37,16 @@
 
 # v9.15.3 (Mon Mar 02 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump tslib from 1.11.0 to 1.11.1
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.11.0 to 1.11.1.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.11.0...1.11.1)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -55,9 +56,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.15.1 (Sun Mar 01 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- only get default config in command that allow it, enables shipit to easily use sub-commands configs  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- only get default config in command that allow it, enables shipit to easily use sub-commands configs ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -67,10 +68,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.15.0 (Sun Mar 01 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- enable autorc configuration for some command flags  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix tests  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- enable autorc configuration for some command flags ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix tests ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -80,15 +81,16 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.13.1 (Mon Feb 24 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump tslib from 1.10.0 to 1.11.0
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.10.0 to 1.11.0.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.10.0...1.11.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -98,9 +100,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.13.0 (Sat Feb 22 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- update docs  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- update docs ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -110,9 +112,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.12.1 (Sat Feb 22 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add warning to CLI flag  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add warning to CLI flag ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -122,9 +124,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.11.0 (Fri Feb 21 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Add new command 'latest' for easier testing and more flexibility  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Add new command 'latest' for easier testing and more flexibility ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -134,11 +136,11 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.10.4 (Thu Feb 06 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- fix test  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- dont exit process when calling info in core  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Run `auto info` when any command is run with --verbose  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix test ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- dont exit process when calling info in core ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Run `auto info` when any command is run with --verbose ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -148,9 +150,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.10.0 (Thu Feb 06 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add "info" command  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add "info" command ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -160,9 +162,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.5.0 (Mon Jan 27 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Overhaul "auto init" experience + make it pluggable  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Overhaul "auto init" experience + make it pluggable ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -172,9 +174,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.2.1 (Fri Jan 24 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- fallback to 0.0.0 in git-tag plugin with no previous releases  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fallback to 0.0.0 in git-tag plugin with no previous releases ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -184,9 +186,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.0.0 (Mon Jan 13 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- be explicit about supported node versions  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- be explicit about supported node versions ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -196,10 +198,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.6.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.5.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Update CHANGELOG.md [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.5.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Update CHANGELOG.md \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -209,16 +211,16 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.5.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.4.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.3.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.2.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Update CHANGELOG.md [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- release: add flag to publish prerelease  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.4.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.3.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.2.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Update CHANGELOG.md \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- release: add flag to publish prerelease ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -228,11 +230,11 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.4.1 (Mon Dec 16 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - alias the canary scope
 
-use alias we define  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+use alias we define ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -242,9 +244,9 @@ use alias we define  ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 # v8.2.0 (Sun Dec 15 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- release: add flag to publish prerelease  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- release: add flag to publish prerelease ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -254,31 +256,31 @@ use alias we define  ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 # v8.0.0 (Wed Dec 11 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.0.0-next.4 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- create v8 announcement  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- switch from dedent to endent to fix multitemplate indentation  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- post comment prerelase version on prerelease version PR branches  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Deprecate "--very-verbose, -w" in favor of "-vv"  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- reset versions  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.8 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.7 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- change skip-release releaseType to just skip  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.6 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.5 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- update docs  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- implment dry-run flag for next command  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- shipit: add flag to only publish to 'latest' tag when "release" label is present  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- allow user to configure what branches are treated as prerelease branches  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- call next from shipit on next branch  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- get next branch release working  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.4 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- create v8 announcement ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- switch from dedent to endent to fix multitemplate indentation ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- post comment prerelase version on prerelease version PR branches ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Deprecate "--very-verbose, -w" in favor of "-vv" ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- reset versions ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.8 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.7 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- change skip-release releaseType to just skip ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.6 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.5 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- update docs ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- implment dry-run flag for next command ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- shipit: add flag to only publish to 'latest' tag when "release" label is present ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- allow user to configure what branches are treated as prerelease branches ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- call next from shipit on next branch ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- get next branch release working ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,8 +1,8 @@
 # v9.16.0 (Thu Mar 05 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- fix tests  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix tests ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -12,9 +12,9 @@
 
 # v9.15.10 (Thu Mar 05 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Fix loading canary versions of offical plugins  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Fix loading canary versions of offical plugins ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -24,12 +24,12 @@
 
 # v9.15.9 (Thu Mar 05 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- fix typo  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- no need for 2 try/catches  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- better comment  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- test for ancestor in windows freindly way  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix typo ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- no need for 2 try/catches ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- better comment ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- test for ancestor in windows freindly way ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -39,9 +39,9 @@
 
 # v9.15.7 (Tue Mar 03 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add license to all sub-packages  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add license to all sub-packages ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -51,10 +51,10 @@
 
 # v9.15.6 (Tue Mar 03 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- format  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- info: handle when there is no previous version  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- format ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- info: handle when there is no previous version ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -64,9 +64,9 @@
 
 # v9.15.5 (Tue Mar 03 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- fix "Push to master" on next branch  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix "Push to master" on next branch ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -76,12 +76,12 @@
 
 # v9.15.4 (Mon Mar 02 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- update tests  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- make --force configurable in the .autorc  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix lint  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Don't release canary on skip-release by default, add force flag  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- update tests ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- make --force configurable in the .autorc ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix lint ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Don't release canary on skip-release by default, add force flag ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -91,23 +91,26 @@
 
 # v9.15.3 (Mon Mar 02 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- don't force publish canary/next for independent lerna projects  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- don't force publish canary/next for independent lerna projects ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Bump @types/node-fetch from 2.5.4 to 2.5.5
 
 Bumps [@types/node-fetch](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/HEAD/types/node-fetch) from 2.5.4 to 2.5.5.
+
 - [Release notes](https://github.com/DefinitelyTyped/DefinitelyTyped/releases)
 - [Commits](https://github.com/DefinitelyTyped/DefinitelyTyped/commits/HEAD/types/node-fetch)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+
 - Bump tslib from 1.11.0 to 1.11.1
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.11.0 to 1.11.1.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.11.0...1.11.1)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 2
 
@@ -118,9 +121,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.15.1 (Sun Mar 01 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- only get default config in command that allow it, enables shipit to easily use sub-commands configs  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- only get default config in command that allow it, enables shipit to easily use sub-commands configs ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -130,35 +133,35 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.15.0 (Sun Mar 01 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- use fromEntries ponyfill until node 10 EOL  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- don't valide config with flag overrides  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- enable autorc configuration for some command flags  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- dont include intersections in valdation error path  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- dont match none labels. this fixes bug where releaseType none labels would get the internal label's description  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix label ordering for validation error paths  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- strip ansi codes from snapshots  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- layout validaiton erros with more space  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix tests  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- validate fully loaded configuration  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- print objects better  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- print arrays better  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- dont report redundant errors  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add test to ensure command configuration doesn't throw errors  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix lint  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add test to make sure auto exits with configuration errors  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix old tests  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- validate raw config  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix union type overriding  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- get array of objects working  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- recursively convert type to exact  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- make plugin configuration helper util  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- exit on invalid config  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- when validating stop at unknown top level keys  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- remove dead code, was never used anywher  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- validate autorc configuration + add validateConfig hook for plugins  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- refactor autorc type  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- use fromEntries ponyfill until node 10 EOL ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- don't valide config with flag overrides ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- enable autorc configuration for some command flags ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- dont include intersections in valdation error path ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- dont match none labels. this fixes bug where releaseType none labels would get the internal label's description ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix label ordering for validation error paths ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- strip ansi codes from snapshots ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- layout validaiton erros with more space ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix tests ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- validate fully loaded configuration ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- print objects better ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- print arrays better ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- dont report redundant errors ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add test to ensure command configuration doesn't throw errors ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix lint ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add test to make sure auto exits with configuration errors ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix old tests ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- validate raw config ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix union type overriding ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- get array of objects working ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- recursively convert type to exact ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- make plugin configuration helper util ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- exit on invalid config ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- when validating stop at unknown top level keys ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- remove dead code, was never used anywher ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- validate autorc configuration + add validateConfig hook for plugins ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- refactor autorc type ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -168,9 +171,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.14.0 (Tue Feb 25 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add scoped plugin support  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add scoped plugin support ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -180,16 +183,17 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.13.1 (Mon Feb 24 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add fallback for when --is-ancestor fails  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add fallback for when --is-ancestor fails ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Bump tslib from 1.10.0 to 1.11.0
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.10.0 to 1.11.0.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.10.0...1.11.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 2
 
@@ -200,12 +204,12 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.13.0 (Sat Feb 22 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- When parsing owner/repo fallback to parsing 'origin'  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- When parsing owner/repo fallback to parsing 'origin' ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - add git version to 'auto info' output
 
-!  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+! ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -215,10 +219,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.12.0 (Fri Feb 21 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add tests  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- ensure remote can be pushed to  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add tests ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- ensure remote can be pushed to ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -228,9 +232,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.11.0 (Fri Feb 21 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Add new command 'latest' for easier testing and more flexibility  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Add new command 'latest' for easier testing and more flexibility ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -240,10 +244,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.10.8 (Fri Feb 21 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- configure agent on request  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Adding proxyagent to graphql  ([@YogiKhan](https://github.com/YogiKhan))
+- configure agent on request ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Adding proxyagent to graphql ([@YogiKhan](https://github.com/YogiKhan))
 
 #### Authors: 2
 
@@ -254,9 +258,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.10.7 (Tue Feb 18 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- filter out bots in first-time contributor plugins  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- filter out bots in first-time contributor plugins ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -270,31 +274,36 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 Thank you, null[@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]), for all your work!
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- get node version in crash friendly way  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix build  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- get node version in crash friendly way ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix build ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Bump https-proxy-agent from 4.0.0 to 5.0.0
 
 Bumps [https-proxy-agent](https://github.com/TooTallNate/node-https-proxy-agent) from 4.0.0 to 5.0.0.
+
 - [Release notes](https://github.com/TooTallNate/node-https-proxy-agent/releases)
 - [Commits](https://github.com/TooTallNate/node-https-proxy-agent/compare/4.0.0...5.0.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+
 - Bump @octokit/core from 2.2.0 to 2.4.0
 
 Bumps [@octokit/core](https://github.com/octokit/core.js) from 2.2.0 to 2.4.0.
+
 - [Release notes](https://github.com/octokit/core.js/releases)
 - [Commits](https://github.com/octokit/core.js/compare/v2.2.0...v2.4.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+
 - Bump @types/semver from 6.2.0 to 7.1.0
 
 Bumps [@types/semver](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/HEAD/types/semver) from 6.2.0 to 7.1.0.
+
 - [Release notes](https://github.com/DefinitelyTyped/DefinitelyTyped/releases)
 - [Commits](https://github.com/DefinitelyTyped/DefinitelyTyped/commits/HEAD/types/semver)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 2
 
@@ -309,16 +318,17 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 Thank you, null[@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]), for all your work!
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- fix build  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix build ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Bump @octokit/rest from 16.38.3 to 16.43.1
 
 Bumps [@octokit/rest](https://github.com/octokit/rest.js) from 16.38.3 to 16.43.1.
+
 - [Release notes](https://github.com/octokit/rest.js/releases)
 - [Commits](https://github.com/octokit/rest.js/compare/v16.38.3...v16.43.1)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 2
 
@@ -329,9 +339,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.10.4 (Thu Feb 06 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- dont exit process when calling info in core  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- dont exit process when calling info in core ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -341,10 +351,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.10.3 (Thu Feb 06 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add user login  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add info about token permission  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add user login ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add info about token permission ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -354,9 +364,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.10.2 (Thu Feb 06 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- handle repos with large amounts of labels  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- handle repos with large amounts of labels ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -366,10 +376,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.10.0 (Thu Feb 06 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- remove space  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add "info" command  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- remove space ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add "info" command ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -379,9 +389,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.8.3 (Thu Jan 30 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- move ICommit to "core" to fix external plugin TS build errors  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- move ICommit to "core" to fix external plugin TS build errors ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -391,10 +401,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.8.1 (Wed Jan 29 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- more descriptive message  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- better error message running release in repo w/o tags  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- more descriptive message ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- better error message running release in repo w/o tags ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -404,10 +414,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.8.0 (Mon Jan 27 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- make unique GitHub releases for each package published in lerna independent monorepo  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- create new hook makeRelease and move current behavior into default tap  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- make unique GitHub releases for each package published in lerna independent monorepo ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- create new hook makeRelease and move current behavior into default tap ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -417,9 +427,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.7.0 (Mon Jan 27 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- enhance BeforeShipit hook to include the type of release that will be made  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- enhance BeforeShipit hook to include the type of release that will be made ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -433,34 +443,39 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 Thank you, null[@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]), for all your work!
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- fix lint  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add next steps  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Overhaul "auto init" experience + make it pluggable  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix build  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix test  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix lint ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add next steps ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Overhaul "auto init" experience + make it pluggable ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix build ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix test ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Bump @octokit/plugin-throttling from 2.7.1 to 3.2.0
 
 Bumps [@octokit/plugin-throttling](https://github.com/octokit/plugin-throttling.js) from 2.7.1 to 3.2.0.
+
 - [Release notes](https://github.com/octokit/plugin-throttling.js/releases)
 - [Commits](https://github.com/octokit/plugin-throttling.js/compare/v2.7.1...v3.2.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@hipstersmoothie](https://github.com/hipstersmoothie))
+
 - Bump @octokit/plugin-retry from 2.2.0 to 3.0.1
 
 Bumps [@octokit/plugin-retry](https://github.com/octokit/plugin-retry.js) from 2.2.0 to 3.0.1.
+
 - [Release notes](https://github.com/octokit/plugin-retry.js/releases)
 - [Commits](https://github.com/octokit/plugin-retry.js/compare/v2.2.0...v3.0.1)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+
 - Bump @octokit/rest from 16.37.0 to 16.38.3
 
 Bumps [@octokit/rest](https://github.com/octokit/rest.js) from 16.37.0 to 16.38.3.
+
 - [Release notes](https://github.com/octokit/rest.js/releases)
 - [Commits](https://github.com/octokit/rest.js/compare/v16.37.0...v16.38.3)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 2
 
@@ -471,10 +486,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.4.0 (Sat Jan 25 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- format detail a little better  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Add html details option to canary hook + Use in npm plugin  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- format detail a little better ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Add html details option to canary hook + Use in npm plugin ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -484,10 +499,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.3.4 (Sat Jan 25 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- fix test  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add better messaging when pr number cannot be detected  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix test ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add better messaging when pr number cannot be detected ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -497,9 +512,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.3.3 (Fri Jan 24 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Add :package: emoji to canary PR message to make it more noticeable  ([@ericclemmons](https://github.com/ericclemmons))
+- Add :package: emoji to canary PR message to make it more noticeable ([@ericclemmons](https://github.com/ericclemmons))
 
 #### Authors: 1
 
@@ -509,9 +524,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.3.2 (Fri Jan 24 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- better logging in dry runs  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- better logging in dry runs ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -521,10 +536,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.3.1 (Fri Jan 24 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add test  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Surface plugin syntax errors to user  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add test ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Surface plugin syntax errors to user ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -534,9 +549,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.2.2 (Fri Jan 24 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Fix error on empty pr body  ([@reckter](https://github.com/reckter))
+- Fix error on empty pr body ([@reckter](https://github.com/reckter))
 
 #### Authors: 1
 
@@ -546,9 +561,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.2.1 (Fri Jan 24 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- fallback to 0.0.0 in git-tag plugin with no previous releases  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fallback to 0.0.0 in git-tag plugin with no previous releases ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -558,10 +573,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.2.0 (Thu Jan 23 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- fix lint warning  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Add ability to manage sub-package contributor lists  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix lint warning ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Add ability to manage sub-package contributor lists ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -571,9 +586,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.1.2 (Thu Jan 23 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- fix omitting renovate release notes when a user manually rebases the renovate PR  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix omitting renovate release notes when a user manually rebases the renovate PR ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -583,9 +598,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.1.1 (Thu Jan 23 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Fix onlyPublishWithReleaseLabel w/o labels  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Fix onlyPublishWithReleaseLabel w/o labels ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -595,24 +610,27 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.1.0 (Tue Jan 21 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- upgrade enquirer  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- canary: try to match commit to PR if not found in env  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- upgrade enquirer ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- canary: try to match commit to PR if not found in env ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Bump @types/node from 12.12.21 to 13.1.8
 
 Bumps [@types/node](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/HEAD/types/node) from 12.12.21 to 13.1.8.
+
 - [Release notes](https://github.com/DefinitelyTyped/DefinitelyTyped/releases)
 - [Commits](https://github.com/DefinitelyTyped/DefinitelyTyped/commits/HEAD/types/node)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+
 - Bump @octokit/rest from 16.36.0 to 16.37.0
 
 Bumps [@octokit/rest](https://github.com/octokit/rest.js) from 16.36.0 to 16.37.0.
+
 - [Release notes](https://github.com/octokit/rest.js/releases)
 - [Commits](https://github.com/octokit/rest.js/compare/v16.36.0...v16.37.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 2
 
@@ -623,9 +641,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.0.1 (Mon Jan 13 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- handle PR numbers that don't exist in repo/fork  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- handle PR numbers that don't exist in repo/fork ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -635,22 +653,25 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.0.0 (Mon Jan 13 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump env-ci from 4.5.2 to 5.0.1
 
 Bumps [env-ci](https://github.com/pvdlg/env-ci) from 4.5.2 to 5.0.1.
+
 - [Release notes](https://github.com/pvdlg/env-ci/releases)
 - [Commits](https://github.com/pvdlg/env-ci/compare/v4.5.2...v5.0.1)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+
 - Bump @octokit/rest from 16.35.2 to 16.36.0
 
 Bumps [@octokit/rest](https://github.com/octokit/rest.js) from 16.35.2 to 16.36.0.
+
 - [Release notes](https://github.com/octokit/rest.js/releases)
 - [Commits](https://github.com/octokit/rest.js/compare/v16.35.2...v16.36.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -660,10 +681,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.8.0 (Thu Jan 02 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Update existing test so behavior matches name  ([@bnigh](https://github.com/bnigh))
-- Add tests to verify changelog section assignment behavior  ([@bnigh](https://github.com/bnigh))
+- Update existing test so behavior matches name ([@bnigh](https://github.com/bnigh))
+- Add tests to verify changelog section assignment behavior ([@bnigh](https://github.com/bnigh))
 
 #### Authors: 1
 
@@ -673,9 +694,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.7.3 (Fri Dec 20 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- check origin head instead of local branch  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- check origin head instead of local branch ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -685,9 +706,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.7.2 (Fri Dec 20 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- find the last greatest tag to help with botched releases  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- find the last greatest tag to help with botched releases ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -697,9 +718,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.7.1 (Thu Dec 19 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add debug info  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add debug info ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -709,10 +730,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.7.0 (Thu Dec 19 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- fix lint  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add context of what type of release was made during shipit  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix lint ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add context of what type of release was made during shipit ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -722,10 +743,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.6.3 (Thu Dec 19 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- fix execpromise logs  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- determine next version using by omitting tags from master  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix execpromise logs ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- determine next version using by omitting tags from master ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -735,11 +756,11 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.6.2 (Wed Dec 18 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- update snapshots  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix test  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- only access auto login if it all exists  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- update snapshots ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix test ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- only access auto login if it all exists ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -749,11 +770,11 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.6.1 (Wed Dec 18 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- fix tests  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix build  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- canary hook can return void to not bail  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix tests ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix build ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- canary hook can return void to not bail ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -763,14 +784,14 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.6.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- make branch at last tag instead of head  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- finish update  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- update versioning prelabel  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.5.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Update CHANGELOG.md [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add ability to manage version branches  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- make branch at last tag instead of head ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- finish update ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- update versioning prelabel ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.5.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Update CHANGELOG.md \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add ability to manage version branches ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -780,46 +801,51 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.5.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.2.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add ability to manage version branches  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Update CHANGELOG.md [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.3.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- version: detect prerelease branch  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- release: detect prerelease branch + be smarter about commit range  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- let modify config actually do something  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- ignore unknown labels during bump calc + fix none type release skipping  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.4.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix and add tests  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- release: add flag to publish prerelease  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add test  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- omit next branch PR Title from being in release notes  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.2.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add ability to manage version branches ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Update CHANGELOG.md \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.3.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- version: detect prerelease branch ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- release: detect prerelease branch + be smarter about commit range ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- let modify config actually do something ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- ignore unknown labels during bump calc + fix none type release skipping ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.4.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix and add tests ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- release: add flag to publish prerelease ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add test ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- omit next branch PR Title from being in release notes ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Bump https-proxy-agent from 3.0.1 to 4.0.0
 
 Bumps [https-proxy-agent](https://github.com/TooTallNate/node-https-proxy-agent) from 3.0.1 to 4.0.0.
+
 - [Release notes](https://github.com/TooTallNate/node-https-proxy-agent/releases)
 - [Commits](https://github.com/TooTallNate/node-https-proxy-agent/compare/3.0.1...4.0.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+
 - Bump @octokit/rest from 16.35.0 to 16.35.2
 
 Bumps [@octokit/rest](https://github.com/octokit/rest.js) from 16.35.0 to 16.35.2.
+
 - [Release notes](https://github.com/octokit/rest.js/releases)
 - [Commits](https://github.com/octokit/rest.js/compare/v16.35.0...v16.35.2)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+
 - Bump semver from 6.3.0 to 7.0.0
 
 Bumps [semver](https://github.com/npm/node-semver) from 6.3.0 to 7.0.0.
+
 - [Release notes](https://github.com/npm/node-semver/releases)
 - [Changelog](https://github.com/npm/node-semver/blob/master/CHANGELOG.md)
 - [Commits](https://github.com/npm/node-semver/compare/v6.3.0...v7.0.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 2
 
@@ -830,46 +856,51 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.5.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.2.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add ability to manage version branches  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Update CHANGELOG.md [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.3.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- version: detect prerelease branch  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- release: detect prerelease branch + be smarter about commit range  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- let modify config actually do something  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- ignore unknown labels during bump calc + fix none type release skipping  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.4.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix and add tests  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- release: add flag to publish prerelease  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add test  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- omit next branch PR Title from being in release notes  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.2.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add ability to manage version branches ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Update CHANGELOG.md \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.3.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- version: detect prerelease branch ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- release: detect prerelease branch + be smarter about commit range ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- let modify config actually do something ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- ignore unknown labels during bump calc + fix none type release skipping ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.4.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix and add tests ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- release: add flag to publish prerelease ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add test ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- omit next branch PR Title from being in release notes ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Bump https-proxy-agent from 3.0.1 to 4.0.0
 
 Bumps [https-proxy-agent](https://github.com/TooTallNate/node-https-proxy-agent) from 3.0.1 to 4.0.0.
+
 - [Release notes](https://github.com/TooTallNate/node-https-proxy-agent/releases)
 - [Commits](https://github.com/TooTallNate/node-https-proxy-agent/compare/3.0.1...4.0.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+
 - Bump @octokit/rest from 16.35.0 to 16.35.2
 
 Bumps [@octokit/rest](https://github.com/octokit/rest.js) from 16.35.0 to 16.35.2.
+
 - [Release notes](https://github.com/octokit/rest.js/releases)
 - [Commits](https://github.com/octokit/rest.js/compare/v16.35.0...v16.35.2)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+
 - Bump semver from 6.3.0 to 7.0.0
 
 Bumps [semver](https://github.com/npm/node-semver) from 6.3.0 to 7.0.0.
+
 - [Release notes](https://github.com/npm/node-semver/releases)
 - [Changelog](https://github.com/npm/node-semver/blob/master/CHANGELOG.md)
 - [Commits](https://github.com/npm/node-semver/compare/v6.3.0...v7.0.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 2
 
@@ -880,9 +911,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.4.0 (Mon Dec 16 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- version: detect prerelease branch  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- version: detect prerelease branch ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -892,31 +923,36 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.3.0 (Mon Dec 16 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- release: detect prerelease branch + be smarter about commit range  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- release: detect prerelease branch + be smarter about commit range ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Bump @octokit/rest from 16.35.0 to 16.35.2
 
 Bumps [@octokit/rest](https://github.com/octokit/rest.js) from 16.35.0 to 16.35.2.
+
 - [Release notes](https://github.com/octokit/rest.js/releases)
 - [Commits](https://github.com/octokit/rest.js/compare/v16.35.0...v16.35.2)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+
 - Bump https-proxy-agent from 3.0.1 to 4.0.0
 
 Bumps [https-proxy-agent](https://github.com/TooTallNate/node-https-proxy-agent) from 3.0.1 to 4.0.0.
+
 - [Release notes](https://github.com/TooTallNate/node-https-proxy-agent/releases)
 - [Commits](https://github.com/TooTallNate/node-https-proxy-agent/compare/3.0.1...4.0.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+
 - Bump semver from 6.3.0 to 7.0.0
 
 Bumps [semver](https://github.com/npm/node-semver) from 6.3.0 to 7.0.0.
+
 - [Release notes](https://github.com/npm/node-semver/releases)
 - [Changelog](https://github.com/npm/node-semver/blob/master/CHANGELOG.md)
 - [Commits](https://github.com/npm/node-semver/compare/v6.3.0...v7.0.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 2
 
@@ -927,10 +963,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.2.0 (Sun Dec 15 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- fix and add tests  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- release: add flag to publish prerelease  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix and add tests ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- release: add flag to publish prerelease ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -940,10 +976,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.1.3 (Sat Dec 14 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add test  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- omit next branch PR Title from being in release notes  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add test ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- omit next branch PR Title from being in release notes ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -953,11 +989,11 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.1.2 (Sat Dec 14 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add test  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- ignore unknown labels during bump calc + fix none type release skipping  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- let modify config actually do something  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add test ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- ignore unknown labels during bump calc + fix none type release skipping ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- let modify config actually do something ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -967,9 +1003,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.1.0 (Sat Dec 14 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- fix bug where merging a none would skip previously meged semver label, ex: merge next into master and next has a none label  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix bug where merging a none would skip previously meged semver label, ex: merge next into master and next has a none label ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -979,61 +1015,61 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.0.0 (Wed Dec 11 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- change skip-release releaseType to just skip  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add hash  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix tests  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix sub-pacakge changelogs  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- only grant contributions for work in commit  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- display message when commit is omitted  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix bug where author would get matched incorrectly  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- handle unknown tag when supplying --from and --to  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add tests  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- omit commits that have already been released  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- do not call afterRelease hooks during dry run  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- update docs  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- switch from dedent to endent to fix multitemplate indentation  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add release notes to prerelease PRs  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- remove false type  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- post comment prerelase version on prerelease version PR branches  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- allow any "N > 2" of --verbose flags for very verbose  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Deprecate "--very-verbose, -w" in favor of "-vv"  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- more logs  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix canary calcs  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- reset versions  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.8 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- change to more explicit property name  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.7 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- move to top level util for ease of testing  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix lint  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add email fallback back in  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add test for none  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add none release type  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- allow user to overwrite base label  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- check for depreacted config  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- get label refactor working  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.6 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- move determineNextVersion to core  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- move git clean check to core  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.5 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.4 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- change getPreviousVersion hook args. can access prefixRelease from root class instead  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- implment dry-run flag for next command  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix test  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- shipit: add flag to only publish to 'latest' tag when "release" label is present  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- allow user to configure what branches are treated as prerelease branches  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- remove prerelease label when released  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- remove old use of prerelease label + add prerelease label to released plugin  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- must set git user before publishing so we know we can commit  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- call next from shipit on next branch  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- get next branch release working  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- change skip-release releaseType to just skip ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add hash ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix tests ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix sub-pacakge changelogs ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- only grant contributions for work in commit ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- display message when commit is omitted ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix bug where author would get matched incorrectly ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- handle unknown tag when supplying --from and --to ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add tests ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- omit commits that have already been released ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- do not call afterRelease hooks during dry run ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- update docs ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- switch from dedent to endent to fix multitemplate indentation ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add release notes to prerelease PRs ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- remove false type ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- post comment prerelase version on prerelease version PR branches ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- allow any "N > 2" of --verbose flags for very verbose ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Deprecate "--very-verbose, -w" in favor of "-vv" ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- more logs ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix canary calcs ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- reset versions ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.8 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- change to more explicit property name ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.7 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- move to top level util for ease of testing ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix lint ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add email fallback back in ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add test for none ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add none release type ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- allow user to overwrite base label ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- check for depreacted config ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- get label refactor working ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.6 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- move determineNextVersion to core ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- move git clean check to core ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.5 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.4 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- change getPreviousVersion hook args. can access prefixRelease from root class instead ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- implment dry-run flag for next command ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix test ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- shipit: add flag to only publish to 'latest' tag when "release" label is present ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- allow user to configure what branches are treated as prerelease branches ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- remove prerelease label when released ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- remove old use of prerelease label + add prerelease label to released plugin ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- must set git user before publishing so we know we can commit ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- call next from shipit on next branch ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- get next branch release working ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 

--- a/packages/core/src/__tests__/__snapshots__/auto.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/auto.test.ts.snap
@@ -6,21 +6,21 @@ exports[`Auto createLabels should create the labels 1`] = `
     Array [
       Array [
         Object {
-          "changelogTitle": "💥  Breaking Change",
+          "changelogTitle": "💥 Breaking Change",
           "description": "Increment the major version when merged",
           "name": "Version: Major",
           "overwrite": true,
           "releaseType": "major",
         },
         Object {
-          "changelogTitle": "🐛  Bug Fix",
+          "changelogTitle": "🐛 Bug Fix",
           "description": "Increment the patch version when merged",
           "name": "Version: Patch",
           "overwrite": true,
           "releaseType": "patch",
         },
         Object {
-          "changelogTitle": "🚀  Enhancement",
+          "changelogTitle": "🚀 Enhancement",
           "description": "Increment the minor version when merged",
           "name": "Version: Minor",
           "overwrite": true,
@@ -37,13 +37,13 @@ exports[`Auto createLabels should create the labels 1`] = `
           "releaseType": "release",
         },
         Object {
-          "changelogTitle": "🏠  Internal",
+          "changelogTitle": "🏠 Internal",
           "description": "Changes only affect the internal API",
           "name": "internal",
           "releaseType": "none",
         },
         Object {
-          "changelogTitle": "📝  Documentation",
+          "changelogTitle": "📝 Documentation",
           "description": "Changes only affect the documentation",
           "name": "documentation",
           "releaseType": "none",
@@ -67,19 +67,19 @@ Object {
   "extends": "@artsy",
   "labels": Array [
     Object {
-      "changelogTitle": "💥  Breaking Change",
+      "changelogTitle": "💥 Breaking Change",
       "description": "Increment the major version when merged",
       "name": "major",
       "releaseType": "major",
     },
     Object {
-      "changelogTitle": "🚀  Enhancement",
+      "changelogTitle": "🚀 Enhancement",
       "description": "Increment the minor version when merged",
       "name": "minor",
       "releaseType": "minor",
     },
     Object {
-      "changelogTitle": "🐛  Bug Fix",
+      "changelogTitle": "🐛 Bug Fix",
       "description": "Increment the patch version when merged",
       "name": "patch",
       "releaseType": "patch",
@@ -95,13 +95,13 @@ Object {
       "releaseType": "release",
     },
     Object {
-      "changelogTitle": "🏠  Internal",
+      "changelogTitle": "🏠 Internal",
       "description": "Changes only affect the internal API",
       "name": "internal",
       "releaseType": "none",
     },
     Object {
-      "changelogTitle": "📝  Documentation",
+      "changelogTitle": "📝 Documentation",
       "description": "Changes only affect the documentation",
       "name": "documentation",
       "releaseType": "none",
@@ -123,19 +123,19 @@ Object {
   "extends": "./fake.json",
   "labels": Array [
     Object {
-      "changelogTitle": "💥  Breaking Change",
+      "changelogTitle": "💥 Breaking Change",
       "description": "Increment the major version when merged",
       "name": "major",
       "releaseType": "major",
     },
     Object {
-      "changelogTitle": "🚀  Enhancement",
+      "changelogTitle": "🚀 Enhancement",
       "description": "Increment the minor version when merged",
       "name": "minor",
       "releaseType": "minor",
     },
     Object {
-      "changelogTitle": "🐛  Bug Fix",
+      "changelogTitle": "🐛 Bug Fix",
       "description": "Increment the patch version when merged",
       "name": "patch",
       "releaseType": "patch",
@@ -151,13 +151,13 @@ Object {
       "releaseType": "release",
     },
     Object {
-      "changelogTitle": "🏠  Internal",
+      "changelogTitle": "🏠 Internal",
       "description": "Changes only affect the internal API",
       "name": "internal",
       "releaseType": "none",
     },
     Object {
-      "changelogTitle": "📝  Documentation",
+      "changelogTitle": "📝 Documentation",
       "description": "Changes only affect the documentation",
       "name": "documentation",
       "releaseType": "none",

--- a/packages/core/src/__tests__/__snapshots__/changelog.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/changelog.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Hooks author 1`] = `
-"#### 🐛  Bug Fix
+"#### 🐛 Bug Fix
 
 - Some Feature [#1234](https://github.custom.com/foobar/auto/pull/1234) (:heart: Adam Dierkens/adam@dierkens.com :heart:)
 
@@ -11,7 +11,7 @@ exports[`Hooks author 1`] = `
 `;
 
 exports[`Hooks title 1`] = `
-":heart: 🐛  Bug Fix :heart:
+":heart: 🐛 Bug Fix :heart:
 - Some Feature [#1234](https://github.custom.com/foobar/auto/pull/1234) (adam@dierkens.com)
 
 #### Authors: 1
@@ -32,7 +32,7 @@ Bam!?
 
 ---
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - First Feature [#1235](https://github.custom.com/foobar/auto/pull/1235) (adam@dierkens.com)
 
@@ -42,7 +42,7 @@ Bam!?
 `;
 
 exports[`generateReleaseNotes additional release notes should have tappable omit 1`] = `
-"#### 🚀  Enhancement
+"#### 🚀 Enhancement
 
 - First Feature [#1235](https://github.custom.com/foobar/auto/pull/1235) (adam@dierkens.com)
 
@@ -52,7 +52,7 @@ exports[`generateReleaseNotes additional release notes should have tappable omit
 `;
 
 exports[`generateReleaseNotes additional release notes should omit renovate prs 1`] = `
-"#### 🚀  Enhancement
+"#### 🚀 Enhancement
 
 - First Feature [#1235](https://github.custom.com/foobar/auto/pull/1235) ([@renovate-bot](https://github.custom.com/renovate-bot))
 
@@ -62,7 +62,7 @@ exports[`generateReleaseNotes additional release notes should omit renovate prs 
 `;
 
 exports[`generateReleaseNotes doesn't add additional release notes when there are none 1`] = `
-"#### 🚀  Enhancement
+"#### 🚀 Enhancement
 
 - First Feature [#1235](https://github.custom.com/foobar/auto/pull/1235) (adam@dierkens.com)
 
@@ -72,13 +72,13 @@ exports[`generateReleaseNotes doesn't add additional release notes when there ar
 `;
 
 exports[`generateReleaseNotes should add "Push to Next" 1`] = `
-"#### 🚀  Enhancement
+"#### 🚀 Enhancement
 
 - First Feature [#1235](https://github.custom.com/foobar/auto/pull/1235) (adam@dierkens.com)
 
 #### ⚠️  Pushed to \`next\`
 
-- I was a push to master  (adam@dierkens.com)
+- I was a push to master (adam@dierkens.com)
 
 #### Authors: 1
 
@@ -94,7 +94,7 @@ Here is how you upgrade
 
 ---
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - First Feature [#1235](https://github.custom.com/foobar/auto/pull/1235) (adam@dierkens.com)
 
@@ -104,13 +104,13 @@ Here is how you upgrade
 `;
 
 exports[`generateReleaseNotes should be able to customize pushToBaseBranch title 1`] = `
-"#### 🚀  Enhancement
+"#### 🚀 Enhancement
 
 - First Feature [#1235](https://github.custom.com/foobar/auto/pull/1235) (adam@dierkens.com)
 
 #### Custom Title
 
-- I was a push to master  (adam@dierkens.com)
+- I was a push to master (adam@dierkens.com)
 
 #### Authors: 1
 
@@ -128,10 +128,10 @@ exports[`generateReleaseNotes should be able to customize titles 1`] = `
 `;
 
 exports[`generateReleaseNotes should combine pr w/no label and labelled pr 1`] = `
-"#### 🐛  Bug Fix
+"#### 🐛 Bug Fix
 
 - Some Feature [#1234](https://github.custom.com/foobar/auto/pull/1234) (adam@dierkens.com)
-- Third  (adam@dierkens.com)
+- Third (adam@dierkens.com)
 
 #### Authors: 1
 
@@ -139,7 +139,7 @@ exports[`generateReleaseNotes should combine pr w/no label and labelled pr 1`] =
 `;
 
 exports[`generateReleaseNotes should create note for PR commits 1`] = `
-"#### 🚀  Enhancement
+"#### 🚀 Enhancement
 
 - Some Feature [#1234](https://github.custom.com/foobar/auto/pull/1234) (adam@dierkens.com)
 
@@ -149,7 +149,7 @@ exports[`generateReleaseNotes should create note for PR commits 1`] = `
 `;
 
 exports[`generateReleaseNotes should create note for PR commits with only non config labels 1`] = `
-"#### 🐛  Bug Fix
+"#### 🐛 Bug Fix
 
 - Some Feature [#1234](https://github.custom.com/foobar/auto/pull/1234) (adam@dierkens.com)
 
@@ -159,7 +159,7 @@ exports[`generateReleaseNotes should create note for PR commits with only non co
 `;
 
 exports[`generateReleaseNotes should create note for PR commits without labels 1`] = `
-"#### 🐛  Bug Fix
+"#### 🐛 Bug Fix
 
 - Some Feature [#1234](https://github.custom.com/foobar/auto/pull/1234) (adam@dierkens.com)
 
@@ -179,13 +179,13 @@ exports[`generateReleaseNotes should create note for PR commits without labels w
 `;
 
 exports[`generateReleaseNotes should include PR-less commits as patches 1`] = `
-"#### 🚀  Enhancement
+"#### 🚀 Enhancement
 
 - First Feature [#1235](https://github.custom.com/foobar/auto/pull/1235) (adam@dierkens.com)
 
 #### ⚠️  Pushed to \`master\`
 
-- I was a push to master  (adam@dierkens.com)
+- I was a push to master (adam@dierkens.com)
 
 #### Authors: 1
 
@@ -193,10 +193,10 @@ exports[`generateReleaseNotes should include PR-less commits as patches 1`] = `
 `;
 
 exports[`generateReleaseNotes should include prs with released label 1`] = `
-"#### 🐛  Bug Fix
+"#### 🐛 Bug Fix
 
 - Some Feature [#1234](https://github.custom.com/foobar/auto/pull/1234) (adam@dierkens.com)
-- Third  (adam@dierkens.com)
+- Third (adam@dierkens.com)
 
 #### Authors: 1
 
@@ -204,14 +204,14 @@ exports[`generateReleaseNotes should include prs with released label 1`] = `
 `;
 
 exports[`generateReleaseNotes should match authors correctly 1`] = `
-"#### 🏠  Internal
+"#### 🏠 Internal
 
-- something  (andrew@email.com)
+- something (andrew@email.com)
 
-#### 📝  Documentation
+#### 📝 Documentation
 
-- docs  (kendall@email.com)
-- another  ([@rdubzz](https://github.custom.com/rdubzz))
+- docs (kendall@email.com)
+- another ([@rdubzz](https://github.custom.com/rdubzz))
 
 #### Authors: 3
 
@@ -232,7 +232,7 @@ exports[`generateReleaseNotes should merge sections with same changelog title 1`
 `;
 
 exports[`generateReleaseNotes should omit authors with invalid email addresses 1`] = `
-"#### 🚀  Enhancement
+"#### 🚀 Enhancement
 
 - Some Feature [#1234](https://github.custom.com/foobar/auto/pull/1234)"
 `;
@@ -246,11 +246,11 @@ foobar
 
 ---
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - First Feature [#1235](https://github.custom.com/foobar/auto/pull/1235) (adam@dierkens.com)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 
 #### Authors: 1
@@ -259,25 +259,25 @@ foobar
 `;
 
 exports[`generateReleaseNotes should order the section major, minor, patch, then the rest 1`] = `
-"#### 💥  Breaking Change
+"#### 💥 Breaking Change
 
 - First Feature [#1235](https://github.custom.com/foobar/auto/pull/1235) (adam@dierkens.com)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - First Feature [#1235](https://github.custom.com/foobar/auto/pull/1235) (adam@dierkens.com)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- I was a push to master  (adam@dierkens.com)
+- I was a push to master (adam@dierkens.com)
 
-#### 📝  Documentation
+#### 📝 Documentation
 
-- docs  (adam@dierkens.com)
+- docs (adam@dierkens.com)
 
-#### 🏠  Internal
+#### 🏠 Internal
 
-- something  (adam@dierkens.com)
+- something (adam@dierkens.com)
 
 #### Authors: 1
 
@@ -295,7 +295,7 @@ exports[`generateReleaseNotes should prefer section defined first in config for 
 `;
 
 exports[`generateReleaseNotes should prefer section of default label for PR with multiple labels of same releaseType 1`] = `
-"#### 🚀  Enhancement
+"#### 🚀 Enhancement
 
 - Some Feature [#1234](https://github.custom.com/foobar/auto/pull/1234) (adam@dierkens.com)
 
@@ -315,7 +315,7 @@ exports[`generateReleaseNotes should prefer section with highest releaseType for
 `;
 
 exports[`generateReleaseNotes should use only email if author name doesn't exist 1`] = `
-"#### 🐛  Bug Fix
+"#### 🐛 Bug Fix
 
 - Another Feature [#1234](https://github.custom.com/foobar/auto/pull/1234) (adam@dierkens.com)
 - One Feature [#1235](https://github.custom.com/foobar/auto/pull/1235)
@@ -326,7 +326,7 @@ exports[`generateReleaseNotes should use only email if author name doesn't exist
 `;
 
 exports[`generateReleaseNotes should use username if present 1`] = `
-"#### 🚀  Enhancement
+"#### 🚀 Enhancement
 
 - Some Feature [#1234](https://github.custom.com/foobar/auto/pull/1234) ([@adam](https://github.custom.com/adam))
 

--- a/packages/core/src/__tests__/__snapshots__/release.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/release.test.ts.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Release generateReleaseNotes should allow user to configure section headings 1`] = `
-"#### 💥  Breaking Change
+"#### 💥 Breaking Change
 
 - First [#1234](https://github.com/web/site/pull/1234) (adam@dierkens.com)
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - Second [#1235](https://github.com/web/site/pull/1235) (adam@dierkens.com)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Fourth [#1237](https://github.com/web/site/pull/1237) (adam@dierkens.com)
 
-#### 🏠  Internal
+#### 🏠 Internal
 
 - Third [#1236](https://github.com/web/site/pull/1236) (adam@dierkens.com)
 
@@ -23,10 +23,10 @@ exports[`Release generateReleaseNotes should allow user to configure section hea
 `;
 
 exports[`Release generateReleaseNotes should find ignore closed prs 1`] = `
-"#### 🐛  Bug Fix
+"#### 🐛 Bug Fix
 
-- Doom Patrol enabled  (adam@dierkens.com)
-- Autobots roll out!  (adam@dierkens.com)
+- Doom Patrol enabled (adam@dierkens.com)
+- Autobots roll out! (adam@dierkens.com)
 
 #### Authors: 1
 
@@ -34,13 +34,13 @@ exports[`Release generateReleaseNotes should find ignore closed prs 1`] = `
 `;
 
 exports[`Release generateReleaseNotes should find matching PRs for shas through search 1`] = `
-"#### 💥  Breaking Change
+"#### 💥 Breaking Change
 
-- Doom Patrol enabled  (adam@dierkens.com)
+- Doom Patrol enabled (adam@dierkens.com)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Autobots roll out!  (adam@dierkens.com)
+- Autobots roll out! (adam@dierkens.com)
 
 #### Authors: 1
 
@@ -48,7 +48,7 @@ exports[`Release generateReleaseNotes should find matching PRs for shas through 
 `;
 
 exports[`Release generateReleaseNotes should get extra user data for login 1`] = `
-"#### 🐛  Bug Fix
+"#### 🐛 Bug Fix
 
 - I have a login attached [#1235](https://github.com/web/site/pull/1235) ([@adierkens](https://github.com/adierkens))
 
@@ -58,13 +58,13 @@ exports[`Release generateReleaseNotes should get extra user data for login 1`] =
 `;
 
 exports[`Release generateReleaseNotes should include PR-less commits 1`] = `
-"#### 🚀  Enhancement
+"#### 🚀 Enhancement
 
 - First Feature [#1235](https://github.com/web/site/pull/1235) (adam@dierkens.com)
 
 #### ⚠️  Pushed to \`master\`
 
-- I should be included  (adam@dierkens.com)
+- I should be included (adam@dierkens.com)
 
 #### Authors: 1
 
@@ -72,7 +72,7 @@ exports[`Release generateReleaseNotes should include PR-less commits 1`] = `
 `;
 
 exports[`Release generateReleaseNotes should include PRs merged to other PRs 1`] = `
-"#### 🐛  Bug Fix
+"#### 🐛 Bug Fix
 
 - Doom [#12343](https://github.com/web/site/pull/12343) (adam@dierkens.com)
 - Dino [#1235](https://github.com/web/site/pull/1235) (adam@dierkens.com)
@@ -83,13 +83,13 @@ exports[`Release generateReleaseNotes should include PRs merged to other PRs 1`]
 `;
 
 exports[`Release generateReleaseNotes should match commits with related PRs 1`] = `
-"#### 🚀  Enhancement
+"#### 🚀 Enhancement
 
 - Feature [#124](https://github.com/web/site/pull/124) (adam@dierkens.com)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- I am a commit with a related PR  (adam@dierkens.com)
+- I am a commit with a related PR (adam@dierkens.com)
 
 #### Authors: 1
 
@@ -97,14 +97,14 @@ exports[`Release generateReleaseNotes should match commits with related PRs 1`] 
 `;
 
 exports[`Release generateReleaseNotes should match rebased commits to PRs 1`] = `
-"#### 🚀  Enhancement
+"#### 🚀 Enhancement
 
 - Feature [#124](https://github.com/web/site/pull/124) (adam@dierkens.com)
 - I was rebased [#123](https://github.com/web/site/pull/123) (adam@dierkens.com)
 
 #### ⚠️  Pushed to \`master\`
 
-- I am a commit to master  (adam@dierkens.com)
+- I am a commit to master (adam@dierkens.com)
 
 #### Authors: 1
 

--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -210,7 +210,7 @@ describe('Auto', () => {
     expect(auto.config!.labels.find(l => l.name === 'feature')).toStrictEqual({
       description: 'Increment the minor version when merged',
       name: 'feature',
-      changelogTitle: '🚀  Enhancement',
+      changelogTitle: '🚀 Enhancement',
       releaseType: SEMVER.minor
     });
   });
@@ -231,7 +231,7 @@ describe('Auto', () => {
     ).toStrictEqual({
       description: 'This is a test',
       name: 'minor',
-      changelogTitle: '🚀  Enhancement',
+      changelogTitle: '🚀 Enhancement',
       releaseType: SEMVER.minor
     });
   });

--- a/packages/core/src/__tests__/changelog.test.ts
+++ b/packages/core/src/__tests__/changelog.test.ts
@@ -344,7 +344,7 @@ describe('generateReleaseNotes', () => {
         files: [],
         authorName: 'Adam Dierkens',
         authorEmail: 'adam@dierkens.com',
-        subject: 'I was a push to master\n\n',
+        subject: 'I was a push to master\n\nfoo bar',
         labels: ['pushToBaseBranch']
       },
       {

--- a/packages/core/src/__tests__/config.test.ts
+++ b/packages/core/src/__tests__/config.test.ts
@@ -27,7 +27,7 @@ describe('normalizeLabel', () => {
     expect(normalizeLabel(label)).toStrictEqual({
       description: 'Increment the major version when merged',
       name: 'foo',
-      changelogTitle: '💥  Breaking Change',
+      changelogTitle: '💥 Breaking Change',
       releaseType: SEMVER.major
     });
   });
@@ -38,7 +38,7 @@ describe('normalizeLabels', () => {
     expect(normalizeLabels({}).find(l => l.name === 'minor')).toStrictEqual({
       description: 'Increment the minor version when merged',
       name: 'minor',
-      changelogTitle: '🚀  Enhancement',
+      changelogTitle: '🚀 Enhancement',
       releaseType: SEMVER.minor
     });
 
@@ -49,7 +49,7 @@ describe('normalizeLabels', () => {
     ).toStrictEqual({
       description: 'Increment the minor version when merged',
       name: 'foo',
-      changelogTitle: '🚀  Enhancement',
+      changelogTitle: '🚀 Enhancement',
       releaseType: SEMVER.minor
     });
   });

--- a/packages/core/src/changelog.ts
+++ b/packages/core/src/changelog.ts
@@ -284,7 +284,7 @@ export default class Changelog {
     }
 
     const user = await this.createUserLinkList(commit);
-    return `- ${subject} ${pr}${user ? ` (${user})` : ''}`;
+    return `- ${subject} ${pr ? ` ${pr}` : ''}${user ? ` (${user})` : ''}`;
   }
 
   /** Get all the authors in the provided commits */

--- a/packages/core/src/changelog.ts
+++ b/packages/core/src/changelog.ts
@@ -271,7 +271,12 @@ export default class Changelog {
 
   /** Transform a commit into a line in the changelog */
   private async generateCommitNote(commit: IExtendedCommit) {
-    const subject = commit.subject ? commit.subject.split('\n')[0].trim() : '';
+    const subject = commit.subject
+      ? commit.subject
+          .split('\n')[0]
+          .trim()
+          .replace('[skip ci]', '\\[skip ci\\]')
+      : '';
 
     let pr = '';
 

--- a/packages/core/src/changelog.ts
+++ b/packages/core/src/changelog.ts
@@ -271,7 +271,8 @@ export default class Changelog {
 
   /** Transform a commit into a line in the changelog */
   private async generateCommitNote(commit: IExtendedCommit) {
-    const subject = commit.subject ? commit.subject.trim() : '';
+    const subject = commit.subject ? commit.subject.split('\n')[0].trim() : '';
+
     let pr = '';
 
     if (commit.pullRequest?.number) {

--- a/packages/core/src/changelog.ts
+++ b/packages/core/src/changelog.ts
@@ -290,7 +290,7 @@ export default class Changelog {
     }
 
     const user = await this.createUserLinkList(commit);
-    return `- ${subject} ${pr ? ` ${pr}` : ''}${user ? ` (${user})` : ''}`;
+    return `- ${subject}${pr ? ` ${pr}` : ''}${user ? ` (${user})` : ''}`;
   }
 
   /** Get all the authors in the provided commits */

--- a/packages/core/src/release.ts
+++ b/packages/core/src/release.ts
@@ -75,19 +75,19 @@ export type ILabelDefinition = t.TypeOf<typeof labelDefinition>;
 export const defaultLabels: ILabelDefinition[] = [
   {
     name: 'major',
-    changelogTitle: '💥  Breaking Change',
+    changelogTitle: '💥 Breaking Change',
     description: 'Increment the major version when merged',
     releaseType: SEMVER.major
   },
   {
     name: 'minor',
-    changelogTitle: '🚀  Enhancement',
+    changelogTitle: '🚀 Enhancement',
     description: 'Increment the minor version when merged',
     releaseType: SEMVER.minor
   },
   {
     name: 'patch',
-    changelogTitle: '🐛  Bug Fix',
+    changelogTitle: '🐛 Bug Fix',
     description: 'Increment the patch version when merged',
     releaseType: SEMVER.patch
   },
@@ -103,13 +103,13 @@ export const defaultLabels: ILabelDefinition[] = [
   },
   {
     name: 'internal',
-    changelogTitle: '🏠  Internal',
+    changelogTitle: '🏠 Internal',
     description: 'Changes only affect the internal API',
     releaseType: 'none'
   },
   {
     name: 'documentation',
-    changelogTitle: '📝  Documentation',
+    changelogTitle: '📝 Documentation',
     description: 'Changes only affect the documentation',
     releaseType: 'none'
   }

--- a/plugins/all-contributors/CHANGELOG.md
+++ b/plugins/all-contributors/CHANGELOG.md
@@ -1,8 +1,8 @@
 # v9.15.7 (Tue Mar 03 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add license to all sub-packages  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add license to all sub-packages ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -12,15 +12,16 @@
 
 # v9.15.3 (Mon Mar 02 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump tslib from 1.11.0 to 1.11.1
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.11.0 to 1.11.1.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.11.0...1.11.1)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -30,12 +31,12 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.15.0 (Sun Mar 01 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- update plugin and autorc docs  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- use fromEntries ponyfill until node 10 EOL  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add fp and io-ts as deps  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add plugin configuration validation  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- update plugin and autorc docs ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- use fromEntries ponyfill until node 10 EOL ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add fp and io-ts as deps ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add plugin configuration validation ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -45,15 +46,16 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.13.1 (Mon Feb 24 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump tslib from 1.10.0 to 1.11.0
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.10.0 to 1.11.0.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.10.0...1.11.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -63,9 +65,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.13.0 (Sat Feb 22 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Fix unhandled promise rejection in tests  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Fix unhandled promise rejection in tests ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -75,11 +77,11 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.12.1 (Sat Feb 22 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- remove test skip  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- ad test  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix all-contributors plugin for non-lerna packages  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- remove test skip ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- ad test ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix all-contributors plugin for non-lerna packages ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -89,9 +91,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.10.8 (Fri Feb 21 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- fix case sensitive username bug and handle error  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix case sensitive username bug and handle error ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -101,12 +103,12 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.3.3 (Fri Jan 24 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Explicitly add npm & yarn step
 
 install-peerdeps wasn't installing anything after prompting to use yarn
-or not  ([@ericclemmons](https://github.com/ericclemmons))
+or not ([@ericclemmons](https://github.com/ericclemmons))
 
 #### Authors: 1
 
@@ -116,10 +118,10 @@ or not  ([@ericclemmons](https://github.com/ericclemmons))
 
 # v9.2.0 (Thu Jan 23 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- remove config option, can be done just by checking for an rc file  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Add ability to manage sub-package contributor lists  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- remove config option, can be done just by checking for an rc file ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Add ability to manage sub-package contributor lists ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -129,15 +131,16 @@ or not  ([@ericclemmons](https://github.com/ericclemmons))
 
 # v9.1.0 (Tue Jan 21 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump all-contributors-cli from 6.12.0 to 6.13.0
 
 Bumps [all-contributors-cli](https://github.com/all-contributors/all-contributors-cli) from 6.12.0 to 6.13.0.
+
 - [Release notes](https://github.com/all-contributors/all-contributors-cli/releases)
 - [Commits](https://github.com/all-contributors/all-contributors-cli/compare/v6.12.0...v6.13.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -147,10 +150,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.0.2 (Tue Jan 14 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- modify tests  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix running cli  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- modify tests ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix running cli ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -160,15 +163,16 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.0.0 (Mon Jan 13 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump all-contributors-cli from 6.11.2 to 6.12.0
 
 Bumps [all-contributors-cli](https://github.com/all-contributors/all-contributors-cli) from 6.11.2 to 6.12.0.
+
 - [Release notes](https://github.com/all-contributors/all-contributors-cli/releases)
 - [Commits](https://github.com/all-contributors/all-contributors-cli/compare/v6.11.2...v6.12.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -178,27 +182,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.6.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.5.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Update CHANGELOG.md [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-
-#### Authors: 1
-
-- Andrew Lisowski ([@hipstersmoothie](https://github.com/hipstersmoothie))
-
----
-
-# v8.5.0 (Tue Dec 17 2019)
-
-#### 🐛  Bug Fix
-
-- Bump version to: v8.4.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.3.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.2.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.5.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Update CHANGELOG.md \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -208,14 +195,31 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.5.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.4.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.3.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.2.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.4.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.3.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.2.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+
+#### Authors: 1
+
+- Andrew Lisowski ([@hipstersmoothie](https://github.com/hipstersmoothie))
+
+---
+
+# v8.5.0 (Tue Dec 17 2019)
+
+#### 🐛 Bug Fix
+
+- Bump version to: v8.4.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.3.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.2.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 2
 
@@ -226,28 +230,29 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.0.0 (Wed Dec 11 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.0.0-next.4 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- only grant contributions for work in commit  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.8 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.7 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.6 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.5 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- reset versions  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.4 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- only grant contributions for work in commit ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.8 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.7 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.6 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.5 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- reset versions ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Bump all-contributors-cli from 6.11.1 to 6.11.2
 
 Bumps [all-contributors-cli](https://github.com/all-contributors/all-contributors-cli) from 6.11.1 to 6.11.2.
+
 - [Release notes](https://github.com/all-contributors/all-contributors-cli/releases)
 - [Commits](https://github.com/all-contributors/all-contributors-cli/compare/v6.11.1...v6.11.2)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 2
 

--- a/plugins/chrome/CHANGELOG.md
+++ b/plugins/chrome/CHANGELOG.md
@@ -1,8 +1,8 @@
 # v9.15.7 (Tue Mar 03 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add license to all sub-packages  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add license to all sub-packages ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -12,15 +12,16 @@
 
 # v9.15.3 (Mon Mar 02 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump tslib from 1.11.0 to 1.11.1
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.11.0 to 1.11.1.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.11.0...1.11.1)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -30,11 +31,11 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.15.0 (Sun Mar 01 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- update plugin and autorc docs  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add fp and io-ts as deps  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add plugin configuration validation  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- update plugin and autorc docs ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add fp and io-ts as deps ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add plugin configuration validation ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -44,15 +45,16 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.13.1 (Mon Feb 24 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump tslib from 1.10.0 to 1.11.0
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.10.0 to 1.11.0.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.10.0...1.11.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -62,9 +64,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.12.0 (Fri Feb 21 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- ensure remote can be pushed to  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- ensure remote can be pushed to ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -78,15 +80,16 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 Thank you, null[@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]), for all your work!
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump @types/semver from 6.2.0 to 7.1.0
 
 Bumps [@types/semver](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/HEAD/types/semver) from 6.2.0 to 7.1.0.
+
 - [Release notes](https://github.com/DefinitelyTyped/DefinitelyTyped/releases)
 - [Commits](https://github.com/DefinitelyTyped/DefinitelyTyped/commits/HEAD/types/semver)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -96,9 +99,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.10.1 (Thu Feb 06 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- must create an annotated tag for it to be pushed with --follow-tags  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- must create an annotated tag for it to be pushed with --follow-tags ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -108,9 +111,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.1.1 (Thu Jan 23 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add clearer docs around creating GH_TOKEN  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add clearer docs around creating GH_TOKEN ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -120,10 +123,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.6.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.5.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Update CHANGELOG.md [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.5.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Update CHANGELOG.md \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -133,23 +136,24 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.5.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.4.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.3.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Update CHANGELOG.md [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.2.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.4.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.3.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Update CHANGELOG.md \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.2.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Bump semver from 6.3.0 to 7.0.0
 
 Bumps [semver](https://github.com/npm/node-semver) from 6.3.0 to 7.0.0.
+
 - [Release notes](https://github.com/npm/node-semver/releases)
 - [Changelog](https://github.com/npm/node-semver/blob/master/CHANGELOG.md)
 - [Commits](https://github.com/npm/node-semver/compare/v6.3.0...v7.0.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 2
 
@@ -160,23 +164,24 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.5.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.4.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.3.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Update CHANGELOG.md [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.2.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.4.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.3.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Update CHANGELOG.md \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.2.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Bump semver from 6.3.0 to 7.0.0
 
 Bumps [semver](https://github.com/npm/node-semver) from 6.3.0 to 7.0.0.
+
 - [Release notes](https://github.com/npm/node-semver/releases)
 - [Changelog](https://github.com/npm/node-semver/blob/master/CHANGELOG.md)
 - [Commits](https://github.com/npm/node-semver/compare/v6.3.0...v7.0.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 2
 
@@ -187,16 +192,17 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.3.0 (Mon Dec 16 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump semver from 6.3.0 to 7.0.0
 
 Bumps [semver](https://github.com/npm/node-semver) from 6.3.0 to 7.0.0.
+
 - [Release notes](https://github.com/npm/node-semver/releases)
 - [Changelog](https://github.com/npm/node-semver/blob/master/CHANGELOG.md)
 - [Commits](https://github.com/npm/node-semver/compare/v6.3.0...v7.0.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -206,21 +212,21 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.0.0 (Wed Dec 11 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- change getPreviousVersion hook args. can access prefixRelease from root class instead  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- reset versions  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.7 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.6 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.5 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.4 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.8 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- change getPreviousVersion hook args. can access prefixRelease from root class instead ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- reset versions ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.7 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.6 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.5 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.4 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.8 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 

--- a/plugins/conventional-commits/CHANGELOG.md
+++ b/plugins/conventional-commits/CHANGELOG.md
@@ -1,8 +1,8 @@
 # v9.15.7 (Tue Mar 03 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add license to all sub-packages  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add license to all sub-packages ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -12,15 +12,16 @@
 
 # v9.15.3 (Mon Mar 02 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump tslib from 1.11.0 to 1.11.1
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.11.0 to 1.11.1.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.11.0...1.11.1)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -30,9 +31,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.15.2 (Sun Mar 01 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Respect PR label when conventional commit message is present  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Respect PR label when conventional commit message is present ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -42,9 +43,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.15.0 (Sun Mar 01 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add plugin configuration validation  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add plugin configuration validation ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -54,15 +55,16 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.13.1 (Mon Feb 24 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump tslib from 1.10.0 to 1.11.0
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.10.0 to 1.11.0.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.10.0...1.11.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -72,10 +74,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.6.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.5.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Update CHANGELOG.md [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.5.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Update CHANGELOG.md \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -85,14 +87,14 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.5.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.4.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.3.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.2.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.4.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.3.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.2.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 2
 
@@ -103,14 +105,14 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.5.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.4.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.3.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.2.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.4.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.3.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.2.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -120,24 +122,24 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.0.0 (Wed Dec 11 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.0.0-next.4 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.8 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.7 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- get label refactor working  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.6 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.5 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- reset versions  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.4 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.8 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.7 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- get label refactor working ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.6 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.5 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- reset versions ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Update README to include required npm plugin
 
-see https://github.com/intuit/auto/issues/775  ([@sarah-vanderlaan](https://github.com/sarah-vanderlaan))
+see https://github.com/intuit/auto/issues/775 ([@sarah-vanderlaan](https://github.com/sarah-vanderlaan))
 
 #### Authors: 1
 

--- a/plugins/crates/CHANGELOG.md
+++ b/plugins/crates/CHANGELOG.md
@@ -1,8 +1,8 @@
 # v9.15.7 (Tue Mar 03 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add license to all sub-packages  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add license to all sub-packages ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -12,15 +12,16 @@
 
 # v9.15.3 (Mon Mar 02 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump tslib from 1.11.0 to 1.11.1
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.11.0 to 1.11.1.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.11.0...1.11.1)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -30,9 +31,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.15.0 (Sun Mar 01 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add plugin configuration validation  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add plugin configuration validation ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -42,15 +43,16 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.13.1 (Mon Feb 24 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump tslib from 1.10.0 to 1.11.0
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.10.0 to 1.11.0.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.10.0...1.11.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -60,9 +62,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.12.0 (Fri Feb 21 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- ensure remote can be pushed to  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- ensure remote can be pushed to ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -72,9 +74,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.7.0 (Mon Jan 27 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- fix hook  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix hook ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -84,15 +86,16 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.0.0 (Mon Jan 13 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump env-ci from 4.5.2 to 5.0.1
 
 Bumps [env-ci](https://github.com/pvdlg/env-ci) from 4.5.2 to 5.0.1.
+
 - [Release notes](https://github.com/pvdlg/env-ci/releases)
 - [Commits](https://github.com/pvdlg/env-ci/compare/v4.5.2...v5.0.1)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -102,10 +105,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.6.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.5.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Update CHANGELOG.md [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.5.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Update CHANGELOG.md \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -115,23 +118,24 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.5.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.4.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.3.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Update CHANGELOG.md [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.2.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.4.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.3.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Update CHANGELOG.md \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.2.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Bump semver from 6.3.0 to 7.0.0
 
 Bumps [semver](https://github.com/npm/node-semver) from 6.3.0 to 7.0.0.
+
 - [Release notes](https://github.com/npm/node-semver/releases)
 - [Changelog](https://github.com/npm/node-semver/blob/master/CHANGELOG.md)
 - [Commits](https://github.com/npm/node-semver/compare/v6.3.0...v7.0.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 2
 
@@ -142,23 +146,24 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.5.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.4.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.3.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Update CHANGELOG.md [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.2.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.4.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.3.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Update CHANGELOG.md \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.2.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Bump semver from 6.3.0 to 7.0.0
 
 Bumps [semver](https://github.com/npm/node-semver) from 6.3.0 to 7.0.0.
+
 - [Release notes](https://github.com/npm/node-semver/releases)
 - [Changelog](https://github.com/npm/node-semver/blob/master/CHANGELOG.md)
 - [Commits](https://github.com/npm/node-semver/compare/v6.3.0...v7.0.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 2
 
@@ -169,16 +174,17 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.3.0 (Mon Dec 16 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump semver from 6.3.0 to 7.0.0
 
 Bumps [semver](https://github.com/npm/node-semver) from 6.3.0 to 7.0.0.
+
 - [Release notes](https://github.com/npm/node-semver/releases)
 - [Changelog](https://github.com/npm/node-semver/blob/master/CHANGELOG.md)
 - [Commits](https://github.com/npm/node-semver/compare/v6.3.0...v7.0.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -188,22 +194,22 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.0.0 (Wed Dec 11 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- change getPreviousVersion hook args. can access prefixRelease from root class instead  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- reset versions  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.7 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.6 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.5 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix lint  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.4 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.8 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- change getPreviousVersion hook args. can access prefixRelease from root class instead ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- reset versions ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.7 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.6 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.5 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix lint ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.4 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.8 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 

--- a/plugins/first-time-contributor/CHANGELOG.md
+++ b/plugins/first-time-contributor/CHANGELOG.md
@@ -1,8 +1,8 @@
 # v9.15.7 (Tue Mar 03 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add license to all sub-packages  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add license to all sub-packages ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -12,15 +12,16 @@
 
 # v9.15.3 (Mon Mar 02 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump tslib from 1.11.0 to 1.11.1
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.11.0 to 1.11.1.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.11.0...1.11.1)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -30,15 +31,16 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.13.1 (Mon Feb 24 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump tslib from 1.10.0 to 1.11.0
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.10.0 to 1.11.0.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.10.0...1.11.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -48,9 +50,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.10.7 (Tue Feb 18 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- filter out bots in first-time contributor plugins  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- filter out bots in first-time contributor plugins ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -60,9 +62,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.10.5 (Thu Feb 13 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- fix build  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix build ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -72,10 +74,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.2.3 (Fri Jan 24 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add tests  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- determine first time contributor by using PR count instead of git history  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add tests ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- determine first time contributor by using PR count instead of git history ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -85,27 +87,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.6.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.5.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Update CHANGELOG.md [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-
-#### Authors: 1
-
-- Andrew Lisowski ([@hipstersmoothie](https://github.com/hipstersmoothie))
-
----
-
-# v8.5.0 (Tue Dec 17 2019)
-
-#### 🐛  Bug Fix
-
-- Bump version to: v8.4.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.3.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.2.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.5.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Update CHANGELOG.md \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -115,14 +100,31 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.5.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.4.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.3.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.2.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.4.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.3.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.2.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+
+#### Authors: 1
+
+- Andrew Lisowski ([@hipstersmoothie](https://github.com/hipstersmoothie))
+
+---
+
+# v8.5.0 (Tue Dec 17 2019)
+
+#### 🐛 Bug Fix
+
+- Bump version to: v8.4.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.3.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.2.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -132,21 +134,21 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.0.0 (Wed Dec 11 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.0.0-next.4 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- switch from dedent to endent to fix multitemplate indentation  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.8 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.7 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.6 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.5 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- reset versions  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.4 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- switch from dedent to endent to fix multitemplate indentation ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.8 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.7 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.6 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.5 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- reset versions ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 

--- a/plugins/git-tag/CHANGELOG.md
+++ b/plugins/git-tag/CHANGELOG.md
@@ -1,8 +1,8 @@
 # v9.15.7 (Tue Mar 03 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add license to all sub-packages  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add license to all sub-packages ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -12,15 +12,16 @@
 
 # v9.15.3 (Mon Mar 02 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump tslib from 1.11.0 to 1.11.1
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.11.0 to 1.11.1.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.11.0...1.11.1)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -30,9 +31,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.15.0 (Sun Mar 01 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add plugin configuration validation  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add plugin configuration validation ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -42,15 +43,16 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.13.1 (Mon Feb 24 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump tslib from 1.10.0 to 1.11.0
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.10.0 to 1.11.0.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.10.0...1.11.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -60,9 +62,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.12.0 (Fri Feb 21 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- ensure remote can be pushed to  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- ensure remote can be pushed to ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -76,15 +78,16 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 Thank you, null[@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]), for all your work!
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump @types/semver from 6.2.0 to 7.1.0
 
 Bumps [@types/semver](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/HEAD/types/semver) from 6.2.0 to 7.1.0.
+
 - [Release notes](https://github.com/DefinitelyTyped/DefinitelyTyped/releases)
 - [Commits](https://github.com/DefinitelyTyped/DefinitelyTyped/commits/HEAD/types/semver)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -94,14 +97,14 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.10.1 (Thu Feb 06 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- fix tests  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- must create an annotated tag for it to be pushed with --follow-tags  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add more logs to git-tag plugin  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix tests ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- must create an annotated tag for it to be pushed with --follow-tags ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add more logs to git-tag plugin ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - make sure tag is annotated
 
-quotes!  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+quotes! ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -111,10 +114,10 @@ quotes!  ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 # v9.2.1 (Fri Jan 24 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add test  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fallback to 0.0.0 in git-tag plugin with no previous releases  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add test ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fallback to 0.0.0 in git-tag plugin with no previous releases ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -124,10 +127,10 @@ quotes!  ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 # v8.6.3 (Thu Dec 19 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- fix execpromise logs  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- use in git-tag plugin too  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix execpromise logs ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- use in git-tag plugin too ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -137,11 +140,11 @@ quotes!  ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 # v8.6.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.5.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Update CHANGELOG.md [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add ability to manage version branches  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.5.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Update CHANGELOG.md \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add ability to manage version branches ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -151,25 +154,26 @@ quotes!  ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 # v8.5.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add ability to manage version branches  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.4.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.3.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Update CHANGELOG.md [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- release: detect prerelease branch + be smarter about commit range  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.2.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add ability to manage version branches ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.4.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.3.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Update CHANGELOG.md \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- release: detect prerelease branch + be smarter about commit range ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.2.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Bump semver from 6.3.0 to 7.0.0
 
 Bumps [semver](https://github.com/npm/node-semver) from 6.3.0 to 7.0.0.
+
 - [Release notes](https://github.com/npm/node-semver/releases)
 - [Changelog](https://github.com/npm/node-semver/blob/master/CHANGELOG.md)
 - [Commits](https://github.com/npm/node-semver/compare/v6.3.0...v7.0.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 2
 
@@ -180,25 +184,26 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.5.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add ability to manage version branches  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.4.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.3.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Update CHANGELOG.md [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- release: detect prerelease branch + be smarter about commit range  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.2.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add ability to manage version branches ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.4.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.3.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Update CHANGELOG.md \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- release: detect prerelease branch + be smarter about commit range ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.2.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Bump semver from 6.3.0 to 7.0.0
 
 Bumps [semver](https://github.com/npm/node-semver) from 6.3.0 to 7.0.0.
+
 - [Release notes](https://github.com/npm/node-semver/releases)
 - [Changelog](https://github.com/npm/node-semver/blob/master/CHANGELOG.md)
 - [Commits](https://github.com/npm/node-semver/compare/v6.3.0...v7.0.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -208,17 +213,18 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.3.0 (Mon Dec 16 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- release: detect prerelease branch + be smarter about commit range  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- release: detect prerelease branch + be smarter about commit range ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Bump semver from 6.3.0 to 7.0.0
 
 Bumps [semver](https://github.com/npm/node-semver) from 6.3.0 to 7.0.0.
+
 - [Release notes](https://github.com/npm/node-semver/releases)
 - [Changelog](https://github.com/npm/node-semver/blob/master/CHANGELOG.md)
 - [Commits](https://github.com/npm/node-semver/compare/v6.3.0...v7.0.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 2
 
@@ -229,25 +235,25 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.0.0 (Wed Dec 11 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- fix tests  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add tests  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.8 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.7 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- move to top level util for ease of testing  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.6 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- move determineNextVersion to core  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.5 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- reset versions  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.4 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- implement prerelease branches for git-tag plugin  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix tests ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add tests ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.8 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.7 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- move to top level util for ease of testing ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.6 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- move determineNextVersion to core ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.5 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- reset versions ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.4 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- implement prerelease branches for git-tag plugin ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 

--- a/plugins/gradle/CHANGELOG.md
+++ b/plugins/gradle/CHANGELOG.md
@@ -1,8 +1,8 @@
 # v9.15.7 (Tue Mar 03 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add license to all sub-packages  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add license to all sub-packages ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -12,15 +12,16 @@
 
 # v9.15.3 (Mon Mar 02 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump tslib from 1.11.0 to 1.11.1
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.11.0 to 1.11.1.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.11.0...1.11.1)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -30,9 +31,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.15.0 (Sun Mar 01 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add plugin configuration validation  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add plugin configuration validation ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -42,15 +43,16 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.13.1 (Mon Feb 24 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump tslib from 1.10.0 to 1.11.0
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.10.0 to 1.11.0.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.10.0...1.11.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -60,9 +62,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.12.0 (Fri Feb 21 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- ensure remote can be pushed to  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- ensure remote can be pushed to ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -76,11 +78,11 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 Thank you, Jeremiah Zucker ([@sugarmanz](https://github.com/sugarmanz)), for all your work!
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - fix: gradle readme use jsonc syntax highlighting
 
-allows comments  ([@sugarmanz](https://github.com/sugarmanz))
+allows comments ([@sugarmanz](https://github.com/sugarmanz))
 
 #### Authors: 1
 
@@ -90,13 +92,13 @@ allows comments  ([@sugarmanz](https://github.com/sugarmanz))
 
 # v7.17.0 (Fri Jan 31 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- PR Fixes: Docs + Required + Consts  (brandon_miller3@intuit.com)
-- Re-name test files to be consistent with plugin/comments.  (brandon_miller3@intuit.com)
-- Fix Documenation Section Title to Gradle.  (brandon_miller3@intuit.com)
-- Documentation + Tests + Gradle Custom Options.  (brandon_miller3@intuit.com)
-- Gradle Release Plugin Contribution.  (brandon_miller3@intuit.com)
+- PR Fixes: Docs + Required + Consts (brandon_miller3@intuit.com)
+- Re-name test files to be consistent with plugin/comments. (brandon_miller3@intuit.com)
+- Fix Documenation Section Title to Gradle. (brandon_miller3@intuit.com)
+- Documentation + Tests + Gradle Custom Options. (brandon_miller3@intuit.com)
+- Gradle Release Plugin Contribution. (brandon_miller3@intuit.com)
 
 #### Authors: 1
 

--- a/plugins/jira/CHANGELOG.md
+++ b/plugins/jira/CHANGELOG.md
@@ -1,8 +1,8 @@
 # v9.15.7 (Tue Mar 03 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add license to all sub-packages  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add license to all sub-packages ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -12,15 +12,16 @@
 
 # v9.15.3 (Mon Mar 02 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump tslib from 1.11.0 to 1.11.1
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.11.0 to 1.11.1.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.11.0...1.11.1)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -30,11 +31,11 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.15.0 (Sun Mar 01 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- update plugin and autorc docs  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add fp and io-ts as deps  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add plugin configuration validation  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- update plugin and autorc docs ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add fp and io-ts as deps ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add plugin configuration validation ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -44,15 +45,16 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.13.1 (Mon Feb 24 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump tslib from 1.10.0 to 1.11.0
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.10.0 to 1.11.0.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.10.0...1.11.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -62,10 +64,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.5.0 (Mon Jan 27 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- fix lint  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Overhaul "auto init" experience + make it pluggable  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix lint ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Overhaul "auto init" experience + make it pluggable ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -75,29 +77,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.6.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.5.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Update CHANGELOG.md [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-
-#### Authors: 1
-
-- Andrew Lisowski ([@hipstersmoothie](https://github.com/hipstersmoothie))
-
----
-
-# v8.5.0 (Tue Dec 17 2019)
-
-#### 🐛  Bug Fix
-
-- Bump version to: v8.4.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.3.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.2.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Update CHANGELOG.md [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix tests?  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.5.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Update CHANGELOG.md \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -107,16 +90,35 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.5.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.4.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.3.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.2.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Update CHANGELOG.md [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix tests?  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.4.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.3.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.2.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Update CHANGELOG.md \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix tests? ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+
+#### Authors: 1
+
+- Andrew Lisowski ([@hipstersmoothie](https://github.com/hipstersmoothie))
+
+---
+
+# v8.5.0 (Tue Dec 17 2019)
+
+#### 🐛 Bug Fix
+
+- Bump version to: v8.4.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.3.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.2.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Update CHANGELOG.md \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix tests? ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -126,9 +128,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.1.3 (Sat Dec 14 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- fix tests?  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix tests? ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -138,21 +140,21 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.0.0 (Wed Dec 11 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.0.0-next.4 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- reset versions  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.7 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- get label refactor working  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.6 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.5 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.8 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.4 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- reset versions ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.7 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- get label refactor working ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.6 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.5 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.8 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 

--- a/plugins/jira/__tests__/__snapshots__/jira.test.ts.snap
+++ b/plugins/jira/__tests__/__snapshots__/jira.test.ts.snap
@@ -1,15 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should create note for JIRA commits 1`] = `
-"#### 💥  Breaking Change
+"#### 💥 Breaking Change
 
 - [PLAYA-5052](https://jira.custom.com/browse/PLAYA-5052): Some Feature [#12345](https://github.custom.com/foobar/auto/pull/12345) (adam@dierkens.com)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Third  (adam@dierkens.com)
+- Third (adam@dierkens.com)
 
-#### 🏠  Internal
+#### 🏠 Internal
 
 - Some Feature [#1234](https://github.custom.com/foobar/auto/pull/1234) (adam@dierkens.com)
 
@@ -19,7 +19,7 @@ exports[`should create note for JIRA commits 1`] = `
 `;
 
 exports[`should create note for jira commits without PR title 1`] = `
-"#### 🐛  Bug Fix
+"#### 🐛 Bug Fix
 
 - [PLAYA-5052](https://jira.custom.com/browse/PLAYA-5052) (adam@dierkens.com)
 

--- a/plugins/maven/CHANGELOG.md
+++ b/plugins/maven/CHANGELOG.md
@@ -1,8 +1,8 @@
 # v9.15.7 (Tue Mar 03 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add license to all sub-packages  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add license to all sub-packages ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -12,15 +12,16 @@
 
 # v9.15.3 (Mon Mar 02 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump tslib from 1.11.0 to 1.11.1
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.11.0 to 1.11.1.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.11.0...1.11.1)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -30,9 +31,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.15.0 (Sun Mar 01 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- fix tests  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix tests ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -42,15 +43,16 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.13.1 (Mon Feb 24 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump tslib from 1.10.0 to 1.11.0
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.10.0 to 1.11.0.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.10.0...1.11.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -60,9 +62,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.12.0 (Fri Feb 21 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- ensure remote can be pushed to  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- ensure remote can be pushed to ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -72,9 +74,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.10.0 (Thu Feb 06 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add "info" command  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add "info" command ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -84,12 +86,12 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.8.4 (Fri Jan 31 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- fix maven release creation  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix maven release creation ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - resolves #922
 
-update maven & jenkins documentation  (navjot_cheema@intuit.com)
+update maven & jenkins documentation (navjot_cheema@intuit.com)
 
 #### Authors: 2
 
@@ -100,9 +102,9 @@ update maven & jenkins documentation  (navjot_cheema@intuit.com)
 
 # v9.1.1 (Thu Jan 23 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add clearer docs around creating GH_TOKEN  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add clearer docs around creating GH_TOKEN ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -112,10 +114,10 @@ update maven & jenkins documentation  (navjot_cheema@intuit.com)
 
 # v8.6.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.5.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Update CHANGELOG.md [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.5.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Update CHANGELOG.md \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -125,23 +127,24 @@ update maven & jenkins documentation  (navjot_cheema@intuit.com)
 
 # v8.5.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.4.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.3.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Update CHANGELOG.md [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.2.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.4.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.3.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Update CHANGELOG.md \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.2.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Bump semver from 6.3.0 to 7.0.0
 
 Bumps [semver](https://github.com/npm/node-semver) from 6.3.0 to 7.0.0.
+
 - [Release notes](https://github.com/npm/node-semver/releases)
 - [Changelog](https://github.com/npm/node-semver/blob/master/CHANGELOG.md)
 - [Commits](https://github.com/npm/node-semver/compare/v6.3.0...v7.0.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 2
 
@@ -152,23 +155,24 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.5.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.4.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.3.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Update CHANGELOG.md [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.2.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.4.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.3.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Update CHANGELOG.md \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.2.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Bump semver from 6.3.0 to 7.0.0
 
 Bumps [semver](https://github.com/npm/node-semver) from 6.3.0 to 7.0.0.
+
 - [Release notes](https://github.com/npm/node-semver/releases)
 - [Changelog](https://github.com/npm/node-semver/blob/master/CHANGELOG.md)
 - [Commits](https://github.com/npm/node-semver/compare/v6.3.0...v7.0.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 2
 
@@ -179,16 +183,17 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.3.0 (Mon Dec 16 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump semver from 6.3.0 to 7.0.0
 
 Bumps [semver](https://github.com/npm/node-semver) from 6.3.0 to 7.0.0.
+
 - [Release notes](https://github.com/npm/node-semver/releases)
 - [Changelog](https://github.com/npm/node-semver/blob/master/CHANGELOG.md)
 - [Commits](https://github.com/npm/node-semver/compare/v6.3.0...v7.0.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -198,21 +203,21 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.0.0 (Wed Dec 11 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.0.0-next.4 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- reset versions  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.7 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.6 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.5 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix tests  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.8 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.4 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- reset versions ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.7 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.6 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.5 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix tests ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.8 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 

--- a/plugins/npm/CHANGELOG.md
+++ b/plugins/npm/CHANGELOG.md
@@ -1,8 +1,8 @@
 # v9.15.7 (Tue Mar 03 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add license to all sub-packages  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add license to all sub-packages ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -12,17 +12,18 @@
 
 # v9.15.3 (Mon Mar 02 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add test and don't display non-canary packages in comment  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- don't force publish canary/next for independent lerna projects  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add test and don't display non-canary packages in comment ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- don't force publish canary/next for independent lerna projects ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Bump tslib from 1.11.0 to 1.11.1
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.11.0 to 1.11.1.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.11.0...1.11.1)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 2
 
@@ -33,12 +34,12 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.15.0 (Sun Mar 01 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- update plugin and autorc docs  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add fp and io-ts as deps  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix old tests  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add plugin configuration validation  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- update plugin and autorc docs ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add fp and io-ts as deps ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix old tests ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add plugin configuration validation ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -48,15 +49,16 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.13.1 (Mon Feb 24 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump tslib from 1.10.0 to 1.11.0
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.10.0 to 1.11.0.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.10.0...1.11.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -66,9 +68,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.13.0 (Sat Feb 22 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- When parsing owner/repo fallback to parsing 'origin'  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- When parsing owner/repo fallback to parsing 'origin' ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -78,9 +80,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.12.1 (Sat Feb 22 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add warning about using npm plugin with noVersionPrefix  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add warning about using npm plugin with noVersionPrefix ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -90,9 +92,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.12.0 (Fri Feb 21 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- ensure remote can be pushed to  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- ensure remote can be pushed to ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -106,15 +108,16 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 Thank you, null[@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]), for all your work!
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump @types/semver from 6.2.0 to 7.1.0
 
 Bumps [@types/semver](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/HEAD/types/semver) from 6.2.0 to 7.1.0.
+
 - [Release notes](https://github.com/DefinitelyTyped/DefinitelyTyped/releases)
 - [Commits](https://github.com/DefinitelyTyped/DefinitelyTyped/commits/HEAD/types/semver)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -124,9 +127,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.10.5 (Thu Feb 13 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- fix build  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix build ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -136,10 +139,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.10.1 (Thu Feb 06 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- fix tests  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- must create an annotated tag for it to be pushed with --follow-tags  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix tests ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- must create an annotated tag for it to be pushed with --follow-tags ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -149,9 +152,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.9.1 (Tue Feb 04 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- dont run git hooks when commiting the version for a single npm package  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- dont run git hooks when commiting the version for a single npm package ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -161,10 +164,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.8.2 (Thu Jan 30 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- fix test  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add fallback to get lerna json  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix test ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add fallback to get lerna json ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -174,10 +177,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.8.0 (Mon Jan 27 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add test  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- make unique GitHub releases for each package published in lerna independent monorepo  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add test ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- make unique GitHub releases for each package published in lerna independent monorepo ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -187,10 +190,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.7.0 (Mon Jan 27 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- use different version commit message for independent projects  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- abort release if lerna reports no unchanged packages  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- use different version commit message for independent projects ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- abort release if lerna reports no unchanged packages ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -200,11 +203,11 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.5.0 (Mon Jan 27 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- fix lint  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add next steps  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Overhaul "auto init" experience + make it pluggable  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix lint ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add next steps ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Overhaul "auto init" experience + make it pluggable ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -214,12 +217,12 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.4.0 (Sat Jan 25 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- clearer sentence  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- more emoji === better  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- include version for canary scope  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Add html details option to canary hook + Use in npm plugin  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- clearer sentence ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- more emoji === better ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- include version for canary scope ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Add html details option to canary hook + Use in npm plugin ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -229,9 +232,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.3.2 (Fri Jan 24 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- do not include private packages in previous version calculation  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- do not include private packages in previous version calculation ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -241,10 +244,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.3.0 (Fri Jan 24 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add docs  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add ability to publish exact versions in monorepo  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add docs ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add ability to publish exact versions in monorepo ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -254,9 +257,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.2.0 (Thu Jan 23 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Add ability to manage sub-package contributor lists  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Add ability to manage sub-package contributor lists ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -266,9 +269,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.1.3 (Thu Jan 23 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- ensure promises are executed sequentially  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- ensure promises are executed sequentially ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -278,16 +281,17 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.0.0 (Mon Jan 13 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- match npm behavior for scoped packages  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- match npm behavior for scoped packages ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Bump env-ci from 4.5.2 to 5.0.1
 
 Bumps [env-ci](https://github.com/pvdlg/env-ci) from 4.5.2 to 5.0.1.
+
 - [Release notes](https://github.com/pvdlg/env-ci/releases)
 - [Commits](https://github.com/pvdlg/env-ci/compare/v4.5.2...v5.0.1)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 2
 
@@ -298,9 +302,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.7.1 (Thu Dec 19 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add debug info  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add debug info ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -310,9 +314,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.6.3 (Thu Dec 19 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- determine next version using by omitting tags from master  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- determine next version using by omitting tags from master ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -322,12 +326,12 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.6.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.5.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Update CHANGELOG.md [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- publish to specific tag  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add ability to manage version branches  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.5.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Update CHANGELOG.md \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- publish to specific tag ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add ability to manage version branches ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -337,31 +341,33 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.5.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- publish to specific tag  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- remove docs  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.4.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.3.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Update CHANGELOG.md [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- release: detect prerelease branch + be smarter about commit range  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add ability to manage version branches  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.2.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix tests?  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- publish to specific tag ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- remove docs ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.4.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.3.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Update CHANGELOG.md \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- release: detect prerelease branch + be smarter about commit range ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add ability to manage version branches ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.2.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix tests? ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - alias the canary scope
 
-use alias we define  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+use alias we define ([@hipstersmoothie](https://github.com/hipstersmoothie))
+
 - Bump semver from 6.3.0 to 7.0.0
 
 Bumps [semver](https://github.com/npm/node-semver) from 6.3.0 to 7.0.0.
+
 - [Release notes](https://github.com/npm/node-semver/releases)
 - [Changelog](https://github.com/npm/node-semver/blob/master/CHANGELOG.md)
 - [Commits](https://github.com/npm/node-semver/compare/v6.3.0...v7.0.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 2
 
@@ -372,31 +378,32 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.4.1 (Mon Dec 16 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - alias the canary scope
 
-use alias we define  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+use alias we define ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
 - Andrew Lisowski ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-----
+---
 
 # v8.3.0 (Mon Dec 16 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- release: detect prerelease branch + be smarter about commit range  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- release: detect prerelease branch + be smarter about commit range ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Bump semver from 6.3.0 to 7.0.0
 
 Bumps [semver](https://github.com/npm/node-semver) from 6.3.0 to 7.0.0.
+
 - [Release notes](https://github.com/npm/node-semver/releases)
 - [Changelog](https://github.com/npm/node-semver/blob/master/CHANGELOG.md)
 - [Commits](https://github.com/npm/node-semver/compare/v6.3.0...v7.0.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 2
 
@@ -407,9 +414,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.1.3 (Sat Dec 14 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- fix tests?  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix tests? ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -419,9 +426,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.1.1 (Sat Dec 14 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- remove docs  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- remove docs ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -431,14 +438,14 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.1.0 (Sat Dec 14 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- clean up docs  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix message bugs  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- write to correct file  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- correct paths  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add create user step  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add canaryScope option  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- clean up docs ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix message bugs ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- write to correct file ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- correct paths ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add create user step ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add canaryScope option ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -448,41 +455,41 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.0.0 (Wed Dec 11 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- move determineNextVersion to core  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix sub-pacakge changelogs  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add tests  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- only need to push tags during prerelease  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- account for detatched head  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- use preid correctly  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix tests  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix canary calcs  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- better monorepo canary version  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- do not commit prerelease versions  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- reset versions  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.8 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.7 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- move to top level util for ease of testing  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- get label refactor working  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.6 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix undefined in changelogs  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- move git clean check to core  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.5 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix canary reporting  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- ensure canary versions dont use extra bumps  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix lint  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.4 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- change getPreviousVersion hook args. can access prefixRelease from root class instead  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- shipit: add flag to only publish to 'latest' tag when "release" label is present  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- allow user to configure what branches are treated as prerelease branches  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- get next branch release working  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- move determineNextVersion to core ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix sub-pacakge changelogs ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add tests ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- only need to push tags during prerelease ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- account for detatched head ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- use preid correctly ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix tests ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix canary calcs ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- better monorepo canary version ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- do not commit prerelease versions ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- reset versions ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.8 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.7 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- move to top level util for ease of testing ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- get label refactor working ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.6 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix undefined in changelogs ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- move git clean check to core ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.5 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix canary reporting ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- ensure canary versions dont use extra bumps ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix lint ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.4 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- change getPreviousVersion hook args. can access prefixRelease from root class instead ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- shipit: add flag to only publish to 'latest' tag when "release" label is present ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- allow user to configure what branches are treated as prerelease branches ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- get next branch release working ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 

--- a/plugins/npm/__tests__/__snapshots__/monorepo-log.test.ts.snap
+++ b/plugins/npm/__tests__/__snapshots__/monorepo-log.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should add versions for independent packages 1`] = `
-"#### 💥  Breaking Change
+"#### 💥 Breaking Change
 
 - woot [#12343](https://github.custom.com/pull/12343) (adam@dierkens.com)
 - \`@foobar/release@1.0.1\`, \`@foobar/party@1.0.3\`
@@ -9,7 +9,7 @@ exports[`should add versions for independent packages 1`] = `
 - \`@foobar/release@1.0.1\`, \`@foobar/party@1.0.3\`
   - [PLAYA-5052] - Some Feature - Revert [#12345](https://github.custom.com/pull/12345) (adam@dierkens.com)
 
-#### 🏠  Internal
+#### 🏠 Internal
 
 - \`@foobar/release@1.0.1\`
   - Another Feature [#1234](https://github.custom.com/pull/1234) (adam@dierkens.com)
@@ -20,7 +20,7 @@ exports[`should add versions for independent packages 1`] = `
 `;
 
 exports[`should create sections for packages 1`] = `
-"#### 💥  Breaking Change
+"#### 💥 Breaking Change
 
 - woot [#12343](https://github.custom.com/pull/12343) (adam@dierkens.com)
 - \`@foobar/release\`, \`@foobar/party\`
@@ -28,7 +28,7 @@ exports[`should create sections for packages 1`] = `
 - \`@foobar/release\`, \`@foobar/party\`
   - [PLAYA-5052] - Some Feature - Revert [#12345](https://github.custom.com/pull/12345) (adam@dierkens.com)
 
-#### 🏠  Internal
+#### 🏠 Internal
 
 - \`@foobar/release\`
   - Another Feature [#1234](https://github.custom.com/pull/1234) (adam@dierkens.com)

--- a/plugins/omit-commits/CHANGELOG.md
+++ b/plugins/omit-commits/CHANGELOG.md
@@ -1,8 +1,8 @@
 # v9.15.7 (Tue Mar 03 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add license to all sub-packages  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add license to all sub-packages ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -12,15 +12,16 @@
 
 # v9.15.3 (Mon Mar 02 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump tslib from 1.11.0 to 1.11.1
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.11.0 to 1.11.1.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.11.0...1.11.1)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -30,11 +31,11 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.15.0 (Sun Mar 01 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- update plugin and autorc docs  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add fp and io-ts as deps  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add plugin configuration validation  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- update plugin and autorc docs ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add fp and io-ts as deps ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add plugin configuration validation ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -44,15 +45,16 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.13.1 (Mon Feb 24 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump tslib from 1.10.0 to 1.11.0
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.10.0 to 1.11.0.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.10.0...1.11.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -62,10 +64,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.6.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.5.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Update CHANGELOG.md [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.5.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Update CHANGELOG.md \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -75,14 +77,14 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.5.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.4.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.3.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.2.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.4.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.3.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.2.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -92,20 +94,20 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.0.0 (Wed Dec 11 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.0.0-next.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- reset versions  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.7 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.6 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.5 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.4 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.8 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- reset versions ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.7 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.6 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.5 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.4 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.8 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 

--- a/plugins/omit-release-notes/CHANGELOG.md
+++ b/plugins/omit-release-notes/CHANGELOG.md
@@ -1,8 +1,8 @@
 # v9.15.7 (Tue Mar 03 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add license to all sub-packages  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add license to all sub-packages ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -12,15 +12,16 @@
 
 # v9.15.3 (Mon Mar 02 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump tslib from 1.11.0 to 1.11.1
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.11.0 to 1.11.1.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.11.0...1.11.1)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -30,11 +31,11 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.15.0 (Sun Mar 01 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- update plugin and autorc docs  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add fp and io-ts as deps  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add plugin configuration validation  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- update plugin and autorc docs ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add fp and io-ts as deps ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add plugin configuration validation ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -44,15 +45,16 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.13.1 (Mon Feb 24 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump tslib from 1.10.0 to 1.11.0
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.10.0 to 1.11.0.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.10.0...1.11.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -62,10 +64,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.6.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.5.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Update CHANGELOG.md [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.5.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Update CHANGELOG.md \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -75,14 +77,14 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.5.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.4.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.3.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.2.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.4.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.3.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.2.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -92,20 +94,20 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.0.0 (Wed Dec 11 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.0.0-next.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- reset versions  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.7 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.6 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.5 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.4 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.8 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- reset versions ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.7 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.6 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.5 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.4 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.8 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 

--- a/plugins/released/CHANGELOG.md
+++ b/plugins/released/CHANGELOG.md
@@ -1,8 +1,8 @@
 # v9.15.7 (Tue Mar 03 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add license to all sub-packages  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add license to all sub-packages ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -12,15 +12,16 @@
 
 # v9.15.3 (Mon Mar 02 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump tslib from 1.11.0 to 1.11.1
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.11.0 to 1.11.1.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.11.0...1.11.1)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -30,11 +31,11 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.15.0 (Sun Mar 01 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- update plugin and autorc docs  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add fp and io-ts as deps  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add plugin configuration validation  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- update plugin and autorc docs ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add fp and io-ts as deps ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add plugin configuration validation ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -44,15 +45,16 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.13.1 (Mon Feb 24 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump tslib from 1.10.0 to 1.11.0
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.10.0 to 1.11.0.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.10.0...1.11.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -62,9 +64,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.8.0 (Mon Jan 27 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- create new hook makeRelease and move current behavior into default tap  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- create new hook makeRelease and move current behavior into default tap ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -74,9 +76,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.4.1 (Sat Jan 25 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Wrap version in code block  ([@ericclemmons](https://github.com/ericclemmons))
+- Wrap version in code block ([@ericclemmons](https://github.com/ericclemmons))
 
 #### Authors: 1
 
@@ -86,9 +88,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.6.3 (Thu Dec 19 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- fix execpromise logs  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix execpromise logs ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -98,10 +100,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.6.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.5.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Update CHANGELOG.md [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.5.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Update CHANGELOG.md \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -111,14 +113,14 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.5.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.4.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.3.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.2.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.4.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.3.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.2.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -128,31 +130,31 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.0.0 (Wed Dec 11 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.0.0-next.4 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- do not call afterRelease hooks during dry run  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- do not add labels or comments to prerelease branch PRs  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- reset versions  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.8 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.7 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- change skip-release releaseType to just skip  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add none release type  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- get label refactor working  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.6 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.5 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix tests  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- allow user to configure what branches are treated as prerelease branches  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- remove prerelease label when released  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- also label PR correctly  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- remove old use of prerelease label + add prerelease label to released plugin  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- don't run released plugin on "next" branch PRs  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.4 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- do not call afterRelease hooks during dry run ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- do not add labels or comments to prerelease branch PRs ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- reset versions ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.8 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.7 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- change skip-release releaseType to just skip ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add none release type ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- get label refactor working ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.6 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.5 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix tests ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- allow user to configure what branches are treated as prerelease branches ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- remove prerelease label when released ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- also label PR correctly ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- remove old use of prerelease label + add prerelease label to released plugin ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- don't run released plugin on "next" branch PRs ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 

--- a/plugins/s3/CHANGELOG.md
+++ b/plugins/s3/CHANGELOG.md
@@ -1,8 +1,8 @@
 # v9.15.7 (Tue Mar 03 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add license to all sub-packages  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add license to all sub-packages ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -12,12 +12,12 @@
 
 # v9.15.0 (Sun Mar 01 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- update plugin and autorc docs  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add fp and io-ts as deps  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix old tests  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add plugin configuration validation  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- update plugin and autorc docs ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add fp and io-ts as deps ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix old tests ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add plugin configuration validation ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -27,10 +27,10 @@
 
 # v8.6.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.5.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Update CHANGELOG.md [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.5.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Update CHANGELOG.md \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -40,14 +40,14 @@
 
 # v8.5.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.4.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.3.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.2.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.4.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.3.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.2.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -57,21 +57,21 @@
 
 # v8.0.0 (Wed Dec 11 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.0.0-next.4 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add tests  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.8 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.7 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.6 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.5 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- reset versions  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.4 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add tests ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.8 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.7 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.6 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.5 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- reset versions ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 

--- a/plugins/slack/CHANGELOG.md
+++ b/plugins/slack/CHANGELOG.md
@@ -1,8 +1,8 @@
 # v9.15.7 (Tue Mar 03 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add license to all sub-packages  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add license to all sub-packages ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -12,22 +12,25 @@
 
 # v9.15.3 (Mon Mar 02 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump @types/node-fetch from 2.5.4 to 2.5.5
 
 Bumps [@types/node-fetch](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/HEAD/types/node-fetch) from 2.5.4 to 2.5.5.
+
 - [Release notes](https://github.com/DefinitelyTyped/DefinitelyTyped/releases)
 - [Commits](https://github.com/DefinitelyTyped/DefinitelyTyped/commits/HEAD/types/node-fetch)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+
 - Bump tslib from 1.11.0 to 1.11.1
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.11.0 to 1.11.1.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.11.0...1.11.1)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -37,10 +40,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.15.0 (Sun Mar 01 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add fp and io-ts as deps  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add plugin configuration validation  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add fp and io-ts as deps ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add plugin configuration validation ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -50,15 +53,16 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.13.1 (Mon Feb 24 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump tslib from 1.10.0 to 1.11.0
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.10.0 to 1.11.0.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.10.0...1.11.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -68,9 +72,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.6.0 (Mon Jan 27 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add ability to store slack hook url in environment variable  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add ability to store slack hook url in environment variable ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -80,10 +84,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.5.0 (Mon Jan 27 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- fix lint  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Overhaul "auto init" experience + make it pluggable  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix lint ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Overhaul "auto init" experience + make it pluggable ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -93,18 +97,18 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.8.0 (Thu Jan 02 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- test: added a test to assure prerelease branches don't trigger a slack  ([@Aghassi](https://github.com/Aghassi))
-- refactor: ensure the fetch call is never made  ([@Aghassi](https://github.com/Aghassi))
-- refactor: fixed incorrect logic for prerelease check  ([@Aghassi](https://github.com/Aghassi))
-- refactor: removed unecessary console logs  ([@Aghassi](https://github.com/Aghassi))
-- test: added tests for when publishPreRelease is set  ([@Aghassi](https://github.com/Aghassi))
-- docs: updated slack plugin docs on publishPreRelease usage  ([@Aghassi](https://github.com/Aghassi))
-- fix: prevent slack from default publishing on prerelease branches  ([@Aghassi](https://github.com/Aghassi))
+- test: added a test to assure prerelease branches don't trigger a slack ([@Aghassi](https://github.com/Aghassi))
+- refactor: ensure the fetch call is never made ([@Aghassi](https://github.com/Aghassi))
+- refactor: fixed incorrect logic for prerelease check ([@Aghassi](https://github.com/Aghassi))
+- refactor: removed unecessary console logs ([@Aghassi](https://github.com/Aghassi))
+- test: added tests for when publishPreRelease is set ([@Aghassi](https://github.com/Aghassi))
+- docs: updated slack plugin docs on publishPreRelease usage ([@Aghassi](https://github.com/Aghassi))
+- fix: prevent slack from default publishing on prerelease branches ([@Aghassi](https://github.com/Aghassi))
 - refactor: removed ternary per @hipstersmoothie feedback
 
-Co-Authored-By: Andrew Lisowski <lisowski54@gmail.com>  ([@Aghassi](https://github.com/Aghassi))
+Co-Authored-By: Andrew Lisowski <lisowski54@gmail.com> ([@Aghassi](https://github.com/Aghassi))
 
 #### Authors: 1
 
@@ -114,10 +118,10 @@ Co-Authored-By: Andrew Lisowski <lisowski54@gmail.com>  ([@Aghassi](https://gith
 
 # v8.6.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.5.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Update CHANGELOG.md [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.5.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Update CHANGELOG.md \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -127,14 +131,14 @@ Co-Authored-By: Andrew Lisowski <lisowski54@gmail.com>  ([@Aghassi](https://gith
 
 # v8.5.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.4.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.3.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.2.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.4.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.3.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.2.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -144,26 +148,26 @@ Co-Authored-By: Andrew Lisowski <lisowski54@gmail.com>  ([@Aghassi](https://gith
 
 # v8.0.0 (Wed Dec 11 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.0.0-next.4 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- do not call afterRelease hooks during dry run  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.8 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.7 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- change skip-release releaseType to just skip  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add none release type  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- get label refactor working  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.6 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.5 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- reset versions  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- fix tests  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- allow user to configure what branches are treated as prerelease branches  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.4 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- do not call afterRelease hooks during dry run ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.8 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.7 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- change skip-release releaseType to just skip ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add none release type ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- get label refactor working ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.6 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.5 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- reset versions ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix tests ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- allow user to configure what branches are treated as prerelease branches ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 

--- a/plugins/twitter/CHANGELOG.md
+++ b/plugins/twitter/CHANGELOG.md
@@ -1,8 +1,8 @@
 # v9.15.7 (Tue Mar 03 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add license to all sub-packages  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add license to all sub-packages ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -12,15 +12,16 @@
 
 # v9.15.3 (Mon Mar 02 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump tslib from 1.11.0 to 1.11.1
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.11.0 to 1.11.1.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.11.0...1.11.1)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -30,11 +31,11 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.15.0 (Sun Mar 01 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- update plugin and autorc docs  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add fp and io-ts as deps  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add plugin configuration validation  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- update plugin and autorc docs ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add fp and io-ts as deps ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add plugin configuration validation ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -44,15 +45,16 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.13.1 (Mon Feb 24 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump tslib from 1.10.0 to 1.11.0
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.10.0 to 1.11.0.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.10.0...1.11.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -66,15 +68,16 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 Thank you, null[@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]), for all your work!
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump @types/semver from 6.2.0 to 7.1.0
 
 Bumps [@types/semver](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/HEAD/types/semver) from 6.2.0 to 7.1.0.
+
 - [Release notes](https://github.com/DefinitelyTyped/DefinitelyTyped/releases)
 - [Commits](https://github.com/DefinitelyTyped/DefinitelyTyped/commits/HEAD/types/semver)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -84,9 +87,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.8.0 (Mon Jan 27 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- create new hook makeRelease and move current behavior into default tap  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- create new hook makeRelease and move current behavior into default tap ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -96,10 +99,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.6.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.5.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Update CHANGELOG.md [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.5.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Update CHANGELOG.md \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -109,23 +112,24 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.5.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.4.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.3.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Update CHANGELOG.md [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.2.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.4.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.3.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Update CHANGELOG.md \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.2.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Bump semver from 6.3.0 to 7.0.0
 
 Bumps [semver](https://github.com/npm/node-semver) from 6.3.0 to 7.0.0.
+
 - [Release notes](https://github.com/npm/node-semver/releases)
 - [Changelog](https://github.com/npm/node-semver/blob/master/CHANGELOG.md)
 - [Commits](https://github.com/npm/node-semver/compare/v6.3.0...v7.0.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 2
 
@@ -136,16 +140,17 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.3.0 (Mon Dec 16 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump semver from 6.3.0 to 7.0.0
 
 Bumps [semver](https://github.com/npm/node-semver) from 6.3.0 to 7.0.0.
+
 - [Release notes](https://github.com/npm/node-semver/releases)
 - [Changelog](https://github.com/npm/node-semver/blob/master/CHANGELOG.md)
 - [Commits](https://github.com/npm/node-semver/compare/v6.3.0...v7.0.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -155,21 +160,21 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.0.0 (Wed Dec 11 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.0.0-next.4 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- switch from dedent to endent to fix multitemplate indentation  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.8 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.7 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.6 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.5 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- reset versions  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.4 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- switch from dedent to endent to fix multitemplate indentation ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.8 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.7 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.6 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.5 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- reset versions ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 

--- a/plugins/upload-assets/CHANGELOG.md
+++ b/plugins/upload-assets/CHANGELOG.md
@@ -1,8 +1,8 @@
 # v9.15.7 (Tue Mar 03 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- add license to all sub-packages  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add license to all sub-packages ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -12,15 +12,16 @@
 
 # v9.15.3 (Mon Mar 02 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump tslib from 1.11.0 to 1.11.1
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.11.0 to 1.11.1.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.11.0...1.11.1)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -30,11 +31,11 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.15.0 (Sun Mar 01 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- update plugin and autorc docs  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add fp and io-ts as deps  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- add plugin configuration validation  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- update plugin and autorc docs ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add fp and io-ts as deps ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- add plugin configuration validation ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -44,15 +45,16 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.13.1 (Mon Feb 24 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Bump tslib from 1.10.0 to 1.11.0
 
 Bumps [tslib](https://github.com/Microsoft/tslib) from 1.10.0 to 1.11.0.
+
 - [Release notes](https://github.com/Microsoft/tslib/releases)
 - [Commits](https://github.com/Microsoft/tslib/compare/1.10.0...1.11.0)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -66,16 +68,17 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 Thank you, null[@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]), for all your work!
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- fix build  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix build ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Bump file-type from 13.1.1 to 14.1.1
 
 Bumps [file-type](https://github.com/sindresorhus/file-type) from 13.1.1 to 14.1.1.
+
 - [Release notes](https://github.com/sindresorhus/file-type/releases)
 - [Commits](https://github.com/sindresorhus/file-type/compare/v13.1.1...v14.1.1)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 2
 
@@ -86,9 +89,9 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.8.0 (Mon Jan 27 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- create new hook makeRelease and move current behavior into default tap  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- create new hook makeRelease and move current behavior into default tap ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -98,16 +101,17 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v9.0.0 (Mon Jan 13 2020)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- fix build  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- fix build ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Bump file-type from 12.4.2 to 13.0.3
 
 Bumps [file-type](https://github.com/sindresorhus/file-type) from 12.4.2 to 13.0.3.
+
 - [Release notes](https://github.com/sindresorhus/file-type/releases)
 - [Commits](https://github.com/sindresorhus/file-type/compare/v12.4.2...v13.0.3)
 
-Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
+Signed-off-by: dependabot-preview[bot] <support@dependabot.com> ([@dependabot-preview[bot]](https://github.com/dependabot-preview[bot]))
 
 #### Authors: 1
 
@@ -117,10 +121,10 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.6.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.5.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Update CHANGELOG.md [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.5.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Update CHANGELOG.md \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -130,14 +134,14 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.5.0 (Tue Dec 17 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.4.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.3.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.2.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.1.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.4.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.3.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.2.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.1.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 1
 
@@ -147,24 +151,24 @@ Signed-off-by: dependabot-preview[bot] <support@dependabot.com>  ([@dependabot-p
 
 # v8.0.0 (Wed Dec 11 2019)
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
-- Bump version to: v8.0.0-next.5 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- switch from dedent to endent to fix multitemplate indentation  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Rename fg to glob  ([@adierkens](https://github.com/adierkens))
-- Add glob support to the upload-assets plugin  ([@adierkens](https://github.com/adierkens))
-- reset versions  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.8 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.7 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.6 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- more resiliant test case  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.4 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.3 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.2 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v8.0.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.1 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Bump version to: v7.17.0-next.0 [skip ci]  ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.5 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- switch from dedent to endent to fix multitemplate indentation ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Rename fg to glob ([@adierkens](https://github.com/adierkens))
+- Add glob support to the upload-assets plugin ([@adierkens](https://github.com/adierkens))
+- reset versions ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.8 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.7 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.6 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- more resiliant test case ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.4 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.3 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.2 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v8.0.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.1 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
+- Bump version to: v7.17.0-next.0 \[skip ci\] ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
 #### Authors: 2
 


### PR DESCRIPTION
# What Changed

Fix formatting to match `prettier`'s output more. 

# Why

This will help when people accidently format their changelogs.

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.16.3-canary.1026.13469.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/auto@9.16.3-canary.1026.13469.0
  npm install @auto-canary/core@9.16.3-canary.1026.13469.0
  npm install @auto-canary/all-contributors@9.16.3-canary.1026.13469.0
  npm install @auto-canary/chrome@9.16.3-canary.1026.13469.0
  npm install @auto-canary/conventional-commits@9.16.3-canary.1026.13469.0
  npm install @auto-canary/crates@9.16.3-canary.1026.13469.0
  npm install @auto-canary/first-time-contributor@9.16.3-canary.1026.13469.0
  npm install @auto-canary/git-tag@9.16.3-canary.1026.13469.0
  npm install @auto-canary/gradle@9.16.3-canary.1026.13469.0
  npm install @auto-canary/jira@9.16.3-canary.1026.13469.0
  npm install @auto-canary/maven@9.16.3-canary.1026.13469.0
  npm install @auto-canary/npm@9.16.3-canary.1026.13469.0
  npm install @auto-canary/omit-commits@9.16.3-canary.1026.13469.0
  npm install @auto-canary/omit-release-notes@9.16.3-canary.1026.13469.0
  npm install @auto-canary/released@9.16.3-canary.1026.13469.0
  npm install @auto-canary/s3@9.16.3-canary.1026.13469.0
  npm install @auto-canary/slack@9.16.3-canary.1026.13469.0
  npm install @auto-canary/twitter@9.16.3-canary.1026.13469.0
  npm install @auto-canary/upload-assets@9.16.3-canary.1026.13469.0
  # or 
  yarn add @auto-canary/auto@9.16.3-canary.1026.13469.0
  yarn add @auto-canary/core@9.16.3-canary.1026.13469.0
  yarn add @auto-canary/all-contributors@9.16.3-canary.1026.13469.0
  yarn add @auto-canary/chrome@9.16.3-canary.1026.13469.0
  yarn add @auto-canary/conventional-commits@9.16.3-canary.1026.13469.0
  yarn add @auto-canary/crates@9.16.3-canary.1026.13469.0
  yarn add @auto-canary/first-time-contributor@9.16.3-canary.1026.13469.0
  yarn add @auto-canary/git-tag@9.16.3-canary.1026.13469.0
  yarn add @auto-canary/gradle@9.16.3-canary.1026.13469.0
  yarn add @auto-canary/jira@9.16.3-canary.1026.13469.0
  yarn add @auto-canary/maven@9.16.3-canary.1026.13469.0
  yarn add @auto-canary/npm@9.16.3-canary.1026.13469.0
  yarn add @auto-canary/omit-commits@9.16.3-canary.1026.13469.0
  yarn add @auto-canary/omit-release-notes@9.16.3-canary.1026.13469.0
  yarn add @auto-canary/released@9.16.3-canary.1026.13469.0
  yarn add @auto-canary/s3@9.16.3-canary.1026.13469.0
  yarn add @auto-canary/slack@9.16.3-canary.1026.13469.0
  yarn add @auto-canary/twitter@9.16.3-canary.1026.13469.0
  yarn add @auto-canary/upload-assets@9.16.3-canary.1026.13469.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
