### PR TITLE
try credentialed remotes first

### DIFF
--- a/packages/core/src/__tests__/remote.test.ts
+++ b/packages/core/src/__tests__/remote.test.ts
@@ -1,12 +1,13 @@
 import Auto from '../auto';
 import { dummyLog } from '../utils/logger';
 
-const defaultRemote = 'git@github.foo.com'
+const defaultRemote = 'git@github.foo.com';
 const defaults = {
   owner: 'foo',
-  repo: 'bar',
-  token: 'XXXX'
+  repo: 'bar'
 };
+
+process.env.GH_TOKEN = 'XXXX';
 
 const reposGet = jest.fn();
 
@@ -32,24 +33,22 @@ const execSpy = jest.fn();
 // @ts-ignore
 jest.mock('../utils/exec-promise.ts', () => (...args) => execSpy(...args));
 
-
 describe('remote parsing', () => {
   test('should fall back to origin when no git', async () => {
     const auto = new Auto(defaults);
     auto.logger = dummyLog();
 
-    execSpy.mockReturnValue(Promise.resolve())
+    execSpy.mockReturnValue(Promise.resolve());
 
     // @ts-ignore
     expect(await auto.getRemote()).toBe('origin');
   });
 
-
   test('should fall back to configured remote when no git', async () => {
     const auto = new Auto(defaults);
     auto.logger = dummyLog();
 
-    execSpy.mockReturnValue(Promise.resolve(defaultRemote))
+    execSpy.mockReturnValue(Promise.resolve(defaultRemote));
 
     // @ts-ignore
     expect(await auto.getRemote()).toBe(defaultRemote);
@@ -59,59 +58,59 @@ describe('remote parsing', () => {
     const auto = new Auto(defaults);
     auto.logger = dummyLog();
 
-    execSpy.mockReturnValue(Promise.resolve(defaultRemote))
+    execSpy.mockReturnValue(Promise.resolve(defaultRemote));
     auto.git = {
       getProject: () => {},
       verifyAuth: () => false
-    } as any
+    } as any;
 
     // @ts-ignore
     expect(await auto.getRemote()).toBe(defaultRemote);
   });
 
   test('use html_url when authed', async () => {
-    const html_url = 'https://my.repo'
+    const html_url = 'https://my.repo';
     const auto = new Auto(defaults);
     auto.logger = dummyLog();
 
-    execSpy.mockReturnValue(Promise.resolve(defaultRemote))
+    execSpy.mockReturnValue(Promise.resolve(defaultRemote));
     auto.git = {
       getProject: () => ({ html_url }),
-      verifyAuth: () => true
-    } as any
+      verifyAuth: (url: string) => url === html_url
+    } as any;
 
     // @ts-ignore
     expect(await auto.getRemote()).toBe(html_url);
   });
 
   test('use fall back to default when not authed', async () => {
-    const html_url = 'https://my.repo'
+    const html_url = 'https://my.repo';
     const auto = new Auto(defaults);
     auto.logger = dummyLog();
 
-    execSpy.mockReturnValue(Promise.resolve(defaultRemote))
+    execSpy.mockReturnValue(Promise.resolve(defaultRemote));
     auto.git = {
       getProject: () => ({ html_url }),
       verifyAuth: () => false
-    } as any
+    } as any;
 
     // @ts-ignore
     expect(await auto.getRemote()).toBe(defaultRemote);
   });
 
-  test('add token to url if html doesn\'t auth', async () => {
-    const html_url = 'https://my.repo'
+  test("add token to url if html doesn't auth", async () => {
+    const html_url = 'https://my.repo';
     const auto = new Auto(defaults);
-    process.env.GH_TOKEN = 'XXXX'
+    process.env.GH_TOKEN = 'XXXX';
     auto.logger = dummyLog();
 
-    execSpy.mockReturnValue(Promise.resolve(defaultRemote))
+    execSpy.mockReturnValue(Promise.resolve(defaultRemote));
     auto.git = {
       getProject: () => ({ html_url }),
       verifyAuth: (url: string) => url !== html_url
-    } as any
+    } as any;
 
     // @ts-ignore
-    expect(await auto.getRemote()).toBe("https://XXXX@my.repo/");
+    expect(await auto.getRemote()).toBe('https://XXXX@my.repo/');
   });
 });

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -543,11 +543,6 @@ export default class Auto {
 
     const { html_url } = (await this.git.getProject()) || { html_url: '' };
 
-    if (html_url && (await this.git.verifyAuth(html_url))) {
-      this.logger.veryVerbose.note('Using bare html URL as remote');
-      return html_url;
-    }
-
     const GIT_TOKENS: Record<string, string | undefined> = {
       // GitHub Actions require the "x-access-token:" prefix for git access
       // https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#http-based-git-access-by-an-installation
@@ -571,6 +566,11 @@ export default class Auto {
         this.logger.veryVerbose.note('Using token + html URL as remote');
         return urlWithAuth;
       }
+    }
+
+    if (html_url && (await this.git.verifyAuth(html_url))) {
+      this.logger.veryVerbose.note('Using bare html URL as remote');
+      return html_url;
     }
 
     this.logger.veryVerbose.note('Using remote set in environment');


### PR DESCRIPTION
# What Changed

Try git url with creds first. Fallback to html_url

# Why

We want auth to be in the remote url if it can. Falling back to the html_url causes problems if we can auth to the html_url but that auth has insufficient permissions.
