### PR TITLE
use release URL from response for an accurate URL

### DIFF
--- a/plugins/slack/__tests__/__snapshots__/slack.test.ts.snap
+++ b/plugins/slack/__tests__/__snapshots__/slack.test.ts.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`postToSlack should call slack api 1`] = `"{\\"text\\":\\"@channel: New release *<https://github.custom.com/adierkens/test/releases/tag/1.0.0|1.0.0>*\\\\n* My Notes*\\\\n• PR <google.com|some link>\\",\\"link_names\\":1}"`;
+exports[`postToSlack should call slack api 1`] = `"{\\"text\\":\\"@channel: New release *<https://git.hub/some/project/releases/v1.0.0|v1.0.0>*\\\\n* My Notes*\\\\n• PR <google.com|some link>\\",\\"link_names\\":1}"`;
 
-exports[`postToSlack should call slack api in env var 1`] = `"{\\"text\\":\\"@channel: New release *<https://github.custom.com/adierkens/test/releases/tag/1.0.0|1.0.0>*\\\\n* My Notes*\\\\n• PR <google.com|some link>\\",\\"link_names\\":1}"`;
+exports[`postToSlack should call slack api in env var 1`] = `"{\\"text\\":\\"@channel: New release *<https://git.hub/some/project/releases/v1.0.0|v1.0.0>*\\\\n* My Notes*\\\\n• PR <google.com|some link>\\",\\"link_names\\":1}"`;
 
-exports[`postToSlack should call slack api with custom atTarget 1`] = `"{\\"text\\":\\"@here: New release *<https://github.custom.com/adierkens/test/releases/tag/1.0.0|1.0.0>*\\\\n* My Notes*\\\\n• PR <google.com|some link>\\",\\"link_names\\":1}"`;
+exports[`postToSlack should call slack api with custom atTarget 1`] = `"{\\"text\\":\\"@here: New release *<https://git.hub/some/project/releases/v1.0.0|v1.0.0>*\\\\n* My Notes*\\\\n• PR <google.com|some link>\\",\\"link_names\\":1}"`;
 
-exports[`postToSlack should call slack api with minimal config 1`] = `"{\\"text\\":\\"@channel: New release *<https://github.custom.com/adierkens/test/releases/tag/1.0.0|1.0.0>*\\\\n* My Notes*\\\\n• PR <google.com|some link>\\",\\"link_names\\":1}"`;
+exports[`postToSlack should call slack api with minimal config 1`] = `"{\\"text\\":\\"@channel: New release *<https://git.hub/some/project/releases/v1.0.0|v1.0.0>*\\\\n* My Notes*\\\\n• PR <google.com|some link>\\",\\"link_names\\":1}"`;

--- a/plugins/slack/__tests__/slack.test.ts
+++ b/plugins/slack/__tests__/slack.test.ts
@@ -17,22 +17,22 @@ beforeEach(() => {
   fetchSpy.mockClear();
 });
 
+const mockResponse = [
+  {
+    data: {
+      html_url: "https://git.hub/some/project/releases/v1.0.0",
+      name: "v1.0.0",
+    },
+  },
+];
+
 // For the purpose of this test, we use the current branch as the "prerelease" branch to fake being on a "next" branch
 const nextBranch = execSync("git rev-parse --abbrev-ref HEAD", {
   encoding: "utf8",
 }).trim();
 
-const mockGit = {
-  options: {
-    owner: "adierkens",
-    repo: "test",
-  },
-  getProject: () => ({
-    html_url: "https://github.custom.com/adierkens/test",
-  }),
-};
 const mockAuto = ({
-  git: mockGit,
+  git: {},
   logger: dummyLog(),
 } as unknown) as Auto;
 
@@ -113,7 +113,7 @@ describe("postToSlack", () => {
     ).rejects.toBeInstanceOf(Error);
   });
 
-  test("doesn't post when prelease branch and using default prereleasePublish setting", async () => {
+  test("doesn't post when prerelease branch and using default prereleasePublish setting", async () => {
     // @ts-ignore
     const plugin = new SlackPlugin({
       url: "https://custom-slack-url",
@@ -141,7 +141,7 @@ describe("postToSlack", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  test("doesn't post when prelease branch setting is false", async () => {
+  test("doesn't post when prerelease branch setting is false", async () => {
     // @ts-ignore
     const plugin = new SlackPlugin({
       url: "https://custom-slack-url",
@@ -170,7 +170,7 @@ describe("postToSlack", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  test("posts when prelease branch setting is true", async () => {
+  test("posts when prerelease branch setting is true", async () => {
     // @ts-ignore
     const plugin = new SlackPlugin({
       url: "https://custom-slack-url",
@@ -192,6 +192,8 @@ describe("postToSlack", () => {
       lastRelease: "0.1.0",
       commits: [makeCommitFromMsg("a patch")],
       releaseNotes: "# My Notes",
+      // @ts-ignore
+      response: mockResponse,
     });
     expect(plugin.postToSlack).toHaveBeenCalledTimes(1);
   });
@@ -205,7 +207,9 @@ describe("postToSlack", () => {
     await plugin.postToSlack(
       { ...mockAuto, logger } as Auto,
       "1.0.0",
-      "# My Notes\n- PR [some link](google.com)"
+      "# My Notes\n- PR [some link](google.com)",
+      // @ts-ignore
+      mockResponse
     );
 
     expect(logger.verbose.warn).toHaveBeenCalled();
@@ -218,7 +222,9 @@ describe("postToSlack", () => {
     await plugin.postToSlack(
       mockAuto,
       "1.0.0",
-      "# My Notes\n- PR [some link](google.com)"
+      "# My Notes\n- PR [some link](google.com)",
+      // @ts-ignore
+      mockResponse
     );
 
     expect(fetchSpy).toHaveBeenCalled();
@@ -239,6 +245,8 @@ describe("postToSlack", () => {
       lastRelease: "0.1.0",
       commits: [makeCommitFromMsg("a patch")],
       releaseNotes: "# My Notes\n- PR [some link](google.com)",
+      // @ts-ignore
+      response: mockResponse,
     });
 
     expect(fetchSpy).toHaveBeenCalled();
@@ -262,6 +270,8 @@ describe("postToSlack", () => {
       lastRelease: "0.1.0",
       commits: [makeCommitFromMsg("a patch")],
       releaseNotes: "# My Notes\n- PR [some link](google.com)",
+      // @ts-ignore
+      response: mockResponse,
     });
 
     expect(fetchSpy).toHaveBeenCalled();
@@ -284,6 +294,8 @@ describe("postToSlack", () => {
       lastRelease: "0.1.0",
       commits: [makeCommitFromMsg("a patch")],
       releaseNotes: "# My Notes\n- PR [some link](google.com)",
+      // @ts-ignore
+      response: mockResponse,
     });
 
     expect(fetchSpy).toHaveBeenCalled();

--- a/plugins/slack/package.json
+++ b/plugins/slack/package.json
@@ -39,11 +39,11 @@
   "dependencies": {
     "@atomist/slack-messages": "~1.1.0",
     "@auto-it/core": "link:../../packages/core",
+    "@octokit/rest": "16.43.1",
     "fp-ts": "^2.5.3",
     "io-ts": "^2.1.2",
     "node-fetch": "2.6.0",
-    "tslib": "1.11.1",
-    "url-join": "^4.0.0"
+    "tslib": "1.11.1"
   },
   "devDependencies": {
     "@types/node-fetch": "2.5.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2747,16 +2747,6 @@
     regexpp "^3.0.0"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@2.25.0":
-  version "2.25.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.25.0.tgz#13691c4fe368bd377b1e5b1e4ad660b220bf7714"
-  integrity sha512-0IZ4ZR5QkFYbaJk+8eJ2kYeA+1tzOE1sBjbwwtSV85oNWYUBep+EyhlZ7DLUCyhMUGuJpcCCFL0fDtYAP1zMZw==
-  dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.25.0"
-    eslint-scope "^5.0.0"
-    eslint-utils "^2.0.0"
-
 "@typescript-eslint/experimental-utils@2.26.0", "@typescript-eslint/experimental-utils@^2.5.0":
   version "2.26.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.26.0.tgz#063390c404d9980767d76274df386c0aa675d91d"
@@ -2776,19 +2766,6 @@
     "@typescript-eslint/experimental-utils" "2.26.0"
     "@typescript-eslint/typescript-estree" "2.26.0"
     eslint-visitor-keys "^1.1.0"
-
-"@typescript-eslint/typescript-estree@2.25.0":
-  version "2.25.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.25.0.tgz#b790497556734b7476fa7dd3fa539955a5c79e2c"
-  integrity sha512-VUksmx5lDxSi6GfmwSK7SSoIKSw9anukWWNitQPqt58LuYrKalzsgeuignbqnB+rK/xxGlSsCy8lYnwFfB6YJg==
-  dependencies:
-    debug "^4.1.1"
-    eslint-visitor-keys "^1.1.0"
-    glob "^7.1.6"
-    is-glob "^4.0.1"
-    lodash "^4.17.15"
-    semver "^6.3.0"
-    tsutils "^3.17.1"
 
 "@typescript-eslint/typescript-estree@2.26.0":
   version "2.26.0"


### PR DESCRIPTION
# What Changed

Previously we were trying to build a url for the release. This didn't account for:

1. multiple releases
2. built the URL wrong

This PR takes out the guess-work and just uses the URLs in the `createRelease` response.

# Why

A project that uses this plugin was posting the wrong release URL to slack.

Todo:

- [x] Add tests


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.22.3-canary.1096.14336.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.22.3-canary.1096.14336.0
  npm install @auto-canary/auto@9.22.3-canary.1096.14336.0
  npm install @auto-canary/core@9.22.3-canary.1096.14336.0
  npm install @auto-canary/all-contributors@9.22.3-canary.1096.14336.0
  npm install @auto-canary/chrome@9.22.3-canary.1096.14336.0
  npm install @auto-canary/cocoapods@9.22.3-canary.1096.14336.0
  npm install @auto-canary/conventional-commits@9.22.3-canary.1096.14336.0
  npm install @auto-canary/crates@9.22.3-canary.1096.14336.0
  npm install @auto-canary/exec@9.22.3-canary.1096.14336.0
  npm install @auto-canary/first-time-contributor@9.22.3-canary.1096.14336.0
  npm install @auto-canary/gh-pages@9.22.3-canary.1096.14336.0
  npm install @auto-canary/git-tag@9.22.3-canary.1096.14336.0
  npm install @auto-canary/gradle@9.22.3-canary.1096.14336.0
  npm install @auto-canary/jira@9.22.3-canary.1096.14336.0
  npm install @auto-canary/maven@9.22.3-canary.1096.14336.0
  npm install @auto-canary/npm@9.22.3-canary.1096.14336.0
  npm install @auto-canary/omit-commits@9.22.3-canary.1096.14336.0
  npm install @auto-canary/omit-release-notes@9.22.3-canary.1096.14336.0
  npm install @auto-canary/released@9.22.3-canary.1096.14336.0
  npm install @auto-canary/s3@9.22.3-canary.1096.14336.0
  npm install @auto-canary/slack@9.22.3-canary.1096.14336.0
  npm install @auto-canary/twitter@9.22.3-canary.1096.14336.0
  npm install @auto-canary/upload-assets@9.22.3-canary.1096.14336.0
  # or 
  yarn add @auto-canary/bot-list@9.22.3-canary.1096.14336.0
  yarn add @auto-canary/auto@9.22.3-canary.1096.14336.0
  yarn add @auto-canary/core@9.22.3-canary.1096.14336.0
  yarn add @auto-canary/all-contributors@9.22.3-canary.1096.14336.0
  yarn add @auto-canary/chrome@9.22.3-canary.1096.14336.0
  yarn add @auto-canary/cocoapods@9.22.3-canary.1096.14336.0
  yarn add @auto-canary/conventional-commits@9.22.3-canary.1096.14336.0
  yarn add @auto-canary/crates@9.22.3-canary.1096.14336.0
  yarn add @auto-canary/exec@9.22.3-canary.1096.14336.0
  yarn add @auto-canary/first-time-contributor@9.22.3-canary.1096.14336.0
  yarn add @auto-canary/gh-pages@9.22.3-canary.1096.14336.0
  yarn add @auto-canary/git-tag@9.22.3-canary.1096.14336.0
  yarn add @auto-canary/gradle@9.22.3-canary.1096.14336.0
  yarn add @auto-canary/jira@9.22.3-canary.1096.14336.0
  yarn add @auto-canary/maven@9.22.3-canary.1096.14336.0
  yarn add @auto-canary/npm@9.22.3-canary.1096.14336.0
  yarn add @auto-canary/omit-commits@9.22.3-canary.1096.14336.0
  yarn add @auto-canary/omit-release-notes@9.22.3-canary.1096.14336.0
  yarn add @auto-canary/released@9.22.3-canary.1096.14336.0
  yarn add @auto-canary/s3@9.22.3-canary.1096.14336.0
  yarn add @auto-canary/slack@9.22.3-canary.1096.14336.0
  yarn add @auto-canary/twitter@9.22.3-canary.1096.14336.0
  yarn add @auto-canary/upload-assets@9.22.3-canary.1096.14336.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
