### PR TITLE
Improve next branch preview changelog

### DIFF
--- a/packages/core/src/__tests__/auto-in-pr-ci.test.ts
+++ b/packages/core/src/__tests__/auto-in-pr-ci.test.ts
@@ -3,6 +3,13 @@ import SEMVER from "../semver";
 import { dummyLog } from "../utils/logger";
 import makeCommitFromMsg from "./make-commit-from-msg";
 import endent from "endent";
+import execPromise from "../utils/exec-promise";
+
+const exec = jest.fn();
+jest.mock("../utils/exec-promise");
+// @ts-ignore
+execPromise.mockImplementation(exec);
+exec.mockResolvedValue("");
 
 jest.mock("env-ci", () => () => ({
   pr: 123,
@@ -160,6 +167,7 @@ describe("next in ci", () => {
   test("should post comment with new version", async () => {
     const auto = new Auto({ ...defaults, plugins: [] });
 
+    exec.mockResolvedValue("v1.0.0");
     // @ts-ignore
     auto.checkClean = () => Promise.resolve(true);
     const prBody = jest.fn();

--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -1195,6 +1195,7 @@ describe("Auto", () => {
       auto.checkClean = () => Promise.resolve(true);
       auto.logger = dummyLog();
       await auto.loadConfig();
+      auto.remote = "origin";
       auto.git!.getProject = () => Promise.resolve({ data: {} } as any);
       auto.git!.getLatestRelease = () => Promise.resolve("1.2.3");
       auto.release!.generateReleaseNotes = () => Promise.resolve("notes");
@@ -1217,6 +1218,7 @@ describe("Auto", () => {
       auto.checkClean = () => Promise.resolve(true);
       auto.logger = dummyLog();
       await auto.loadConfig();
+      auto.remote = "origin";
       auto.git!.publish = () => Promise.resolve({} as any);
       auto.git!.getLatestTagInBranch = () => Promise.resolve("1.2.3");
       auto.git!.getLatestRelease = () => Promise.resolve("1.2.3");

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1188,7 +1188,9 @@ export default class Auto {
     await this.setGitUser();
 
     const lastRelease = await this.git.getLatestRelease();
-    const lastTag = await this.git.getLatestTagInBranch();
+    const lastTag = await this.git.getTagNotInBaseBranch(getCurrentBranch()!, {
+      first: true,
+    });
     const commits = await this.release.getCommitsInRelease(lastTag);
     const releaseNotes = await this.release.generateReleaseNotes(lastTag);
     const labels = commits.map((commit) => commit.labels);
@@ -1198,8 +1200,9 @@ export default class Auto {
 
     if (options.dryRun) {
       this.logger.log.success(
-        `Would have created prerelease version with: ${bump}`
+        `Would have created prerelease version with: ${bump} from ${lastTag}`
       );
+      this.logger.log.info(releaseNotes);
 
       return { newVersion: "", commitsInRelease: commits, context: "next" };
     }
@@ -1549,7 +1552,7 @@ export default class Auto {
     const bump = await this.release.getSemverBump(lastRelease, to);
     const releaseNotes = await this.release.generateReleaseNotes(
       lastRelease,
-      to || undefined,
+      to,
       this.versionBump
     );
 

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -303,7 +303,7 @@ export default class Auto {
   options: ApiOptions;
   /** The branch auto uses as master. */
   baseBranch: string;
-  /** The remote git to push changes to */
+  /** The remote git to push changes to. This is the full URL with auth */
   remote!: string;
   /** The user configuration of auto (.autorc) */
   config?: LoadedAutoRc;
@@ -1193,7 +1193,7 @@ export default class Auto {
         await execPromise("git", [
           "rev-list",
           "--boundary",
-          `${currentBranch}...${this.remote}/${this.baseBranch}`,
+          `${currentBranch}...origin/${this.baseBranch}`,
           "--left-only",
         ])
       )

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1193,7 +1193,7 @@ export default class Auto {
         await execPromise("git", [
           "rev-list",
           "--boundary",
-          `${currentBranch}...master`,
+          `${currentBranch}...${this.remote}/${this.baseBranch}`,
           "--left-only",
         ])
       )


### PR DESCRIPTION
# What Changed

The preview changelog in a prerelease branch PR will now include a changelog that starts at the initial fork commit instead of the first unique tag. Waiting for the first tag ignores commits pushed directly to the next branch before that tag.

# Why

Changelogs should have all the changes!

Todo:

- [ ] Add tests
- [ ] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.26.3-canary.1132.14691.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.26.3-canary.1132.14691.0
  npm install @auto-canary/auto@9.26.3-canary.1132.14691.0
  npm install @auto-canary/core@9.26.3-canary.1132.14691.0
  npm install @auto-canary/all-contributors@9.26.3-canary.1132.14691.0
  npm install @auto-canary/brew@9.26.3-canary.1132.14691.0
  npm install @auto-canary/chrome@9.26.3-canary.1132.14691.0
  npm install @auto-canary/cocoapods@9.26.3-canary.1132.14691.0
  npm install @auto-canary/conventional-commits@9.26.3-canary.1132.14691.0
  npm install @auto-canary/crates@9.26.3-canary.1132.14691.0
  npm install @auto-canary/exec@9.26.3-canary.1132.14691.0
  npm install @auto-canary/first-time-contributor@9.26.3-canary.1132.14691.0
  npm install @auto-canary/gh-pages@9.26.3-canary.1132.14691.0
  npm install @auto-canary/git-tag@9.26.3-canary.1132.14691.0
  npm install @auto-canary/gradle@9.26.3-canary.1132.14691.0
  npm install @auto-canary/jira@9.26.3-canary.1132.14691.0
  npm install @auto-canary/maven@9.26.3-canary.1132.14691.0
  npm install @auto-canary/npm@9.26.3-canary.1132.14691.0
  npm install @auto-canary/omit-commits@9.26.3-canary.1132.14691.0
  npm install @auto-canary/omit-release-notes@9.26.3-canary.1132.14691.0
  npm install @auto-canary/released@9.26.3-canary.1132.14691.0
  npm install @auto-canary/s3@9.26.3-canary.1132.14691.0
  npm install @auto-canary/slack@9.26.3-canary.1132.14691.0
  npm install @auto-canary/twitter@9.26.3-canary.1132.14691.0
  npm install @auto-canary/upload-assets@9.26.3-canary.1132.14691.0
  # or 
  yarn add @auto-canary/bot-list@9.26.3-canary.1132.14691.0
  yarn add @auto-canary/auto@9.26.3-canary.1132.14691.0
  yarn add @auto-canary/core@9.26.3-canary.1132.14691.0
  yarn add @auto-canary/all-contributors@9.26.3-canary.1132.14691.0
  yarn add @auto-canary/brew@9.26.3-canary.1132.14691.0
  yarn add @auto-canary/chrome@9.26.3-canary.1132.14691.0
  yarn add @auto-canary/cocoapods@9.26.3-canary.1132.14691.0
  yarn add @auto-canary/conventional-commits@9.26.3-canary.1132.14691.0
  yarn add @auto-canary/crates@9.26.3-canary.1132.14691.0
  yarn add @auto-canary/exec@9.26.3-canary.1132.14691.0
  yarn add @auto-canary/first-time-contributor@9.26.3-canary.1132.14691.0
  yarn add @auto-canary/gh-pages@9.26.3-canary.1132.14691.0
  yarn add @auto-canary/git-tag@9.26.3-canary.1132.14691.0
  yarn add @auto-canary/gradle@9.26.3-canary.1132.14691.0
  yarn add @auto-canary/jira@9.26.3-canary.1132.14691.0
  yarn add @auto-canary/maven@9.26.3-canary.1132.14691.0
  yarn add @auto-canary/npm@9.26.3-canary.1132.14691.0
  yarn add @auto-canary/omit-commits@9.26.3-canary.1132.14691.0
  yarn add @auto-canary/omit-release-notes@9.26.3-canary.1132.14691.0
  yarn add @auto-canary/released@9.26.3-canary.1132.14691.0
  yarn add @auto-canary/s3@9.26.3-canary.1132.14691.0
  yarn add @auto-canary/slack@9.26.3-canary.1132.14691.0
  yarn add @auto-canary/twitter@9.26.3-canary.1132.14691.0
  yarn add @auto-canary/upload-assets@9.26.3-canary.1132.14691.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
