### PR TITLE
"version" would be wrong with label-less PRs + 'none' release types

### DIFF
--- a/packages/core/src/__tests__/semver.test.ts
+++ b/packages/core/src/__tests__/semver.test.ts
@@ -38,6 +38,12 @@ describe('calculateSemVerBump', () => {
     ).toBe(SEMVER.noVersion);
   });
 
+  test('should release a patch for unlabeled pr merged along with none releases', () => {
+    expect(calculateSemVerBump([[], ['documentation']], semverMap)).toBe(
+      SEMVER.patch
+    );
+  });
+
   test('should not skip things before none', () => {
     expect(calculateSemVerBump([['none'], ['major']], semverMap)).toBe(
       SEMVER.major

--- a/packages/core/src/semver.ts
+++ b/packages/core/src/semver.ts
@@ -51,7 +51,12 @@ export function calculateSemVerBump(
   const labelSet = new Set<string>();
   const skipReleaseLabels = labelMap.get('skip') || [];
 
-  labels.forEach(pr => {
+  labels.forEach((pr, index) => {
+    // If the head pr has no labels we default to a patch
+    if (pr.length === 0 && index === 0) {
+      labelSet.add(SEMVER.patch);
+    }
+
     pr.forEach(label => {
       const userLabel = [...labelMap.entries()].find(pair =>
         pair[1].includes(label)


### PR DESCRIPTION
# What Changed

Default the head PR to `patch` when calculating the semver bump.

# Why

if merging a pr on top of a `none` release type the release would be skipped alltogether.

- pr 1: no labels
- pr 2: documenation

Was: SEMVER.noVersions
Now: SEMVER.patch

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.16.7-canary.1032.13561.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.16.7-canary.1032.13561.0
  npm install @auto-canary/auto@9.16.7-canary.1032.13561.0
  npm install @auto-canary/core@9.16.7-canary.1032.13561.0
  npm install @auto-canary/all-contributors@9.16.7-canary.1032.13561.0
  npm install @auto-canary/chrome@9.16.7-canary.1032.13561.0
  npm install @auto-canary/conventional-commits@9.16.7-canary.1032.13561.0
  npm install @auto-canary/crates@9.16.7-canary.1032.13561.0
  npm install @auto-canary/first-time-contributor@9.16.7-canary.1032.13561.0
  npm install @auto-canary/git-tag@9.16.7-canary.1032.13561.0
  npm install @auto-canary/gradle@9.16.7-canary.1032.13561.0
  npm install @auto-canary/jira@9.16.7-canary.1032.13561.0
  npm install @auto-canary/maven@9.16.7-canary.1032.13561.0
  npm install @auto-canary/npm@9.16.7-canary.1032.13561.0
  npm install @auto-canary/omit-commits@9.16.7-canary.1032.13561.0
  npm install @auto-canary/omit-release-notes@9.16.7-canary.1032.13561.0
  npm install @auto-canary/released@9.16.7-canary.1032.13561.0
  npm install @auto-canary/s3@9.16.7-canary.1032.13561.0
  npm install @auto-canary/slack@9.16.7-canary.1032.13561.0
  npm install @auto-canary/twitter@9.16.7-canary.1032.13561.0
  npm install @auto-canary/upload-assets@9.16.7-canary.1032.13561.0
  # or 
  yarn add @auto-canary/bot-list@9.16.7-canary.1032.13561.0
  yarn add @auto-canary/auto@9.16.7-canary.1032.13561.0
  yarn add @auto-canary/core@9.16.7-canary.1032.13561.0
  yarn add @auto-canary/all-contributors@9.16.7-canary.1032.13561.0
  yarn add @auto-canary/chrome@9.16.7-canary.1032.13561.0
  yarn add @auto-canary/conventional-commits@9.16.7-canary.1032.13561.0
  yarn add @auto-canary/crates@9.16.7-canary.1032.13561.0
  yarn add @auto-canary/first-time-contributor@9.16.7-canary.1032.13561.0
  yarn add @auto-canary/git-tag@9.16.7-canary.1032.13561.0
  yarn add @auto-canary/gradle@9.16.7-canary.1032.13561.0
  yarn add @auto-canary/jira@9.16.7-canary.1032.13561.0
  yarn add @auto-canary/maven@9.16.7-canary.1032.13561.0
  yarn add @auto-canary/npm@9.16.7-canary.1032.13561.0
  yarn add @auto-canary/omit-commits@9.16.7-canary.1032.13561.0
  yarn add @auto-canary/omit-release-notes@9.16.7-canary.1032.13561.0
  yarn add @auto-canary/released@9.16.7-canary.1032.13561.0
  yarn add @auto-canary/s3@9.16.7-canary.1032.13561.0
  yarn add @auto-canary/slack@9.16.7-canary.1032.13561.0
  yarn add @auto-canary/twitter@9.16.7-canary.1032.13561.0
  yarn add @auto-canary/upload-assets@9.16.7-canary.1032.13561.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
