### PR TITLE
Add --title flag to 'auto changelog'

### DIFF
--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -368,6 +368,13 @@ export const commands: AutoCommand[] = [
         description: "Tag to end changelog generation on. Defaults to HEAD.",
       },
       {
+        name: "title",
+        type: String,
+        group: "main",
+        description:
+          "Override the title used in the addition to the CHANGELOG.md.",
+      },
+      {
         ...message,
         description:
           "Message to commit the changelog with. Defaults to 'Update CHANGELOG.md [skip ci]'",

--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -787,6 +787,23 @@ describe("Auto", () => {
       expect(addToChangelog).not.toHaveBeenCalled();
     });
 
+    test("should be able to override title", async () => {
+      const auto = new Auto(defaults);
+
+      auto.logger = dummyLog();
+      await auto.loadConfig();
+
+      const addToChangelog = jest.fn();
+      auto.release!.addToChangelog = addToChangelog;
+      jest.spyOn(auto.release!, "generateReleaseNotes").mockImplementation();
+
+      await auto.changelog({ from: "v1.0.0", dryRun: true, title: "foo" });
+      // @ts-ignore
+      expect(await auto.release?.hooks.createChangelogTitle.promise()).toBe(
+        "foo"
+      );
+    });
+
     test("should skip getRepository hook if passed in via cli", async () => {
       process.env.GH_TOKEN = "XXXX";
       const auto = new Auto({

--- a/packages/core/src/auto-args.ts
+++ b/packages/core/src/auto-args.ts
@@ -60,6 +60,8 @@ export interface IChangelogOptions extends Partial<AuthorInformation> {
   to?: string;
   /** The commit message to commit the changelog changes with */
   message?: string;
+  /** Override the title use in the addition to the CHANGELOG.md. */
+  title?: string;
 }
 
 export interface IReleaseOptions extends Partial<RepoInformation> {

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1509,6 +1509,7 @@ export default class Auto {
       dryRun,
       from,
       to,
+      title,
       message = "Update CHANGELOG.md [skip ci]",
     } = options;
 
@@ -1517,6 +1518,13 @@ export default class Auto {
     }
 
     await this.setGitUser();
+
+    if (title) {
+      this.release.hooks.createChangelogTitle.tap(
+        "Changelog Flag",
+        () => title
+      );
+    }
 
     const lastRelease = from || (await this.git.getLatestRelease());
     const bump = await this.release.getSemverBump(lastRelease, to);


### PR DESCRIPTION
# What Changed

see title

# Why

If you're not using `shipit` you might want to be able to override the title that is put in the changelog.

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.22.0-canary.1084.14207.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.22.0-canary.1084.14207.0
  npm install @auto-canary/auto@9.22.0-canary.1084.14207.0
  npm install @auto-canary/core@9.22.0-canary.1084.14207.0
  npm install @auto-canary/all-contributors@9.22.0-canary.1084.14207.0
  npm install @auto-canary/chrome@9.22.0-canary.1084.14207.0
  npm install @auto-canary/cocoapods@9.22.0-canary.1084.14207.0
  npm install @auto-canary/conventional-commits@9.22.0-canary.1084.14207.0
  npm install @auto-canary/crates@9.22.0-canary.1084.14207.0
  npm install @auto-canary/exec@9.22.0-canary.1084.14207.0
  npm install @auto-canary/first-time-contributor@9.22.0-canary.1084.14207.0
  npm install @auto-canary/gh-pages@9.22.0-canary.1084.14207.0
  npm install @auto-canary/git-tag@9.22.0-canary.1084.14207.0
  npm install @auto-canary/gradle@9.22.0-canary.1084.14207.0
  npm install @auto-canary/jira@9.22.0-canary.1084.14207.0
  npm install @auto-canary/maven@9.22.0-canary.1084.14207.0
  npm install @auto-canary/npm@9.22.0-canary.1084.14207.0
  npm install @auto-canary/omit-commits@9.22.0-canary.1084.14207.0
  npm install @auto-canary/omit-release-notes@9.22.0-canary.1084.14207.0
  npm install @auto-canary/released@9.22.0-canary.1084.14207.0
  npm install @auto-canary/s3@9.22.0-canary.1084.14207.0
  npm install @auto-canary/slack@9.22.0-canary.1084.14207.0
  npm install @auto-canary/twitter@9.22.0-canary.1084.14207.0
  npm install @auto-canary/upload-assets@9.22.0-canary.1084.14207.0
  # or 
  yarn add @auto-canary/bot-list@9.22.0-canary.1084.14207.0
  yarn add @auto-canary/auto@9.22.0-canary.1084.14207.0
  yarn add @auto-canary/core@9.22.0-canary.1084.14207.0
  yarn add @auto-canary/all-contributors@9.22.0-canary.1084.14207.0
  yarn add @auto-canary/chrome@9.22.0-canary.1084.14207.0
  yarn add @auto-canary/cocoapods@9.22.0-canary.1084.14207.0
  yarn add @auto-canary/conventional-commits@9.22.0-canary.1084.14207.0
  yarn add @auto-canary/crates@9.22.0-canary.1084.14207.0
  yarn add @auto-canary/exec@9.22.0-canary.1084.14207.0
  yarn add @auto-canary/first-time-contributor@9.22.0-canary.1084.14207.0
  yarn add @auto-canary/gh-pages@9.22.0-canary.1084.14207.0
  yarn add @auto-canary/git-tag@9.22.0-canary.1084.14207.0
  yarn add @auto-canary/gradle@9.22.0-canary.1084.14207.0
  yarn add @auto-canary/jira@9.22.0-canary.1084.14207.0
  yarn add @auto-canary/maven@9.22.0-canary.1084.14207.0
  yarn add @auto-canary/npm@9.22.0-canary.1084.14207.0
  yarn add @auto-canary/omit-commits@9.22.0-canary.1084.14207.0
  yarn add @auto-canary/omit-release-notes@9.22.0-canary.1084.14207.0
  yarn add @auto-canary/released@9.22.0-canary.1084.14207.0
  yarn add @auto-canary/s3@9.22.0-canary.1084.14207.0
  yarn add @auto-canary/slack@9.22.0-canary.1084.14207.0
  yarn add @auto-canary/twitter@9.22.0-canary.1084.14207.0
  yarn add @auto-canary/upload-assets@9.22.0-canary.1084.14207.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
