### PR TITLE
Better GitHub Actions support + docs for github action + handle GITHUB_TOKEN

### DIFF
--- a/docs/pages/build-platforms/github-actions.md
+++ b/docs/pages/build-platforms/github-actions.md
@@ -21,7 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+
+      - run: git fetch --tags
 
       - name: Use Node.js 12.x
         uses: actions/setup-node@v1
@@ -38,7 +40,6 @@ jobs:
 
       - name: Create Release
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           yarn install --frozen-lockfile
@@ -50,11 +51,8 @@ jobs:
 
 If you are having problems make sure you have done the following:
 
-- Any required secrets for plugins are set (Ex; `NPM_TOKEN` with the NPM plugin)
-- Make sure you give the `GH_TOKEN` `repo` permission or `shipit` will fail!
+- Any required secrets for plugins are set (Ex; `NPM_TOKEN` with the NPM plugin
 - Update references of `<your-github-user>`, `<project-owner>`, and `<project-repo>` with the appropriate values
-
-To add a secret for actions go to `https://github.com/<owner>/<repo>/settings/secrets/new`
 
 ## Examples
 

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -32,13 +32,22 @@ export async function run(command: string, args: ApiOptions) {
     await auto.loadConfig();
 
     if (args.verbose || command === 'info') {
-      const { hasError } = await auto.info();
+      try {
+        // We don't want auto.info throwing an error during another 
+        // command
+        const { hasError } = await auto.info();
 
-      if (command === 'info') {
-        if (hasError) {
+        if (command === 'info') {
+          // eslint-disable-next-line max-depth
+          if (hasError) {
+            process.exit(1);
+          } else {
+            return;
+          }
+        }
+      } catch (error) {
+        if (command === 'info') {
           process.exit(1);
-        } else {
-          return;
         }
       }
     }

--- a/packages/core/src/__tests__/get-remote.test.ts
+++ b/packages/core/src/__tests__/get-remote.test.ts
@@ -1,10 +1,12 @@
 import Auto from '../auto';
 
+jest.mock('child_process');
+
 describe('getRemote', () => {
   test('should fall back to origin with no git client', async () => {
     const auto = new Auto();
     // @ts-ignore
-    expect(await auto.getRemote()).toBe('https://github.com/intuit/auto.git');
+    expect(await auto.getRemote()).toBe('origin');
   });
 
   test('should use html_url if we can push', async () => {

--- a/packages/core/src/__tests__/get-remote.test.ts
+++ b/packages/core/src/__tests__/get-remote.test.ts
@@ -1,0 +1,47 @@
+import Auto from '../auto';
+
+describe('getRemote', () => {
+  test('should fall back to origin with no git client', async () => {
+    const auto = new Auto();
+    // @ts-ignore
+    expect(await auto.getRemote()).toBe('https://github.com/intuit/auto.git');
+  });
+
+  test('should use html_url if we can push', async () => {
+    const auto = new Auto();
+    const html_url = 'https://github.com/fake/remote';
+    auto.git = {
+      verifyAuth: (url: string) => url === html_url,
+      getProject: () => Promise.resolve({ html_url })
+    } as any;
+    // @ts-ignore
+    expect(await auto.getRemote()).toBe(html_url);
+  });
+
+  test('should put token in url', async () => {
+    const auto = new Auto();
+    const html_url = 'https://github.com/fake/remote';
+    process.env.GH_TOKEN = 'XXXX';
+    auto.git = {
+      verifyAuth: (url: string) => url.includes('XXXX'),
+      getProject: () => Promise.resolve({ html_url })
+    } as any;
+    // @ts-ignore
+    expect(await auto.getRemote()).toBe('https://XXXX@github.com/fake/remote');
+  });
+
+  test('should GitHub action user in url', async () => {
+    const auto = new Auto();
+    const html_url = 'https://github.com/fake/remote';
+    process.env.GITHUB_TOKEN = 'XXXX';
+    process.env.GITHUB_ACTION = 'true';
+    auto.git = {
+      verifyAuth: (url: string) => url.includes('x-access-token:'),
+      getProject: () => Promise.resolve({ html_url })
+    } as any;
+    // @ts-ignore
+    expect(await auto.getRemote()).toBe(
+      'https://x-access-token:XXXX@github.com/fake/remote'
+    );
+  });
+});

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -542,6 +542,7 @@ export default class Auto {
     const { html_url } = (await this.git.getProject()) || { html_url: '' };
 
     if (html_url && (await this.git.verifyAuth(html_url))) {
+      this.logger.veryVerbose.note('Using bare html URL as remote');
       return html_url;
     }
 
@@ -565,10 +566,12 @@ export default class Auto {
       });
 
       if (await this.git.verifyAuth(urlWithAuth)) {
+        this.logger.veryVerbose.note('Using token + html URL as remote');
         return urlWithAuth;
       }
     }
 
+    this.logger.veryVerbose.note('Using remote set in environment');
     return configuredRemote;
   }
 

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -492,7 +492,10 @@ export default class Auto {
     };
     this.config = config;
     const repository = await this.getRepo(config);
-    const token = (repository && repository.token) || process.env.GH_TOKEN;
+    const token =
+      (repository && repository.token) ||
+      process.env.GH_TOKEN ||
+      process.env.GITHUB_TOKEN;
 
     if (!token || token === 'undefined') {
       this.logger.log.error(
@@ -545,12 +548,12 @@ export default class Auto {
     const GIT_TOKENS: Record<string, string | undefined> = {
       // GitHub Actions require the "x-access-token:" prefix for git access
       // https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#http-based-git-access-by-an-installation
-      GITHUB_TOKEN: process.env.GITHUB_ACTION ? 'x-access-token:' : undefined
+      GITHUB_TOKEN: process.env.GITHUB_ACTION
+        ? `x-access-token:${process.env.GITHUB_TOKEN}`
+        : undefined
     };
     const envVar = Object.keys(GIT_TOKENS).find(v => process.env[v]) || '';
-    const gitCredentials = GIT_TOKENS[envVar]
-      ? `${GIT_TOKENS[envVar] || ''}${process.env[envVar] || ''}`
-      : process.env.GH_TOKEN;
+    const gitCredentials = GIT_TOKENS[envVar] || process.env.GH_TOKEN;
 
     if (gitCredentials) {
       const { port, hostname, ...parsed } = parseUrl(html_url);

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -9,6 +9,7 @@ import { HttpsProxyAgent } from 'https-proxy-agent';
 import tinyColor from 'tinycolor2';
 import { promisify } from 'util';
 import endent from 'endent';
+import on from 'await-to-js';
 
 import { Memoize as memoize } from 'typescript-memoize';
 
@@ -371,7 +372,13 @@ export default class Git {
   /** Get collaborator permission level to the repo. */
   @memoize()
   async getTokenPermissionLevel() {
-    const user = await this.github.users.getAuthenticated();
+    const [, user] = await on(this.github.users.getAuthenticated());
+
+    if (!user) {
+      return {
+        permission: 'none'
+      };
+    }
 
     try {
       const { permission } = (


### PR DESCRIPTION
# What Changed

see title

# Why

Some things updated in GitHub actions. Using the Github token means less config

Todo:

- [x] Add tests
- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.19.1-canary.1036.13695.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.19.1-canary.1036.13695.0
  npm install @auto-canary/auto@9.19.1-canary.1036.13695.0
  npm install @auto-canary/core@9.19.1-canary.1036.13695.0
  npm install @auto-canary/all-contributors@9.19.1-canary.1036.13695.0
  npm install @auto-canary/chrome@9.19.1-canary.1036.13695.0
  npm install @auto-canary/conventional-commits@9.19.1-canary.1036.13695.0
  npm install @auto-canary/crates@9.19.1-canary.1036.13695.0
  npm install @auto-canary/exec@9.19.1-canary.1036.13695.0
  npm install @auto-canary/first-time-contributor@9.19.1-canary.1036.13695.0
  npm install @auto-canary/gh-pages@9.19.1-canary.1036.13695.0
  npm install @auto-canary/git-tag@9.19.1-canary.1036.13695.0
  npm install @auto-canary/gradle@9.19.1-canary.1036.13695.0
  npm install @auto-canary/jira@9.19.1-canary.1036.13695.0
  npm install @auto-canary/maven@9.19.1-canary.1036.13695.0
  npm install @auto-canary/npm@9.19.1-canary.1036.13695.0
  npm install @auto-canary/omit-commits@9.19.1-canary.1036.13695.0
  npm install @auto-canary/omit-release-notes@9.19.1-canary.1036.13695.0
  npm install @auto-canary/released@9.19.1-canary.1036.13695.0
  npm install @auto-canary/s3@9.19.1-canary.1036.13695.0
  npm install @auto-canary/slack@9.19.1-canary.1036.13695.0
  npm install @auto-canary/twitter@9.19.1-canary.1036.13695.0
  npm install @auto-canary/upload-assets@9.19.1-canary.1036.13695.0
  # or 
  yarn add @auto-canary/bot-list@9.19.1-canary.1036.13695.0
  yarn add @auto-canary/auto@9.19.1-canary.1036.13695.0
  yarn add @auto-canary/core@9.19.1-canary.1036.13695.0
  yarn add @auto-canary/all-contributors@9.19.1-canary.1036.13695.0
  yarn add @auto-canary/chrome@9.19.1-canary.1036.13695.0
  yarn add @auto-canary/conventional-commits@9.19.1-canary.1036.13695.0
  yarn add @auto-canary/crates@9.19.1-canary.1036.13695.0
  yarn add @auto-canary/exec@9.19.1-canary.1036.13695.0
  yarn add @auto-canary/first-time-contributor@9.19.1-canary.1036.13695.0
  yarn add @auto-canary/gh-pages@9.19.1-canary.1036.13695.0
  yarn add @auto-canary/git-tag@9.19.1-canary.1036.13695.0
  yarn add @auto-canary/gradle@9.19.1-canary.1036.13695.0
  yarn add @auto-canary/jira@9.19.1-canary.1036.13695.0
  yarn add @auto-canary/maven@9.19.1-canary.1036.13695.0
  yarn add @auto-canary/npm@9.19.1-canary.1036.13695.0
  yarn add @auto-canary/omit-commits@9.19.1-canary.1036.13695.0
  yarn add @auto-canary/omit-release-notes@9.19.1-canary.1036.13695.0
  yarn add @auto-canary/released@9.19.1-canary.1036.13695.0
  yarn add @auto-canary/s3@9.19.1-canary.1036.13695.0
  yarn add @auto-canary/slack@9.19.1-canary.1036.13695.0
  yarn add @auto-canary/twitter@9.19.1-canary.1036.13695.0
  yarn add @auto-canary/upload-assets@9.19.1-canary.1036.13695.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
