### PR TITLE
When checking if remote commits ignore git error message

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -384,7 +384,9 @@ export default class Auto {
 
         if (remoteHead) {
           // This will throw if the branch is ahead of the current branch
-          execSync(`git merge-base --is-ancestor ${remoteHead} HEAD`);
+          execSync(`git merge-base --is-ancestor ${remoteHead} HEAD`, {
+            stdio: 'ignore'
+          });
         }
 
         this.logger.verbose.info(


### PR DESCRIPTION
# What Changed

see title

# Why

We actually want this error. It's how we detect the current commit is behind the remote. The uses hsould just not. see this message

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.19.2-canary.1038.13720.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.19.2-canary.1038.13720.0
  npm install @auto-canary/auto@9.19.2-canary.1038.13720.0
  npm install @auto-canary/core@9.19.2-canary.1038.13720.0
  npm install @auto-canary/all-contributors@9.19.2-canary.1038.13720.0
  npm install @auto-canary/chrome@9.19.2-canary.1038.13720.0
  npm install @auto-canary/conventional-commits@9.19.2-canary.1038.13720.0
  npm install @auto-canary/crates@9.19.2-canary.1038.13720.0
  npm install @auto-canary/exec@9.19.2-canary.1038.13720.0
  npm install @auto-canary/first-time-contributor@9.19.2-canary.1038.13720.0
  npm install @auto-canary/gh-pages@9.19.2-canary.1038.13720.0
  npm install @auto-canary/git-tag@9.19.2-canary.1038.13720.0
  npm install @auto-canary/gradle@9.19.2-canary.1038.13720.0
  npm install @auto-canary/jira@9.19.2-canary.1038.13720.0
  npm install @auto-canary/maven@9.19.2-canary.1038.13720.0
  npm install @auto-canary/npm@9.19.2-canary.1038.13720.0
  npm install @auto-canary/omit-commits@9.19.2-canary.1038.13720.0
  npm install @auto-canary/omit-release-notes@9.19.2-canary.1038.13720.0
  npm install @auto-canary/released@9.19.2-canary.1038.13720.0
  npm install @auto-canary/s3@9.19.2-canary.1038.13720.0
  npm install @auto-canary/slack@9.19.2-canary.1038.13720.0
  npm install @auto-canary/twitter@9.19.2-canary.1038.13720.0
  npm install @auto-canary/upload-assets@9.19.2-canary.1038.13720.0
  # or 
  yarn add @auto-canary/bot-list@9.19.2-canary.1038.13720.0
  yarn add @auto-canary/auto@9.19.2-canary.1038.13720.0
  yarn add @auto-canary/core@9.19.2-canary.1038.13720.0
  yarn add @auto-canary/all-contributors@9.19.2-canary.1038.13720.0
  yarn add @auto-canary/chrome@9.19.2-canary.1038.13720.0
  yarn add @auto-canary/conventional-commits@9.19.2-canary.1038.13720.0
  yarn add @auto-canary/crates@9.19.2-canary.1038.13720.0
  yarn add @auto-canary/exec@9.19.2-canary.1038.13720.0
  yarn add @auto-canary/first-time-contributor@9.19.2-canary.1038.13720.0
  yarn add @auto-canary/gh-pages@9.19.2-canary.1038.13720.0
  yarn add @auto-canary/git-tag@9.19.2-canary.1038.13720.0
  yarn add @auto-canary/gradle@9.19.2-canary.1038.13720.0
  yarn add @auto-canary/jira@9.19.2-canary.1038.13720.0
  yarn add @auto-canary/maven@9.19.2-canary.1038.13720.0
  yarn add @auto-canary/npm@9.19.2-canary.1038.13720.0
  yarn add @auto-canary/omit-commits@9.19.2-canary.1038.13720.0
  yarn add @auto-canary/omit-release-notes@9.19.2-canary.1038.13720.0
  yarn add @auto-canary/released@9.19.2-canary.1038.13720.0
  yarn add @auto-canary/s3@9.19.2-canary.1038.13720.0
  yarn add @auto-canary/slack@9.19.2-canary.1038.13720.0
  yarn add @auto-canary/twitter@9.19.2-canary.1038.13720.0
  yarn add @auto-canary/upload-assets@9.19.2-canary.1038.13720.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
