### PR TITLE
fix: push to master w/--only-publish-with-release-label creating release

### DIFF
--- a/packages/core/src/__tests__/semver.test.ts
+++ b/packages/core/src/__tests__/semver.test.ts
@@ -50,9 +50,17 @@ describe("calculateSemVerBump", () => {
     );
   });
 
-  test("should respect onlyPublishWithReleaseLabel when no labels present", () => {
+  test("should respect onlyPublishWithReleaseLabel when no labels present on PR", () => {
     expect(
       calculateSemVerBump([[]], semverMap, {
+        onlyPublishWithReleaseLabel: true,
+      })
+    ).toBe(SEMVER.noVersion);
+  });
+
+  test("should respect onlyPublishWithReleaseLabel when no labels present on push to master", () => {
+    expect(
+      calculateSemVerBump([], semverMap, {
         onlyPublishWithReleaseLabel: true,
       })
     ).toBe(SEMVER.noVersion);

--- a/packages/core/src/semver.ts
+++ b/packages/core/src/semver.ts
@@ -64,15 +64,11 @@ export function calculateSemVerBump(
     });
   });
 
-  let skipRelease = false;
-
-  if (labels.length > 0) {
-    const releaseLabels = labelMap.get("release") || [];
-
-    skipRelease = onlyPublishWithReleaseLabel
-      ? !labels[0].some((label) => releaseLabels.includes(label))
-      : labels[0].some((label) => skipReleaseLabels.includes(label));
-  }
+  const lastMergedCommitLabels = labels[0] || [];
+  const releaseLabels = labelMap.get("release") || [];
+  const skipRelease = onlyPublishWithReleaseLabel
+    ? !lastMergedCommitLabels.some((label) => releaseLabels.includes(label))
+    : lastMergedCommitLabels.some((label) => skipReleaseLabels.includes(label));
 
   // If PRs only have none or skip labels, skip the release
   const onlyNoReleaseLabels = [...labelSet].reduce(


### PR DESCRIPTION
# What Changed

`--dry-run` before:

```
/usr/local/bin/npx auto shipit --dry-run --only-publish-with-release-label --repo auto-action --owner terradatum --plugins npm released

✔  success   Calculated version bump: patch
ℹ  info      Potential Changelog Addition:
 
ℹ  info      Current "Latest Release" on Github: v1.0.5
ℹ  info      Using release notes:

ℹ  info      Would have created a release on GitHub for version: 1.0.6
●  note      The above version would only get released if ran with "shipit" or a custom script that bumps the version using the "version" command
⚠  warning   Published version would be: 1.0.6
```

`--dry-run` after:

```
/usr/local/bin/npx auto shipit --dry-run --only-publish-with-release-label --repo auto-action --owner terradatum --plugins npm released

✔  success   Calculated version bump: none
ℹ  info      No version published.
```

# Why

closes #1119 

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.26.1-canary.1121.14567.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.26.1-canary.1121.14567.0
  npm install @auto-canary/auto@9.26.1-canary.1121.14567.0
  npm install @auto-canary/core@9.26.1-canary.1121.14567.0
  npm install @auto-canary/all-contributors@9.26.1-canary.1121.14567.0
  npm install @auto-canary/brew@9.26.1-canary.1121.14567.0
  npm install @auto-canary/chrome@9.26.1-canary.1121.14567.0
  npm install @auto-canary/cocoapods@9.26.1-canary.1121.14567.0
  npm install @auto-canary/conventional-commits@9.26.1-canary.1121.14567.0
  npm install @auto-canary/crates@9.26.1-canary.1121.14567.0
  npm install @auto-canary/exec@9.26.1-canary.1121.14567.0
  npm install @auto-canary/first-time-contributor@9.26.1-canary.1121.14567.0
  npm install @auto-canary/gh-pages@9.26.1-canary.1121.14567.0
  npm install @auto-canary/git-tag@9.26.1-canary.1121.14567.0
  npm install @auto-canary/gradle@9.26.1-canary.1121.14567.0
  npm install @auto-canary/jira@9.26.1-canary.1121.14567.0
  npm install @auto-canary/maven@9.26.1-canary.1121.14567.0
  npm install @auto-canary/npm@9.26.1-canary.1121.14567.0
  npm install @auto-canary/omit-commits@9.26.1-canary.1121.14567.0
  npm install @auto-canary/omit-release-notes@9.26.1-canary.1121.14567.0
  npm install @auto-canary/released@9.26.1-canary.1121.14567.0
  npm install @auto-canary/s3@9.26.1-canary.1121.14567.0
  npm install @auto-canary/slack@9.26.1-canary.1121.14567.0
  npm install @auto-canary/twitter@9.26.1-canary.1121.14567.0
  npm install @auto-canary/upload-assets@9.26.1-canary.1121.14567.0
  # or 
  yarn add @auto-canary/bot-list@9.26.1-canary.1121.14567.0
  yarn add @auto-canary/auto@9.26.1-canary.1121.14567.0
  yarn add @auto-canary/core@9.26.1-canary.1121.14567.0
  yarn add @auto-canary/all-contributors@9.26.1-canary.1121.14567.0
  yarn add @auto-canary/brew@9.26.1-canary.1121.14567.0
  yarn add @auto-canary/chrome@9.26.1-canary.1121.14567.0
  yarn add @auto-canary/cocoapods@9.26.1-canary.1121.14567.0
  yarn add @auto-canary/conventional-commits@9.26.1-canary.1121.14567.0
  yarn add @auto-canary/crates@9.26.1-canary.1121.14567.0
  yarn add @auto-canary/exec@9.26.1-canary.1121.14567.0
  yarn add @auto-canary/first-time-contributor@9.26.1-canary.1121.14567.0
  yarn add @auto-canary/gh-pages@9.26.1-canary.1121.14567.0
  yarn add @auto-canary/git-tag@9.26.1-canary.1121.14567.0
  yarn add @auto-canary/gradle@9.26.1-canary.1121.14567.0
  yarn add @auto-canary/jira@9.26.1-canary.1121.14567.0
  yarn add @auto-canary/maven@9.26.1-canary.1121.14567.0
  yarn add @auto-canary/npm@9.26.1-canary.1121.14567.0
  yarn add @auto-canary/omit-commits@9.26.1-canary.1121.14567.0
  yarn add @auto-canary/omit-release-notes@9.26.1-canary.1121.14567.0
  yarn add @auto-canary/released@9.26.1-canary.1121.14567.0
  yarn add @auto-canary/s3@9.26.1-canary.1121.14567.0
  yarn add @auto-canary/slack@9.26.1-canary.1121.14567.0
  yarn add @auto-canary/twitter@9.26.1-canary.1121.14567.0
  yarn add @auto-canary/upload-assets@9.26.1-canary.1121.14567.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
