### PR TITLE
Re-introduce `build` option back, but make it configurable so that

### DIFF
--- a/plugins/gradle/README.md
+++ b/plugins/gradle/README.md
@@ -53,4 +53,9 @@ This plugin will also call the `publish` task with the release version, if confi
 
 ### Configure `snapshotSuffix`
 
-This plugins will use the `snapshotSuffix` in `gradle.properties` or `build.gradle` if configured.
+This plugin will use the `snapshotSuffix` in `gradle.properties` or `build.gradle` if configured.
+
+### Build After Version Bump Automatically
+
+This plugin will allow build to occur in-line for native apps versus libraries.  It
+will do so if `buildDuringRelease` in `gradle.properties` or `build.gradle` is configured.

--- a/plugins/gradle/__tests__/gradle.test.ts
+++ b/plugins/gradle/__tests__/gradle.test.ts
@@ -78,6 +78,30 @@ describe('Gradle Plugin', () => {
       ]);
     });
 
+    test('should version release - major version - w/build', async () => {
+      const properties = `
+        version: 1.0.0
+        buildDuringRelease: true
+      `;
+
+      mockProperties(properties);
+      await hooks.beforeRun.promise({} as any);
+
+      const spy = jest.fn();
+      mockProperties(properties).mockImplementation(spy);
+
+      await hooks.version.promise(Auto.SEMVER.major);
+
+      expect(spy).toHaveBeenCalledWith(expect.stringMatching('gradle'), [
+        'release',
+        '-Prelease.useAutomaticVersion=true',
+        `-Prelease.newVersion=2.0.0`,
+        '-x createReleaseTag',
+        '-x preTagCommit',
+        '-x commitNewVersion'
+      ]);
+    }); 
+
     test('should version release - minor version', async () => {
       const properties = 'version: 1.1.0';
       mockProperties(properties);
@@ -116,7 +140,8 @@ describe('Gradle Plugin', () => {
       const properties = `
       version: 1.0.0.SNAP
       snapshotSuffix: .SNAP
-    `;
+      `;
+
       mockProperties(properties);
       await hooks.beforeRun.promise({} as any);
 

--- a/plugins/gradle/src/index.ts
+++ b/plugins/gradle/src/index.ts
@@ -100,7 +100,7 @@ export default class GradleReleasePluginPlugin implements IPlugin {
   private updateGradleVersion = async (
     version: string,
     commitMsg?: string,
-    buildFlag: boolean = true
+    buildFlag = true
   ) => {
     if (buildFlag) {
       // don't create release, tag, or commit since auto will do this


### PR DESCRIPTION
# What Changed
Re-introducing build as configurable param... 

# Why
So that the build can occur inline for native applications -- IE versioning/building can happen in the same place.

Todo:

- [X] Add tests
- [X] Add docs
