### PR TITLE
--dry-run improvements

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1061,7 +1061,9 @@ export default class Auto {
       process.exit(0);
     }
 
-    await this.checkClean();
+    if (!args.dryRun) {
+      await this.checkClean();
+    }
 
     let { pr, build } = await this.getPrEnvInfo();
     pr = options.pr ? String(options.pr) : pr;
@@ -1179,7 +1181,10 @@ export default class Auto {
       process.exit(0);
     }
 
-    await this.checkClean();
+    if (!args.dryRun) {
+      await this.checkClean();
+    }
+
     await this.setGitUser();
 
     const lastRelease = await this.git.getLatestRelease();

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1407,7 +1407,7 @@ export default class Auto {
 
     const version = await this.getVersion(options);
 
-    this.logger.log.success(`Calculated version bump: ${version}`);
+    this.logger.log.success(`Calculated version bump: ${version || "none"}`);
 
     if (version === "") {
       this.logger.log.info("No version published.");
@@ -1591,7 +1591,9 @@ export default class Auto {
     // This will usually resolve to something on head
     const [err, latestTag] = await on(this.git.getLatestTagInBranch());
 
-    if (err?.message.includes("No names found")) {
+    // If its a dry run we want to show what would happen. Otherwise no
+    // tags indicates that something would definitely go wrong.
+    if (err?.message.includes("No names found") && !args.dryRun) {
       this.logger.log.error(
         endent`
           Could not find any tags in the local repository. Exiting early.


### PR DESCRIPTION
# What Changed

- When there were no tags in a repo `shipit --dry-run` would exit early always => no it allows the dry-run to go further
- Change `Calculated version bump: ` => `Calculated version bump: none`
- don't run checkClean during dry-runs

# Why

`shipit --dry-run` shouldn't produce errors in a new repo

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.25.3-canary.1114.14521.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.25.3-canary.1114.14521.0
  npm install @auto-canary/auto@9.25.3-canary.1114.14521.0
  npm install @auto-canary/core@9.25.3-canary.1114.14521.0
  npm install @auto-canary/all-contributors@9.25.3-canary.1114.14521.0
  npm install @auto-canary/brew@9.25.3-canary.1114.14521.0
  npm install @auto-canary/chrome@9.25.3-canary.1114.14521.0
  npm install @auto-canary/cocoapods@9.25.3-canary.1114.14521.0
  npm install @auto-canary/conventional-commits@9.25.3-canary.1114.14521.0
  npm install @auto-canary/crates@9.25.3-canary.1114.14521.0
  npm install @auto-canary/exec@9.25.3-canary.1114.14521.0
  npm install @auto-canary/first-time-contributor@9.25.3-canary.1114.14521.0
  npm install @auto-canary/gh-pages@9.25.3-canary.1114.14521.0
  npm install @auto-canary/git-tag@9.25.3-canary.1114.14521.0
  npm install @auto-canary/gradle@9.25.3-canary.1114.14521.0
  npm install @auto-canary/jira@9.25.3-canary.1114.14521.0
  npm install @auto-canary/maven@9.25.3-canary.1114.14521.0
  npm install @auto-canary/npm@9.25.3-canary.1114.14521.0
  npm install @auto-canary/omit-commits@9.25.3-canary.1114.14521.0
  npm install @auto-canary/omit-release-notes@9.25.3-canary.1114.14521.0
  npm install @auto-canary/released@9.25.3-canary.1114.14521.0
  npm install @auto-canary/s3@9.25.3-canary.1114.14521.0
  npm install @auto-canary/slack@9.25.3-canary.1114.14521.0
  npm install @auto-canary/twitter@9.25.3-canary.1114.14521.0
  npm install @auto-canary/upload-assets@9.25.3-canary.1114.14521.0
  # or 
  yarn add @auto-canary/bot-list@9.25.3-canary.1114.14521.0
  yarn add @auto-canary/auto@9.25.3-canary.1114.14521.0
  yarn add @auto-canary/core@9.25.3-canary.1114.14521.0
  yarn add @auto-canary/all-contributors@9.25.3-canary.1114.14521.0
  yarn add @auto-canary/brew@9.25.3-canary.1114.14521.0
  yarn add @auto-canary/chrome@9.25.3-canary.1114.14521.0
  yarn add @auto-canary/cocoapods@9.25.3-canary.1114.14521.0
  yarn add @auto-canary/conventional-commits@9.25.3-canary.1114.14521.0
  yarn add @auto-canary/crates@9.25.3-canary.1114.14521.0
  yarn add @auto-canary/exec@9.25.3-canary.1114.14521.0
  yarn add @auto-canary/first-time-contributor@9.25.3-canary.1114.14521.0
  yarn add @auto-canary/gh-pages@9.25.3-canary.1114.14521.0
  yarn add @auto-canary/git-tag@9.25.3-canary.1114.14521.0
  yarn add @auto-canary/gradle@9.25.3-canary.1114.14521.0
  yarn add @auto-canary/jira@9.25.3-canary.1114.14521.0
  yarn add @auto-canary/maven@9.25.3-canary.1114.14521.0
  yarn add @auto-canary/npm@9.25.3-canary.1114.14521.0
  yarn add @auto-canary/omit-commits@9.25.3-canary.1114.14521.0
  yarn add @auto-canary/omit-release-notes@9.25.3-canary.1114.14521.0
  yarn add @auto-canary/released@9.25.3-canary.1114.14521.0
  yarn add @auto-canary/s3@9.25.3-canary.1114.14521.0
  yarn add @auto-canary/slack@9.25.3-canary.1114.14521.0
  yarn add @auto-canary/twitter@9.25.3-canary.1114.14521.0
  yarn add @auto-canary/upload-assets@9.25.3-canary.1114.14521.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
