### PR TITLE
always use tag version for release title, prevent using annotation

### DIFF
--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -774,6 +774,7 @@ export default class Git {
       owner: this.options.owner,
       repo: this.options.repo,
       tag_name: tag,
+      name: tag,
       body: releaseNotes,
       prerelease,
     });


### PR DESCRIPTION
# What Changed

Enforce the title of a GitHub release when creating it.

# Why

The `repos.createRelease` function will make the title of the release the annotation for the tag. This annotation may contain more than just the number as seen [here](https://github.com/intuit/auto/releases?after=v8.0.0). We always just want the title to be the tag version.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.21.2-canary.1083.14191.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.21.2-canary.1083.14191.0
  npm install @auto-canary/auto@9.21.2-canary.1083.14191.0
  npm install @auto-canary/core@9.21.2-canary.1083.14191.0
  npm install @auto-canary/all-contributors@9.21.2-canary.1083.14191.0
  npm install @auto-canary/chrome@9.21.2-canary.1083.14191.0
  npm install @auto-canary/cocoapods@9.21.2-canary.1083.14191.0
  npm install @auto-canary/conventional-commits@9.21.2-canary.1083.14191.0
  npm install @auto-canary/crates@9.21.2-canary.1083.14191.0
  npm install @auto-canary/exec@9.21.2-canary.1083.14191.0
  npm install @auto-canary/first-time-contributor@9.21.2-canary.1083.14191.0
  npm install @auto-canary/gh-pages@9.21.2-canary.1083.14191.0
  npm install @auto-canary/git-tag@9.21.2-canary.1083.14191.0
  npm install @auto-canary/gradle@9.21.2-canary.1083.14191.0
  npm install @auto-canary/jira@9.21.2-canary.1083.14191.0
  npm install @auto-canary/maven@9.21.2-canary.1083.14191.0
  npm install @auto-canary/npm@9.21.2-canary.1083.14191.0
  npm install @auto-canary/omit-commits@9.21.2-canary.1083.14191.0
  npm install @auto-canary/omit-release-notes@9.21.2-canary.1083.14191.0
  npm install @auto-canary/released@9.21.2-canary.1083.14191.0
  npm install @auto-canary/s3@9.21.2-canary.1083.14191.0
  npm install @auto-canary/slack@9.21.2-canary.1083.14191.0
  npm install @auto-canary/twitter@9.21.2-canary.1083.14191.0
  npm install @auto-canary/upload-assets@9.21.2-canary.1083.14191.0
  # or 
  yarn add @auto-canary/bot-list@9.21.2-canary.1083.14191.0
  yarn add @auto-canary/auto@9.21.2-canary.1083.14191.0
  yarn add @auto-canary/core@9.21.2-canary.1083.14191.0
  yarn add @auto-canary/all-contributors@9.21.2-canary.1083.14191.0
  yarn add @auto-canary/chrome@9.21.2-canary.1083.14191.0
  yarn add @auto-canary/cocoapods@9.21.2-canary.1083.14191.0
  yarn add @auto-canary/conventional-commits@9.21.2-canary.1083.14191.0
  yarn add @auto-canary/crates@9.21.2-canary.1083.14191.0
  yarn add @auto-canary/exec@9.21.2-canary.1083.14191.0
  yarn add @auto-canary/first-time-contributor@9.21.2-canary.1083.14191.0
  yarn add @auto-canary/gh-pages@9.21.2-canary.1083.14191.0
  yarn add @auto-canary/git-tag@9.21.2-canary.1083.14191.0
  yarn add @auto-canary/gradle@9.21.2-canary.1083.14191.0
  yarn add @auto-canary/jira@9.21.2-canary.1083.14191.0
  yarn add @auto-canary/maven@9.21.2-canary.1083.14191.0
  yarn add @auto-canary/npm@9.21.2-canary.1083.14191.0
  yarn add @auto-canary/omit-commits@9.21.2-canary.1083.14191.0
  yarn add @auto-canary/omit-release-notes@9.21.2-canary.1083.14191.0
  yarn add @auto-canary/released@9.21.2-canary.1083.14191.0
  yarn add @auto-canary/s3@9.21.2-canary.1083.14191.0
  yarn add @auto-canary/slack@9.21.2-canary.1083.14191.0
  yarn add @auto-canary/twitter@9.21.2-canary.1083.14191.0
  yarn add @auto-canary/upload-assets@9.21.2-canary.1083.14191.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
