### PR TITLE
Cocoapods plugin

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/auto.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/auto.test.ts.snap
@@ -109,6 +109,7 @@ Object {
   ],
   "onlyPublishWithReleaseLabel": true,
   "owner": "foo",
+  "plugins": undefined,
   "prereleaseBranches": Array [
     "next",
   ],
@@ -165,6 +166,7 @@ Object {
   ],
   "noVersionPrefix": true,
   "owner": "foo",
+  "plugins": undefined,
   "prereleaseBranches": Array [
     "next",
   ],

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -486,7 +486,7 @@ export default class Auto {
     }
 
     const config = {
-      ...userConfig,
+      ...this.config,
       // This Line overrides config with args
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ...omit(this.options, ['_command', '_all', 'main'] as any),

--- a/plugins/cocoapods/README.md
+++ b/plugins/cocoapods/README.md
@@ -1,6 +1,6 @@
 # Cocoapods Plugin
 
-Use auto to version your [Cocoapod](https://cocoapods.org/), and push to your specs repository!
+Use `auto` to version your [Cocoapod](https://cocoapods.org/), and push to your specs repository!
 
 ## Installation
 
@@ -27,10 +27,7 @@ yarn add -D @auto-it/cocoapods
       }
     ]
     // other plugins
-  ],
-  // THIS IS REQUIRED
-  // Cocoapods cannot work with tags in the format v1.0.0
-  "noVersionPrefix": true
+  ]
 }
 ```
 
@@ -41,10 +38,6 @@ yarn add -D @auto-it/cocoapods
 - The machine running this plugin must have the [Cocoapods](https://cocoapods.org/) `pod` CLI installed already.
 
 - Your `podspec` file must pass `pod lib lint` in order for publishing to a Specs repository to work.
-
-### Versioning
-
-[Cocoapods](https://cocoapods.org/) does not work with the version prefix of `v1.0.0` so all versions must be the plain semver number (`1.0.0`). You are required to set the `noVersionPrefix` setting in your auto configuration.
 
 ### Pushing to the Cocoapods Trunk
 

--- a/plugins/cocoapods/README.md
+++ b/plugins/cocoapods/README.md
@@ -1,0 +1,24 @@
+# Cocoapods Plugin
+
+Use auto to version your cocoapod
+
+## Installation
+
+This plugin is not included with the `auto` CLI installed via NPM. To install:
+
+```sh
+npm i --save-dev @auto-it/cocoapods
+# or
+yarn add -D @auto-it/cocoapods
+```
+
+## Usage
+
+```json
+{
+  "plugins": [
+    ["cocoapods"]
+    // other plugins
+  ]
+}
+```

--- a/plugins/cocoapods/README.md
+++ b/plugins/cocoapods/README.md
@@ -1,6 +1,6 @@
 # Cocoapods Plugin
 
-Use auto to version your cocoapod
+Use auto to version your [Cocoapod](https://cocoapods.org/), and push to your specs repository!
 
 ## Installation
 
@@ -14,11 +14,42 @@ yarn add -D @auto-it/cocoapods
 
 ## Usage
 
-```json
+```jsonc
 {
   "plugins": [
-    ["cocoapods"]
+    [
+      "cocoapods",
+      {
+        // Required, the relative path to your podspec file
+        "podspecPath": "./Test.podspec",
+        // Optional, the specs repo to push to
+        "specsRepo": "https://github.com/intuit/TestSpecs.git"
+      }
+    ]
     // other plugins
-  ]
+  ],
+  // THIS IS REQUIRED
+  // Cocoapods cannot work with tags in the format v1.0.0
+  "noVersionPrefix": true
 }
 ```
+
+## Requirements
+
+### General
+
+- The machine running this plugin must have the [Cocoapods](https://cocoapods.org/) `pod` CLI installed already.
+
+- Your `podspec` file must pass `pod lib lint` in order for publishing to a Specs repository to work.
+
+### Versioning
+
+[Cocoapods](https://cocoapods.org/) does not work with the version prefix of `v1.0.0` so all versions must be the plain semver number (`1.0.0`). You are required to set the `noVersionPrefix` setting in your auto configuration.
+
+### Pushing to the Cocoapods Trunk
+
+If a `specsRepo` is not provided in the plugin options, this plugin will push to the cocoapods trunk repository. This requires that the machine running this has followed the steps for pushing to trunk, the guide for that can be found [here](https://guides.cocoapods.org/making/getting-setup-with-trunk.html#getting-started).
+
+### Pushing to a private specs repo
+
+If `specsRepo` is provided in the configuration, this plugin will add that repo under a temporary name, push to it, and remove the repo from the cocoapods installation on the machine. The machine that is running the plugin must have the appropriate git credentials to push to that repository.

--- a/plugins/cocoapods/__tests__/cocoapods.test.ts
+++ b/plugins/cocoapods/__tests__/cocoapods.test.ts
@@ -113,6 +113,14 @@ describe('Cocoapods Plugin', () => {
       expect(mock).lastCalledWith(expect.any(String), specWithVersion('0.0.2'));
     });
   });
+  describe('modifyConfig hook', () => {
+    test('should set noVersionPrefix to true', () => {
+      const config = {};
+      expect(hooks.modifyConfig.call(config as any)).toStrictEqual({
+        noVersionPrefix: true
+      });
+    });
+  });
   describe('getPreviousVersion hook', () => {
     test('should get previous version from podspec', async () => {
       mockPodspec(specWithVersion('0.0.1'));

--- a/plugins/cocoapods/__tests__/cocoapods.test.ts
+++ b/plugins/cocoapods/__tests__/cocoapods.test.ts
@@ -1,0 +1,238 @@
+import * as Auto from '@auto-it/core';
+import { dummyLog } from '@auto-it/core/dist/utils/logger';
+import { makeHooks } from '@auto-it/core/dist/utils/make-hooks';
+import * as utilities from '../src/utilities';
+import CocoapodsPlugin, {
+  ICocoapodsPluginOptions,
+  getParsedPodspecContents,
+  getVersion,
+  updatePodspecVersion
+} from '../src';
+
+const specWithVersion = (version: string) => `
+      Pod:: Spec.new do | s |
+        s.name             = 'Test'
+        s.version = '${version}'
+        s.summary = 'A short description of Test.'
+
+      # This description is used to generate tags and improve search results.
+      #   * Think: What does it do? Why did you write it ? What is the focus ?
+      #   * Try to keep it short, snappy and to the point.
+      #   * Write the description between the DESC delimiters below.
+      #   * Finally, don't worry about the indent, CocoaPods strips it!
+
+      s.description = << -DESC
+      TODO: Add long description of the pod here.
+        DESC
+
+      s.homepage = 'https://github.com/intuit/auto'
+      # s.screenshots = 'www.example.com/screenshots_1', 'www.example.com/screenshots_2'
+      s.license = { : type => 'MIT', : file => 'LICENSE' }
+      s.author = { 'hborawski' => 'harris_borawski@intuit.com' }
+      s.source = { : git => 'https://github.com/intuit/auto.git', : tag => s.version.to_s }
+
+      s.ios.deployment_target = '11.0'
+
+      s.source_files = 'Test/Classes/**/*'
+
+
+      # s.public_header_files = 'Pod/Classes/**/*.h'
+      # s.frameworks = 'UIKit', 'MapKit'
+      # s.dependency 'Alamofire'
+      end
+      `;
+
+const mockPodspec = (contents: string) => {
+  return jest.spyOn(utilities, 'getPodspecContents').mockReturnValue(contents);
+};
+
+describe('Cocoapods Plugin', () => {
+  let hooks: Auto.IAutoHooks;
+  const prefixRelease: (a: string) => string = (version: string) => {
+    return `v${version}`;
+  };
+
+  const options: ICocoapodsPluginOptions = {
+    podspecPath: './Test.podspec'
+  };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    const plugin = new CocoapodsPlugin(options);
+    hooks = makeHooks();
+    plugin.apply({ hooks, logger: dummyLog(), prefixRelease } as Auto.Auto);
+    jest.spyOn(Auto, 'execPromise').mockReturnValue(Promise.resolve(''));
+  });
+
+  describe('getParsedPodspecContents', () => {
+    test('should return null if contents cant be parsed with regex', () => {
+      mockPodspec('bad podspec');
+
+      expect(getParsedPodspecContents('./Test.podspec')).toBeNull();
+    });
+    test('should return parsed contents', () => {
+      mockPodspec(specWithVersion('0.0.1'));
+      const contents = getParsedPodspecContents('./Test.podspec');
+      expect(contents).toHaveProperty('groups', { version: '0.0.1' });
+    });
+  });
+  describe('getVersion', () => {
+    test('should throw error if parsed podspec is returned as null', () => {
+      mockPodspec('bad podspec');
+
+      expect(() => getVersion('./Test.podspec')).toThrow();
+    });
+    test('should return version', () => {
+      mockPodspec(specWithVersion('0.0.1'));
+
+      expect(getVersion('./Test.podspec')).toBe('0.0.1');
+    });
+  });
+  describe('updatePodspecVersion', () => {
+    test('should throw error if there is an error writing file', async () => {
+      mockPodspec(specWithVersion('0.0.1'));
+
+      jest
+        .spyOn(utilities, 'writePodspecContents')
+        .mockImplementationOnce(() => {
+          throw new Error('Filesystem Error');
+        });
+
+      await expect(
+        updatePodspecVersion('./Test.podspec', '0.0.2')
+      ).rejects.toThrowError(
+        'Error updating version in podspec: ./Test.podspec'
+      );
+    });
+    test('should successfully write new version', async () => {
+      mockPodspec(specWithVersion('0.0.1'));
+
+      const mock = jest.spyOn(utilities, 'writePodspecContents');
+
+      await updatePodspecVersion('./Test.podspec', '0.0.2');
+      expect(mock).lastCalledWith(expect.any(String), specWithVersion('0.0.2'));
+    });
+  });
+  describe('getPreviousVersion hook', () => {
+    test('should get previous version from podspec', async () => {
+      mockPodspec(specWithVersion('0.0.1'));
+
+      expect(await hooks.getPreviousVersion.promise()).toBe('v0.0.1');
+    });
+
+    test('should throw if no version found', async () => {
+      mockPodspec(specWithVersion(''));
+
+      await expect(hooks.getPreviousVersion.promise()).rejects.toThrowError(
+        'Version could not be found in podspec: ./Test.podspec'
+      );
+    });
+  });
+  describe('version hook', () => {
+    test('should version release - patch version', async () => {
+      mockPodspec(specWithVersion('0.0.1'));
+
+      const mock = jest.spyOn(utilities, 'writePodspecContents');
+
+      await hooks.version.promise(Auto.SEMVER.patch);
+
+      expect(mock).lastCalledWith(expect.any(String), specWithVersion('0.0.2'));
+    });
+    test('should version release - minor version', async () => {
+      mockPodspec(specWithVersion('0.0.1'));
+
+      const mock = jest.spyOn(utilities, 'writePodspecContents');
+
+      await hooks.version.promise(Auto.SEMVER.minor);
+
+      expect(mock).lastCalledWith(expect.any(String), specWithVersion('0.1.0'));
+    });
+    test('should version release - major version', async () => {
+      mockPodspec(specWithVersion('0.0.1'));
+
+      const mock = jest.spyOn(utilities, 'writePodspecContents');
+
+      await hooks.version.promise(Auto.SEMVER.major);
+
+      expect(mock).lastCalledWith(expect.any(String), specWithVersion('1.0.0'));
+    });
+    test('should throw if there is an error writing new version', async () => {
+      mockPodspec(specWithVersion('0.0.1'));
+
+      const mock = jest
+        .spyOn(utilities, 'writePodspecContents')
+        .mockImplementationOnce(() => {
+          throw new Error('Filesystem Error');
+        });
+
+      await expect(
+        hooks.version.promise(Auto.SEMVER.major)
+      ).rejects.toThrowError(
+        'Error updating version in podspec: ./Test.podspec'
+      );
+
+      expect(mock).lastCalledWith(expect.any(String), specWithVersion('1.0.0'));
+    });
+  });
+  describe('publish hook', () => {
+    test('should push to trunk if no specsRepo in options', async () => {
+      mockPodspec(specWithVersion('0.0.1'));
+
+      const mock = jest
+        .spyOn(Auto, 'execPromise')
+        .mockReturnValue(Promise.resolve(''));
+
+      const plugin = new CocoapodsPlugin(options);
+      const hook = makeHooks();
+      plugin.apply({
+        hooks: hook,
+        logger: dummyLog(),
+        prefixRelease
+      } as Auto.Auto);
+
+      await hook.publish.promise(Auto.SEMVER.patch);
+
+      expect(mock).toBeCalledTimes(2);
+      expect(mock).lastCalledWith('pod', ['trunk', 'push', './Test.podspec']);
+    });
+    test('should push to specs repo if specsRepo in options', async () => {
+      mockPodspec(specWithVersion('0.0.1'));
+
+      const mock = jest
+        .spyOn(Auto, 'execPromise')
+        .mockReturnValue(Promise.resolve(''));
+
+      const plugin = new CocoapodsPlugin({
+        ...options,
+        specsRepo: 'someSpecsRepo'
+      });
+      const hook = makeHooks();
+      plugin.apply({
+        hooks: hook,
+        logger: dummyLog(),
+        prefixRelease
+      } as Auto.Auto);
+
+      await hook.publish.promise(Auto.SEMVER.patch);
+
+      expect(mock).toBeCalledTimes(4);
+      expect(mock).toHaveBeenNthCalledWith(2, 'pod', [
+        'repo',
+        'add',
+        'autoPublishRepo',
+        'someSpecsRepo'
+      ]);
+      expect(mock).toHaveBeenNthCalledWith(3, 'pod', [
+        'repo',
+        'push',
+        'autoPublishRepo',
+        './Test.podspec'
+      ]);
+      expect(mock).toHaveBeenNthCalledWith(4, 'pod', [
+        'repo',
+        'remove',
+        'autoPublishRepo'
+      ]);
+    });
+  });
+});

--- a/plugins/cocoapods/package.json
+++ b/plugins/cocoapods/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@auto-it/cocoapods",
+  "version": "9.19.5",
+  "main": "dist/index.js",
+  "description": "Use auto to version your cocoapod",
+  "license": "MIT",
+  "author": {
+    "name": "Andrew Lisowski",
+    "email": "lisowski54@gmail.com"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/intuit/auto"
+  },
+  "files": [
+    "dist"
+  ],
+  "keywords": [
+    "automation",
+    "semantic",
+    "release",
+    "github",
+    "labels",
+    "automated",
+    "continuos integration",
+    "changelog"
+  ],
+  "scripts": {
+    "build": "tsc -b",
+    "start": "npm run build -- -w",
+    "lint": "eslint src --ext .ts",
+    "test": "jest --maxWorkers=2 --config ../../package.json"
+  },
+  "dependencies": {
+    "@auto-it/core": "link:../../packages/core",
+    "tslib": "1.10.0"
+  }
+}

--- a/plugins/cocoapods/package.json
+++ b/plugins/cocoapods/package.json
@@ -37,6 +37,9 @@
   },
   "dependencies": {
     "@auto-it/core": "link:../../packages/core",
+    "fp-ts": "^2.5.3",
+    "io-ts": "^2.1.2",
+    "semver": "^7.1.3",
     "tslib": "1.10.0"
   }
 }

--- a/plugins/cocoapods/src/index.ts
+++ b/plugins/cocoapods/src/index.ts
@@ -1,0 +1,175 @@
+import { Auto, IPlugin, execPromise } from '@auto-it/core';
+
+import { inc, ReleaseType } from 'semver';
+
+import { getPodspecContents, writePodspecContents } from './utilities';
+
+const logPrefix = '[Cocoapods-Plugin]';
+
+/** Regex used to pull the version line from the spec */
+const versionRegex = /\.version\s*=\s*['|"](?<version>\d+\.\d+\.\d+)['|"]/;
+/**
+ * Wrapper to add logPrefix to messages
+ *
+ * @param msg - The message to add a prefix to
+ * @returns Log message with prefix prepended
+ */
+const logMessage = (msg: string): string => `${logPrefix} ${msg}`;
+
+export interface ICocoapodsPluginOptions {
+  /** path to podspec file */
+  podspecPath: string;
+
+  /** the Cocoapods repo to publish to */
+  specsRepo?: string;
+}
+
+/**
+ * Returns the regex'd version of the podspec file
+ *
+ * @param podspecPath - The relative path to the podspec file
+ * @returns The regular expression array for use in replacing file contents
+ */
+export function getParsedPodspecContents(
+  podspecPath: string
+): RegExpExecArray | null {
+  const podspecContents = getPodspecContents(podspecPath);
+  return versionRegex.exec(podspecContents);
+}
+
+/**
+ * Retrieves the version currently in the podspec file
+ *
+ * @param podspecPath - The relative path to the podspec file
+ */
+export function getVersion(podspecPath: string): string {
+  const podspecContents = getParsedPodspecContents(podspecPath);
+  if (
+    podspecContents &&
+    podspecContents.groups &&
+    podspecContents.groups.version
+  ) {
+    return podspecContents.groups.version;
+  }
+
+  throw new Error(`Version could not be found in podspec: ${podspecPath}`);
+}
+
+/**
+ * Updates the version in the podspec to the supplied version
+ *
+ * @param podspecPath - The relative path to the podspec file
+ * @param version - The version to update the podspec to
+ */
+export async function updatePodspecVersion(
+  podspecPath: string,
+  version: string
+) {
+  const previousVersion = getVersion(podspecPath);
+  const parsedContents = getParsedPodspecContents(podspecPath);
+  const podspecContents = getPodspecContents(podspecPath);
+
+  try {
+    if (parsedContents && parsedContents[0]) {
+      const newVersionString = parsedContents[0].replace(
+        previousVersion,
+        version
+      );
+      const newPodspec = podspecContents.replace(
+        versionRegex,
+        newVersionString
+      );
+      writePodspecContents(podspecPath, newPodspec);
+      await execPromise('git', [
+        'commit',
+        '-am',
+        `"update version: ${version} [skip ci]"`,
+        '--no-verify'
+      ]);
+    }
+  } catch (error) {
+    console.log(error);
+    throw new Error(`Error updating version in podspec: ${podspecPath}`);
+  }
+}
+
+/** Use auto to version your cocoapod */
+export default class CocoapodsPlugin implements IPlugin {
+  /** The name of the plugin */
+  name = 'cocoapods';
+
+  /** The options of the plugin */
+  readonly options: ICocoapodsPluginOptions;
+
+  /** Initialize the plugin with it's options */
+  constructor(options: ICocoapodsPluginOptions) {
+    this.options = options;
+  }
+
+  /** Tap into auto plugin points. */
+  apply(auto: Auto) {
+    auto.hooks.getPreviousVersion.tapPromise(this.name, async () => {
+      return auto.prefixRelease(getVersion(this.options.podspecPath));
+    });
+
+    auto.hooks.version.tapPromise(this.name, async (version: string) => {
+      const previousVersion = getVersion(this.options.podspecPath);
+      const releaseVersion = inc(previousVersion, version as ReleaseType);
+      if (!releaseVersion) {
+        throw new Error(
+          `Could not increment previous version: ${previousVersion}`
+        );
+      }
+
+      await updatePodspecVersion(this.options.podspecPath, releaseVersion);
+
+      // Ensure tag is on this commit, changelog will be added automatically
+      await execPromise('git', [
+        'tag',
+        releaseVersion,
+        '-m',
+        `"Update version to ${releaseVersion}"`
+      ]);
+    });
+
+    auto.hooks.publish.tapPromise(this.name, async () => {
+      await execPromise('git', [
+        'push',
+        '--follow-tags',
+        '--set-upstream',
+        auto.remote,
+        auto.baseBranch
+      ]);
+      if (this.options.specsRepo) {
+        try {
+          await execPromise('pod', [
+            'repo',
+            'add',
+            'autoPublishRepo',
+            this.options.specsRepo
+          ]);
+          auto.logger.log.info(
+            logMessage(`Pushing to specs repo: ${this.options.specsRepo}`)
+          );
+          await execPromise('pod', [
+            'repo',
+            'push',
+            'autoPublishRepo',
+            this.options.podspecPath
+          ]);
+        } catch (error) {
+          auto.logger.log.error(
+            logMessage(
+              `Error pushing to specs repo: ${this.options.specsRepo}. Error: ${error}`
+            )
+          );
+        } finally {
+          await execPromise('pod', ['repo', 'remove', 'autoPublishRepo']);
+        }
+      } else {
+        auto.logger.log.info(logMessage(`Pushing to Cocoapods trunk`));
+        await execPromise('pod', ['trunk', 'push', this.options.podspecPath]);
+      }
+    });
+  }
+}

--- a/plugins/cocoapods/src/utilities.ts
+++ b/plugins/cocoapods/src/utilities.ts
@@ -1,0 +1,22 @@
+import path from 'path';
+import fs from 'fs';
+
+/**
+ * Retrieves the contents of the podspec file
+ *
+ * @param podspecPath - The relative path to the podspec file
+ * @returns A string that is the contents of the file
+ */
+export function getPodspecContents(podspecPath: string): string {
+  return fs.readFileSync(path.join(process.cwd(), podspecPath)).toString();
+}
+
+/**
+ * Write the podspec file contents
+ *
+ * @param podspecPath - The relative path to the podspec file
+ * @param contents - The contents to write to the podspec path
+ */
+export function writePodspecContents(podspecPath: string, contents: string) {
+  fs.writeFileSync(path.join(process.cwd(), podspecPath), contents);
+}

--- a/plugins/cocoapods/tsconfig.json
+++ b/plugins/cocoapods/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*", "../../typings/**/*"],
+
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+
+  "references": [
+    {
+      "path": "../../packages/core"
+    }
+  ]
+}

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -58,6 +58,9 @@
     },
     {
       "path": "plugins/exec"
+    },
+    {
+      "path": "plugins/cocoapods"
     }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6944,8 +6944,8 @@ forwarded@~0.1.2:
 
 fp-ts@^2.5.3:
   version "2.5.3"
-  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.5.3.tgz#7f09cc7f3e09623c6ade303d98a2cccdb2cc861f"
-  integrity sha512-lQd+hahLd8cygNoXbEHDjH/cbF6XVWlEPb8h5GXXlozjCSDxWgclvkpOoTRfBA0P+r69l9VvW1nEsSGIJRQpWw==
+  resolved "https://registry.npmjs.intuit.com:443/artifactory/api/npm/npm-intuit/fp-ts/-/fp-ts-2.5.3.tgz#7f09cc7f3e09623c6ade303d98a2cccdb2cc861f"
+  integrity sha1-fwnMfz4JYjxq3jA9mKLMzbLMhh8=
 
 fragment-cache@^0.2.1:
   version "0.2.1"
@@ -8305,8 +8305,8 @@ invert-kv@^1.0.0:
 
 io-ts@^2.1.2:
   version "2.1.2"
-  resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-2.1.2.tgz#8ea4439c902c3d15cda343900bed7ee5a9977f42"
-  integrity sha512-whVRGaNBZSrkPrg1y+sSy/kv/fDjweQPP1UCLhKwJUHWGD6rFgbZ44FBF98JlY/FFzTA0MkhGeHWZ/aFhF42eA==
+  resolved "https://registry.npmjs.intuit.com:443/artifactory/api/npm/npm-intuit/io-ts/-/io-ts-2.1.2.tgz#8ea4439c902c3d15cda343900bed7ee5a9977f42"
+  integrity sha1-jqRDnJAsPRXNo0OQC+1+5amXf0I=
 
 ip-regex@^1.0.1:
   version "1.0.3"
@@ -13381,6 +13381,11 @@ semver@^7.0.0, semver@^7.1.1:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.3.tgz#e4345ce73071c53f336445cfc19efb1c311df2a6"
   integrity sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA==
+
+semver@^7.1.3:
+  version "7.1.3"
+  resolved "https://registry.npmjs.intuit.com:443/artifactory/api/npm/npm-intuit/semver/-/semver-7.1.3.tgz#e4345ce73071c53f336445cfc19efb1c311df2a6"
+  integrity sha1-5DRc5zBxxT8zZEXPwZ77HDEd8qY=
 
 semver@~5.3.0:
   version "5.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6944,8 +6944,8 @@ forwarded@~0.1.2:
 
 fp-ts@^2.5.3:
   version "2.5.3"
-  resolved "https://registry.npmjs.intuit.com:443/artifactory/api/npm/npm-intuit/fp-ts/-/fp-ts-2.5.3.tgz#7f09cc7f3e09623c6ade303d98a2cccdb2cc861f"
-  integrity sha1-fwnMfz4JYjxq3jA9mKLMzbLMhh8=
+  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.5.3.tgz#7f09cc7f3e09623c6ade303d98a2cccdb2cc861f"
+  integrity sha512-lQd+hahLd8cygNoXbEHDjH/cbF6XVWlEPb8h5GXXlozjCSDxWgclvkpOoTRfBA0P+r69l9VvW1nEsSGIJRQpWw==
 
 fragment-cache@^0.2.1:
   version "0.2.1"
@@ -8305,8 +8305,8 @@ invert-kv@^1.0.0:
 
 io-ts@^2.1.2:
   version "2.1.2"
-  resolved "https://registry.npmjs.intuit.com:443/artifactory/api/npm/npm-intuit/io-ts/-/io-ts-2.1.2.tgz#8ea4439c902c3d15cda343900bed7ee5a9977f42"
-  integrity sha1-jqRDnJAsPRXNo0OQC+1+5amXf0I=
+  resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-2.1.2.tgz#8ea4439c902c3d15cda343900bed7ee5a9977f42"
+  integrity sha512-whVRGaNBZSrkPrg1y+sSy/kv/fDjweQPP1UCLhKwJUHWGD6rFgbZ44FBF98JlY/FFzTA0MkhGeHWZ/aFhF42eA==
 
 ip-regex@^1.0.1:
   version "1.0.3"
@@ -13377,15 +13377,10 @@ semver@^6.0.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.0.0, semver@^7.1.1:
+semver@^7.0.0, semver@^7.1.1, semver@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.3.tgz#e4345ce73071c53f336445cfc19efb1c311df2a6"
   integrity sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA==
-
-semver@^7.1.3:
-  version "7.1.3"
-  resolved "https://registry.npmjs.intuit.com:443/artifactory/api/npm/npm-intuit/semver/-/semver-7.1.3.tgz#e4345ce73071c53f336445cfc19efb1c311df2a6"
-  integrity sha1-5DRc5zBxxT8zZEXPwZ77HDEd8qY=
 
 semver@~5.3.0:
   version "5.3.0"


### PR DESCRIPTION
# What Changed
Added a plugin to support versioning and publishing [Cocoapods](https://cocoapods.org/)

Unfortunately, Cocoapods does not use a declarative package definition file, and it's a ruby file. Their `pod` tool does not provide any way to retrieve information from that file either. This approach uses a regular expression to read and write the version number for the package definition file (`.podspec`).

# Why
Auto should be able to version any kind of package, and Cocoapods are the leading package distribution for iOS currently (SPM is gaining more traction, but still missing some key functionality.)

Todo:
- [x] Address any PR comments
- [x] Add tests
- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.20.0-canary.1066.14021.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.20.0-canary.1066.14021.0
  npm install @auto-canary/auto@9.20.0-canary.1066.14021.0
  npm install @auto-canary/core@9.20.0-canary.1066.14021.0
  npm install @auto-canary/all-contributors@9.20.0-canary.1066.14021.0
  npm install @auto-canary/chrome@9.20.0-canary.1066.14021.0
  npm install @auto-canary/cocoapods@9.20.0-canary.1066.14021.0
  npm install @auto-canary/conventional-commits@9.20.0-canary.1066.14021.0
  npm install @auto-canary/crates@9.20.0-canary.1066.14021.0
  npm install @auto-canary/exec@9.20.0-canary.1066.14021.0
  npm install @auto-canary/first-time-contributor@9.20.0-canary.1066.14021.0
  npm install @auto-canary/gh-pages@9.20.0-canary.1066.14021.0
  npm install @auto-canary/git-tag@9.20.0-canary.1066.14021.0
  npm install @auto-canary/gradle@9.20.0-canary.1066.14021.0
  npm install @auto-canary/jira@9.20.0-canary.1066.14021.0
  npm install @auto-canary/maven@9.20.0-canary.1066.14021.0
  npm install @auto-canary/npm@9.20.0-canary.1066.14021.0
  npm install @auto-canary/omit-commits@9.20.0-canary.1066.14021.0
  npm install @auto-canary/omit-release-notes@9.20.0-canary.1066.14021.0
  npm install @auto-canary/released@9.20.0-canary.1066.14021.0
  npm install @auto-canary/s3@9.20.0-canary.1066.14021.0
  npm install @auto-canary/slack@9.20.0-canary.1066.14021.0
  npm install @auto-canary/twitter@9.20.0-canary.1066.14021.0
  npm install @auto-canary/upload-assets@9.20.0-canary.1066.14021.0
  # or 
  yarn add @auto-canary/bot-list@9.20.0-canary.1066.14021.0
  yarn add @auto-canary/auto@9.20.0-canary.1066.14021.0
  yarn add @auto-canary/core@9.20.0-canary.1066.14021.0
  yarn add @auto-canary/all-contributors@9.20.0-canary.1066.14021.0
  yarn add @auto-canary/chrome@9.20.0-canary.1066.14021.0
  yarn add @auto-canary/cocoapods@9.20.0-canary.1066.14021.0
  yarn add @auto-canary/conventional-commits@9.20.0-canary.1066.14021.0
  yarn add @auto-canary/crates@9.20.0-canary.1066.14021.0
  yarn add @auto-canary/exec@9.20.0-canary.1066.14021.0
  yarn add @auto-canary/first-time-contributor@9.20.0-canary.1066.14021.0
  yarn add @auto-canary/gh-pages@9.20.0-canary.1066.14021.0
  yarn add @auto-canary/git-tag@9.20.0-canary.1066.14021.0
  yarn add @auto-canary/gradle@9.20.0-canary.1066.14021.0
  yarn add @auto-canary/jira@9.20.0-canary.1066.14021.0
  yarn add @auto-canary/maven@9.20.0-canary.1066.14021.0
  yarn add @auto-canary/npm@9.20.0-canary.1066.14021.0
  yarn add @auto-canary/omit-commits@9.20.0-canary.1066.14021.0
  yarn add @auto-canary/omit-release-notes@9.20.0-canary.1066.14021.0
  yarn add @auto-canary/released@9.20.0-canary.1066.14021.0
  yarn add @auto-canary/s3@9.20.0-canary.1066.14021.0
  yarn add @auto-canary/slack@9.20.0-canary.1066.14021.0
  yarn add @auto-canary/twitter@9.20.0-canary.1066.14021.0
  yarn add @auto-canary/upload-assets@9.20.0-canary.1066.14021.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
