### PR TITLE
Exit with warning when canary or next is unimplemented

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1038,14 +1038,14 @@ export default class Auto {
     }
 
     if (!this.hooks.canary.isUsed()) {
-      this.logger.log.error(endent`
+      this.logger.log.warn(endent`
         None of the plugins that you are using implement the \`canary\` command!
 
         "canary" releases are versions that are used solely to test changes. They make sense on some platforms (ex: npm) but not all!
         
         If you think your package manager has the ability to support canaries please file an issue or submit a pull request,
       `);
-      process.exit(1);
+      process.exit(0);
     }
 
     await this.checkClean();
@@ -1156,14 +1156,14 @@ export default class Auto {
     }
 
     if (!this.hooks.next.isUsed()) {
-      this.logger.log.error(endent`
+      this.logger.log.warn(endent`
         None of the plugins that you are using implement the \`next\` command!
 
         "next" releases are pre-releases such as betas or alphas. They make sense on some platforms (ex: npm) but not all!
 
         If you think your package manager has the ability to support "next" releases please file an issue or submit a pull request,
       `);
-      process.exit(1);
+      process.exit(0);
     }
 
     await this.checkClean();


### PR DESCRIPTION
# What Changed

Exit with warnings instead of errors when `next` or `canary` hook is unimplemented.

# Why

We don't want to fail these builds for users of `auto shipit`. Since we suggest users always run `shipit` at the end of a build, it doesn't make sense to fail the builds.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.21.3-canary.1085.14213.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.21.3-canary.1085.14213.0
  npm install @auto-canary/auto@9.21.3-canary.1085.14213.0
  npm install @auto-canary/core@9.21.3-canary.1085.14213.0
  npm install @auto-canary/all-contributors@9.21.3-canary.1085.14213.0
  npm install @auto-canary/chrome@9.21.3-canary.1085.14213.0
  npm install @auto-canary/cocoapods@9.21.3-canary.1085.14213.0
  npm install @auto-canary/conventional-commits@9.21.3-canary.1085.14213.0
  npm install @auto-canary/crates@9.21.3-canary.1085.14213.0
  npm install @auto-canary/exec@9.21.3-canary.1085.14213.0
  npm install @auto-canary/first-time-contributor@9.21.3-canary.1085.14213.0
  npm install @auto-canary/gh-pages@9.21.3-canary.1085.14213.0
  npm install @auto-canary/git-tag@9.21.3-canary.1085.14213.0
  npm install @auto-canary/gradle@9.21.3-canary.1085.14213.0
  npm install @auto-canary/jira@9.21.3-canary.1085.14213.0
  npm install @auto-canary/maven@9.21.3-canary.1085.14213.0
  npm install @auto-canary/npm@9.21.3-canary.1085.14213.0
  npm install @auto-canary/omit-commits@9.21.3-canary.1085.14213.0
  npm install @auto-canary/omit-release-notes@9.21.3-canary.1085.14213.0
  npm install @auto-canary/released@9.21.3-canary.1085.14213.0
  npm install @auto-canary/s3@9.21.3-canary.1085.14213.0
  npm install @auto-canary/slack@9.21.3-canary.1085.14213.0
  npm install @auto-canary/twitter@9.21.3-canary.1085.14213.0
  npm install @auto-canary/upload-assets@9.21.3-canary.1085.14213.0
  # or 
  yarn add @auto-canary/bot-list@9.21.3-canary.1085.14213.0
  yarn add @auto-canary/auto@9.21.3-canary.1085.14213.0
  yarn add @auto-canary/core@9.21.3-canary.1085.14213.0
  yarn add @auto-canary/all-contributors@9.21.3-canary.1085.14213.0
  yarn add @auto-canary/chrome@9.21.3-canary.1085.14213.0
  yarn add @auto-canary/cocoapods@9.21.3-canary.1085.14213.0
  yarn add @auto-canary/conventional-commits@9.21.3-canary.1085.14213.0
  yarn add @auto-canary/crates@9.21.3-canary.1085.14213.0
  yarn add @auto-canary/exec@9.21.3-canary.1085.14213.0
  yarn add @auto-canary/first-time-contributor@9.21.3-canary.1085.14213.0
  yarn add @auto-canary/gh-pages@9.21.3-canary.1085.14213.0
  yarn add @auto-canary/git-tag@9.21.3-canary.1085.14213.0
  yarn add @auto-canary/gradle@9.21.3-canary.1085.14213.0
  yarn add @auto-canary/jira@9.21.3-canary.1085.14213.0
  yarn add @auto-canary/maven@9.21.3-canary.1085.14213.0
  yarn add @auto-canary/npm@9.21.3-canary.1085.14213.0
  yarn add @auto-canary/omit-commits@9.21.3-canary.1085.14213.0
  yarn add @auto-canary/omit-release-notes@9.21.3-canary.1085.14213.0
  yarn add @auto-canary/released@9.21.3-canary.1085.14213.0
  yarn add @auto-canary/s3@9.21.3-canary.1085.14213.0
  yarn add @auto-canary/slack@9.21.3-canary.1085.14213.0
  yarn add @auto-canary/twitter@9.21.3-canary.1085.14213.0
  yarn add @auto-canary/upload-assets@9.21.3-canary.1085.14213.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
