### PR TITLE
Only trim exec output if its a string

### DIFF
--- a/plugins/exec/src/index.ts
+++ b/plugins/exec/src/index.ts
@@ -13,6 +13,7 @@ import { execSync } from 'child_process';
 
 type CommandMap = Record<string, string | undefined>;
 
+/** Safely trim the value if it's a string */
 function trim(val: string | undefined) {
   if (typeof val === 'string') {
     return val.trim();


### PR DESCRIPTION
# What Changed

If an exec step doesn't return anything, calling `.trim()` will throw an error. 

# Why

Todo:

- [ ] Add tests
- [ ] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.19.4-canary.1052.13881.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.19.4-canary.1052.13881.0
  npm install @auto-canary/auto@9.19.4-canary.1052.13881.0
  npm install @auto-canary/core@9.19.4-canary.1052.13881.0
  npm install @auto-canary/all-contributors@9.19.4-canary.1052.13881.0
  npm install @auto-canary/chrome@9.19.4-canary.1052.13881.0
  npm install @auto-canary/conventional-commits@9.19.4-canary.1052.13881.0
  npm install @auto-canary/crates@9.19.4-canary.1052.13881.0
  npm install @auto-canary/exec@9.19.4-canary.1052.13881.0
  npm install @auto-canary/first-time-contributor@9.19.4-canary.1052.13881.0
  npm install @auto-canary/gh-pages@9.19.4-canary.1052.13881.0
  npm install @auto-canary/git-tag@9.19.4-canary.1052.13881.0
  npm install @auto-canary/gradle@9.19.4-canary.1052.13881.0
  npm install @auto-canary/jira@9.19.4-canary.1052.13881.0
  npm install @auto-canary/maven@9.19.4-canary.1052.13881.0
  npm install @auto-canary/npm@9.19.4-canary.1052.13881.0
  npm install @auto-canary/omit-commits@9.19.4-canary.1052.13881.0
  npm install @auto-canary/omit-release-notes@9.19.4-canary.1052.13881.0
  npm install @auto-canary/released@9.19.4-canary.1052.13881.0
  npm install @auto-canary/s3@9.19.4-canary.1052.13881.0
  npm install @auto-canary/slack@9.19.4-canary.1052.13881.0
  npm install @auto-canary/twitter@9.19.4-canary.1052.13881.0
  npm install @auto-canary/upload-assets@9.19.4-canary.1052.13881.0
  # or 
  yarn add @auto-canary/bot-list@9.19.4-canary.1052.13881.0
  yarn add @auto-canary/auto@9.19.4-canary.1052.13881.0
  yarn add @auto-canary/core@9.19.4-canary.1052.13881.0
  yarn add @auto-canary/all-contributors@9.19.4-canary.1052.13881.0
  yarn add @auto-canary/chrome@9.19.4-canary.1052.13881.0
  yarn add @auto-canary/conventional-commits@9.19.4-canary.1052.13881.0
  yarn add @auto-canary/crates@9.19.4-canary.1052.13881.0
  yarn add @auto-canary/exec@9.19.4-canary.1052.13881.0
  yarn add @auto-canary/first-time-contributor@9.19.4-canary.1052.13881.0
  yarn add @auto-canary/gh-pages@9.19.4-canary.1052.13881.0
  yarn add @auto-canary/git-tag@9.19.4-canary.1052.13881.0
  yarn add @auto-canary/gradle@9.19.4-canary.1052.13881.0
  yarn add @auto-canary/jira@9.19.4-canary.1052.13881.0
  yarn add @auto-canary/maven@9.19.4-canary.1052.13881.0
  yarn add @auto-canary/npm@9.19.4-canary.1052.13881.0
  yarn add @auto-canary/omit-commits@9.19.4-canary.1052.13881.0
  yarn add @auto-canary/omit-release-notes@9.19.4-canary.1052.13881.0
  yarn add @auto-canary/released@9.19.4-canary.1052.13881.0
  yarn add @auto-canary/s3@9.19.4-canary.1052.13881.0
  yarn add @auto-canary/slack@9.19.4-canary.1052.13881.0
  yarn add @auto-canary/twitter@9.19.4-canary.1052.13881.0
  yarn add @auto-canary/upload-assets@9.19.4-canary.1052.13881.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
