### PR TITLE
Fix info command in fresh envs + list plugins in binary

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,6 +52,7 @@
     "endent": "^1.3.0",
     "enquirer": "^2.3.4",
     "env-ci": "^5.0.1",
+    "fast-glob": "^3.1.1",
     "fp-ts": "^2.5.3",
     "fromentries": "^1.2.0",
     "gitlogplus": "^3.1.2",

--- a/packages/core/src/__tests__/__snapshots__/auto.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/auto.test.ts.snap
@@ -109,7 +109,9 @@ Object {
   ],
   "onlyPublishWithReleaseLabel": true,
   "owner": "foo",
-  "plugins": undefined,
+  "plugins": Array [
+    "npm",
+  ],
   "prereleaseBranches": Array [
     "next",
   ],
@@ -166,7 +168,9 @@ Object {
   ],
   "noVersionPrefix": true,
   "owner": "foo",
-  "plugins": undefined,
+  "plugins": Array [
+    "npm",
+  ],
   "prereleaseBranches": Array [
     "next",
   ],

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -615,7 +615,7 @@ export default class Auto {
       ? link(latestRelease.tag_name, latestRelease.html_url)
       : "";
     const { headers } = await this.git.github.request("HEAD /");
-    const access = headers as Record<string, string>;
+    const access = headers as Record<string, string | undefined>;
     const rateLimitRefresh = new Date(
       Number(access["x-ratelimit-reset"]) * 1000
     );
@@ -683,7 +683,7 @@ export default class Auto {
       ${logSuccess(!(permission === 'admin' || permission === 'write'))} Repo Permission:  ${permission}
       ${logSuccess(!user?.login)} User:             ${user?.login}
       ${logSuccess()} API:              ${link(this.git.options.baseUrl!, this.git.options.baseUrl!)}
-      ${logSuccess(!access['x-oauth-scopes'].includes('repo'))} Enabled Scopes:   ${access['x-oauth-scopes']}
+      ${logSuccess(!access['x-oauth-scopes']?.includes('repo'))} Enabled Scopes:   ${access['x-oauth-scopes']}
       ${logSuccess(Number(access['x-ratelimit-remaining']) === 0)} Rate Limit:       ${access['x-ratelimit-remaining'] || '∞'}/${access['x-ratelimit-limit'] || '∞'} ${access['ratelimit-reset'] ? `(Renews @ ${tokenRefresh})` : ''}
     `);
     console.log("");

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -64,6 +64,7 @@ import {
 } from "./validate-config";
 import { omit } from "./utils/omit";
 import { execSync } from "child_process";
+import isBinary from "./utils/is-binary";
 
 const proxyUrl = process.env.https_proxy || process.env.http_proxy;
 const env = envCi();
@@ -1824,8 +1825,7 @@ export default class Auto {
    * Apply all of the plugins in the config.
    */
   private loadPlugins(config: AutoRc) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const defaultPlugins = [(process as any).pkg ? "git-tag" : "npm"];
+    const defaultPlugins = [isBinary() ? "git-tag" : "npm"];
     const pluginsPaths = [
       require.resolve("./plugins/filter-non-pull-request"),
       ...(Array.isArray(config.plugins) ? config.plugins : defaultPlugins),

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1825,12 +1825,13 @@ export default class Auto {
    * Apply all of the plugins in the config.
    */
   private loadPlugins(config: AutoRc) {
-    const defaultPlugins = [isBinary() ? "git-tag" : "npm"];
+    config.plugins = config.plugins || [isBinary() ? "git-tag" : "npm"];
+
+    const extendedLocation = this.getExtendedLocation(config);
     const pluginsPaths = [
       require.resolve("./plugins/filter-non-pull-request"),
-      ...(Array.isArray(config.plugins) ? config.plugins : defaultPlugins),
+      ...config.plugins,
     ];
-    const extendedLocation = this.getExtendedLocation(config);
 
     pluginsPaths
       .map((plugin) =>

--- a/packages/core/src/utils/is-binary.ts
+++ b/packages/core/src/utils/is-binary.ts
@@ -1,0 +1,3 @@
+/** Determine if auto is installed as a binary */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default () => (process as any).pkg;

--- a/packages/core/src/utils/load-plugins.ts
+++ b/packages/core/src/utils/load-plugins.ts
@@ -238,16 +238,12 @@ export const listPlugins = async (
   extendedLocation?: string
 ) => {
   const rcPlugins = plugins.map((plugin) => {
-    if (typeof plugin === "string") {
-      return {
-        name: plugin,
-        path: findPlugin(plugin, logger, extendedLocation) || "",
-      };
-    }
+    const name = typeof plugin === "string" ? plugin : plugin[0];
+    const pluginPath = findPlugin(name, logger, extendedLocation) || "";
 
     return {
-      name: plugin[0],
-      path: findPlugin(plugin[0], logger, extendedLocation) || "",
+      name,
+      path: pluginPath.replace("/dist/index.js", ""),
     };
   });
 


### PR DESCRIPTION
# What Changed

- We were treating undefined as a string in one spot, causing the info command to always fail in a fresh env
- The `--list-plugins` command wasn't ever listing the plugins included in the binary if `npm` wasn't installed.
- `--list-plugins` now also list the default plugins if no plugins are defined in the `.autorc`

Here is the repo I was testing with: https://github.com/hipstersmoothie/testing-info/runs/558826232?check_suite_focus=true

# Why

closes #1109 

Todo:

- [ ] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.25.1-canary.1110.14462.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.25.1-canary.1110.14462.0
  npm install @auto-canary/auto@9.25.1-canary.1110.14462.0
  npm install @auto-canary/core@9.25.1-canary.1110.14462.0
  npm install @auto-canary/all-contributors@9.25.1-canary.1110.14462.0
  npm install @auto-canary/brew@9.25.1-canary.1110.14462.0
  npm install @auto-canary/chrome@9.25.1-canary.1110.14462.0
  npm install @auto-canary/cocoapods@9.25.1-canary.1110.14462.0
  npm install @auto-canary/conventional-commits@9.25.1-canary.1110.14462.0
  npm install @auto-canary/crates@9.25.1-canary.1110.14462.0
  npm install @auto-canary/exec@9.25.1-canary.1110.14462.0
  npm install @auto-canary/first-time-contributor@9.25.1-canary.1110.14462.0
  npm install @auto-canary/gh-pages@9.25.1-canary.1110.14462.0
  npm install @auto-canary/git-tag@9.25.1-canary.1110.14462.0
  npm install @auto-canary/gradle@9.25.1-canary.1110.14462.0
  npm install @auto-canary/jira@9.25.1-canary.1110.14462.0
  npm install @auto-canary/maven@9.25.1-canary.1110.14462.0
  npm install @auto-canary/npm@9.25.1-canary.1110.14462.0
  npm install @auto-canary/omit-commits@9.25.1-canary.1110.14462.0
  npm install @auto-canary/omit-release-notes@9.25.1-canary.1110.14462.0
  npm install @auto-canary/released@9.25.1-canary.1110.14462.0
  npm install @auto-canary/s3@9.25.1-canary.1110.14462.0
  npm install @auto-canary/slack@9.25.1-canary.1110.14462.0
  npm install @auto-canary/twitter@9.25.1-canary.1110.14462.0
  npm install @auto-canary/upload-assets@9.25.1-canary.1110.14462.0
  # or 
  yarn add @auto-canary/bot-list@9.25.1-canary.1110.14462.0
  yarn add @auto-canary/auto@9.25.1-canary.1110.14462.0
  yarn add @auto-canary/core@9.25.1-canary.1110.14462.0
  yarn add @auto-canary/all-contributors@9.25.1-canary.1110.14462.0
  yarn add @auto-canary/brew@9.25.1-canary.1110.14462.0
  yarn add @auto-canary/chrome@9.25.1-canary.1110.14462.0
  yarn add @auto-canary/cocoapods@9.25.1-canary.1110.14462.0
  yarn add @auto-canary/conventional-commits@9.25.1-canary.1110.14462.0
  yarn add @auto-canary/crates@9.25.1-canary.1110.14462.0
  yarn add @auto-canary/exec@9.25.1-canary.1110.14462.0
  yarn add @auto-canary/first-time-contributor@9.25.1-canary.1110.14462.0
  yarn add @auto-canary/gh-pages@9.25.1-canary.1110.14462.0
  yarn add @auto-canary/git-tag@9.25.1-canary.1110.14462.0
  yarn add @auto-canary/gradle@9.25.1-canary.1110.14462.0
  yarn add @auto-canary/jira@9.25.1-canary.1110.14462.0
  yarn add @auto-canary/maven@9.25.1-canary.1110.14462.0
  yarn add @auto-canary/npm@9.25.1-canary.1110.14462.0
  yarn add @auto-canary/omit-commits@9.25.1-canary.1110.14462.0
  yarn add @auto-canary/omit-release-notes@9.25.1-canary.1110.14462.0
  yarn add @auto-canary/released@9.25.1-canary.1110.14462.0
  yarn add @auto-canary/s3@9.25.1-canary.1110.14462.0
  yarn add @auto-canary/slack@9.25.1-canary.1110.14462.0
  yarn add @auto-canary/twitter@9.25.1-canary.1110.14462.0
  yarn add @auto-canary/upload-assets@9.25.1-canary.1110.14462.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
