### PR TITLE
Skip next commit hooks

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1194,12 +1194,14 @@ export default class Auto {
 
     this.hooks.onCreateLogParse.tap("Omit merges from master", (logParse) => {
       logParse.hooks.omitCommit.tap("Omit merges from master", (commit) => {
-        console.log(
-          "Omit merges from master",
-          commit.subject.includes(`Merge origin/${this.baseBranch}`),
-          commit.subject
+        const shouldOmit = commit.subject.includes(
+          `Merge origin/${this.baseBranch}`
         );
-        if (commit.subject.includes(`Merge origin/${this.baseBranch}`)) {
+        this.logger.verbose.info(
+          `Omit merges from master?" ${shouldOmit}: ${commit.subject}`
+        );
+
+        if (shouldOmit) {
           return true;
         }
       });

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1194,6 +1194,11 @@ export default class Auto {
 
     this.hooks.onCreateLogParse.tap("Omit merges from master", (logParse) => {
       logParse.hooks.omitCommit.tap("Omit merges from master", (commit) => {
+        console.log(
+          "Omit merges from master",
+          commit.subject.includes(`Merge origin/${this.baseBranch}`),
+          commit.subject
+        );
         if (commit.subject.includes(`Merge origin/${this.baseBranch}`)) {
           return true;
         }

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -743,6 +743,7 @@ export default class NPMPlugin implements IPlugin {
         "version",
         canaryVersion,
         "--no-git-tag-version",
+        "--no-commit-hooks",
         ...verboseArgs,
       ]);
 
@@ -810,6 +811,7 @@ export default class NPMPlugin implements IPlugin {
           "--yes",
           // do not add ^ to next versions, this can result in `npm i` resolving the wrong next version
           "--exact",
+          "--no-commit-hooks",
           ...verboseArgs,
         ]);
 


### PR DESCRIPTION
# What Changed

Don't run commit hooks when publishing next releases

# Why

This will generally cause releases to fail.


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.26.7-canary.1136.14752.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.26.7-canary.1136.14752.0
  npm install @auto-canary/auto@9.26.7-canary.1136.14752.0
  npm install @auto-canary/core@9.26.7-canary.1136.14752.0
  npm install @auto-canary/all-contributors@9.26.7-canary.1136.14752.0
  npm install @auto-canary/brew@9.26.7-canary.1136.14752.0
  npm install @auto-canary/chrome@9.26.7-canary.1136.14752.0
  npm install @auto-canary/cocoapods@9.26.7-canary.1136.14752.0
  npm install @auto-canary/conventional-commits@9.26.7-canary.1136.14752.0
  npm install @auto-canary/crates@9.26.7-canary.1136.14752.0
  npm install @auto-canary/exec@9.26.7-canary.1136.14752.0
  npm install @auto-canary/first-time-contributor@9.26.7-canary.1136.14752.0
  npm install @auto-canary/gh-pages@9.26.7-canary.1136.14752.0
  npm install @auto-canary/git-tag@9.26.7-canary.1136.14752.0
  npm install @auto-canary/gradle@9.26.7-canary.1136.14752.0
  npm install @auto-canary/jira@9.26.7-canary.1136.14752.0
  npm install @auto-canary/maven@9.26.7-canary.1136.14752.0
  npm install @auto-canary/npm@9.26.7-canary.1136.14752.0
  npm install @auto-canary/omit-commits@9.26.7-canary.1136.14752.0
  npm install @auto-canary/omit-release-notes@9.26.7-canary.1136.14752.0
  npm install @auto-canary/released@9.26.7-canary.1136.14752.0
  npm install @auto-canary/s3@9.26.7-canary.1136.14752.0
  npm install @auto-canary/slack@9.26.7-canary.1136.14752.0
  npm install @auto-canary/twitter@9.26.7-canary.1136.14752.0
  npm install @auto-canary/upload-assets@9.26.7-canary.1136.14752.0
  # or 
  yarn add @auto-canary/bot-list@9.26.7-canary.1136.14752.0
  yarn add @auto-canary/auto@9.26.7-canary.1136.14752.0
  yarn add @auto-canary/core@9.26.7-canary.1136.14752.0
  yarn add @auto-canary/all-contributors@9.26.7-canary.1136.14752.0
  yarn add @auto-canary/brew@9.26.7-canary.1136.14752.0
  yarn add @auto-canary/chrome@9.26.7-canary.1136.14752.0
  yarn add @auto-canary/cocoapods@9.26.7-canary.1136.14752.0
  yarn add @auto-canary/conventional-commits@9.26.7-canary.1136.14752.0
  yarn add @auto-canary/crates@9.26.7-canary.1136.14752.0
  yarn add @auto-canary/exec@9.26.7-canary.1136.14752.0
  yarn add @auto-canary/first-time-contributor@9.26.7-canary.1136.14752.0
  yarn add @auto-canary/gh-pages@9.26.7-canary.1136.14752.0
  yarn add @auto-canary/git-tag@9.26.7-canary.1136.14752.0
  yarn add @auto-canary/gradle@9.26.7-canary.1136.14752.0
  yarn add @auto-canary/jira@9.26.7-canary.1136.14752.0
  yarn add @auto-canary/maven@9.26.7-canary.1136.14752.0
  yarn add @auto-canary/npm@9.26.7-canary.1136.14752.0
  yarn add @auto-canary/omit-commits@9.26.7-canary.1136.14752.0
  yarn add @auto-canary/omit-release-notes@9.26.7-canary.1136.14752.0
  yarn add @auto-canary/released@9.26.7-canary.1136.14752.0
  yarn add @auto-canary/s3@9.26.7-canary.1136.14752.0
  yarn add @auto-canary/slack@9.26.7-canary.1136.14752.0
  yarn add @auto-canary/twitter@9.26.7-canary.1136.14752.0
  yarn add @auto-canary/upload-assets@9.26.7-canary.1136.14752.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
