### PR TITLE
include first commit in changelogs

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/git.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/git.test.ts.snap
@@ -1,20 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`github getGitLog  1`] = `
-Array [
-  Object {
-    "authorEmail": "lisowski54@gmail.com",
-    "authorName": "Andrew Lisowski",
-    "files": Array [
-      "<PROJECT_ROOT>/src/__tests__/git.test.ts",
-    ],
-    "hash": "a7f6634429731055a5a44bae24ac88c5f9822e58",
-    "subject": "update tests
-",
-  },
-]
-`;
-
 exports[`github getGitLog - merge commits 1`] = `
 Object {
   "authorEmail": "lisowski54@gmail.com",
@@ -31,4 +16,73 @@ Object {
 
 determine if branch behind remote and exit before trying to publish",
 }
+`;
+
+exports[`github getGitLog 1`] = `
+Array [
+  Object {
+    "authorEmail": "lisowski54@gmail.com",
+    "authorName": "Andrew Lisowski",
+    "files": Array [
+      "<PROJECT_ROOT>/src/__tests__/git.test.ts",
+    ],
+    "hash": "a7f6634429731055a5a44bae24ac88c5f9822e58",
+    "subject": "update tests
+",
+  },
+  Object {
+    "authorEmail": "lisowski54@gmail.com",
+    "authorName": "Andrew Lisowski",
+    "files": Array [
+      "<PROJECT_ROOT>/.circleci/config.yml",
+      "<PROJECT_ROOT>/.gitignore",
+      "<PROJECT_ROOT>/.vscode/settings.json",
+      "<PROJECT_ROOT>/CHANGELOG.md",
+      "<PROJECT_ROOT>/LICENSE",
+      "<PROJECT_ROOT>/README.md",
+      "<PROJECT_ROOT>/package.json",
+      "<PROJECT_ROOT>/scripts/post-install.sh",
+      "<PROJECT_ROOT>/scripts/release.sh",
+      "<PROJECT_ROOT>/src/__tests__/__snapshots__/git.test.ts.snap",
+      "<PROJECT_ROOT>/src/__tests__/__snapshots__/log-parse.test.ts.snap",
+      "<PROJECT_ROOT>/src/__tests__/__snapshots__/main.test.ts.snap",
+      "<PROJECT_ROOT>/src/__tests__/git-changed-packages.test.ts",
+      "<PROJECT_ROOT>/src/__tests__/git.test.ts",
+      "<PROJECT_ROOT>/src/__tests__/github-responses/bad-credentials.json",
+      "<PROJECT_ROOT>/src/__tests__/github-responses/pr-labels.json",
+      "<PROJECT_ROOT>/src/__tests__/log-parse.test.ts",
+      "<PROJECT_ROOT>/src/__tests__/main.test.ts",
+      "<PROJECT_ROOT>/src/__tests__/make-commit-from-msg.ts",
+      "<PROJECT_ROOT>/src/__tests__/semver.test.ts",
+      "<PROJECT_ROOT>/src/auto-rc.json",
+      "<PROJECT_ROOT>/src/bin/__tests__/bin.test.ts",
+      "<PROJECT_ROOT>/src/bin/auto.ts",
+      "<PROJECT_ROOT>/src/cli/__tests__/args.test.ts",
+      "<PROJECT_ROOT>/src/cli/args.ts",
+      "<PROJECT_ROOT>/src/git.ts",
+      "<PROJECT_ROOT>/src/log-parse.ts",
+      "<PROJECT_ROOT>/src/main.ts",
+      "<PROJECT_ROOT>/src/semver.ts",
+      "<PROJECT_ROOT>/src/types/parse-git.d.ts",
+      "<PROJECT_ROOT>/src/types/registry-url.d.ts",
+      "<PROJECT_ROOT>/src/utils/__tests__/__snapshots__/slack.test.ts.snap",
+      "<PROJECT_ROOT>/src/utils/__tests__/exec-promise.test.ts",
+      "<PROJECT_ROOT>/src/utils/__tests__/github-token.test.ts",
+      "<PROJECT_ROOT>/src/utils/__tests__/package-config.test.ts",
+      "<PROJECT_ROOT>/src/utils/__tests__/slack.test.ts",
+      "<PROJECT_ROOT>/src/utils/exec-promise.ts",
+      "<PROJECT_ROOT>/src/utils/github-token.ts",
+      "<PROJECT_ROOT>/src/utils/logger.ts",
+      "<PROJECT_ROOT>/src/utils/package-config.ts",
+      "<PROJECT_ROOT>/src/utils/slack.ts",
+      "<PROJECT_ROOT>/tsconfig.build.json",
+      "<PROJECT_ROOT>/tsconfig.json",
+      "<PROJECT_ROOT>/tslint.json",
+      "<PROJECT_ROOT>/yarn.lock",
+    ],
+    "hash": "0b2af75d8b55c8869cda93d0e5589ad9f2677e18",
+    "subject": "init
+",
+  },
+]
 `;

--- a/packages/core/src/__tests__/git.test.ts
+++ b/packages/core/src/__tests__/git.test.ts
@@ -210,7 +210,7 @@ describe("github", () => {
     expect(await gh.getLastTagNotInBaseBranch("alpha")).toBe("0.4.0-alpha.1");
   });
 
-  test("getGitLog ", async () => {
+  test("getGitLog", async () => {
     const gh = new Git(options);
 
     expect(


### PR DESCRIPTION
# What Changed

The way were calculating the changelog would never include the initial commit. Now that commit will be included 🎉 

# Why

It seems like it should have always been included.

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.25.3-canary.1115.14520.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.25.3-canary.1115.14520.0
  npm install @auto-canary/auto@9.25.3-canary.1115.14520.0
  npm install @auto-canary/core@9.25.3-canary.1115.14520.0
  npm install @auto-canary/all-contributors@9.25.3-canary.1115.14520.0
  npm install @auto-canary/brew@9.25.3-canary.1115.14520.0
  npm install @auto-canary/chrome@9.25.3-canary.1115.14520.0
  npm install @auto-canary/cocoapods@9.25.3-canary.1115.14520.0
  npm install @auto-canary/conventional-commits@9.25.3-canary.1115.14520.0
  npm install @auto-canary/crates@9.25.3-canary.1115.14520.0
  npm install @auto-canary/exec@9.25.3-canary.1115.14520.0
  npm install @auto-canary/first-time-contributor@9.25.3-canary.1115.14520.0
  npm install @auto-canary/gh-pages@9.25.3-canary.1115.14520.0
  npm install @auto-canary/git-tag@9.25.3-canary.1115.14520.0
  npm install @auto-canary/gradle@9.25.3-canary.1115.14520.0
  npm install @auto-canary/jira@9.25.3-canary.1115.14520.0
  npm install @auto-canary/maven@9.25.3-canary.1115.14520.0
  npm install @auto-canary/npm@9.25.3-canary.1115.14520.0
  npm install @auto-canary/omit-commits@9.25.3-canary.1115.14520.0
  npm install @auto-canary/omit-release-notes@9.25.3-canary.1115.14520.0
  npm install @auto-canary/released@9.25.3-canary.1115.14520.0
  npm install @auto-canary/s3@9.25.3-canary.1115.14520.0
  npm install @auto-canary/slack@9.25.3-canary.1115.14520.0
  npm install @auto-canary/twitter@9.25.3-canary.1115.14520.0
  npm install @auto-canary/upload-assets@9.25.3-canary.1115.14520.0
  # or 
  yarn add @auto-canary/bot-list@9.25.3-canary.1115.14520.0
  yarn add @auto-canary/auto@9.25.3-canary.1115.14520.0
  yarn add @auto-canary/core@9.25.3-canary.1115.14520.0
  yarn add @auto-canary/all-contributors@9.25.3-canary.1115.14520.0
  yarn add @auto-canary/brew@9.25.3-canary.1115.14520.0
  yarn add @auto-canary/chrome@9.25.3-canary.1115.14520.0
  yarn add @auto-canary/cocoapods@9.25.3-canary.1115.14520.0
  yarn add @auto-canary/conventional-commits@9.25.3-canary.1115.14520.0
  yarn add @auto-canary/crates@9.25.3-canary.1115.14520.0
  yarn add @auto-canary/exec@9.25.3-canary.1115.14520.0
  yarn add @auto-canary/first-time-contributor@9.25.3-canary.1115.14520.0
  yarn add @auto-canary/gh-pages@9.25.3-canary.1115.14520.0
  yarn add @auto-canary/git-tag@9.25.3-canary.1115.14520.0
  yarn add @auto-canary/gradle@9.25.3-canary.1115.14520.0
  yarn add @auto-canary/jira@9.25.3-canary.1115.14520.0
  yarn add @auto-canary/maven@9.25.3-canary.1115.14520.0
  yarn add @auto-canary/npm@9.25.3-canary.1115.14520.0
  yarn add @auto-canary/omit-commits@9.25.3-canary.1115.14520.0
  yarn add @auto-canary/omit-release-notes@9.25.3-canary.1115.14520.0
  yarn add @auto-canary/released@9.25.3-canary.1115.14520.0
  yarn add @auto-canary/s3@9.25.3-canary.1115.14520.0
  yarn add @auto-canary/slack@9.25.3-canary.1115.14520.0
  yarn add @auto-canary/twitter@9.25.3-canary.1115.14520.0
  yarn add @auto-canary/upload-assets@9.25.3-canary.1115.14520.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
