### PR TITLE
all contributors: add ability to add non-code contributions

### DIFF
--- a/plugins/all-contributors/README.md
+++ b/plugins/all-contributors/README.md
@@ -58,6 +58,21 @@ If you configure an pre-configured contribution type the arrays are not merged, 
 }
 ```
 
+### Adding Non-Code Contributions
+
+Sometimes you worked with a person that didn't touch the code personally so this plugin would never attribute them with any contributions.
+Since these contributions cannot be automated you can instead just list out another contributor's (name + GitHub username) contributions directly in the PR.
+
+Add the following to a PR body and auto will try to parse it and add contributors from it.
+
+```md
+# Contributions
+
+- Some Guy (@some_guy) - design, doc
+```
+
+To ensure you are doing it right `auto` will comment on the PR with the people + contributions you are manually adding.
+
 ### Exclude Users
 
 Useful for excluding bots from getting into your contributors.

--- a/plugins/all-contributors/README.md
+++ b/plugins/all-contributors/README.md
@@ -96,7 +96,7 @@ Useful for excluding bots from getting into your contributors.
 
 Maintain contributors lists for sub-packages in a monorepo setup (`lerna`/`yarn`).
 
-All you need to do is initialize each sub-package you want contributors tracked in with an `.all-contributorsrc`. If no rc file is found nothing will happen for that package.
+All you need to do is initialize each sub-package you want contributors tracked in with an `.all-contributorsrc`. If no rc file is found nothing will happen for that package. Any non-code contribution listed in the PR body will also be added to the sub-package contributors list.
 
 ```sh
 cd packages/your-package

--- a/plugins/all-contributors/__tests__/__snapshots__/all-contributors.test.ts.snap
+++ b/plugins/all-contributors/__tests__/__snapshots__/all-contributors.test.ts.snap
@@ -5,5 +5,5 @@ exports[`All Contributors Plugin beforeShipit should comment confirming extra co
 
 The following contributions will be added to all-contributors (as well as any code contributions) when this PR is released :tada::
 
-- andrew - design, doc"
+- @andrew - design, doc"
 `;

--- a/plugins/all-contributors/__tests__/__snapshots__/all-contributors.test.ts.snap
+++ b/plugins/all-contributors/__tests__/__snapshots__/all-contributors.test.ts.snap
@@ -7,3 +7,18 @@ The following contributions will be added to all-contributors (as well as any co
 
 - @andrew - design, doc"
 `;
+
+exports[`All Contributors Plugin beforeShipit should warn about unknown contribution types 1`] = `
+"# Extra Contributions
+
+The following contributions will be added to all-contributors (as well as any code contributions) when this PR is released :tada::
+
+- @andrew - doc
+
+## Unknown Contribution Types
+
+We found some unknown contribution types in your PR body!
+These contributions will not be counted and you should fix them.
+
+- design123"
+`;

--- a/plugins/all-contributors/__tests__/__snapshots__/all-contributors.test.ts.snap
+++ b/plugins/all-contributors/__tests__/__snapshots__/all-contributors.test.ts.snap
@@ -20,5 +20,5 @@ The following contributions will be added to all-contributors (as well as any co
 We found some unknown contribution types in your PR body!
 These contributions will not be counted and you should fix them.
 
-- design123"
+- \`design123\`"
 `;

--- a/plugins/all-contributors/__tests__/__snapshots__/all-contributors.test.ts.snap
+++ b/plugins/all-contributors/__tests__/__snapshots__/all-contributors.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`All Contributors Plugin beforeShipit should comment confirming extra contributions 1`] = `
+"# Extra Contributions
+
+The following contributions will be added to all-contributors (as well as any code contributions) when this PR is released :tada::
+
+- andrew - design, doc"
+`;

--- a/plugins/all-contributors/__tests__/__snapshots__/all-contributors.test.ts.snap
+++ b/plugins/all-contributors/__tests__/__snapshots__/all-contributors.test.ts.snap
@@ -8,6 +8,19 @@ The following contributions will be added to all-contributors (as well as any co
 - @andrew - design, doc"
 `;
 
+exports[`All Contributors Plugin beforeShipit should warn about unknown contribution types - no valid 1`] = `
+"# Extra Contributions
+
+No valid contribution types found!
+
+## Unknown Contribution Types
+
+We found some unknown contribution types in your PR body!
+These contributions will not be counted and you should fix them.
+
+- \`design123\`,- \`doc456\`"
+`;
+
 exports[`All Contributors Plugin beforeShipit should warn about unknown contribution types 1`] = `
 "# Extra Contributions
 

--- a/plugins/all-contributors/__tests__/__snapshots__/all-contributors.test.ts.snap
+++ b/plugins/all-contributors/__tests__/__snapshots__/all-contributors.test.ts.snap
@@ -21,6 +21,21 @@ These contributions will not be counted and you should fix them.
 - \`design123\`,- \`doc456\`"
 `;
 
+exports[`All Contributors Plugin beforeShipit should warn about unknown contribution types - some valid 1`] = `
+"# Extra Contributions
+
+The following contributions will be added to all-contributors (as well as any code contributions) when this PR is released :tada::
+
+- @adam - doc
+
+## Unknown Contribution Types
+
+We found some unknown contribution types in your PR body!
+These contributions will not be counted and you should fix them.
+
+- \`design123\`,- \`doc456\`"
+`;
+
 exports[`All Contributors Plugin beforeShipit should warn about unknown contribution types 1`] = `
 "# Extra Contributions
 

--- a/plugins/all-contributors/__tests__/all-contributors.test.ts
+++ b/plugins/all-contributors/__tests__/all-contributors.test.ts
@@ -145,7 +145,7 @@ describe("All Contributors Plugin", () => {
           getPullRequest: () => ({
             data: {
               body:
-                "A body with contributions\n\n# Contributions\n\n- @andrew - design, doc",
+                "# What Changed\r\n\r\nsee title\r\n\r\n# Why\r\n\r\ncloses #1147 \r\n\r\n# Contributions\r\n\r\n- @andrew - design, doc\r\n\r\n",
             },
           }),
         } as any,

--- a/plugins/all-contributors/__tests__/all-contributors.test.ts
+++ b/plugins/all-contributors/__tests__/all-contributors.test.ts
@@ -213,6 +213,34 @@ describe("All Contributors Plugin", () => {
 
       expect(comment.mock.calls[0][0].message).toMatchSnapshot();
     });
+
+    test("should warn about unknown contribution types - some valid", async () => {
+      const releasedLabel = new AllContributors();
+      const autoHooks = makeHooks();
+      const comment = jest.fn();
+
+      envMock.mockReturnValueOnce({ pr: 123 });
+
+      releasedLabel.apply({
+        comment: comment as any,
+        hooks: autoHooks,
+        logger: dummyLog(),
+        git: {
+          getPullRequest: () => ({
+            data: {
+              body:
+                "# What Changed\r\n\r\nsee title\r\n\r\n# Why\r\n\r\ncloses #1147 \r\n\r\n# Contributions\r\n\r\n- @andrew - design123, doc456\r\n- @adam - doc\r\n\r\n",
+            },
+          }),
+        } as any,
+      } as Auto.Auto);
+
+      await autoHooks.beforeShipIt.promise({
+        releaseType: "canary",
+      });
+
+      expect(comment.mock.calls[0][0].message).toMatchSnapshot();
+    });
   });
 
   test("should do nothing for username-less commits", async () => {

--- a/plugins/all-contributors/__tests__/all-contributors.test.ts
+++ b/plugins/all-contributors/__tests__/all-contributors.test.ts
@@ -157,6 +157,34 @@ describe("All Contributors Plugin", () => {
 
       expect(comment.mock.calls[0][0].message).toMatchSnapshot();
     });
+
+    test("should warn about unknown contribution types", async () => {
+      const releasedLabel = new AllContributors();
+      const autoHooks = makeHooks();
+      const comment = jest.fn();
+
+      envMock.mockReturnValueOnce({ pr: 123 });
+
+      releasedLabel.apply({
+        comment: comment as any,
+        hooks: autoHooks,
+        logger: dummyLog(),
+        git: {
+          getPullRequest: () => ({
+            data: {
+              body:
+                "# What Changed\r\n\r\nsee title\r\n\r\n# Why\r\n\r\ncloses #1147 \r\n\r\n# Contributions\r\n\r\n- @andrew - design123, doc\r\n\r\n",
+            },
+          }),
+        } as any,
+      } as Auto.Auto);
+
+      await autoHooks.beforeShipIt.promise({
+        releaseType: "canary",
+      });
+
+      expect(comment.mock.calls[0][0].message).toMatchSnapshot();
+    });
   });
 
   test("should do nothing for username-less commits", async () => {

--- a/plugins/all-contributors/__tests__/all-contributors.test.ts
+++ b/plugins/all-contributors/__tests__/all-contributors.test.ts
@@ -185,6 +185,34 @@ describe("All Contributors Plugin", () => {
 
       expect(comment.mock.calls[0][0].message).toMatchSnapshot();
     });
+
+    test("should warn about unknown contribution types - no valid", async () => {
+      const releasedLabel = new AllContributors();
+      const autoHooks = makeHooks();
+      const comment = jest.fn();
+
+      envMock.mockReturnValueOnce({ pr: 123 });
+
+      releasedLabel.apply({
+        comment: comment as any,
+        hooks: autoHooks,
+        logger: dummyLog(),
+        git: {
+          getPullRequest: () => ({
+            data: {
+              body:
+                "# What Changed\r\n\r\nsee title\r\n\r\n# Why\r\n\r\ncloses #1147 \r\n\r\n# Contributions\r\n\r\n- @andrew - design123, doc456\r\n\r\n",
+            },
+          }),
+        } as any,
+      } as Auto.Auto);
+
+      await autoHooks.beforeShipIt.promise({
+        releaseType: "canary",
+      });
+
+      expect(comment.mock.calls[0][0].message).toMatchSnapshot();
+    });
   });
 
   test("should do nothing for username-less commits", async () => {

--- a/plugins/all-contributors/__tests__/all-contributors.test.ts
+++ b/plugins/all-contributors/__tests__/all-contributors.test.ts
@@ -4,20 +4,26 @@ import { makeHooks } from "@auto-it/core/dist/utils/make-hooks";
 import makeCommitFromMsg from "@auto-it/core/dist/__tests__/make-commit-from-msg";
 import { dummyLog } from "@auto-it/core/dist/utils/logger";
 import fs from "fs";
+import env from "env-ci";
 
 import AllContributors from "../src";
 
+const envMock = jest.fn();
 const exec = jest.fn();
 const gitShow = jest.fn();
 const getLernaPackages = jest.fn();
 
+envMock.mockReturnValue({});
 getLernaPackages.mockReturnValue(Promise.resolve([]));
 gitShow.mockReturnValue(Promise.resolve(""));
 exec.mockReturnValue("");
 
+jest.mock("env-ci");
 jest.mock("child_process");
 // @ts-ignore
 execSync.mockImplementation(exec);
+// @ts-ignore
+env.mockImplementation(envMock);
 // @ts-ignore
 jest.spyOn(Auto, "execPromise").mockImplementation(gitShow);
 jest.spyOn(Auto, "getLernaPackages").mockImplementation(getLernaPackages);
@@ -32,6 +38,125 @@ const mockRead = (result: string) =>
 describe("All Contributors Plugin", () => {
   afterEach(() => {
     jest.clearAllMocks();
+  });
+
+  describe("beforeShipit", () => {
+    test("should not do anything for certain release types", async () => {
+      const releasedLabel = new AllContributors();
+      const autoHooks = makeHooks();
+      const comment = jest.fn();
+
+      releasedLabel.apply({
+        comment: comment as any,
+        hooks: autoHooks,
+        logger: dummyLog(),
+      } as Auto.Auto);
+
+      await autoHooks.beforeShipIt.promise({
+        releaseType: "latest",
+      });
+
+      expect(comment).not.toHaveBeenCalled();
+
+      await autoHooks.beforeShipIt.promise({
+        releaseType: "old",
+      });
+
+      expect(comment).not.toHaveBeenCalled();
+    });
+
+    test("should not do anything without a PR", async () => {
+      const releasedLabel = new AllContributors();
+      const autoHooks = makeHooks();
+      const comment = jest.fn();
+
+      envMock.mockReturnValueOnce({ pr: undefined });
+
+      releasedLabel.apply({
+        comment: comment as any,
+        hooks: autoHooks,
+        logger: dummyLog(),
+      } as Auto.Auto);
+
+      await autoHooks.beforeShipIt.promise({
+        releaseType: "canary",
+      });
+
+      expect(comment).not.toHaveBeenCalled();
+    });
+
+    test("should not do anything if PR doesn't exist", async () => {
+      const releasedLabel = new AllContributors();
+      const autoHooks = makeHooks();
+      const comment = jest.fn();
+
+      envMock.mockReturnValueOnce({ pr: 123 });
+
+      releasedLabel.apply({
+        comment: comment as any,
+        hooks: autoHooks,
+        logger: dummyLog(),
+      } as Auto.Auto);
+
+      await autoHooks.beforeShipIt.promise({
+        releaseType: "canary",
+      });
+
+      expect(comment).not.toHaveBeenCalled();
+    });
+
+    test("should not do anything if no extra contributions found", async () => {
+      const releasedLabel = new AllContributors();
+      const autoHooks = makeHooks();
+      const comment = jest.fn();
+
+      envMock.mockReturnValueOnce({ pr: 123 });
+
+      releasedLabel.apply({
+        comment: comment as any,
+        hooks: autoHooks,
+        logger: dummyLog(),
+        git: {
+          getPullRequest: () => ({
+            data: { body: "A body with no contributions" },
+          }),
+        } as any,
+      } as Auto.Auto);
+
+      await autoHooks.beforeShipIt.promise({
+        releaseType: "canary",
+      });
+
+      expect(comment).not.toHaveBeenCalled();
+    });
+
+    test("should comment confirming extra contributions", async () => {
+      const releasedLabel = new AllContributors();
+      const autoHooks = makeHooks();
+      const comment = jest.fn();
+
+      envMock.mockReturnValueOnce({ pr: 123 });
+
+      releasedLabel.apply({
+        comment: comment as any,
+        hooks: autoHooks,
+        logger: dummyLog(),
+        git: {
+          getPullRequest: () => ({
+            data: {
+              body:
+                "A body with contributions\n\n# Contributions\n\n- @andrew - design, doc",
+            },
+          }),
+        } as any,
+      } as Auto.Auto);
+
+      await autoHooks.beforeShipIt.promise({
+        releaseType: "canary",
+      });
+
+      expect(comment.mock.calls[0][0].message).toMatchSnapshot();
+    });
   });
 
   test("should do nothing for username-less commits", async () => {

--- a/plugins/all-contributors/src/index.ts
+++ b/plugins/all-contributors/src/index.ts
@@ -18,7 +18,6 @@ import { IExtendedCommit } from "@auto-it/core/src/log-parse";
 import * as t from "io-ts";
 import fromEntries from "fromentries";
 
-const env = envCi();
 const contributionTypes = [
   "blog",
   "bug",
@@ -169,6 +168,8 @@ export default class AllContributorsPlugin implements IPlugin {
 
   /** Tap into auto plugin points. */
   apply(auto: Auto) {
+    const env = envCi();
+
     auto.hooks.validateConfig.tapPromise(this.name, async (name, options) => {
       if (name === this.name || name === `@auto-it/${this.name}`) {
         return validatePluginConfiguration(this.name, pluginOptions, options);
@@ -205,7 +206,7 @@ export default class AllContributorsPlugin implements IPlugin {
       }
 
       const message = endent`
-        # Extra Contribution
+        # Extra Contributions
 
         The following contributions will be added to all-contributors (as well as any code contributions) when this PR is released :tada::
 

--- a/plugins/all-contributors/src/index.ts
+++ b/plugins/all-contributors/src/index.ts
@@ -234,11 +234,11 @@ export default class AllContributorsPlugin implements IPlugin {
                 );
 
                 if (!validContributions.length) {
-                  return;
+                  return "";
                 }
 
                 return `- @${username} - ${validContributions.join(", ")}`;
-              })}
+              }).filter(Boolean).join('\n')}
             `
             : "No valid contribution types found!"
         }

--- a/plugins/all-contributors/src/index.ts
+++ b/plugins/all-contributors/src/index.ts
@@ -213,7 +213,7 @@ export default class AllContributorsPlugin implements IPlugin {
 
         ${Object.entries(extra).map(
           ([username, contributions]) =>
-            `- ${username} - ${[...contributions].join(", ")}`
+            `- @${username} - ${[...contributions].join(", ")}`
         )}
       `;
 

--- a/plugins/all-contributors/src/index.ts
+++ b/plugins/all-contributors/src/index.ts
@@ -117,7 +117,8 @@ function getExtraContributors(body?: string) {
   }
 
   body
-    .slice(start.index)
+    .slice((start.index || 0) + (start[0] || "").length)
+    .replace(/\r\n/g, "\n")
     .split("\n")
     .forEach((line) => {
       if (line.startsWith("#") || line.startsWith("<!--")) {

--- a/plugins/all-contributors/src/index.ts
+++ b/plugins/all-contributors/src/index.ts
@@ -210,24 +210,38 @@ export default class AllContributorsPlugin implements IPlugin {
         return;
       }
 
-      const unknownTypes = Object.values(extra)
-        .reduce((all, i) => [...all, ...i], [] as string[])
-        .filter(
-          (contribution) =>
-            !contributionTypes.includes(contribution as Contribution)
-        );
+      const allContributions = Object.values(extra).reduce(
+        (all, i) => [...all, ...i],
+        [] as string[]
+      );
+      const unknownTypes = allContributions.filter(
+        (contribution) =>
+          !contributionTypes.includes(contribution as Contribution)
+      );
+      const hasValidTypes = allContributions.length !== unknownTypes.length;
 
       const message = endent`
         # Extra Contributions
 
-        The following contributions will be added to all-contributors (as well as any code contributions) when this PR is released :tada::
+        ${
+          hasValidTypes
+            ? endent`
+              The following contributions will be added to all-contributors (as well as any code contributions) when this PR is released :tada::
 
-        ${Object.entries(extra).map(
-          ([username, contributions]) =>
-            `- @${username} - ${[...contributions]
-              .filter(isContribution)
-              .join(", ")}`
-        )}
+              ${Object.entries(extra).map(([username, contributions]) => {
+                const validContributions = [...contributions].filter(
+                  isContribution
+                );
+
+                if (!validContributions.length) {
+                  return;
+                }
+
+                return `- @${username} - ${validContributions.join(", ")}`;
+              })}
+            `
+            : "No valid contribution types found!"
+        }
 
         ${
           unknownTypes.length

--- a/plugins/all-contributors/src/index.ts
+++ b/plugins/all-contributors/src/index.ts
@@ -6,6 +6,8 @@ import {
   inFolder,
   validatePluginConfiguration,
 } from "@auto-it/core";
+import envCi from "env-ci";
+import endent from "endent";
 import botList from "@auto-it/bot-list";
 import fs from "fs";
 import path from "path";
@@ -16,6 +18,7 @@ import { IExtendedCommit } from "@auto-it/core/src/log-parse";
 import * as t from "io-ts";
 import fromEntries from "fromentries";
 
+const env = envCi();
 const contributionTypes = [
   "blog",
   "bug",
@@ -97,6 +100,57 @@ const defaultOptions: IAllContributorsPluginOptions = {
   },
 };
 
+const title = /^[#]{0,5}[ ]*[C|c]ontributions$/;
+const contributorLine = /^[-*] @(\S+)\s+[:-]\s+([\S ,]+)$/;
+
+/** Find contributions listed in PR bodies */
+function getExtraContributors(body?: string) {
+  const authorContributions: Record<string, Set<Contribution>> = {};
+
+  if (!body) {
+    return;
+  }
+
+  const start = body.match(title);
+
+  if (!start) {
+    return;
+  }
+
+  body
+    .slice(start.index)
+    .split("\n")
+    .forEach((line) => {
+      if (line.startsWith("#") || line.startsWith("<!--")) {
+        return;
+      }
+
+      const contributor = line.match(contributorLine);
+
+      if (!contributor) {
+        return;
+      }
+
+      const [, username, contributions] = contributor;
+
+      if (!authorContributions[username]) {
+        authorContributions[username] = new Set();
+      }
+
+      contributions
+        .split(",")
+        .map((contribution) => contribution.trim())
+        .filter((contribution): contribution is Contribution =>
+          contributionTypes.includes(contribution as Contribution)
+        )
+        .forEach((contribution) =>
+          authorContributions[username].add(contribution)
+        );
+    });
+
+  return authorContributions;
+}
+
 /** Automatically add contributors as changelogs are produced. */
 export default class AllContributorsPlugin implements IPlugin {
   /** The name of the plugin */
@@ -121,6 +175,50 @@ export default class AllContributorsPlugin implements IPlugin {
       }
     });
 
+    auto.hooks.beforeShipIt.tapPromise(this.name, async (context) => {
+      if (
+        context.releaseType === "latest" ||
+        context.releaseType === "old" ||
+        !("pr" in env)
+      ) {
+        return;
+      }
+
+      const pr = Number(env.pr);
+
+      if (!pr) {
+        return;
+      }
+
+      const prInfo = await auto.git?.getPullRequest(pr);
+
+      if (!prInfo) {
+        return;
+      }
+
+      const extra = getExtraContributors(prInfo.data.body);
+
+      if (!extra || !Object.keys(extra).length) {
+        return;
+      }
+
+      await auto.comment({
+        pr,
+        context: "Extra Contributions",
+        edit: true,
+        message: endent`
+          # Extra Contribution
+
+          The following contributions will be added to all-contributors (as well as any code contributions) when this PR is released :tada::
+
+          ${Object.entries(extra).map(
+            ([username, contributions]) =>
+              `- ${username} - ${[...contributions].join(", ")}`
+          )}
+        `,
+      });
+    });
+
     auto.hooks.afterAddToChangelog.tapPromise(
       this.name,
       async ({ commits }) => {
@@ -133,8 +231,9 @@ export default class AllContributorsPlugin implements IPlugin {
           packages = [...packages, ...(await getLernaPackages())];
         } catch (error) {}
 
-        // Cannot run git operations in parallel
+        // Go through each package and update code contributions
         await packages.reduce(async (last, { name, path }) => {
+          // Cannot run git operations in parallel
           await last;
 
           auto.logger.verbose.info(`Updating contributors for: ${name}`);
@@ -211,6 +310,7 @@ export default class AllContributorsPlugin implements IPlugin {
       const { authors } = commit;
       let { files } = commit;
 
+      // Find automated contribution for type globs
       Object.keys(this.options.types || {})
         .filter((type): type is Contribution => {
           /** Determine if path is the contribution type */
@@ -234,6 +334,21 @@ export default class AllContributorsPlugin implements IPlugin {
             authorContributions[username].add(contribution);
           });
         });
+
+      // Find contributions listed in PR bodies
+      const extra = getExtraContributors(commit.rawBody);
+
+      if (extra) {
+        Object.entries(extra).forEach(([username, contributions]) => {
+          if (!authorContributions[username]) {
+            authorContributions[username] = new Set();
+          }
+
+          contributions.forEach((contribution) =>
+            authorContributions[username].add(contribution)
+          );
+        });
+      }
     });
 
     auto.logger.verbose.info("Found contributions:", authorContributions);

--- a/plugins/all-contributors/src/index.ts
+++ b/plugins/all-contributors/src/index.ts
@@ -100,7 +100,7 @@ const defaultOptions: IAllContributorsPluginOptions = {
   },
 };
 
-const title = /^[#]{0,5}[ ]*[C|c]ontributions$/;
+const title = /[#]{0,5}[ ]*[C|c]ontributions/;
 const contributorLine = /^[-*] @(\S+)\s+[:-]\s+([\S ,]+)$/;
 
 /** Find contributions listed in PR bodies */

--- a/plugins/all-contributors/src/index.ts
+++ b/plugins/all-contributors/src/index.ts
@@ -191,31 +191,35 @@ export default class AllContributorsPlugin implements IPlugin {
       }
 
       const prInfo = await auto.git?.getPullRequest(pr);
+      auto.logger.log.info(this.name, { prInfo });
 
       if (!prInfo) {
         return;
       }
 
       const extra = getExtraContributors(prInfo.data.body);
+      auto.logger.log.info(this.name, { extra });
 
       if (!extra || !Object.keys(extra).length) {
         return;
       }
 
+      const message = endent`
+        # Extra Contribution
+
+        The following contributions will be added to all-contributors (as well as any code contributions) when this PR is released :tada::
+
+        ${Object.entries(extra).map(
+          ([username, contributions]) =>
+            `- ${username} - ${[...contributions].join(", ")}`
+        )}
+      `;
+
       await auto.comment({
         pr,
         context: "Extra Contributions",
         edit: true,
-        message: endent`
-          # Extra Contribution
-
-          The following contributions will be added to all-contributors (as well as any code contributions) when this PR is released :tada::
-
-          ${Object.entries(extra).map(
-            ([username, contributions]) =>
-              `- ${username} - ${[...contributions].join(", ")}`
-          )}
-        `,
+        message,
       });
     });
 

--- a/plugins/all-contributors/src/index.ts
+++ b/plugins/all-contributors/src/index.ts
@@ -49,13 +49,12 @@ const contributionTypes = [
 ] as const;
 type Contribution = typeof contributionTypes[number];
 
-const isContribution = /**
+const isContribution =
+  /**
 ccccccccccccccccccccccc *
 ccccccccccccccccccccccc */
-(
-  contribution: string | Contribution
-): contribution is Contribution =>
-  contributionTypes.includes(contribution as Contribution);
+  (contribution: string | Contribution): contribution is Contribution =>
+    contributionTypes.includes(contribution as Contribution);
 
 /** Get an rc file if there is one. */
 function getRcFile() {
@@ -238,7 +237,7 @@ export default class AllContributorsPlugin implements IPlugin {
                 We found some unknown contribution types in your PR body!
                 These contributions will not be counted and you should fix them.
 
-                ${unknownTypes.map((type) => `- ${type}`)}
+                ${unknownTypes.map((type) => `- \`${type}\``)}
               `
             : ""
         }


### PR DESCRIPTION
# What Changed

see title

# Why

closes #1147 

Todo:

- [x] Add tests
- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.26.9-canary.1148.14918.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.26.9-canary.1148.14918.0
  npm install @auto-canary/auto@9.26.9-canary.1148.14918.0
  npm install @auto-canary/core@9.26.9-canary.1148.14918.0
  npm install @auto-canary/all-contributors@9.26.9-canary.1148.14918.0
  npm install @auto-canary/brew@9.26.9-canary.1148.14918.0
  npm install @auto-canary/chrome@9.26.9-canary.1148.14918.0
  npm install @auto-canary/cocoapods@9.26.9-canary.1148.14918.0
  npm install @auto-canary/conventional-commits@9.26.9-canary.1148.14918.0
  npm install @auto-canary/crates@9.26.9-canary.1148.14918.0
  npm install @auto-canary/exec@9.26.9-canary.1148.14918.0
  npm install @auto-canary/first-time-contributor@9.26.9-canary.1148.14918.0
  npm install @auto-canary/gh-pages@9.26.9-canary.1148.14918.0
  npm install @auto-canary/git-tag@9.26.9-canary.1148.14918.0
  npm install @auto-canary/gradle@9.26.9-canary.1148.14918.0
  npm install @auto-canary/jira@9.26.9-canary.1148.14918.0
  npm install @auto-canary/maven@9.26.9-canary.1148.14918.0
  npm install @auto-canary/npm@9.26.9-canary.1148.14918.0
  npm install @auto-canary/omit-commits@9.26.9-canary.1148.14918.0
  npm install @auto-canary/omit-release-notes@9.26.9-canary.1148.14918.0
  npm install @auto-canary/released@9.26.9-canary.1148.14918.0
  npm install @auto-canary/s3@9.26.9-canary.1148.14918.0
  npm install @auto-canary/slack@9.26.9-canary.1148.14918.0
  npm install @auto-canary/twitter@9.26.9-canary.1148.14918.0
  npm install @auto-canary/upload-assets@9.26.9-canary.1148.14918.0
  # or 
  yarn add @auto-canary/bot-list@9.26.9-canary.1148.14918.0
  yarn add @auto-canary/auto@9.26.9-canary.1148.14918.0
  yarn add @auto-canary/core@9.26.9-canary.1148.14918.0
  yarn add @auto-canary/all-contributors@9.26.9-canary.1148.14918.0
  yarn add @auto-canary/brew@9.26.9-canary.1148.14918.0
  yarn add @auto-canary/chrome@9.26.9-canary.1148.14918.0
  yarn add @auto-canary/cocoapods@9.26.9-canary.1148.14918.0
  yarn add @auto-canary/conventional-commits@9.26.9-canary.1148.14918.0
  yarn add @auto-canary/crates@9.26.9-canary.1148.14918.0
  yarn add @auto-canary/exec@9.26.9-canary.1148.14918.0
  yarn add @auto-canary/first-time-contributor@9.26.9-canary.1148.14918.0
  yarn add @auto-canary/gh-pages@9.26.9-canary.1148.14918.0
  yarn add @auto-canary/git-tag@9.26.9-canary.1148.14918.0
  yarn add @auto-canary/gradle@9.26.9-canary.1148.14918.0
  yarn add @auto-canary/jira@9.26.9-canary.1148.14918.0
  yarn add @auto-canary/maven@9.26.9-canary.1148.14918.0
  yarn add @auto-canary/npm@9.26.9-canary.1148.14918.0
  yarn add @auto-canary/omit-commits@9.26.9-canary.1148.14918.0
  yarn add @auto-canary/omit-release-notes@9.26.9-canary.1148.14918.0
  yarn add @auto-canary/released@9.26.9-canary.1148.14918.0
  yarn add @auto-canary/s3@9.26.9-canary.1148.14918.0
  yarn add @auto-canary/slack@9.26.9-canary.1148.14918.0
  yarn add @auto-canary/twitter@9.26.9-canary.1148.14918.0
  yarn add @auto-canary/upload-assets@9.26.9-canary.1148.14918.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
