### PR TITLE
fix creating canary with no Latest Release

### DIFF
--- a/packages/core/src/__tests__/determine-next-version.test.ts
+++ b/packages/core/src/__tests__/determine-next-version.test.ts
@@ -1,0 +1,33 @@
+import { determineNextVersion } from "../auto";
+import SEMVER from "../semver";
+
+describe("determineNextVersion", () => {
+  test("should make a incremented canary version", () => {
+    expect(
+      determineNextVersion("v3.0.0", "v3.2.0", SEMVER.patch, "canary.5b2e7d3")
+    ).toBe("3.2.1-canary.5b2e7d3.0");
+  });
+
+  test("should make a incremented canary version without any previous release", () => {
+    expect(
+      determineNextVersion(
+        "7dd0b07625203f69cd55d779d873f1adcffaa84a",
+        "v3.2.0",
+        SEMVER.patch,
+        "canary.5b2e7d3"
+      )
+    ).toBe("3.2.1-canary.5b2e7d3.0");
+  });
+
+  test("should make a incremented canary version of latest", () => {
+    expect(
+      determineNextVersion("v4.0.0", "v3.2.0", SEMVER.patch, "canary.5b2e7d3")
+    ).toBe("4.0.1-canary.5b2e7d3.0");
+  });
+
+  test("should make a incremented next version", () => {
+    expect(determineNextVersion("1.0.0", "2.0.0-next.0", SEMVER.patch)).toBe(
+      "2.0.0-next.1"
+    );
+  });
+});

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -268,12 +268,11 @@ export function determineNextVersion(
   lastVersion: string,
   currentVersion: string,
   bump: SEMVER,
-  tag: string
+  tag?: string
 ) {
-  const next =
-    inc(lastVersion, `pre${bump}` as ReleaseType, tag) || "prerelease";
+  const next = inc(lastVersion, `pre${bump}` as ReleaseType, tag);
 
-  return lte(next, currentVersion)
+  return !next || lte(next, currentVersion)
     ? inc(currentVersion, "prerelease", tag) || "prerelease"
     : next;
 }


### PR DESCRIPTION
# What Changed

handle case in `determineNextVersion` where there is no latest release.

# Why

![Screen Shot 2020-04-07 at 9 38 50 AM](https://user-images.githubusercontent.com/1192452/78695900-986d4b00-78b3-11ea-983f-9b91cb3d628c.png)

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.26.5-canary.1134.14715.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.26.5-canary.1134.14715.0
  npm install @auto-canary/auto@9.26.5-canary.1134.14715.0
  npm install @auto-canary/core@9.26.5-canary.1134.14715.0
  npm install @auto-canary/all-contributors@9.26.5-canary.1134.14715.0
  npm install @auto-canary/brew@9.26.5-canary.1134.14715.0
  npm install @auto-canary/chrome@9.26.5-canary.1134.14715.0
  npm install @auto-canary/cocoapods@9.26.5-canary.1134.14715.0
  npm install @auto-canary/conventional-commits@9.26.5-canary.1134.14715.0
  npm install @auto-canary/crates@9.26.5-canary.1134.14715.0
  npm install @auto-canary/exec@9.26.5-canary.1134.14715.0
  npm install @auto-canary/first-time-contributor@9.26.5-canary.1134.14715.0
  npm install @auto-canary/gh-pages@9.26.5-canary.1134.14715.0
  npm install @auto-canary/git-tag@9.26.5-canary.1134.14715.0
  npm install @auto-canary/gradle@9.26.5-canary.1134.14715.0
  npm install @auto-canary/jira@9.26.5-canary.1134.14715.0
  npm install @auto-canary/maven@9.26.5-canary.1134.14715.0
  npm install @auto-canary/npm@9.26.5-canary.1134.14715.0
  npm install @auto-canary/omit-commits@9.26.5-canary.1134.14715.0
  npm install @auto-canary/omit-release-notes@9.26.5-canary.1134.14715.0
  npm install @auto-canary/released@9.26.5-canary.1134.14715.0
  npm install @auto-canary/s3@9.26.5-canary.1134.14715.0
  npm install @auto-canary/slack@9.26.5-canary.1134.14715.0
  npm install @auto-canary/twitter@9.26.5-canary.1134.14715.0
  npm install @auto-canary/upload-assets@9.26.5-canary.1134.14715.0
  # or 
  yarn add @auto-canary/bot-list@9.26.5-canary.1134.14715.0
  yarn add @auto-canary/auto@9.26.5-canary.1134.14715.0
  yarn add @auto-canary/core@9.26.5-canary.1134.14715.0
  yarn add @auto-canary/all-contributors@9.26.5-canary.1134.14715.0
  yarn add @auto-canary/brew@9.26.5-canary.1134.14715.0
  yarn add @auto-canary/chrome@9.26.5-canary.1134.14715.0
  yarn add @auto-canary/cocoapods@9.26.5-canary.1134.14715.0
  yarn add @auto-canary/conventional-commits@9.26.5-canary.1134.14715.0
  yarn add @auto-canary/crates@9.26.5-canary.1134.14715.0
  yarn add @auto-canary/exec@9.26.5-canary.1134.14715.0
  yarn add @auto-canary/first-time-contributor@9.26.5-canary.1134.14715.0
  yarn add @auto-canary/gh-pages@9.26.5-canary.1134.14715.0
  yarn add @auto-canary/git-tag@9.26.5-canary.1134.14715.0
  yarn add @auto-canary/gradle@9.26.5-canary.1134.14715.0
  yarn add @auto-canary/jira@9.26.5-canary.1134.14715.0
  yarn add @auto-canary/maven@9.26.5-canary.1134.14715.0
  yarn add @auto-canary/npm@9.26.5-canary.1134.14715.0
  yarn add @auto-canary/omit-commits@9.26.5-canary.1134.14715.0
  yarn add @auto-canary/omit-release-notes@9.26.5-canary.1134.14715.0
  yarn add @auto-canary/released@9.26.5-canary.1134.14715.0
  yarn add @auto-canary/s3@9.26.5-canary.1134.14715.0
  yarn add @auto-canary/slack@9.26.5-canary.1134.14715.0
  yarn add @auto-canary/twitter@9.26.5-canary.1134.14715.0
  yarn add @auto-canary/upload-assets@9.26.5-canary.1134.14715.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
