### PR TITLE
Fix omitting merges from master into next when running "shipit"

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1150,6 +1150,8 @@ export default class Auto {
       this.logger.log.success(
         `Published canary version${newVersion ? `: ${newVersion}` : ""}`
       );
+
+      await execPromise("git", ["reset", "--hard", "HEAD"]);
     }
 
     let latestTag: string;
@@ -1291,6 +1293,7 @@ export default class Auto {
       }
     }
 
+    await execPromise("git", ["reset", "--hard", "HEAD"]);
     return { newVersion, commitsInRelease: commits, context: "next" };
   }
 

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1196,9 +1196,7 @@ export default class Auto {
 
     this.hooks.onCreateLogParse.tap("Omit merges from master", (logParse) => {
       logParse.hooks.omitCommit.tap("Omit merges from master", (commit) => {
-        const shouldOmit = commit.subject.includes(
-          `Merge origin/${this.baseBranch}`
-        );
+        const shouldOmit = commit.subject.match(/^Merge (?:\S+\/)*master/);
         this.logger.verbose.info(
           `Omit merges from master?" ${shouldOmit}: ${commit.subject}`
         );
@@ -1225,6 +1223,9 @@ export default class Auto {
     const lastRelease =
       initialForkCommit || (await this.git.getLatestRelease());
     const lastTag = await this.git.getLastTagNotInBaseBranch(currentBranch!);
+    const fullReleaseNotes = await this.release.generateReleaseNotes(
+      lastRelease
+    );
     const commits = await this.release.getCommitsInRelease(lastTag);
     const releaseNotes = await this.release.generateReleaseNotes(lastTag);
     const labels = commits.map((commit) => commit.labels);
@@ -1232,15 +1233,18 @@ export default class Auto {
       calculateSemVerBump(labels, this.semVerLabels!, this.config) ||
       SEMVER.patch;
 
+    this.logger.log.info("Full Release notes for next release:");
+    console.log(fullReleaseNotes);
+
+    if (releaseNotes) {
+      this.logger.log.info("Release notes for last change in next release");
+      console.log(releaseNotes);
+    }
+
     if (options.dryRun) {
       this.logger.log.success(
         `Would have created prerelease version with: ${bump} from ${lastTag}`
       );
-
-      this.logger.log.info("Full Release notes for next release:");
-      console.log(await this.release.generateReleaseNotes(lastRelease));
-      this.logger.log.info("Release notes for last change in next release");
-      console.log(releaseNotes);
 
       return { newVersion: "", commitsInRelease: commits, context: "next" };
     }
@@ -1286,7 +1290,7 @@ export default class Auto {
             <details>
               <summary>Changelog</summary>
 
-              ${await this.release.generateReleaseNotes(lastRelease)}
+              ${fullReleaseNotes}
             </details>
           `,
         });

--- a/packages/core/src/release.ts
+++ b/packages/core/src/release.ts
@@ -517,7 +517,6 @@ export default class Release {
   }
 
   /** Create the class that will parse the log for PR info */
-  @memoize()
   private async createLogParse() {
     const logParse = new LogParse();
 


### PR DESCRIPTION
# What Changed

We have a little code to omit merges from master into a pre-release branch. This code was not executing when `next` was ran by `shipit`. Now we don't memoize the creation of the log parser so `auto` can dynamically tap the log parser.


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.26.8-canary.1137.14764.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.26.8-canary.1137.14764.0
  npm install @auto-canary/auto@9.26.8-canary.1137.14764.0
  npm install @auto-canary/core@9.26.8-canary.1137.14764.0
  npm install @auto-canary/all-contributors@9.26.8-canary.1137.14764.0
  npm install @auto-canary/brew@9.26.8-canary.1137.14764.0
  npm install @auto-canary/chrome@9.26.8-canary.1137.14764.0
  npm install @auto-canary/cocoapods@9.26.8-canary.1137.14764.0
  npm install @auto-canary/conventional-commits@9.26.8-canary.1137.14764.0
  npm install @auto-canary/crates@9.26.8-canary.1137.14764.0
  npm install @auto-canary/exec@9.26.8-canary.1137.14764.0
  npm install @auto-canary/first-time-contributor@9.26.8-canary.1137.14764.0
  npm install @auto-canary/gh-pages@9.26.8-canary.1137.14764.0
  npm install @auto-canary/git-tag@9.26.8-canary.1137.14764.0
  npm install @auto-canary/gradle@9.26.8-canary.1137.14764.0
  npm install @auto-canary/jira@9.26.8-canary.1137.14764.0
  npm install @auto-canary/maven@9.26.8-canary.1137.14764.0
  npm install @auto-canary/npm@9.26.8-canary.1137.14764.0
  npm install @auto-canary/omit-commits@9.26.8-canary.1137.14764.0
  npm install @auto-canary/omit-release-notes@9.26.8-canary.1137.14764.0
  npm install @auto-canary/released@9.26.8-canary.1137.14764.0
  npm install @auto-canary/s3@9.26.8-canary.1137.14764.0
  npm install @auto-canary/slack@9.26.8-canary.1137.14764.0
  npm install @auto-canary/twitter@9.26.8-canary.1137.14764.0
  npm install @auto-canary/upload-assets@9.26.8-canary.1137.14764.0
  # or 
  yarn add @auto-canary/bot-list@9.26.8-canary.1137.14764.0
  yarn add @auto-canary/auto@9.26.8-canary.1137.14764.0
  yarn add @auto-canary/core@9.26.8-canary.1137.14764.0
  yarn add @auto-canary/all-contributors@9.26.8-canary.1137.14764.0
  yarn add @auto-canary/brew@9.26.8-canary.1137.14764.0
  yarn add @auto-canary/chrome@9.26.8-canary.1137.14764.0
  yarn add @auto-canary/cocoapods@9.26.8-canary.1137.14764.0
  yarn add @auto-canary/conventional-commits@9.26.8-canary.1137.14764.0
  yarn add @auto-canary/crates@9.26.8-canary.1137.14764.0
  yarn add @auto-canary/exec@9.26.8-canary.1137.14764.0
  yarn add @auto-canary/first-time-contributor@9.26.8-canary.1137.14764.0
  yarn add @auto-canary/gh-pages@9.26.8-canary.1137.14764.0
  yarn add @auto-canary/git-tag@9.26.8-canary.1137.14764.0
  yarn add @auto-canary/gradle@9.26.8-canary.1137.14764.0
  yarn add @auto-canary/jira@9.26.8-canary.1137.14764.0
  yarn add @auto-canary/maven@9.26.8-canary.1137.14764.0
  yarn add @auto-canary/npm@9.26.8-canary.1137.14764.0
  yarn add @auto-canary/omit-commits@9.26.8-canary.1137.14764.0
  yarn add @auto-canary/omit-release-notes@9.26.8-canary.1137.14764.0
  yarn add @auto-canary/released@9.26.8-canary.1137.14764.0
  yarn add @auto-canary/s3@9.26.8-canary.1137.14764.0
  yarn add @auto-canary/slack@9.26.8-canary.1137.14764.0
  yarn add @auto-canary/twitter@9.26.8-canary.1137.14764.0
  yarn add @auto-canary/upload-assets@9.26.8-canary.1137.14764.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
