### PR TITLE
fix(conventional-commits): skip release when no increment detected

### DIFF
--- a/plugins/conventional-commits/__tests__/conventional-commits.test.ts
+++ b/plugins/conventional-commits/__tests__/conventional-commits.test.ts
@@ -211,3 +211,57 @@ test("should add conventional commit label if none/skip", async () => {
   const result = await logParse.normalizeCommit(commit);
   expect(result?.labels).toStrictEqual(["skip-release", "internal", "patch"]);
 });
+
+test("should not add skip when a non skip commit is present with a skip commit", async () => {
+  const commit = makeCommitFromMsg("fix: a test");
+  const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
+  const logParse = new LogParse();
+  const autoHooks = makeHooks();
+  const mockGit = ({
+    getUserByEmail: jest.fn(),
+    searchRepo: jest.fn(),
+    getCommitDate: jest.fn(),
+    getFirstCommit: jest.fn(),
+    getPr: jest.fn(),
+    getLatestRelease: () => Promise.resolve("1.2.3"),
+    getGitLog: () =>
+      Promise.resolve([commit, makeCommitFromMsg("chore: a test 2")]),
+    getCommitsForPR: () => Promise.resolve([{ sha: "1" }]),
+  } as unknown) as Git;
+
+  conventionalCommitsPlugin.apply({
+    hooks: autoHooks,
+    labels: defaultLabels,
+    semVerLabels: versionLabels,
+    logger: dummyLog(),
+    git: mockGit,
+    release: new Release(mockGit),
+  } as Auto);
+
+  autoHooks.onCreateLogParse.call(logParse);
+
+  const result = await logParse.normalizeCommit(commit);
+  expect(result?.labels).toStrictEqual(["patch"]);
+});
+
+test("should skip when not a fix/feat/breaking change commit", async () => {
+  const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
+  const autoHooks = makeHooks();
+  conventionalCommitsPlugin.apply({
+    hooks: autoHooks,
+    labels: defaultLabels,
+    semVerLabels: versionLabels,
+    logger: dummyLog(),
+  } as Auto);
+
+  const logParseHooks = makeLogParseHooks();
+  autoHooks.onCreateLogParse.call({
+    hooks: logParseHooks,
+  } as LogParse);
+
+  const commit = makeCommitFromMsg("chore: i should not trigger a release");
+  expect(await logParseHooks.parseCommit.promise({ ...commit })).toStrictEqual({
+    ...commit,
+    labels: ["skip-release"],
+  });
+});

--- a/plugins/conventional-commits/src/index.ts
+++ b/plugins/conventional-commits/src/index.ts
@@ -23,9 +23,10 @@ export default class ConventionalCommitsPlugin implements IPlugin {
             mappers.increment,
             parse(commit.subject)
           );
-          const incrementLabel = auto.semVerLabels.get(
-            conventionalCommit.increment as VersionLabel
-          );
+          // conventional commits will return a falsy value when no incrememnt is detected (e.g., chore/perf/refactor commits)
+          const commitIncrement =
+            (conventionalCommit.increment as VersionLabel) || "skip";
+          const incrementLabel = auto.semVerLabels.get(commitIncrement);
           const allSemVerLabels = [
             auto.semVerLabels.get(SEMVER.major),
             auto.semVerLabels.get(SEMVER.minor),


### PR DESCRIPTION
# What Changed

Conventional Commit plugin behavior to account for non increment commit types.

# Why

This change treats the falsy value from conventional commits as
no increment detected, in which case we tell auto to skip it for
release consideration.

Prior to this change, a `chore: foo` or a `perf: bar` would trigger a `patch` by default. After this change, these are set as `skip` releaseType as they (by conventional commits standards) should not trigger a release.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.22.2-canary.1086.14242.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.22.2-canary.1086.14242.0
  npm install @auto-canary/auto@9.22.2-canary.1086.14242.0
  npm install @auto-canary/core@9.22.2-canary.1086.14242.0
  npm install @auto-canary/all-contributors@9.22.2-canary.1086.14242.0
  npm install @auto-canary/chrome@9.22.2-canary.1086.14242.0
  npm install @auto-canary/cocoapods@9.22.2-canary.1086.14242.0
  npm install @auto-canary/conventional-commits@9.22.2-canary.1086.14242.0
  npm install @auto-canary/crates@9.22.2-canary.1086.14242.0
  npm install @auto-canary/exec@9.22.2-canary.1086.14242.0
  npm install @auto-canary/first-time-contributor@9.22.2-canary.1086.14242.0
  npm install @auto-canary/gh-pages@9.22.2-canary.1086.14242.0
  npm install @auto-canary/git-tag@9.22.2-canary.1086.14242.0
  npm install @auto-canary/gradle@9.22.2-canary.1086.14242.0
  npm install @auto-canary/jira@9.22.2-canary.1086.14242.0
  npm install @auto-canary/maven@9.22.2-canary.1086.14242.0
  npm install @auto-canary/npm@9.22.2-canary.1086.14242.0
  npm install @auto-canary/omit-commits@9.22.2-canary.1086.14242.0
  npm install @auto-canary/omit-release-notes@9.22.2-canary.1086.14242.0
  npm install @auto-canary/released@9.22.2-canary.1086.14242.0
  npm install @auto-canary/s3@9.22.2-canary.1086.14242.0
  npm install @auto-canary/slack@9.22.2-canary.1086.14242.0
  npm install @auto-canary/twitter@9.22.2-canary.1086.14242.0
  npm install @auto-canary/upload-assets@9.22.2-canary.1086.14242.0
  # or 
  yarn add @auto-canary/bot-list@9.22.2-canary.1086.14242.0
  yarn add @auto-canary/auto@9.22.2-canary.1086.14242.0
  yarn add @auto-canary/core@9.22.2-canary.1086.14242.0
  yarn add @auto-canary/all-contributors@9.22.2-canary.1086.14242.0
  yarn add @auto-canary/chrome@9.22.2-canary.1086.14242.0
  yarn add @auto-canary/cocoapods@9.22.2-canary.1086.14242.0
  yarn add @auto-canary/conventional-commits@9.22.2-canary.1086.14242.0
  yarn add @auto-canary/crates@9.22.2-canary.1086.14242.0
  yarn add @auto-canary/exec@9.22.2-canary.1086.14242.0
  yarn add @auto-canary/first-time-contributor@9.22.2-canary.1086.14242.0
  yarn add @auto-canary/gh-pages@9.22.2-canary.1086.14242.0
  yarn add @auto-canary/git-tag@9.22.2-canary.1086.14242.0
  yarn add @auto-canary/gradle@9.22.2-canary.1086.14242.0
  yarn add @auto-canary/jira@9.22.2-canary.1086.14242.0
  yarn add @auto-canary/maven@9.22.2-canary.1086.14242.0
  yarn add @auto-canary/npm@9.22.2-canary.1086.14242.0
  yarn add @auto-canary/omit-commits@9.22.2-canary.1086.14242.0
  yarn add @auto-canary/omit-release-notes@9.22.2-canary.1086.14242.0
  yarn add @auto-canary/released@9.22.2-canary.1086.14242.0
  yarn add @auto-canary/s3@9.22.2-canary.1086.14242.0
  yarn add @auto-canary/slack@9.22.2-canary.1086.14242.0
  yarn add @auto-canary/twitter@9.22.2-canary.1086.14242.0
  yarn add @auto-canary/upload-assets@9.22.2-canary.1086.14242.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
