### PR TITLE
move botlist to package and use it in release notes exclusion

### DIFF
--- a/packages/bot-list/README.md
+++ b/packages/bot-list/README.md
@@ -1,0 +1,3 @@
+# @auto-it/bot-list
+
+A list of bots for `auto` and it's plugins to ignore.

--- a/packages/bot-list/package.json
+++ b/packages/bot-list/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@auto-it/bot-list",
+  "main": "dist/index.js",
+  "description": "A list of bots for auto plugins to ignore",
+  "version": "9.15.8",
+  "license": "MIT",
+  "author": {
+    "name": "Andrew Lisowski",
+    "email": "lisowski54@gmail.com"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/intuit/auto"
+  },
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=10.x"
+  },
+  "keywords": [
+    "automation",
+    "semantic",
+    "release",
+    "github",
+    "labels",
+    "automated",
+    "continuos integration",
+    "changelog",
+    "cli"
+  ],
+  "scripts": {
+    "build": "tsc -b",
+    "start": "npm run build -- -w",
+    "lint": "eslint src --ext .ts",
+    "test": "jest --maxWorkers=2"
+  }
+}

--- a/packages/bot-list/src/index.ts
+++ b/packages/bot-list/src/index.ts
@@ -1,0 +1,10 @@
+export default [
+  'dependabot-preview[bot]',
+  'greenkeeper[bot]',
+  'dependabot[bot]',
+  'fossabot',
+  'renovate',
+  'renovate-bot',
+  'renovate[bot]',
+  'renovate-approve'
+];

--- a/packages/bot-list/tsconfig.json
+++ b/packages/bot-list/tsconfig.json
@@ -6,11 +6,5 @@
     "outDir": "./dist",
     "rootDir": "./src",
     "composite": true
-  },
-
-  "references": [
-    {
-      "path": "../../packages/bot-list"
-    }
-  ]
+  }
 }

--- a/packages/core/src/changelog.ts
+++ b/packages/core/src/changelog.ts
@@ -1,6 +1,7 @@
 import { AsyncSeriesBailHook, AsyncSeriesWaterfallHook } from 'tapable';
 import { URL } from 'url';
 import join from 'url-join';
+import botList from '@auto-it/bot-list';
 
 import { ICommitAuthor, IExtendedCommit } from './log-parse';
 import { ILabelDefinition } from './release';
@@ -121,15 +122,12 @@ export default class Changelog {
       'Default',
       (label, changelogTitles) => `#### ${changelogTitles[label]}\n`
     );
-    this.hooks.omitReleaseNotes.tap('Renovate', commit => {
-      const names = ['renovate-pro[bot]', 'renovate-bot'];
-
+    this.hooks.omitReleaseNotes.tap('Bots', commit => {
       if (
-        commit.authors.find(author =>
-          Boolean(
-            (author.name && names.includes(author.name)) ||
-              (author.username && names.includes(author.username))
-          )
+        commit.authors.some(
+          author =>
+            (author.name && botList.includes(author.name)) ||
+            (author.username && botList.includes(author.username))
         )
       ) {
         return true;

--- a/plugins/all-contributors/package.json
+++ b/plugins/all-contributors/package.json
@@ -37,6 +37,7 @@
     "test": "jest --maxWorkers=2 --config ../../package.json"
   },
   "dependencies": {
+    "@auto-it/bot-list": "link:../../packages/bot-list",
     "@auto-it/core": "link:../../packages/core",
     "anymatch": "^3.1.1",
     "await-to-js": "^2.1.1",

--- a/plugins/all-contributors/src/index.ts
+++ b/plugins/all-contributors/src/index.ts
@@ -6,6 +6,7 @@ import {
   inFolder,
   validatePluginConfiguration
 } from '@auto-it/core';
+import botList from '@auto-it/bot-list';
 import fs from 'fs';
 import path from 'path';
 import match from 'anymatch';
@@ -86,16 +87,7 @@ interface AllContributorsRc {
 }
 
 const defaultOptions: IAllContributorsPluginOptions = {
-  exclude: [
-    'dependabot-preview[bot]',
-    'greenkeeper[bot]',
-    'dependabot[bot]',
-    'fossabot',
-    'renovate',
-    'renovate-bot',
-    'renovate[bot]',
-    'renovate-approve'
-  ],
+  exclude: botList,
   types: {
     doc: ['**/*.mdx', '**/*.md', '**/docs/**/*', '**/documentation/**/*'],
     example: ['**/*.stories*', '**/*.story.*'],

--- a/plugins/all-contributors/tsconfig.json
+++ b/plugins/all-contributors/tsconfig.json
@@ -11,6 +11,9 @@
   "references": [
     {
       "path": "../../packages/core"
+    },
+    {
+      "path": "../../packages/bot-list"
     }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,9 @@
   resolved "https://registry.yarnpkg.com/@atomist/slack-messages/-/slack-messages-1.1.1.tgz#9de42932e89065fb4fe4842978ca2d1ed3424cea"
   integrity sha512-m2OzlTDbhvzK4hgswH9Lx0cdpq1AntXu53Klz5RGkFfuoDvKsnlU7tmtVfNWtUiP0zZbGtrb/BZYH7aB6TRnMA==
 
+"@auto-it/bot-list@link:packages/bot-list":
+  version "9.15.8"
+
 "@auto-it/core@link:packages/core":
   version "9.15.2"
   dependencies:


### PR DESCRIPTION
# What Changed

Create a package for a shared bot list.

# Why

Why repeat this array everywhere. Also good not to bloat core anymore


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.16.1-canary.1027.13443.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.16.1-canary.1027.13443.0
  npm install @auto-canary/auto@9.16.1-canary.1027.13443.0
  npm install @auto-canary/core@9.16.1-canary.1027.13443.0
  npm install @auto-canary/all-contributors@9.16.1-canary.1027.13443.0
  npm install @auto-canary/chrome@9.16.1-canary.1027.13443.0
  npm install @auto-canary/conventional-commits@9.16.1-canary.1027.13443.0
  npm install @auto-canary/crates@9.16.1-canary.1027.13443.0
  npm install @auto-canary/first-time-contributor@9.16.1-canary.1027.13443.0
  npm install @auto-canary/git-tag@9.16.1-canary.1027.13443.0
  npm install @auto-canary/gradle@9.16.1-canary.1027.13443.0
  npm install @auto-canary/jira@9.16.1-canary.1027.13443.0
  npm install @auto-canary/maven@9.16.1-canary.1027.13443.0
  npm install @auto-canary/npm@9.16.1-canary.1027.13443.0
  npm install @auto-canary/omit-commits@9.16.1-canary.1027.13443.0
  npm install @auto-canary/omit-release-notes@9.16.1-canary.1027.13443.0
  npm install @auto-canary/released@9.16.1-canary.1027.13443.0
  npm install @auto-canary/s3@9.16.1-canary.1027.13443.0
  npm install @auto-canary/slack@9.16.1-canary.1027.13443.0
  npm install @auto-canary/twitter@9.16.1-canary.1027.13443.0
  npm install @auto-canary/upload-assets@9.16.1-canary.1027.13443.0
  # or 
  yarn add @auto-canary/bot-list@9.16.1-canary.1027.13443.0
  yarn add @auto-canary/auto@9.16.1-canary.1027.13443.0
  yarn add @auto-canary/core@9.16.1-canary.1027.13443.0
  yarn add @auto-canary/all-contributors@9.16.1-canary.1027.13443.0
  yarn add @auto-canary/chrome@9.16.1-canary.1027.13443.0
  yarn add @auto-canary/conventional-commits@9.16.1-canary.1027.13443.0
  yarn add @auto-canary/crates@9.16.1-canary.1027.13443.0
  yarn add @auto-canary/first-time-contributor@9.16.1-canary.1027.13443.0
  yarn add @auto-canary/git-tag@9.16.1-canary.1027.13443.0
  yarn add @auto-canary/gradle@9.16.1-canary.1027.13443.0
  yarn add @auto-canary/jira@9.16.1-canary.1027.13443.0
  yarn add @auto-canary/maven@9.16.1-canary.1027.13443.0
  yarn add @auto-canary/npm@9.16.1-canary.1027.13443.0
  yarn add @auto-canary/omit-commits@9.16.1-canary.1027.13443.0
  yarn add @auto-canary/omit-release-notes@9.16.1-canary.1027.13443.0
  yarn add @auto-canary/released@9.16.1-canary.1027.13443.0
  yarn add @auto-canary/s3@9.16.1-canary.1027.13443.0
  yarn add @auto-canary/slack@9.16.1-canary.1027.13443.0
  yarn add @auto-canary/twitter@9.16.1-canary.1027.13443.0
  yarn add @auto-canary/upload-assets@9.16.1-canary.1027.13443.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
