### PR TITLE
Add most flags for version+changelog+release to shipit/latest

### DIFF
--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -186,10 +186,36 @@ const message: AutoOption = {
   alias: "m",
 };
 
+const changelogTitle: AutoOption = {
+  name: "title",
+  type: String,
+  group: "main",
+  description: "Override the title used in the addition to the CHANGELOG.md.",
+};
+
+const changelogCommitMessage: AutoOption = {
+  ...message,
+  description:
+    "Message to commit the changelog with. Defaults to 'Update CHANGELOG.md [skip ci]'",
+  config: true,
+};
+
 interface AutoCommand extends Command {
   /** Options for the command */
   options?: AutoOption[];
 }
+
+const latestCommandArgs: AutoOption[] = [
+  name,
+  email,
+  onlyPublishWithReleaseLabel,
+  baseBranch,
+  dryRun,
+  noVersionPrefix,
+  prerelease,
+  changelogTitle,
+  changelogCommitMessage,
+];
 
 export const commands: AutoCommand[] = [
   {
@@ -385,19 +411,8 @@ export const commands: AutoCommand[] = [
         group: "main",
         description: "Tag to end changelog generation on. Defaults to HEAD.",
       },
-      {
-        name: "title",
-        type: String,
-        group: "main",
-        description:
-          "Override the title used in the addition to the CHANGELOG.md.",
-      },
-      {
-        ...message,
-        description:
-          "Message to commit the changelog with. Defaults to 'Update CHANGELOG.md [skip ci]'",
-        config: true,
-      },
+      changelogTitle,
+      changelogCommitMessage,
       baseBranch,
     ],
     examples: [
@@ -455,9 +470,7 @@ export const commands: AutoCommand[] = [
     `,
     examples: ["{green $} auto shipit"],
     options: [
-      baseBranch,
-      dryRun,
-      onlyPublishWithReleaseLabel,
+      ...latestCommandArgs,
       {
         name: "only-graduate-with-release-label",
         type: Boolean,
@@ -467,10 +480,6 @@ export const commands: AutoCommand[] = [
           'Make auto publish prerelease versions when merging to master. Only PRs merged with "release" label will generate a "latest" release. Only use this flag if you do not want to maintain a prerelease branch, and instead only want to use master.',
         config: true,
       },
-      name,
-      email,
-      noVersionPrefix,
-      prerelease,
     ],
   },
   {
@@ -480,15 +489,7 @@ export const commands: AutoCommand[] = [
       Run the full \`auto\` release pipeline. Force a release to latest and bypass \`shipit\` safeguards.
     `,
     examples: ["{green $} auto latest"],
-    options: [
-      name,
-      email,
-      onlyPublishWithReleaseLabel,
-      baseBranch,
-      dryRun,
-      noVersionPrefix,
-      prerelease,
-    ],
+    options: latestCommandArgs,
   },
   {
     name: "canary",

--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -467,6 +467,7 @@ export const commands: AutoCommand[] = [
       },
       name,
       email,
+      noVersionPrefix,
     ],
   },
   {
@@ -476,7 +477,14 @@ export const commands: AutoCommand[] = [
       Run the full \`auto\` release pipeline. Force a release to latest and bypass \`shipit\` safeguards.
     `,
     examples: ["{green $} auto latest"],
-    options: [name, email, onlyPublishWithReleaseLabel, baseBranch, dryRun],
+    options: [
+      name,
+      email,
+      onlyPublishWithReleaseLabel,
+      baseBranch,
+      dryRun,
+      noVersionPrefix,
+    ],
   },
   {
     name: "canary",

--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -65,6 +65,14 @@ const version: AutoOption = {
   group: "global",
 };
 
+const prerelease: AutoOption = {
+  name: "prerelease",
+  type: Boolean,
+  group: "main",
+  description: "Publish a prerelease on GitHub.",
+  config: true,
+};
+
 const onlyPublishWithReleaseLabel: AutoOption = {
   name: "only-publish-with-release-label",
   type: Boolean,
@@ -427,13 +435,7 @@ export const commands: AutoCommand[] = [
           "Version number to publish as. Defaults to reading from the package definition for the platform.",
       },
       baseBranch,
-      {
-        name: "prerelease",
-        type: Boolean,
-        group: "main",
-        description: "Publish a prerelease.",
-        config: true,
-      },
+      prerelease,
     ],
     examples: [
       "{green $} auto release",
@@ -468,6 +470,7 @@ export const commands: AutoCommand[] = [
       name,
       email,
       noVersionPrefix,
+      prerelease,
     ],
   },
   {
@@ -484,6 +487,7 @@ export const commands: AutoCommand[] = [
       baseBranch,
       dryRun,
       noVersionPrefix,
+      prerelease,
     ],
   },
   {

--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -476,7 +476,7 @@ export const commands: AutoCommand[] = [
       Run the full \`auto\` release pipeline. Force a release to latest and bypass \`shipit\` safeguards.
     `,
     examples: ["{green $} auto latest"],
-    options: [name, email, baseBranch, dryRun],
+    options: [name, email, onlyPublishWithReleaseLabel, baseBranch, dryRun],
   },
   {
     name: "canary",

--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -465,6 +465,8 @@ export const commands: AutoCommand[] = [
           'Make auto publish prerelease versions when merging to master. Only PRs merged with "release" label will generate a "latest" release. Only use this flag if you do not want to maintain a prerelease branch, and instead only want to use master.',
         config: true,
       },
+      name,
+      email,
     ],
   },
   {
@@ -474,7 +476,7 @@ export const commands: AutoCommand[] = [
       Run the full \`auto\` release pipeline. Force a release to latest and bypass \`shipit\` safeguards.
     `,
     examples: ["{green $} auto latest"],
-    options: [baseBranch, dryRun],
+    options: [name, email, baseBranch, dryRun],
   },
   {
     name: "canary",

--- a/packages/core/src/auto-args.ts
+++ b/packages/core/src/auto-args.ts
@@ -49,62 +49,92 @@ export type IVersionOptions = ReleaseCalculationOptions & {
   from?: string;
 };
 
-export interface IChangelogOptions extends Partial<AuthorInformation> {
+interface NoVersionPrefix {
   /** Whether to prefix the version with a "v" */
   noVersionPrefix?: boolean;
+}
+
+interface DryRun {
   /** Do not actually do anything */
   dryRun?: boolean;
-  /** Commit to start calculating the changelog from */
-  from?: string;
-  /** Commit to start calculating the changelog to */
-  to?: string;
+}
+
+interface ChangelogMessage {
   /** The commit message to commit the changelog changes with */
   message?: string;
+}
+
+interface ChangelogTitle {
   /** Override the title use in the addition to the CHANGELOG.md. */
   title?: string;
 }
 
-export interface IReleaseOptions extends Partial<RepoInformation> {
-  /** Whether to prefix the version with a "v" */
-  noVersionPrefix?: boolean;
-  /** Do not actually do anything */
-  dryRun?: boolean;
-  /** Commit to start calculating the release from */
-  from?: string;
-  /** Override the version to release */
-  useVersion?: string;
+interface Prerelease {
   /** Create a prerelease */
   prerelease?: boolean;
 }
 
-export interface ICommentOptions {
+interface BaseBranch {
+  /** The branch to treat as the base. Default is master */
+  baseBranch?: string;
+}
+
+export type IChangelogOptions = BaseBranch &
+  ChangelogTitle &
+  ChangelogMessage &
+  DryRun &
+  NoVersionPrefix &
+  Partial<AuthorInformation> & {
+    /** Commit to start calculating the changelog from */
+    from?: string;
+    /** Commit to start calculating the changelog to */
+    to?: string;
+  };
+
+export type IReleaseOptions = BaseBranch &
+  Prerelease &
+  DryRun &
+  NoVersionPrefix &
+  Partial<AuthorInformation> &
+  Partial<RepoInformation> & {
+    /** Commit to start calculating the release from */
+    from?: string;
+    /** Override the version to release */
+    useVersion?: string;
+  };
+
+export type ICommentOptions = DryRun & {
   /** The message to use when commenting */
   message?: string;
   /** THe PR to comment on */
   pr?: number;
   /** The context the message should be attached to. Use to post multiple comments to a PR */
   context?: string;
-  /** Do not actually do anything */
-  dryRun?: boolean;
   /** Delete the previous comment */
   delete?: boolean;
   /** Instead of deleting/adding a new comment. Just edit the old one */
   edit?: boolean;
-}
+};
 
 export type IPRBodyOptions = Omit<ICommentOptions, "edit" | "delete">;
 
-export interface IShipItOptions {
-  /** Do not actually do anything */
-  dryRun?: boolean;
-  /**
-   * Make auto publish prerelease versions when merging to master.
-   * Only PRs merged with "release" label will generate a "latest" release.
-   * Only use this flag if you do not want to maintain a prerelease branch,
-   * and instead only want to use master.
-   */
-  onlyGraduateWithReleaseLabel?: boolean;
-}
+export type IShipItOptions = BaseBranch &
+  Prerelease &
+  NoVersionPrefix &
+  ChangelogMessage &
+  ChangelogTitle &
+  DryRun &
+  Partial<AuthorInformation> &
+  Partial<RepoInformation> &
+  ReleaseCalculationOptions & {
+    /**
+     * Make auto publish prerelease versions when merging to master.
+     * Only PRs merged with "release" label will generate a "latest" release.
+     * Only use this flag if you do not want to maintain a prerelease branch,
+     * and instead only want to use master.
+     */
+    onlyGraduateWithReleaseLabel?: boolean;
+  };
 
 export interface ICanaryOptions {
   /** Do not actually do anything */

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1269,8 +1269,8 @@ export default class Auto {
    * 4. Create a release
    */
   async shipit(args: IShipItOptions = {}) {
-    const options: IShipItOptions = {
-      ...this.getCommandDefault("shipit"),
+    const options = {
+      ...(this.getCommandDefault("shipit") as IShipItOptions),
       ...args,
     };
 


### PR DESCRIPTION
# What Changed

Shipit runs `version+changelog+release` and should supports all the flags they do (at least the ones that makes sense).

This PR adds the following flags to shipit/latest:

- name
- email
- onlyPublishWithReleaseLabel
- noVersionPrefix
- prerelease
- title
- message

# Why

closes #1116 


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.25.4-canary.1117.14538.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.25.4-canary.1117.14538.0
  npm install @auto-canary/auto@9.25.4-canary.1117.14538.0
  npm install @auto-canary/core@9.25.4-canary.1117.14538.0
  npm install @auto-canary/all-contributors@9.25.4-canary.1117.14538.0
  npm install @auto-canary/brew@9.25.4-canary.1117.14538.0
  npm install @auto-canary/chrome@9.25.4-canary.1117.14538.0
  npm install @auto-canary/cocoapods@9.25.4-canary.1117.14538.0
  npm install @auto-canary/conventional-commits@9.25.4-canary.1117.14538.0
  npm install @auto-canary/crates@9.25.4-canary.1117.14538.0
  npm install @auto-canary/exec@9.25.4-canary.1117.14538.0
  npm install @auto-canary/first-time-contributor@9.25.4-canary.1117.14538.0
  npm install @auto-canary/gh-pages@9.25.4-canary.1117.14538.0
  npm install @auto-canary/git-tag@9.25.4-canary.1117.14538.0
  npm install @auto-canary/gradle@9.25.4-canary.1117.14538.0
  npm install @auto-canary/jira@9.25.4-canary.1117.14538.0
  npm install @auto-canary/maven@9.25.4-canary.1117.14538.0
  npm install @auto-canary/npm@9.25.4-canary.1117.14538.0
  npm install @auto-canary/omit-commits@9.25.4-canary.1117.14538.0
  npm install @auto-canary/omit-release-notes@9.25.4-canary.1117.14538.0
  npm install @auto-canary/released@9.25.4-canary.1117.14538.0
  npm install @auto-canary/s3@9.25.4-canary.1117.14538.0
  npm install @auto-canary/slack@9.25.4-canary.1117.14538.0
  npm install @auto-canary/twitter@9.25.4-canary.1117.14538.0
  npm install @auto-canary/upload-assets@9.25.4-canary.1117.14538.0
  # or 
  yarn add @auto-canary/bot-list@9.25.4-canary.1117.14538.0
  yarn add @auto-canary/auto@9.25.4-canary.1117.14538.0
  yarn add @auto-canary/core@9.25.4-canary.1117.14538.0
  yarn add @auto-canary/all-contributors@9.25.4-canary.1117.14538.0
  yarn add @auto-canary/brew@9.25.4-canary.1117.14538.0
  yarn add @auto-canary/chrome@9.25.4-canary.1117.14538.0
  yarn add @auto-canary/cocoapods@9.25.4-canary.1117.14538.0
  yarn add @auto-canary/conventional-commits@9.25.4-canary.1117.14538.0
  yarn add @auto-canary/crates@9.25.4-canary.1117.14538.0
  yarn add @auto-canary/exec@9.25.4-canary.1117.14538.0
  yarn add @auto-canary/first-time-contributor@9.25.4-canary.1117.14538.0
  yarn add @auto-canary/gh-pages@9.25.4-canary.1117.14538.0
  yarn add @auto-canary/git-tag@9.25.4-canary.1117.14538.0
  yarn add @auto-canary/gradle@9.25.4-canary.1117.14538.0
  yarn add @auto-canary/jira@9.25.4-canary.1117.14538.0
  yarn add @auto-canary/maven@9.25.4-canary.1117.14538.0
  yarn add @auto-canary/npm@9.25.4-canary.1117.14538.0
  yarn add @auto-canary/omit-commits@9.25.4-canary.1117.14538.0
  yarn add @auto-canary/omit-release-notes@9.25.4-canary.1117.14538.0
  yarn add @auto-canary/released@9.25.4-canary.1117.14538.0
  yarn add @auto-canary/s3@9.25.4-canary.1117.14538.0
  yarn add @auto-canary/slack@9.25.4-canary.1117.14538.0
  yarn add @auto-canary/twitter@9.25.4-canary.1117.14538.0
  yarn add @auto-canary/upload-assets@9.25.4-canary.1117.14538.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
