### PR TITLE
pr-check: succeed on pre-release branch PRs

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -858,29 +858,35 @@ export default class Auto {
           !skipReleaseLabels.includes(l) &&
           l !== "release"
       );
+      const branch = getCurrentBranch();
 
-      if (semverTag === undefined && !skipReleaseTag) {
+      if (branch && this.config?.prereleaseBranches.includes(branch)) {
+        msg = {
+          description: "PR will graduate prerelease once merged",
+          state: "success",
+        };
+      } else if (semverTag === undefined && !skipReleaseTag) {
         throw new Error("No semver label!");
-      }
-
-      this.logger.log.success(
-        `PR is using label: ${semverTag || skipReleaseTag}`
-      );
-
-      let description;
-
-      if (skipReleaseTag) {
-        description = "PR will not create a release";
-      } else if (releaseTag) {
-        description = `PR will create release once merged - ${semverTag}`;
       } else {
-        description = `CI - ${semverTag}`;
-      }
+        this.logger.log.success(
+          `PR is using label: ${semverTag || skipReleaseTag}`
+        );
 
-      msg = {
-        description,
-        state: "success",
-      };
+        let description;
+
+        if (skipReleaseTag) {
+          description = "PR will not create a release";
+        } else if (releaseTag) {
+          description = `PR will create release once merged - ${semverTag}`;
+        } else {
+          description = `CI - ${semverTag}`;
+        }
+
+        msg = {
+          description,
+          state: "success",
+        };
+      }
     } catch (error) {
       msg = {
         description: error.message,


### PR DESCRIPTION
# What Changed

see title

# Why

`pr-check` was always failing on prerelease PRs that don't need a semver label.


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.26.4-canary.1133.14703.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.26.4-canary.1133.14703.0
  npm install @auto-canary/auto@9.26.4-canary.1133.14703.0
  npm install @auto-canary/core@9.26.4-canary.1133.14703.0
  npm install @auto-canary/all-contributors@9.26.4-canary.1133.14703.0
  npm install @auto-canary/brew@9.26.4-canary.1133.14703.0
  npm install @auto-canary/chrome@9.26.4-canary.1133.14703.0
  npm install @auto-canary/cocoapods@9.26.4-canary.1133.14703.0
  npm install @auto-canary/conventional-commits@9.26.4-canary.1133.14703.0
  npm install @auto-canary/crates@9.26.4-canary.1133.14703.0
  npm install @auto-canary/exec@9.26.4-canary.1133.14703.0
  npm install @auto-canary/first-time-contributor@9.26.4-canary.1133.14703.0
  npm install @auto-canary/gh-pages@9.26.4-canary.1133.14703.0
  npm install @auto-canary/git-tag@9.26.4-canary.1133.14703.0
  npm install @auto-canary/gradle@9.26.4-canary.1133.14703.0
  npm install @auto-canary/jira@9.26.4-canary.1133.14703.0
  npm install @auto-canary/maven@9.26.4-canary.1133.14703.0
  npm install @auto-canary/npm@9.26.4-canary.1133.14703.0
  npm install @auto-canary/omit-commits@9.26.4-canary.1133.14703.0
  npm install @auto-canary/omit-release-notes@9.26.4-canary.1133.14703.0
  npm install @auto-canary/released@9.26.4-canary.1133.14703.0
  npm install @auto-canary/s3@9.26.4-canary.1133.14703.0
  npm install @auto-canary/slack@9.26.4-canary.1133.14703.0
  npm install @auto-canary/twitter@9.26.4-canary.1133.14703.0
  npm install @auto-canary/upload-assets@9.26.4-canary.1133.14703.0
  # or 
  yarn add @auto-canary/bot-list@9.26.4-canary.1133.14703.0
  yarn add @auto-canary/auto@9.26.4-canary.1133.14703.0
  yarn add @auto-canary/core@9.26.4-canary.1133.14703.0
  yarn add @auto-canary/all-contributors@9.26.4-canary.1133.14703.0
  yarn add @auto-canary/brew@9.26.4-canary.1133.14703.0
  yarn add @auto-canary/chrome@9.26.4-canary.1133.14703.0
  yarn add @auto-canary/cocoapods@9.26.4-canary.1133.14703.0
  yarn add @auto-canary/conventional-commits@9.26.4-canary.1133.14703.0
  yarn add @auto-canary/crates@9.26.4-canary.1133.14703.0
  yarn add @auto-canary/exec@9.26.4-canary.1133.14703.0
  yarn add @auto-canary/first-time-contributor@9.26.4-canary.1133.14703.0
  yarn add @auto-canary/gh-pages@9.26.4-canary.1133.14703.0
  yarn add @auto-canary/git-tag@9.26.4-canary.1133.14703.0
  yarn add @auto-canary/gradle@9.26.4-canary.1133.14703.0
  yarn add @auto-canary/jira@9.26.4-canary.1133.14703.0
  yarn add @auto-canary/maven@9.26.4-canary.1133.14703.0
  yarn add @auto-canary/npm@9.26.4-canary.1133.14703.0
  yarn add @auto-canary/omit-commits@9.26.4-canary.1133.14703.0
  yarn add @auto-canary/omit-release-notes@9.26.4-canary.1133.14703.0
  yarn add @auto-canary/released@9.26.4-canary.1133.14703.0
  yarn add @auto-canary/s3@9.26.4-canary.1133.14703.0
  yarn add @auto-canary/slack@9.26.4-canary.1133.14703.0
  yarn add @auto-canary/twitter@9.26.4-canary.1133.14703.0
  yarn add @auto-canary/upload-assets@9.26.4-canary.1133.14703.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
