### PR TITLE
📦 🐈 Yarn 2 Compatibility

### DIFF
--- a/docs/pages/getting-started.md
+++ b/docs/pages/getting-started.md
@@ -8,6 +8,10 @@ yarn add -D auto
 
 If you are using `auto` in a non-javascript project, you can install `auto` and all it's official plugins via the [releases](https://github.com/intuit/auto/releases) page. Here you will find a build of `auto` for all major OSes. This build has `node` bundled so you don't need it installed!
 
+::: message is-warning
+:warning: If you use `yarn@2` none of the default plugins (`npm` and `released`) are included so you must install them if you want to use them.
+:::
+
 ## Help
 
 To get detailed help for any command use the `--help` flag.

--- a/packages/cli/src/bin/auto.ts
+++ b/packages/cli/src/bin/auto.ts
@@ -10,7 +10,14 @@ try {
   if (json.name.startsWith('@auto-canary')) {
     moduleAlias.addAliases({
       '@auto-it': (fromPath: string, request: string) =>
-        request.startsWith('@auto-it') ? '@auto-canary' : '@auto-it'
+        // We want to rewrite all the imports for canary (ex: npm plugin requiring core)
+        request.startsWith('@auto-it') &&
+        // but we also want to be able to require official plugins from a canary
+        !fromPath.endsWith('noop.js') &&
+        // and don't want to override those plugins's imports
+        !fromPath.includes('@auto-it')
+          ? '@auto-canary'
+          : '@auto-it'
     });
   }
 } catch (error) {}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,6 +57,7 @@
     "gitlogplus": "^3.1.2",
     "https-proxy-agent": "^5.0.0",
     "import-cwd": "^3.0.0",
+    "import-from": "^3.0.0",
     "io-ts": "^2.1.2",
     "lodash.chunk": "^4.2.0",
     "log-symbols": "^3.0.0",

--- a/packages/core/src/__tests__/__snapshots__/auto.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/auto.test.ts.snap
@@ -64,7 +64,7 @@ exports[`Auto createLabels should create the labels 1`] = `
 exports[`Auto should extend config 1`] = `
 Object {
   "baseBranch": "master",
-  "extends": "@artsy",
+  "extends": "@artsy/auto-config/package.json",
   "labels": Array [
     Object {
       "changelogTitle": "💥 Breaking Change",
@@ -120,7 +120,7 @@ Object {
 exports[`Auto should extend local config 1`] = `
 Object {
   "baseBranch": "master",
-  "extends": "./fake.json",
+  "extends": "<PROJECT_ROOT>fake.json",
   "labels": Array [
     Object {
       "changelogTitle": "💥 Breaking Change",

--- a/packages/core/src/__tests__/config.test.ts
+++ b/packages/core/src/__tests__/config.test.ts
@@ -128,6 +128,7 @@ describe('loadExtendConfig', () => {
     );
 
     expect(await config.loadExtendConfig('@artsy')).toStrictEqual({
+      extends: '@artsy/auto-config/package.json',
       onlyPublishWithReleaseLabel: true
     });
   });
@@ -142,6 +143,7 @@ describe('loadExtendConfig', () => {
     );
 
     expect(await config.loadExtendConfig('fuego')).toStrictEqual({
+      extends: 'auto-config-fuego/package.json',
       noVersionPrefix: true
     });
   });

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1781,9 +1781,15 @@ export default class Auto {
       require.resolve('./plugins/filter-non-pull-request'),
       ...(Array.isArray(config.plugins) ? config.plugins : defaultPlugins)
     ];
-    const extendedLocation = config.extends
-      ? require.resolve(config.extends)
-      : undefined;
+    let extendedLocation: string | undefined;
+
+    try {
+      if (config.extends) {
+        extendedLocation = require.resolve(config.extends);
+      }
+    } catch (error) {
+      this.logger.veryVerbose.error();
+    }
 
     pluginsPaths
       .map(plugin =>

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1781,13 +1781,16 @@ export default class Auto {
       require.resolve('./plugins/filter-non-pull-request'),
       ...(Array.isArray(config.plugins) ? config.plugins : defaultPlugins)
     ];
+    const extendedLocation = config.extends
+      ? require.resolve(config.extends)
+      : undefined;
 
     pluginsPaths
       .map(plugin =>
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         typeof plugin === 'string' ? ([plugin, {}] as [string, any]) : plugin
       )
-      .map(plugin => loadPlugin(plugin, this.logger))
+      .map(plugin => loadPlugin(plugin, this.logger, extendedLocation))
       .filter((plugin): plugin is IPlugin => Boolean(plugin))
       .forEach(plugin => {
         this.logger.verbose.info(`Using ${plugin.name} Plugin...`);

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -151,6 +151,10 @@ export default class Config {
       config = tryRequire(scope);
       config = config?.auto;
       this.logger.verbose.note(`${scope} found: ${config}`);
+
+      if (config) {
+        config.extends = scope;
+      }
     }
 
     if (!config) {
@@ -158,10 +162,19 @@ export default class Config {
       config = tryRequire(scope);
       config = config?.auto;
       this.logger.verbose.note(`${scope} found: ${config}`);
+
+      if (config) {
+        config.extends = scope;
+      }
     }
 
     if (!config) {
-      config = tryRequire(path.join(process.cwd(), extend));
+      const localPath = path.join(process.cwd(), extend);
+      config = tryRequire(localPath);
+
+      if (config) {
+        config.extends = localPath;
+      }
     }
 
     if (!config) {

--- a/packages/core/src/utils/__tests__/load-plugin.test.ts
+++ b/packages/core/src/utils/__tests__/load-plugin.test.ts
@@ -48,9 +48,9 @@ describe('loadPlugins', () => {
   });
 
   test('should load scoped plugins', () => {
-    expect(
-      loadPlugin(['@my-scope/auto-plugin-bar', {}], logger)?.name
-    ).toBe('bar');
+    expect(loadPlugin(['@my-scope/auto-plugin-bar', {}], logger)?.name).toBe(
+      'bar'
+    );
   });
 
   test('should require custom plugins -- fallback to cwd', () => {

--- a/packages/core/src/utils/__tests__/test.js
+++ b/packages/core/src/utils/__tests__/test.js
@@ -1,0 +1,1 @@
+module.exports = 'success';

--- a/packages/core/src/utils/__tests__/try-require.test.ts
+++ b/packages/core/src/utils/__tests__/try-require.test.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import tryRequire from '../try-require';
 
 jest.mock('test', () => 'success', {
@@ -19,5 +20,11 @@ describe('try require', () => {
 
   test('should return nothing if not found', async () => {
     expect(tryRequire('foobar')).toBeUndefined();
+  });
+
+  test('should require from a directory', async () => {
+    expect(
+      tryRequire('./__tests__/test', path.resolve(path.join(__dirname, '..')))
+    ).toBe('success');
   });
 });

--- a/packages/core/src/utils/try-require.ts
+++ b/packages/core/src/utils/try-require.ts
@@ -13,7 +13,7 @@ export default function tryRequire(tryPath: string) {
     }
 
     // If a plugin has any errors we want to inform the user
-    if (!error.message.includes('Cannot find module')) {
+    if (error.code !== 'MODULE_NOT_FOUND') {
       throw error;
     }
 

--- a/packages/core/src/utils/try-require.ts
+++ b/packages/core/src/utils/try-require.ts
@@ -1,5 +1,8 @@
 import importCwd from 'import-cwd';
 import importFrom from 'import-from';
+import createLog from './logger';
+
+const logger = createLog();
 
 /** Try to require something either from the CWD or the regular way */
 export default function tryRequire(tryPath: string, from?: string) {
@@ -25,8 +28,11 @@ export default function tryRequire(tryPath: string, from?: string) {
 
     if (from) {
       try {
+        // For loading plugins specified in a configuration (yarn 2)
         return importFrom(from, tryPath);
-      } catch (error) {}
+      } catch (error) {
+        logger.veryVerbose.warn({ from, tryPath, error });
+      }
     }
   }
 }

--- a/packages/core/src/utils/try-require.ts
+++ b/packages/core/src/utils/try-require.ts
@@ -1,7 +1,8 @@
 import importCwd from 'import-cwd';
+import importFrom from 'import-from';
 
 /** Try to require something either from the CWD or the regular way */
-export default function tryRequire(tryPath: string) {
+export default function tryRequire(tryPath: string, from?: string) {
   try {
     // Require from CWD
     return importCwd(tryPath);
@@ -21,5 +22,11 @@ export default function tryRequire(tryPath: string) {
       // Require from __dirname. Needed for npx and global installs
       return require(tryPath);
     } catch (error) {}
+
+    if (from) {
+      try {
+        return importFrom(from, tryPath);
+      } catch (error) {}
+    }
   }
 }

--- a/plugins/first-time-contributor/package.json
+++ b/plugins/first-time-contributor/package.json
@@ -38,7 +38,9 @@
   "dependencies": {
     "@auto-it/core": "link:../../packages/core",
     "array.prototype.flatmap": "^1.2.2",
-    "tslib": "1.11.1"
+    "endent": "^1.3.0",
+    "tslib": "1.11.1",
+    "url-join": "^4.0.0"
   },
   "devDependencies": {
     "@types/array.prototype.flatmap": "^1.2.0"


### PR DESCRIPTION
Various fixes to make `auto` and `@auto-canary/auto` work with `yarn@2`

- Use error code instead of message to determine `Module Not Found`
- try to import plugins from the directory of the extended config
- Fix `@auto-canary` module aliasing
- add note for yarn 2 users about installing default plugins (this really can't be accommodated for given where the dependancies are defined) 
- add missing dependencies to `first-time-contributor` closes #757 

## Questions

- [x] How would shared configs work? the current error fails is the package were running from doesn't have a hard dep on the plugin in the shared config. 
  - [x] code
  - [x] test

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.17.1-canary.1029.13601.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.17.1-canary.1029.13601.0
  npm install @auto-canary/auto@9.17.1-canary.1029.13601.0
  npm install @auto-canary/core@9.17.1-canary.1029.13601.0
  npm install @auto-canary/all-contributors@9.17.1-canary.1029.13601.0
  npm install @auto-canary/chrome@9.17.1-canary.1029.13601.0
  npm install @auto-canary/conventional-commits@9.17.1-canary.1029.13601.0
  npm install @auto-canary/crates@9.17.1-canary.1029.13601.0
  npm install @auto-canary/first-time-contributor@9.17.1-canary.1029.13601.0
  npm install @auto-canary/gh-pages@9.17.1-canary.1029.13601.0
  npm install @auto-canary/git-tag@9.17.1-canary.1029.13601.0
  npm install @auto-canary/gradle@9.17.1-canary.1029.13601.0
  npm install @auto-canary/jira@9.17.1-canary.1029.13601.0
  npm install @auto-canary/maven@9.17.1-canary.1029.13601.0
  npm install @auto-canary/npm@9.17.1-canary.1029.13601.0
  npm install @auto-canary/omit-commits@9.17.1-canary.1029.13601.0
  npm install @auto-canary/omit-release-notes@9.17.1-canary.1029.13601.0
  npm install @auto-canary/released@9.17.1-canary.1029.13601.0
  npm install @auto-canary/s3@9.17.1-canary.1029.13601.0
  npm install @auto-canary/slack@9.17.1-canary.1029.13601.0
  npm install @auto-canary/twitter@9.17.1-canary.1029.13601.0
  npm install @auto-canary/upload-assets@9.17.1-canary.1029.13601.0
  # or 
  yarn add @auto-canary/bot-list@9.17.1-canary.1029.13601.0
  yarn add @auto-canary/auto@9.17.1-canary.1029.13601.0
  yarn add @auto-canary/core@9.17.1-canary.1029.13601.0
  yarn add @auto-canary/all-contributors@9.17.1-canary.1029.13601.0
  yarn add @auto-canary/chrome@9.17.1-canary.1029.13601.0
  yarn add @auto-canary/conventional-commits@9.17.1-canary.1029.13601.0
  yarn add @auto-canary/crates@9.17.1-canary.1029.13601.0
  yarn add @auto-canary/first-time-contributor@9.17.1-canary.1029.13601.0
  yarn add @auto-canary/gh-pages@9.17.1-canary.1029.13601.0
  yarn add @auto-canary/git-tag@9.17.1-canary.1029.13601.0
  yarn add @auto-canary/gradle@9.17.1-canary.1029.13601.0
  yarn add @auto-canary/jira@9.17.1-canary.1029.13601.0
  yarn add @auto-canary/maven@9.17.1-canary.1029.13601.0
  yarn add @auto-canary/npm@9.17.1-canary.1029.13601.0
  yarn add @auto-canary/omit-commits@9.17.1-canary.1029.13601.0
  yarn add @auto-canary/omit-release-notes@9.17.1-canary.1029.13601.0
  yarn add @auto-canary/released@9.17.1-canary.1029.13601.0
  yarn add @auto-canary/s3@9.17.1-canary.1029.13601.0
  yarn add @auto-canary/slack@9.17.1-canary.1029.13601.0
  yarn add @auto-canary/twitter@9.17.1-canary.1029.13601.0
  yarn add @auto-canary/upload-assets@9.17.1-canary.1029.13601.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
