### PR TITLE
Add Exec Plugin

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -471,7 +471,7 @@ export default class Auto {
         '\n'
       );
       this.logger.log.warn(
-        'This errors are for the fully loaded configuration (this is why some paths might seem off).'
+        'These errors are for the fully loaded configuration (this is why some paths might seem off).'
       );
 
       if (this.config.extends) {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -141,8 +141,7 @@ export default class Config {
 
       this.logger.verbose.note(`${extend} found: ${config}`);
     } else {
-      config = tryRequire(`${extend}/package.json`);
-      config = config?.auto;
+      config = tryRequire(`${extend}/package.json`)?.auto;
       this.logger.verbose.note(`${extend} found: ${config}`);
     }
 

--- a/plugins/exec/README.md
+++ b/plugins/exec/README.md
@@ -61,7 +61,8 @@ Please look at the docs for [writing plugins](../../docs/pages/writing-plugins.m
       "exec",
       {
         "version": "npm version $ARG_0",
-        "publish": "npm publish && git push --tags"
+        "publish": "npm publish && git push --tags",
+        "afterRelease": "yarn docs && push-dir --dir=docs --branch=gh-pages"
       }
     ]
     // other plugins

--- a/plugins/exec/README.md
+++ b/plugins/exec/README.md
@@ -1,11 +1,14 @@
 # Exec Plugin
 
-Tap into select hooks and run a command on the terminal.
+Tap into hooks and run commands on the terminal.
 
-Tapable hooks, in call order:
+Main hooks, in call order:
 
 - beforeRun
+- getRepository
+- getAuthor
 - beforeShipIt
+- getPreviousVersion
 - afterAddToChangelog
 - beforeCommitChangelog
 - version
@@ -15,7 +18,23 @@ Tapable hooks, in call order:
 - afterRelease
 - afterShipIt
 
-Don't see the hook you want? Try making a pull request if you can figure out how to make that type of hook to work!
+Other hooks:
+
+- canary
+- next
+- modifyConfig
+- makeRelease
+- onCreateLogParse
+  - parseCommit
+  - omitCommit
+- onCreateChangelog
+  - renderChangelogLine
+  - renderChangelogTitle
+  - renderChangelogAuthor
+  - renderChangelogAuthorLine
+  - omitReleaseNotes
+- onCreateRelease
+  - createChangelogTitle
 
 ## Installation
 
@@ -31,7 +50,7 @@ yarn add -D @auto-it/exec
 
 Here is an example of replacing the `npm` plugins with a light-weight version.
 
-All args to a hook are exposed on the process in enviroment variables.
+All args to a hook are exposed on the process in environment variables.
 The format looks like `$ARG_0`, `$ARG_1`, and so on.
 Please look at the docs for [writing plugins](../../docs/pages/writing-plugins.md) for more detail on what's available.
 
@@ -49,3 +68,7 @@ Please look at the docs for [writing plugins](../../docs/pages/writing-plugins.m
   ]
 }
 ```
+
+::: message is-warning
+:warning: If you are tapping into a waterfall or bail hook you will need to return some value (ex: JSON or a boolean). Please refer to the documentation and return the right thing!
+:::

--- a/plugins/exec/README.md
+++ b/plugins/exec/README.md
@@ -1,0 +1,24 @@
+# Exec Plugin
+
+Tap into select hooks and run a command on the terminal
+
+## Installation
+
+This plugin is not included with the `auto` CLI installed via NPM. To install:
+
+```sh
+npm i --save-dev @auto-it/exec
+# or
+yarn add -D @auto-it/exec
+```
+
+## Usage
+
+```json
+{
+  "plugins": [
+    ["exec"]
+    // other plugins
+  ]
+}
+```

--- a/plugins/exec/README.md
+++ b/plugins/exec/README.md
@@ -1,6 +1,21 @@
 # Exec Plugin
 
-Tap into select hooks and run a command on the terminal
+Tap into select hooks and run a command on the terminal.
+
+Tapable hooks, in call order:
+
+- beforeRun
+- beforeShipIt
+- afterAddToChangelog
+- beforeCommitChangelog
+- version
+- afterVersion
+- publish
+- afterPublish
+- afterRelease
+- afterShipIt
+
+Don't see the hook you want? Try making a pull request if you can figure out how to make that type of hook to work!
 
 ## Installation
 
@@ -14,10 +29,22 @@ yarn add -D @auto-it/exec
 
 ## Usage
 
+Here is an example of replacing the `npm` plugins with a light-weight version.
+
+All args to a hook are exposed on the process in enviroment variables.
+The format looks like `$ARG_0`, `$ARG_1`, and so on.
+Please look at the docs for [writing plugins](../../docs/pages/writing-plugins.md) for more detail on what's available.
+
 ```json
 {
   "plugins": [
-    ["exec"]
+    [
+      "exec",
+      {
+        "version": "npm version $ARG_0",
+        "publish": "npm publish && git push --tags"
+      }
+    ]
     // other plugins
   ]
 }

--- a/plugins/exec/__tests__/__snapshots__/exec.test.ts.snap
+++ b/plugins/exec/__tests__/__snapshots__/exec.test.ts.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Exec Plugin should warn about invalid config 1`] = `
+Array [
+  "\\"exec\\"
+
+Found unknown configuration keys: notAHook
+",
+]
+`;

--- a/plugins/exec/__tests__/exec.test.ts
+++ b/plugins/exec/__tests__/exec.test.ts
@@ -1,7 +1,203 @@
-import Auto from '@auto-it/core';
+import Auto, { SEMVER } from '@auto-it/core';
+import {
+  makeHooks,
+  makeReleaseHooks,
+  makeLogParseHooks,
+  makeChangelogHooks
+} from '@auto-it/core/dist/utils/make-hooks';
+import { execSync } from 'child_process';
+
 import Exec from '../src';
 
+const execSpy = execSync as jest.Mock;
+jest.mock('child_process');
+execSpy.mockReturnValue('');
+
 describe('Exec Plugin', () => {
-  test('should do something', async () => {
+  beforeEach(() => {
+    execSpy.mockClear();
+  });
+
+  test('should warn about invalid config', async () => {
+    const options = { notAHook: 'echo foo' };
+    // @ts-ignore
+    const plugins = new Exec(options);
+    const hooks = makeHooks();
+
+    plugins.apply({ hooks } as Auto);
+
+    expect(
+      await hooks.validateConfig.promise('exec', options)
+    ).toMatchSnapshot();
+  });
+
+  test('should handle SyncHook hooks', () => {
+    const plugins = new Exec({ beforeRun: 'echo foo' });
+    const hooks = makeHooks();
+
+    plugins.apply({ hooks } as Auto);
+    hooks.beforeRun.call({} as any);
+
+    expect(execSpy).toHaveBeenCalledWith('echo foo', expect.anything());
+  });
+
+  test('should handle AsyncParallelHook hooks', async () => {
+    const plugins = new Exec({ version: 'echo bar' });
+    const hooks = makeHooks();
+
+    plugins.apply({ hooks } as Auto);
+    await hooks.version.promise(SEMVER.patch);
+
+    expect(execSpy).toHaveBeenCalledWith('echo bar', expect.anything());
+  });
+
+  test('should handle AsyncSeriesHook hooks w/args', async () => {
+    const plugins = new Exec({ beforeShipIt: 'echo baz' });
+    const hooks = makeHooks();
+
+    plugins.apply({ hooks } as Auto);
+    await hooks.beforeShipIt.promise({ releaseType: 'latest' });
+
+    expect(execSpy).toHaveBeenCalledWith(
+      'echo baz',
+      expect.objectContaining({
+        env: expect.objectContaining({ ARG_0: '{"releaseType":"latest"}' })
+      })
+    );
+  });
+
+  test('should handle Bail hooks', async () => {
+    const plugins = new Exec({
+      getRepository: `echo "{ "repo": "foo", "owner": "bar" }"`
+    });
+    const hooks = makeHooks();
+
+    execSpy.mockReturnValueOnce('{ "repo": "foo", "owner": "bar" }');
+    plugins.apply({ hooks } as Auto);
+
+    expect(await hooks.getRepository.promise()).toStrictEqual({
+      repo: 'foo',
+      owner: 'bar'
+    });
+  });
+
+  describe('canary', () => {
+    test('should handle string returns', async () => {
+      const canaryVersion = '0.1.0-canary';
+      const plugins = new Exec({
+        canary: `echo ${canaryVersion}`
+      });
+      const hooks = makeHooks();
+
+      execSpy.mockReturnValueOnce(canaryVersion);
+      plugins.apply({ hooks } as Auto);
+
+      expect(await hooks.canary.promise(SEMVER.patch, '-canary')).toBe(
+        canaryVersion
+      );
+    });
+
+    test('should handle object return values', async () => {
+      const canaryVersion = { newVersion: '0.1.0-canary', details: 'foo' };
+      const plugins = new Exec({
+        canary: `echo ${JSON.stringify(canaryVersion)}`
+      });
+      const hooks = makeHooks();
+
+      execSpy.mockReturnValueOnce(canaryVersion);
+      plugins.apply({ hooks } as Auto);
+
+      expect(await hooks.canary.promise(SEMVER.patch, '-canary')).toStrictEqual(
+        canaryVersion
+      );
+    });
+  });
+
+  describe('onCreateRelease', () => {
+    test('should handle createChangelogTitle', async () => {
+      const plugins = new Exec({
+        onCreateRelease: { createChangelogTitle: 'echo here' }
+      });
+      const hooks = makeHooks();
+      const releaseHooks = makeReleaseHooks();
+
+      execSpy.mockReturnValueOnce('here');
+      plugins.apply({ hooks } as Auto);
+      hooks.onCreateRelease.call({ hooks: releaseHooks } as any);
+
+      expect(await releaseHooks.createChangelogTitle.promise()).toBe('here');
+    });
+  });
+
+  describe('onCreateLogParse', () => {
+    test('should omitCommit', async () => {
+      const plugins = new Exec({
+        onCreateLogParse: { omitCommit: 'echo true' }
+      });
+      const hooks = makeHooks();
+      const logParsehooks = makeLogParseHooks();
+
+      execSpy.mockReturnValueOnce('true');
+      plugins.apply({ hooks } as Auto);
+      hooks.onCreateLogParse.call({ hooks: logParsehooks } as any);
+
+      expect(
+        await logParsehooks.omitCommit.promise({
+          hash: '123',
+          subject: 'test',
+          authors: [],
+          files: [],
+          labels: []
+        })
+      ).toBe(true);
+    });
+
+    test('should not omitCommit', async () => {
+      const plugins = new Exec({
+        onCreateLogParse: { omitCommit: 'echo' }
+      });
+      const hooks = makeHooks();
+      const logParsehooks = makeLogParseHooks();
+
+      plugins.apply({ hooks } as Auto);
+      hooks.onCreateLogParse.call({ hooks: logParsehooks } as any);
+
+      expect(
+        await logParsehooks.omitCommit.promise({
+          hash: '123',
+          subject: 'test',
+          authors: [],
+          files: [],
+          labels: []
+        })
+      ).toBeUndefined();
+    });
+  });
+
+  describe('onCreateChangelog', () => {
+    test('should omitReleaseNotes', async () => {
+      const plugins = new Exec({
+        onCreateChangelog: { omitReleaseNotes: 'echo true' }
+      });
+      const hooks = makeHooks();
+      const changelogHooks = makeChangelogHooks();
+
+      execSpy.mockReturnValueOnce('true');
+      plugins.apply({ hooks } as Auto);
+      hooks.onCreateChangelog.call(
+        { hooks: changelogHooks } as any,
+        SEMVER.patch
+      );
+
+      expect(
+        await changelogHooks.omitReleaseNotes.promise({
+          hash: '123',
+          subject: 'test',
+          authors: [],
+          files: [],
+          labels: []
+        })
+      ).toBe(true);
+    });
   });
 });

--- a/plugins/exec/__tests__/exec.test.ts
+++ b/plugins/exec/__tests__/exec.test.ts
@@ -1,0 +1,7 @@
+import Auto from '@auto-it/core';
+import Exec from '../src';
+
+describe('Exec Plugin', () => {
+  test('should do something', async () => {
+  });
+});

--- a/plugins/exec/__tests__/exec.test.ts
+++ b/plugins/exec/__tests__/exec.test.ts
@@ -104,7 +104,7 @@ describe('Exec Plugin', () => {
       });
       const hooks = makeHooks();
 
-      execSpy.mockReturnValueOnce(canaryVersion);
+      execSpy.mockReturnValueOnce(JSON.stringify(canaryVersion));
       plugins.apply({ hooks } as Auto);
 
       expect(await hooks.canary.promise(SEMVER.patch, '-canary')).toStrictEqual(

--- a/plugins/exec/package.json
+++ b/plugins/exec/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@auto-it/exec",
+  "version": "9.17.0",
+  "main": "dist/index.js",
+  "description": "Tap into select hooks and run a command on the terminal",
+  "license": "MIT",
+  "author": {
+    "name": "Andrew Lisowski",
+    "email": "lisowski54@gmail.com"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/intuit/auto"
+  },
+  "files": [
+    "dist"
+  ],
+  "keywords": [
+    "automation",
+    "semantic",
+    "release",
+    "github",
+    "labels",
+    "automated",
+    "continuos integration",
+    "changelog"
+  ],
+  "scripts": {
+    "build": "tsc -b",
+    "start": "npm run build -- -w",
+    "lint": "eslint src --ext .ts",
+    "test": "jest --maxWorkers=2 --config ../../package.json"
+  },
+  "dependencies": {
+    "@auto-it/core": "link:../../packages/core",
+    "fp-ts": "^2.5.3",
+    "io-ts": "^2.1.2",
+    "tslib": "1.10.0"
+  }
+}

--- a/plugins/exec/src/index.ts
+++ b/plugins/exec/src/index.ts
@@ -107,10 +107,10 @@ const tapHook = (name: string, hook: any, command: string) => {
   ) {
     hook.tap(`exec ${name}`, (...args: any[]) => {
       const value = execSync(command, {
-        stdio: ['pipe', 'inherit'],
+        stdio: ['ignore', 'pipe', 'inherit'],
         encoding: 'utf8',
         env: createEnv(args)
-      });
+      }).trim();
 
       if (name !== 'canary') {
         return JSON.parse(value);
@@ -126,10 +126,10 @@ const tapHook = (name: string, hook: any, command: string) => {
   } else if (name === 'omitCommit' || name === 'omitReleaseNotes') {
     hook.tap(`exec ${name}`, (...args: any[]) => {
       const value = execSync(command, {
-        stdio: ['pipe', 'inherit'],
+        stdio: ['ignore', 'pipe', 'inherit'],
         encoding: 'utf8',
         env: createEnv(args)
-      });
+      }).trim();
 
       if (value === 'true') {
         return true;
@@ -148,7 +148,7 @@ const tapHook = (name: string, hook: any, command: string) => {
         env: createEnv(args),
         stdio:
           name === 'createChangelogTitle' || name === 'getPreviousVersion'
-            ? ['pipe', 'inherit']
+            ? ['ignore', 'pipe', 'inherit']
             : 'inherit'
       }).trim()
     );

--- a/plugins/exec/src/index.ts
+++ b/plugins/exec/src/index.ts
@@ -1,4 +1,5 @@
-/* eslint-disable no-lonely-if */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import { Auto, IPlugin } from '@auto-it/core';
 import {
   makeHooks,
@@ -87,7 +88,7 @@ export default class ExecPlugin implements IPlugin {
 
   /** Tap into auto plugin points. */
   apply(auto: Auto) {
-    Object.entries(this.options).map(([key, command]) => {
+    Object.entries(this.options).forEach(([key, command]) => {
       const name = key as keyof IExecPluginOptions;
 
       /** Tap a hook if possible */
@@ -96,6 +97,7 @@ export default class ExecPlugin implements IPlugin {
 
         if (
           name === 'SyncWaterfallHook' ||
+          name === 'AsyncSeriesBailHook' ||
           name === 'AsyncSeriesWaterfallHook'
         ) {
           auto.logger.log.error(
@@ -108,24 +110,8 @@ export default class ExecPlugin implements IPlugin {
           name === 'AsyncParallelHook'
         ) {
           hook.tap(this.name, (...args: any[]) => {
-            return execSync(command, {
+            execSync(command, {
               stdio: 'inherit',
-              env: {
-                ...process.env,
-                ...fromEntries(
-                  args.map((arg, index) => [
-                    `ARG_${index}`,
-                    JSON.stringify(arg)
-                  ])
-                )
-              }
-            });
-          });
-        } else if (
-          name === 'AsyncSeriesBailHook' 
-        ) {
-          hook.tap(this.name, (...args: any[]) => {
-            return execSync(command, {
               env: {
                 ...process.env,
                 ...fromEntries(

--- a/plugins/exec/src/index.ts
+++ b/plugins/exec/src/index.ts
@@ -1,0 +1,175 @@
+/* eslint-disable no-lonely-if */
+import { Auto, IPlugin } from '@auto-it/core';
+import {
+  makeHooks,
+  makeReleaseHooks,
+  makeLogParseHooks,
+  makeChangelogHooks
+} from '@auto-it/core/dist/utils/make-hooks';
+import * as t from 'io-ts';
+import fromEntries from 'fromentries';
+import { execSync } from 'child_process';
+
+type ChangelogHooks = keyof ReturnType<typeof makeChangelogHooks>;
+const changelogHooks = Object.keys(makeChangelogHooks()) as ChangelogHooks[];
+
+const onCreateChangelog = t.partial(
+  fromEntries(changelogHooks.map(name => [name, t.string] as const)) as Record<
+    ChangelogHooks,
+    t.StringC
+  >
+);
+
+type LogParseHooks = keyof ReturnType<typeof makeLogParseHooks>;
+const logParseHooks = Object.keys(makeLogParseHooks()) as LogParseHooks[];
+
+const onCreateLogParse = t.partial(
+  fromEntries(logParseHooks.map(name => [name, t.string] as const)) as Record<
+    LogParseHooks,
+    t.StringC
+  >
+);
+
+type ReleaseHook = keyof ReturnType<typeof makeReleaseHooks>;
+const releaseHooks = Object.keys(makeReleaseHooks()) as ReleaseHook[];
+
+const onCreateReleaseOptions = [
+  'onCreateChangelog',
+  'onCreateLogParse'
+] as const;
+
+const onCreateRelease = t.partial(
+  fromEntries(
+    releaseHooks
+      .map(name => [name, t.string] as const)
+      .filter(([hook]) => !onCreateReleaseOptions.includes(hook as any))
+  ) as Record<
+    Exclude<ReleaseHook, typeof onCreateReleaseOptions[number]>,
+    t.StringC
+  >
+);
+
+type RootHook = keyof ReturnType<typeof makeHooks>;
+const rootHooks = Object.keys(makeHooks()) as RootHook[];
+
+const complextRootOptions = [
+  'onCreateRelease',
+  'onCreateChangelog',
+  'onCreateLogParse'
+] as const;
+const rootOptions = t.partial(
+  fromEntries(
+    rootHooks
+      .map(name => [name, t.string] as const)
+      .filter(([hook]) => !complextRootOptions.includes(hook as any))
+  ) as Record<Exclude<RootHook, typeof complextRootOptions[number]>, t.StringC>
+);
+
+const pluginOptions = t.intersection([
+  rootOptions,
+  t.partial({ onCreateRelease, onCreateLogParse, onCreateChangelog })
+]);
+
+export type IExecPluginOptions = t.TypeOf<typeof pluginOptions>;
+
+/** Tap into select hooks and run a command on the terminal */
+export default class ExecPlugin implements IPlugin {
+  /** The name of the plugin */
+  name = 'exec';
+
+  /** The options of the plugin */
+  readonly options: IExecPluginOptions;
+
+  /** Initialize the plugin with it's options */
+  constructor(options: IExecPluginOptions) {
+    this.options = options;
+  }
+
+  /** Tap into auto plugin points. */
+  apply(auto: Auto) {
+    Object.entries(this.options).map(([key, command]) => {
+      const name = key as keyof IExecPluginOptions;
+
+      /** Tap a hook if possible */
+      const tapHook = (hook: any, command: string) => {
+        const name = hook.constructor.name;
+
+        if (
+          name === 'SyncWaterfallHook' ||
+          name === 'AsyncSeriesWaterfallHook'
+        ) {
+          auto.logger.log.error(
+            `"${name}" cannot easily be used from the "exec" plugin. Please consider writing your own plugin in JavaScript or TypeScript.`
+          );
+          process.exit(1);
+        } else if (
+          name === 'SyncHook' ||
+          name === 'AsyncSeriesHook' ||
+          name === 'AsyncParallelHook'
+        ) {
+          hook.tap(this.name, (...args: any[]) => {
+            return execSync(command, {
+              stdio: 'inherit',
+              env: {
+                ...process.env,
+                ...fromEntries(
+                  args.map((arg, index) => [
+                    `ARG_${index}`,
+                    JSON.stringify(arg)
+                  ])
+                )
+              }
+            });
+          });
+        } else if (
+          name === 'AsyncSeriesBailHook' 
+        ) {
+          hook.tap(this.name, (...args: any[]) => {
+            return execSync(command, {
+              env: {
+                ...process.env,
+                ...fromEntries(
+                  args.map((arg, index) => [
+                    `ARG_${index}`,
+                    JSON.stringify(arg)
+                  ])
+                )
+              }
+            });
+          });
+        }
+      };
+
+      if (name === 'onCreateRelease') {
+        auto.hooks.onCreateRelease.tap(this.name, release => {
+          Object.entries(
+            command as Record<string, string>
+          ).map(([key, command]) =>
+            tapHook(release.hooks[key as keyof typeof release.hooks], command)
+          );
+        });
+      } else if (name === 'onCreateChangelog') {
+        auto.hooks.onCreateChangelog.tap(this.name, changelog => {
+          Object.entries(
+            command as Record<string, string>
+          ).map(([key, command]) =>
+            tapHook(
+              changelog.hooks[key as keyof typeof changelog.hooks],
+              command
+            )
+          );
+        });
+      } else if (name === 'onCreateLogParse') {
+        auto.hooks.onCreateLogParse.tap(this.name, logParse => {
+          Object.entries(
+            command as Record<string, string>
+          ).map(([key, command]) =>
+            tapHook(logParse.hooks[key as keyof typeof logParse.hooks], command)
+          );
+        });
+      } else {
+        tapHook(auto.hooks[name], command as string);
+      }
+    });
+  }
+}

--- a/plugins/exec/tsconfig.json
+++ b/plugins/exec/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*", "../../typings/**/*"],
+
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+
+  "references": [
+    {
+      "path": "../../packages/core"
+    }
+  ]
+}

--- a/plugins/omit-commits/README.md
+++ b/plugins/omit-commits/README.md
@@ -16,7 +16,7 @@ yarn add -D @auto-it/omit-commits
 
 Yarn can omit by most any field available on a commit. Each options accepts either a string or an array of strings.
 
-```json
+```jsonc
 {
   "plugins": [
     [

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -55,6 +55,9 @@
     },
     {
       "path": "plugins/gh-pages"
+    },
+    {
+      "path": "plugins/exec"
     }
   ]
 }


### PR DESCRIPTION
# Release Notes

Install `@auto-it/exec` to easily run bash scripts during the `auto` release pipeline! Right now it doesn't handle every hook in `auto` but it exposes enough to quickly write plugins.

```jsonc
{
  "plugins": [
    [
      "exec",
      {
        "afterShipIt": "echo 'Do something cool'"
      }
    ]
    // other plugins
  ]
}
```

Here is an example of a super light weight version of the `npm` and `gh-pages` plugins (Note: This misses out on a lot of features that are in the official plugins)

```jsonc
{
  "plugins": [
    [
      "exec",
      {
        "version": "npm version $ARG_0",
        "publish": "npm publish && git push --tags",
        "afterRelease": "yarn docs && push-dir --dir=docs --branch=gh-pages"
      }
    ]
    // other plugins
  ]
}
```


# Why

[this comment](https://github.com/intuit/auto/issues/176#issuecomment-560695035)

Todo:

- [x] Add tests
- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.18.0-canary.1033.13632.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.18.0-canary.1033.13632.0
  npm install @auto-canary/auto@9.18.0-canary.1033.13632.0
  npm install @auto-canary/core@9.18.0-canary.1033.13632.0
  npm install @auto-canary/all-contributors@9.18.0-canary.1033.13632.0
  npm install @auto-canary/chrome@9.18.0-canary.1033.13632.0
  npm install @auto-canary/conventional-commits@9.18.0-canary.1033.13632.0
  npm install @auto-canary/crates@9.18.0-canary.1033.13632.0
  npm install @auto-canary/exec@9.18.0-canary.1033.13632.0
  npm install @auto-canary/first-time-contributor@9.18.0-canary.1033.13632.0
  npm install @auto-canary/gh-pages@9.18.0-canary.1033.13632.0
  npm install @auto-canary/git-tag@9.18.0-canary.1033.13632.0
  npm install @auto-canary/gradle@9.18.0-canary.1033.13632.0
  npm install @auto-canary/jira@9.18.0-canary.1033.13632.0
  npm install @auto-canary/maven@9.18.0-canary.1033.13632.0
  npm install @auto-canary/npm@9.18.0-canary.1033.13632.0
  npm install @auto-canary/omit-commits@9.18.0-canary.1033.13632.0
  npm install @auto-canary/omit-release-notes@9.18.0-canary.1033.13632.0
  npm install @auto-canary/released@9.18.0-canary.1033.13632.0
  npm install @auto-canary/s3@9.18.0-canary.1033.13632.0
  npm install @auto-canary/slack@9.18.0-canary.1033.13632.0
  npm install @auto-canary/twitter@9.18.0-canary.1033.13632.0
  npm install @auto-canary/upload-assets@9.18.0-canary.1033.13632.0
  # or 
  yarn add @auto-canary/bot-list@9.18.0-canary.1033.13632.0
  yarn add @auto-canary/auto@9.18.0-canary.1033.13632.0
  yarn add @auto-canary/core@9.18.0-canary.1033.13632.0
  yarn add @auto-canary/all-contributors@9.18.0-canary.1033.13632.0
  yarn add @auto-canary/chrome@9.18.0-canary.1033.13632.0
  yarn add @auto-canary/conventional-commits@9.18.0-canary.1033.13632.0
  yarn add @auto-canary/crates@9.18.0-canary.1033.13632.0
  yarn add @auto-canary/exec@9.18.0-canary.1033.13632.0
  yarn add @auto-canary/first-time-contributor@9.18.0-canary.1033.13632.0
  yarn add @auto-canary/gh-pages@9.18.0-canary.1033.13632.0
  yarn add @auto-canary/git-tag@9.18.0-canary.1033.13632.0
  yarn add @auto-canary/gradle@9.18.0-canary.1033.13632.0
  yarn add @auto-canary/jira@9.18.0-canary.1033.13632.0
  yarn add @auto-canary/maven@9.18.0-canary.1033.13632.0
  yarn add @auto-canary/npm@9.18.0-canary.1033.13632.0
  yarn add @auto-canary/omit-commits@9.18.0-canary.1033.13632.0
  yarn add @auto-canary/omit-release-notes@9.18.0-canary.1033.13632.0
  yarn add @auto-canary/released@9.18.0-canary.1033.13632.0
  yarn add @auto-canary/s3@9.18.0-canary.1033.13632.0
  yarn add @auto-canary/slack@9.18.0-canary.1033.13632.0
  yarn add @auto-canary/twitter@9.18.0-canary.1033.13632.0
  yarn add @auto-canary/upload-assets@9.18.0-canary.1033.13632.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
