### PR TITLE
Changelog bugs

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/match-sha-to-pr.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/match-sha-to-pr.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`buildSearchQuery generates a valid query 1`] = `
 "{
-    hash_abc123: search(query: \\"repo:Andrew/test abc123\\", type: ISSUE, first: 1) {
+    hash_abc123: search(query: \\"repo:Andrew/test abc123\\", type: ISSUE, first: 10) {
   edges {
     node {
       ... on PullRequest {
@@ -21,7 +21,7 @@ exports[`buildSearchQuery generates a valid query 1`] = `
   }
 }
 
-hash_3def78: search(query: \\"repo:Andrew/test 3def78\\", type: ISSUE, first: 1) {
+hash_3def78: search(query: \\"repo:Andrew/test 3def78\\", type: ISSUE, first: 10) {
   edges {
     node {
       ... on PullRequest {

--- a/packages/core/src/__tests__/__snapshots__/release.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/release.test.ts.snap
@@ -22,17 +22,6 @@ exports[`Release generateReleaseNotes should allow user to configure section hea
 - Adam Dierkens (adam@dierkens.com)"
 `;
 
-exports[`Release generateReleaseNotes should find ignore closed prs 1`] = `
-"#### 🐛 Bug Fix
-
-- Doom Patrol enabled (adam@dierkens.com)
-- Autobots roll out! (adam@dierkens.com)
-
-#### Authors: 1
-
-- Adam Dierkens (adam@dierkens.com)"
-`;
-
 exports[`Release generateReleaseNotes should find matching PRs for shas through search 1`] = `
 "#### 💥 Breaking Change
 
@@ -55,6 +44,17 @@ exports[`Release generateReleaseNotes should get extra user data for login 1`] =
 #### Authors: 1
 
 - Adam Dierkens ([@adierkens](https://github.com/adierkens))"
+`;
+
+exports[`Release generateReleaseNotes should ignore closed prs 1`] = `
+"#### 🐛 Bug Fix
+
+- Doom Patrol enabled (adam@dierkens.com)
+- Autobots roll out! (adam@dierkens.com)
+
+#### Authors: 1
+
+- Adam Dierkens (adam@dierkens.com)"
 `;
 
 exports[`Release generateReleaseNotes should include PR-less commits 1`] = `

--- a/packages/core/src/__tests__/release.test.ts
+++ b/packages/core/src/__tests__/release.test.ts
@@ -706,21 +706,24 @@ describe("Release", () => {
       graphql.mockReturnValueOnce({
         hash_1: {
           edges: [
-            { node: { labels: { edges: [{ node: { name: "major" } }] } } },
+            {
+              node: {
+                state: "MERGED",
+                labels: { edges: [{ node: { name: "major" } }] },
+              },
+            },
           ],
         },
-      });
-      // PR with no label, should become patch
-      graphql.mockReturnValueOnce({
+        // PR with no label, should become patch
         hash_2: {
-          edges: [{ node: { labels: undefined } }],
+          edges: [{ node: { state: "MERGED", labels: undefined } }],
         },
       });
 
       expect(await gh.generateReleaseNotes("1234", "123")).toMatchSnapshot();
     });
 
-    test("should find ignore closed prs", async () => {
+    test("should ignore closed prs", async () => {
       const gh = new Release(git);
 
       getGitLog.mockReturnValueOnce([
@@ -738,17 +741,16 @@ describe("Release", () => {
             {
               node: {
                 labels: {
-                  edges: [{ node: { name: "major", state: "CLOSED" } }],
+                  edges: [{ node: { name: "major" } }],
                 },
+                state: "CLOSED",
               },
             },
           ],
         },
-      });
-      // PR with no label, should become patch
-      graphql.mockReturnValueOnce({
+        // PR with no label, should become patch
         hash_2: {
-          edges: [{ node: { labels: undefined } }],
+          edges: [{ node: { labels: undefined, state: "MERGED" } }],
         },
       });
 


### PR DESCRIPTION
# What Changed

- Fix monorepo package bug => The packages were dissappearing
- Match SHAs only to merged PRs
- Fix an await problem

# Why

I was seeing commits get matched to open PRs when using a `next` branch

Todo:

- [ ] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.25.2-canary.1111.14474.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.25.2-canary.1111.14474.0
  npm install @auto-canary/auto@9.25.2-canary.1111.14474.0
  npm install @auto-canary/core@9.25.2-canary.1111.14474.0
  npm install @auto-canary/all-contributors@9.25.2-canary.1111.14474.0
  npm install @auto-canary/brew@9.25.2-canary.1111.14474.0
  npm install @auto-canary/chrome@9.25.2-canary.1111.14474.0
  npm install @auto-canary/cocoapods@9.25.2-canary.1111.14474.0
  npm install @auto-canary/conventional-commits@9.25.2-canary.1111.14474.0
  npm install @auto-canary/crates@9.25.2-canary.1111.14474.0
  npm install @auto-canary/exec@9.25.2-canary.1111.14474.0
  npm install @auto-canary/first-time-contributor@9.25.2-canary.1111.14474.0
  npm install @auto-canary/gh-pages@9.25.2-canary.1111.14474.0
  npm install @auto-canary/git-tag@9.25.2-canary.1111.14474.0
  npm install @auto-canary/gradle@9.25.2-canary.1111.14474.0
  npm install @auto-canary/jira@9.25.2-canary.1111.14474.0
  npm install @auto-canary/maven@9.25.2-canary.1111.14474.0
  npm install @auto-canary/npm@9.25.2-canary.1111.14474.0
  npm install @auto-canary/omit-commits@9.25.2-canary.1111.14474.0
  npm install @auto-canary/omit-release-notes@9.25.2-canary.1111.14474.0
  npm install @auto-canary/released@9.25.2-canary.1111.14474.0
  npm install @auto-canary/s3@9.25.2-canary.1111.14474.0
  npm install @auto-canary/slack@9.25.2-canary.1111.14474.0
  npm install @auto-canary/twitter@9.25.2-canary.1111.14474.0
  npm install @auto-canary/upload-assets@9.25.2-canary.1111.14474.0
  # or 
  yarn add @auto-canary/bot-list@9.25.2-canary.1111.14474.0
  yarn add @auto-canary/auto@9.25.2-canary.1111.14474.0
  yarn add @auto-canary/core@9.25.2-canary.1111.14474.0
  yarn add @auto-canary/all-contributors@9.25.2-canary.1111.14474.0
  yarn add @auto-canary/brew@9.25.2-canary.1111.14474.0
  yarn add @auto-canary/chrome@9.25.2-canary.1111.14474.0
  yarn add @auto-canary/cocoapods@9.25.2-canary.1111.14474.0
  yarn add @auto-canary/conventional-commits@9.25.2-canary.1111.14474.0
  yarn add @auto-canary/crates@9.25.2-canary.1111.14474.0
  yarn add @auto-canary/exec@9.25.2-canary.1111.14474.0
  yarn add @auto-canary/first-time-contributor@9.25.2-canary.1111.14474.0
  yarn add @auto-canary/gh-pages@9.25.2-canary.1111.14474.0
  yarn add @auto-canary/git-tag@9.25.2-canary.1111.14474.0
  yarn add @auto-canary/gradle@9.25.2-canary.1111.14474.0
  yarn add @auto-canary/jira@9.25.2-canary.1111.14474.0
  yarn add @auto-canary/maven@9.25.2-canary.1111.14474.0
  yarn add @auto-canary/npm@9.25.2-canary.1111.14474.0
  yarn add @auto-canary/omit-commits@9.25.2-canary.1111.14474.0
  yarn add @auto-canary/omit-release-notes@9.25.2-canary.1111.14474.0
  yarn add @auto-canary/released@9.25.2-canary.1111.14474.0
  yarn add @auto-canary/s3@9.25.2-canary.1111.14474.0
  yarn add @auto-canary/slack@9.25.2-canary.1111.14474.0
  yarn add @auto-canary/twitter@9.25.2-canary.1111.14474.0
  yarn add @auto-canary/upload-assets@9.25.2-canary.1111.14474.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
