### PR TITLE
add link in released comment + handle multiple releases

### DIFF
--- a/plugins/released/__tests__/released-label.test.ts
+++ b/plugins/released/__tests__/released-label.test.ts
@@ -34,6 +34,15 @@ const lockIssue = jest.fn();
 git.lockIssue = lockIssue;
 lockIssue.mockReturnValue([]);
 
+const mockResponse = [
+  {
+    data: {
+      html_url: "https://git.hub/some/project/releases/v1.0.0",
+      name: "v1.0.0",
+    },
+  },
+];
+
 describe("release label plugin", () => {
   beforeEach(() => {
     comment.mockClear();
@@ -199,11 +208,14 @@ describe("release label plugin", () => {
       lastRelease: "0.1.0",
       commits: await log.normalizeCommits([commit]),
       releaseNotes: "",
+      // @ts-ignore
+      response: mockResponse,
     });
 
     expect(comment).toHaveBeenCalledWith(
       expect.objectContaining({
-        message: ":rocket: PR was released in `1.0.0` :rocket:",
+        message:
+          ":rocket: PR was released in [`v1.0.0`](https://git.hub/some/project/releases/v1.0.0) :rocket:",
       })
     );
   });
@@ -229,12 +241,14 @@ describe("release label plugin", () => {
       lastRelease: "0.1.0",
       commits: await log.normalizeCommits([commit]),
       releaseNotes: "",
+      // @ts-ignore
+      response: mockResponse,
     });
 
     expect(comment).toHaveBeenCalledWith(
       expect.objectContaining({
         message:
-          ":rocket: PR is fixed. PR was released in [1.0.0](https://github.com/intuit/auto/releases/tag/1.0.0) :rocket:",
+          ":rocket: PR is fixed. PR was released in [v1.0.0](https://github.com/intuit/auto/releases/tag/v1.0.0) :rocket:",
       })
     );
   });
@@ -344,12 +358,15 @@ describe("release label plugin", () => {
       lastRelease: "0.1.0",
       commits: await log.normalizeCommits([commit]),
       releaseNotes: "",
+      // @ts-ignore
+      response: mockResponse,
     });
 
     expect(comment).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
-        message: ":rocket: Issue was released in `1.0.0` :rocket:",
+        message:
+          ":rocket: Issue was released in [`v1.0.0`](https://git.hub/some/project/releases/v1.0.0) :rocket:",
         pr: 420,
         context: "released",
       })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2747,16 +2747,6 @@
     regexpp "^3.0.0"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@2.25.0":
-  version "2.25.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.25.0.tgz#13691c4fe368bd377b1e5b1e4ad660b220bf7714"
-  integrity sha512-0IZ4ZR5QkFYbaJk+8eJ2kYeA+1tzOE1sBjbwwtSV85oNWYUBep+EyhlZ7DLUCyhMUGuJpcCCFL0fDtYAP1zMZw==
-  dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.25.0"
-    eslint-scope "^5.0.0"
-    eslint-utils "^2.0.0"
-
 "@typescript-eslint/experimental-utils@2.26.0", "@typescript-eslint/experimental-utils@^2.5.0":
   version "2.26.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.26.0.tgz#063390c404d9980767d76274df386c0aa675d91d"
@@ -2776,19 +2766,6 @@
     "@typescript-eslint/experimental-utils" "2.26.0"
     "@typescript-eslint/typescript-estree" "2.26.0"
     eslint-visitor-keys "^1.1.0"
-
-"@typescript-eslint/typescript-estree@2.25.0":
-  version "2.25.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.25.0.tgz#b790497556734b7476fa7dd3fa539955a5c79e2c"
-  integrity sha512-VUksmx5lDxSi6GfmwSK7SSoIKSw9anukWWNitQPqt58LuYrKalzsgeuignbqnB+rK/xxGlSsCy8lYnwFfB6YJg==
-  dependencies:
-    debug "^4.1.1"
-    eslint-visitor-keys "^1.1.0"
-    glob "^7.1.6"
-    is-glob "^4.0.1"
-    lodash "^4.17.15"
-    semver "^6.3.0"
-    tsutils "^3.17.1"
 
 "@typescript-eslint/typescript-estree@2.26.0":
   version "2.26.0"


### PR DESCRIPTION
# What Changed

See title

# Why

Links make life easier

Todo:

- [x] Add tests


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.22.3-canary.1097.14341.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.22.3-canary.1097.14341.0
  npm install @auto-canary/auto@9.22.3-canary.1097.14341.0
  npm install @auto-canary/core@9.22.3-canary.1097.14341.0
  npm install @auto-canary/all-contributors@9.22.3-canary.1097.14341.0
  npm install @auto-canary/chrome@9.22.3-canary.1097.14341.0
  npm install @auto-canary/cocoapods@9.22.3-canary.1097.14341.0
  npm install @auto-canary/conventional-commits@9.22.3-canary.1097.14341.0
  npm install @auto-canary/crates@9.22.3-canary.1097.14341.0
  npm install @auto-canary/exec@9.22.3-canary.1097.14341.0
  npm install @auto-canary/first-time-contributor@9.22.3-canary.1097.14341.0
  npm install @auto-canary/gh-pages@9.22.3-canary.1097.14341.0
  npm install @auto-canary/git-tag@9.22.3-canary.1097.14341.0
  npm install @auto-canary/gradle@9.22.3-canary.1097.14341.0
  npm install @auto-canary/jira@9.22.3-canary.1097.14341.0
  npm install @auto-canary/maven@9.22.3-canary.1097.14341.0
  npm install @auto-canary/npm@9.22.3-canary.1097.14341.0
  npm install @auto-canary/omit-commits@9.22.3-canary.1097.14341.0
  npm install @auto-canary/omit-release-notes@9.22.3-canary.1097.14341.0
  npm install @auto-canary/released@9.22.3-canary.1097.14341.0
  npm install @auto-canary/s3@9.22.3-canary.1097.14341.0
  npm install @auto-canary/slack@9.22.3-canary.1097.14341.0
  npm install @auto-canary/twitter@9.22.3-canary.1097.14341.0
  npm install @auto-canary/upload-assets@9.22.3-canary.1097.14341.0
  # or 
  yarn add @auto-canary/bot-list@9.22.3-canary.1097.14341.0
  yarn add @auto-canary/auto@9.22.3-canary.1097.14341.0
  yarn add @auto-canary/core@9.22.3-canary.1097.14341.0
  yarn add @auto-canary/all-contributors@9.22.3-canary.1097.14341.0
  yarn add @auto-canary/chrome@9.22.3-canary.1097.14341.0
  yarn add @auto-canary/cocoapods@9.22.3-canary.1097.14341.0
  yarn add @auto-canary/conventional-commits@9.22.3-canary.1097.14341.0
  yarn add @auto-canary/crates@9.22.3-canary.1097.14341.0
  yarn add @auto-canary/exec@9.22.3-canary.1097.14341.0
  yarn add @auto-canary/first-time-contributor@9.22.3-canary.1097.14341.0
  yarn add @auto-canary/gh-pages@9.22.3-canary.1097.14341.0
  yarn add @auto-canary/git-tag@9.22.3-canary.1097.14341.0
  yarn add @auto-canary/gradle@9.22.3-canary.1097.14341.0
  yarn add @auto-canary/jira@9.22.3-canary.1097.14341.0
  yarn add @auto-canary/maven@9.22.3-canary.1097.14341.0
  yarn add @auto-canary/npm@9.22.3-canary.1097.14341.0
  yarn add @auto-canary/omit-commits@9.22.3-canary.1097.14341.0
  yarn add @auto-canary/omit-release-notes@9.22.3-canary.1097.14341.0
  yarn add @auto-canary/released@9.22.3-canary.1097.14341.0
  yarn add @auto-canary/s3@9.22.3-canary.1097.14341.0
  yarn add @auto-canary/slack@9.22.3-canary.1097.14341.0
  yarn add @auto-canary/twitter@9.22.3-canary.1097.14341.0
  yarn add @auto-canary/upload-assets@9.22.3-canary.1097.14341.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
