### PR TITLE
ensure commits pushed directly to next branch are labelled correctly in next-PR changelog

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/match-sha-to-pr.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/match-sha-to-pr.test.ts.snap
@@ -9,6 +9,10 @@ exports[`buildSearchQuery generates a valid query 1`] = `
         number
         state
         body
+        headRefName
+        headRepositoryOwner {
+          login
+        }
         labels(first: 10) {
           edges {
             node {
@@ -28,6 +32,10 @@ hash_3def78: search(query: \\"repo:Andrew/test 3def78\\", type: ISSUE, first: 10
         number
         state
         body
+        headRefName
+        headRepositoryOwner {
+          login
+        }
         labels(first: 10) {
           edges {
             node {

--- a/packages/core/src/__tests__/__snapshots__/release.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/release.test.ts.snap
@@ -22,6 +22,20 @@ exports[`Release generateReleaseNotes should allow user to configure section hea
 - Adam Dierkens (adam@dierkens.com)"
 `;
 
+exports[`Release generateReleaseNotes should detect pre-release branches 1`] = `
+"#### 🐛 Bug Fix
+
+- Autobots roll out! (adam@dierkens.com)
+
+#### ⚠️  Pushed to \`next\`
+
+- Doom Patrol enabled (adam@dierkens.com)
+
+#### Authors: 1
+
+- Adam Dierkens (adam@dierkens.com)"
+`;
+
 exports[`Release generateReleaseNotes should find matching PRs for shas through search 1`] = `
 "#### 💥 Breaking Change
 

--- a/packages/core/src/changelog.ts
+++ b/packages/core/src/changelog.ts
@@ -95,12 +95,15 @@ export default class Changelog {
           currentBranch) ||
         options.baseBranch;
 
-      this.options.labels.push({
-        name: "pushToBaseBranch",
-        changelogTitle: `⚠️  Pushed to \`${branch}\``,
-        description: "N/A",
-        releaseType: SEMVER.patch,
-      });
+      this.options.labels = [
+        ...this.options.labels,
+        {
+          name: "pushToBaseBranch",
+          changelogTitle: `⚠️  Pushed to \`${branch}\``,
+          description: "N/A",
+          releaseType: SEMVER.patch,
+        },
+      ];
     }
   }
 

--- a/packages/core/src/match-sha-to-pr.ts
+++ b/packages/core/src/match-sha-to-pr.ts
@@ -12,6 +12,13 @@ interface ISearchEdge {
     state: "MERGED" | "CLOSED" | "OPEN";
     /** Body of the PR */
     body: string;
+    /** Name of the branch the PR was made from */
+    headRefName: string;
+    /** Use of the fork the PR was made from */
+    headRepositoryOwner: {
+      /** Username of the owner of the fork the PR was made from */
+      login: string;
+    };
     /** Labels attached to the PR */
     labels: {
       /** Edges of the Query */
@@ -56,6 +63,10 @@ export function buildSearchQuery(
               number
               state
               body
+              headRefName
+              headRepositoryOwner {
+                login
+              }
               labels(first: 10) {
                 edges {
                   node {
@@ -86,12 +97,25 @@ export function buildSearchQuery(
 }
 
 /** Use the graphql query result to fill in more information about a commit */
-export function processQueryResult(
-  key: string,
-  result: ISearchResult,
-  commitsWithoutPR: IExtendedCommit[]
-) {
-  const hash = key.split("hash_")[1];
+export function processQueryResult({
+  owner,
+  sha,
+  result,
+  commitsWithoutPR,
+  prereleaseBranches,
+}: {
+  /** The owner of the main fork of the repo to automate releases for */
+  owner: string;
+  /** The commit sha to process */
+  sha: string;
+  /** The graphql response for the search query hash */
+  result: ISearchResult;
+  /** Commits that do not yet have a PR matched to them */
+  commitsWithoutPR: IExtendedCommit[];
+  /** Branches to treat as pre-releases */
+  prereleaseBranches: string[];
+}) {
+  const hash = sha.split("hash_")[1];
   const commit = commitsWithoutPR.find(
     (commitWithoutPR) => commitWithoutPR.hash === hash
   );
@@ -103,6 +127,11 @@ export function processQueryResult(
   // When matching SHA to PR only take merged into account. You can have
   // multiple open PRs with the same commits, such as in a rebase.
   const prs = result.edges.filter((edge) => edge.node.state === "MERGED");
+  const isInPrerelease = result.edges.filter(
+    (edge) =>
+      prereleaseBranches.includes(edge.node.headRefName) &&
+      edge.node.headRepositoryOwner.login === owner
+  );
 
   if (prs.length) {
     const pr = prs[0].node;
@@ -114,7 +143,7 @@ export function processQueryResult(
       body: pr.body,
     };
     commit.labels = [...labels.map((label) => label.name), ...commit.labels];
-  } else if (!result.edges.length) {
+  } else if (!result.edges.length || isInPrerelease.length) {
     commit.labels = ["pushToBaseBranch", ...commit.labels];
   }
 

--- a/packages/core/src/release.ts
+++ b/packages/core/src/release.ts
@@ -276,7 +276,13 @@ export default class Release {
           Boolean(result[1])
         )
         .map(([key, result]) =>
-          processQueryResult(key, result, commitsWithoutPR)
+          processQueryResult({
+            sha: key,
+            result,
+            commitsWithoutPR,
+            owner: this.git.options.owner,
+            prereleaseBranches: this.config.prereleaseBranches,
+          })
         )
         .filter((commit): commit is IExtendedCommit => Boolean(commit))
         .map(async (commit) => {


### PR DESCRIPTION
# What Changed

see title

# Why

In the next branch PR in our internal repo every commit pushed to the next branch was labelled as a `bug` instead of being in the `Push to \`next\`` section.

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.26.2-canary.1123.14579.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.26.2-canary.1123.14579.0
  npm install @auto-canary/auto@9.26.2-canary.1123.14579.0
  npm install @auto-canary/core@9.26.2-canary.1123.14579.0
  npm install @auto-canary/all-contributors@9.26.2-canary.1123.14579.0
  npm install @auto-canary/brew@9.26.2-canary.1123.14579.0
  npm install @auto-canary/chrome@9.26.2-canary.1123.14579.0
  npm install @auto-canary/cocoapods@9.26.2-canary.1123.14579.0
  npm install @auto-canary/conventional-commits@9.26.2-canary.1123.14579.0
  npm install @auto-canary/crates@9.26.2-canary.1123.14579.0
  npm install @auto-canary/exec@9.26.2-canary.1123.14579.0
  npm install @auto-canary/first-time-contributor@9.26.2-canary.1123.14579.0
  npm install @auto-canary/gh-pages@9.26.2-canary.1123.14579.0
  npm install @auto-canary/git-tag@9.26.2-canary.1123.14579.0
  npm install @auto-canary/gradle@9.26.2-canary.1123.14579.0
  npm install @auto-canary/jira@9.26.2-canary.1123.14579.0
  npm install @auto-canary/maven@9.26.2-canary.1123.14579.0
  npm install @auto-canary/npm@9.26.2-canary.1123.14579.0
  npm install @auto-canary/omit-commits@9.26.2-canary.1123.14579.0
  npm install @auto-canary/omit-release-notes@9.26.2-canary.1123.14579.0
  npm install @auto-canary/released@9.26.2-canary.1123.14579.0
  npm install @auto-canary/s3@9.26.2-canary.1123.14579.0
  npm install @auto-canary/slack@9.26.2-canary.1123.14579.0
  npm install @auto-canary/twitter@9.26.2-canary.1123.14579.0
  npm install @auto-canary/upload-assets@9.26.2-canary.1123.14579.0
  # or 
  yarn add @auto-canary/bot-list@9.26.2-canary.1123.14579.0
  yarn add @auto-canary/auto@9.26.2-canary.1123.14579.0
  yarn add @auto-canary/core@9.26.2-canary.1123.14579.0
  yarn add @auto-canary/all-contributors@9.26.2-canary.1123.14579.0
  yarn add @auto-canary/brew@9.26.2-canary.1123.14579.0
  yarn add @auto-canary/chrome@9.26.2-canary.1123.14579.0
  yarn add @auto-canary/cocoapods@9.26.2-canary.1123.14579.0
  yarn add @auto-canary/conventional-commits@9.26.2-canary.1123.14579.0
  yarn add @auto-canary/crates@9.26.2-canary.1123.14579.0
  yarn add @auto-canary/exec@9.26.2-canary.1123.14579.0
  yarn add @auto-canary/first-time-contributor@9.26.2-canary.1123.14579.0
  yarn add @auto-canary/gh-pages@9.26.2-canary.1123.14579.0
  yarn add @auto-canary/git-tag@9.26.2-canary.1123.14579.0
  yarn add @auto-canary/gradle@9.26.2-canary.1123.14579.0
  yarn add @auto-canary/jira@9.26.2-canary.1123.14579.0
  yarn add @auto-canary/maven@9.26.2-canary.1123.14579.0
  yarn add @auto-canary/npm@9.26.2-canary.1123.14579.0
  yarn add @auto-canary/omit-commits@9.26.2-canary.1123.14579.0
  yarn add @auto-canary/omit-release-notes@9.26.2-canary.1123.14579.0
  yarn add @auto-canary/released@9.26.2-canary.1123.14579.0
  yarn add @auto-canary/s3@9.26.2-canary.1123.14579.0
  yarn add @auto-canary/slack@9.26.2-canary.1123.14579.0
  yarn add @auto-canary/twitter@9.26.2-canary.1123.14579.0
  yarn add @auto-canary/upload-assets@9.26.2-canary.1123.14579.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
