### PR TITLE
shipit: expose --only-publish-with-release-label

### DIFF
--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -65,6 +65,13 @@ const version: AutoOption = {
   group: "global",
 };
 
+const onlyPublishWithReleaseLabel: AutoOption = {
+  name: "only-publish-with-release-label",
+  type: Boolean,
+  description: "Only bump version if 'release' label is on pull request",
+  group: "main",
+};
+
 const defaultOptions: AutoOption[] = [
   {
     name: "verbose",
@@ -331,12 +338,7 @@ export const commands: AutoCommand[] = [
     description:
       "Get the semantic version bump for the given changes. Requires all PRs to have labels for the change type. If a PR does not have a label associated with it, it will default to `patch`.",
     options: [
-      {
-        name: "only-publish-with-release-label",
-        type: Boolean,
-        description: "Only bump version if 'release' label is on pull request",
-        group: "main",
-      },
+      onlyPublishWithReleaseLabel,
       {
         name: "from",
         type: String,
@@ -453,6 +455,7 @@ export const commands: AutoCommand[] = [
     options: [
       baseBranch,
       dryRun,
+      onlyPublishWithReleaseLabel,
       {
         name: "only-graduate-with-release-label",
         type: Boolean,

--- a/packages/core/src/semver.ts
+++ b/packages/core/src/semver.ts
@@ -1,4 +1,5 @@
 import { VersionLabel } from "./release";
+import { ReleaseCalculationOptions } from "./types";
 
 enum SEMVER {
   major = "major",
@@ -33,11 +34,6 @@ export function getHigherSemverTag(left: SEMVER, right: string): SEMVER {
   return SEMVER.patch;
 }
 
-interface ISemVerOptions {
-  /** Only publish changes when "release" label is present */
-  onlyPublishWithReleaseLabel?: boolean;
-}
-
 /**
  * Determine the version bump from the labels on merged PRs.
  * Respects skip-release labels and the "onlyPublishWithReleaseLabel"
@@ -46,7 +42,7 @@ interface ISemVerOptions {
 export function calculateSemVerBump(
   labels: string[][],
   labelMap: IVersionLabels,
-  { onlyPublishWithReleaseLabel }: ISemVerOptions = {}
+  { onlyPublishWithReleaseLabel }: ReleaseCalculationOptions = {}
 ) {
   const labelSet = new Set<string>();
   const skipReleaseLabels = labelMap.get("skip") || [];

--- a/packages/core/src/utils/load-plugins.ts
+++ b/packages/core/src/utils/load-plugins.ts
@@ -39,14 +39,13 @@ export const getInstalledPlugins = (global = false): InstalledModule[] => {
   let modules: string[] = [];
 
   try {
-    const stdout = execSync(`npm2 ls --parseable ${global ? "--global" : ""}`, {
+    const stdout = execSync(`npm ls --parseable ${global ? "--global" : ""}`, {
       encoding: "utf8",
       stdio: ["pipe", "pipe", "ignore"],
     });
 
     modules = stdout.split("\n");
   } catch (error) {
-    console.log(error);
     modules = error.stdout.split("\n");
   }
 


### PR DESCRIPTION
# What Changed

see title.

# Why

closes #1107 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.25.0-canary.1108.14441.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.25.0-canary.1108.14441.0
  npm install @auto-canary/auto@9.25.0-canary.1108.14441.0
  npm install @auto-canary/core@9.25.0-canary.1108.14441.0
  npm install @auto-canary/all-contributors@9.25.0-canary.1108.14441.0
  npm install @auto-canary/brew@9.25.0-canary.1108.14441.0
  npm install @auto-canary/chrome@9.25.0-canary.1108.14441.0
  npm install @auto-canary/cocoapods@9.25.0-canary.1108.14441.0
  npm install @auto-canary/conventional-commits@9.25.0-canary.1108.14441.0
  npm install @auto-canary/crates@9.25.0-canary.1108.14441.0
  npm install @auto-canary/exec@9.25.0-canary.1108.14441.0
  npm install @auto-canary/first-time-contributor@9.25.0-canary.1108.14441.0
  npm install @auto-canary/gh-pages@9.25.0-canary.1108.14441.0
  npm install @auto-canary/git-tag@9.25.0-canary.1108.14441.0
  npm install @auto-canary/gradle@9.25.0-canary.1108.14441.0
  npm install @auto-canary/jira@9.25.0-canary.1108.14441.0
  npm install @auto-canary/maven@9.25.0-canary.1108.14441.0
  npm install @auto-canary/npm@9.25.0-canary.1108.14441.0
  npm install @auto-canary/omit-commits@9.25.0-canary.1108.14441.0
  npm install @auto-canary/omit-release-notes@9.25.0-canary.1108.14441.0
  npm install @auto-canary/released@9.25.0-canary.1108.14441.0
  npm install @auto-canary/s3@9.25.0-canary.1108.14441.0
  npm install @auto-canary/slack@9.25.0-canary.1108.14441.0
  npm install @auto-canary/twitter@9.25.0-canary.1108.14441.0
  npm install @auto-canary/upload-assets@9.25.0-canary.1108.14441.0
  # or 
  yarn add @auto-canary/bot-list@9.25.0-canary.1108.14441.0
  yarn add @auto-canary/auto@9.25.0-canary.1108.14441.0
  yarn add @auto-canary/core@9.25.0-canary.1108.14441.0
  yarn add @auto-canary/all-contributors@9.25.0-canary.1108.14441.0
  yarn add @auto-canary/brew@9.25.0-canary.1108.14441.0
  yarn add @auto-canary/chrome@9.25.0-canary.1108.14441.0
  yarn add @auto-canary/cocoapods@9.25.0-canary.1108.14441.0
  yarn add @auto-canary/conventional-commits@9.25.0-canary.1108.14441.0
  yarn add @auto-canary/crates@9.25.0-canary.1108.14441.0
  yarn add @auto-canary/exec@9.25.0-canary.1108.14441.0
  yarn add @auto-canary/first-time-contributor@9.25.0-canary.1108.14441.0
  yarn add @auto-canary/gh-pages@9.25.0-canary.1108.14441.0
  yarn add @auto-canary/git-tag@9.25.0-canary.1108.14441.0
  yarn add @auto-canary/gradle@9.25.0-canary.1108.14441.0
  yarn add @auto-canary/jira@9.25.0-canary.1108.14441.0
  yarn add @auto-canary/maven@9.25.0-canary.1108.14441.0
  yarn add @auto-canary/npm@9.25.0-canary.1108.14441.0
  yarn add @auto-canary/omit-commits@9.25.0-canary.1108.14441.0
  yarn add @auto-canary/omit-release-notes@9.25.0-canary.1108.14441.0
  yarn add @auto-canary/released@9.25.0-canary.1108.14441.0
  yarn add @auto-canary/s3@9.25.0-canary.1108.14441.0
  yarn add @auto-canary/slack@9.25.0-canary.1108.14441.0
  yarn add @auto-canary/twitter@9.25.0-canary.1108.14441.0
  yarn add @auto-canary/upload-assets@9.25.0-canary.1108.14441.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
