### PR TITLE
Add renovate-pro[bot] to bot list

### DIFF
--- a/packages/bot-list/src/index.ts
+++ b/packages/bot-list/src/index.ts
@@ -6,5 +6,6 @@ export default [
   "renovate",
   "renovate-bot",
   "renovate[bot]",
+  "renovate-pro[bot]",
   "renovate-approve",
 ];


### PR DESCRIPTION
# What Changed

see title

# Why

Renovate is a bot of many different names (5 and counting)
