### PR TITLE
Cocoapods -> CocoaPods

### DIFF
--- a/plugins/cocoapods/README.md
+++ b/plugins/cocoapods/README.md
@@ -1,6 +1,6 @@
-# Cocoapods Plugin
+# CocoaPods Plugin
 
-Use `auto` to version your [Cocoapod](https://cocoapods.org/), and push to your specs repository!
+Use `auto` to version your [CocoaPod](https://cocoapods.org/), and push to your specs repository!
 
 ## Installation
 
@@ -35,14 +35,14 @@ yarn add -D @auto-it/cocoapods
 
 ### General
 
-- The machine running this plugin must have the [Cocoapods](https://cocoapods.org/) `pod` CLI installed already.
+- The machine running this plugin must have the [CocoapPods](https://cocoapods.org/) `pod` CLI installed already.
 
 - Your `podspec` file must pass `pod lib lint` in order for publishing to a Specs repository to work.
 
-### Pushing to the Cocoapods Trunk
+### Pushing to the CocoaPods Trunk
 
-If a `specsRepo` is not provided in the plugin options, this plugin will push to the cocoapods trunk repository. This requires that the machine running this has followed the steps for pushing to trunk, the guide for that can be found [here](https://guides.cocoapods.org/making/getting-setup-with-trunk.html#getting-started).
+If a `specsRepo` is not provided in the plugin options, this plugin will push to the CocoaPods trunk repository. This requires that the machine running this has followed the steps for pushing to trunk, the guide for that can be found [here](https://guides.cocoapods.org/making/getting-setup-with-trunk.html#getting-started).
 
 ### Pushing to a private specs repo
 
-If `specsRepo` is provided in the configuration, this plugin will add that repo under a temporary name, push to it, and remove the repo from the cocoapods installation on the machine. The machine that is running the plugin must have the appropriate git credentials to push to that repository.
+If `specsRepo` is provided in the configuration, this plugin will add that repo under a temporary name, push to it, and remove the repo from the CocoaPods installation on the machine. The machine that is running the plugin must have the appropriate git credentials to push to that repository.

--- a/plugins/cocoapods/README.md
+++ b/plugins/cocoapods/README.md
@@ -35,7 +35,7 @@ yarn add -D @auto-it/cocoapods
 
 ### General
 
-- The machine running this plugin must have the [CocoapPods](https://cocoapods.org/) `pod` CLI installed already.
+- The machine running this plugin must have the [CocoaPods](https://cocoapods.org/) `pod` CLI installed already.
 
 - Your `podspec` file must pass `pod lib lint` in order for publishing to a Specs repository to work.
 


### PR DESCRIPTION
# What Changed

Fixed capitalization 

# Why

Well... You wouldn't want to call GitHub Github 🍡 