### PR TITLE
upload-assets: update deprecated option

### DIFF
--- a/packages/core/src/__tests__/auto-in-pr-ci.test.ts
+++ b/packages/core/src/__tests__/auto-in-pr-ci.test.ts
@@ -167,6 +167,8 @@ describe("next in ci", () => {
   test("should post comment with new version", async () => {
     const auto = new Auto({ ...defaults, plugins: [] });
 
+    // @ts-ignore
+    jest.spyOn(console, 'log').mockImplementation();
     exec.mockResolvedValue("v1.0.0");
     // @ts-ignore
     auto.checkClean = () => Promise.resolve(true);

--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -871,7 +871,7 @@ describe("Auto", () => {
       await auto.loadConfig();
       auto.git!.getLatestRelease = () => Promise.resolve("1.2.3");
 
-      jest.spyOn(auto.git!, "publish").mockReturnValueOnce({} as any);
+      jest.spyOn(auto.git!, "publish").mockReturnValueOnce({ data: {} } as any);
       jest
         .spyOn(auto.release!, "generateReleaseNotes")
         .mockImplementation(() => Promise.resolve("releaseNotes"));
@@ -910,7 +910,7 @@ describe("Auto", () => {
       auto.git!.getPreviousTagInBranch = () => Promise.resolve("1.2.3");
       auto.git!.getLatestTagInBranch = () => Promise.resolve("1.2.4");
 
-      jest.spyOn(auto.git!, "publish").mockReturnValueOnce({} as any);
+      jest.spyOn(auto.git!, "publish").mockReturnValueOnce({ data: {} } as any);
       jest
         .spyOn(auto.release!, "generateReleaseNotes")
         .mockImplementation(() => Promise.resolve("releaseNotes"));
@@ -947,7 +947,7 @@ describe("Auto", () => {
       await auto.loadConfig();
       auto.git!.getLatestRelease = () => Promise.resolve("1.2.3");
 
-      jest.spyOn(auto.git!, "publish").mockReturnValueOnce({} as any);
+      jest.spyOn(auto.git!, "publish").mockReturnValueOnce({ data: {} } as any);
       jest
         .spyOn(auto.release!, "generateReleaseNotes")
         .mockImplementation(() => Promise.resolve("releaseNotes"));
@@ -986,7 +986,7 @@ describe("Auto", () => {
       await auto.loadConfig();
       auto.git!.getLatestRelease = () => Promise.resolve("1.2.3");
 
-      jest.spyOn(auto.git!, "publish").mockReturnValueOnce({} as any);
+      jest.spyOn(auto.git!, "publish").mockReturnValueOnce({ data: {} } as any);
       jest
         .spyOn(auto.release!, "generateReleaseNotes")
         .mockImplementation(() => Promise.resolve("releaseNotes"));

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -440,11 +440,14 @@ export default class Auto {
       } else {
         this.logger.log.info(`Releasing ${options.newVersion} to GitHub.`);
 
-        return this.git!.publish(
+        const release = await this.git!.publish(
           options.fullReleaseNotes,
           options.newVersion,
           options.isPrerelease
         );
+
+        this.logger.log.info(release.data.html_url);
+        return release;
       }
     });
   }

--- a/plugins/upload-assets/src/index.ts
+++ b/plugins/upload-assets/src/index.ts
@@ -67,7 +67,7 @@ export default class UploadAssetsPlugin implements IPlugin {
           const type = await FileType.fromBuffer(file);
 
           const options = {
-            file,
+            data: file,
             name: path.basename(asset),
             headers: {
               "content-length": stats.size,


### PR DESCRIPTION
# What Changed

`file` deprecated for `data`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.27.3-canary.1152.14958.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.27.3-canary.1152.14958.0
  npm install @auto-canary/auto@9.27.3-canary.1152.14958.0
  npm install @auto-canary/core@9.27.3-canary.1152.14958.0
  npm install @auto-canary/all-contributors@9.27.3-canary.1152.14958.0
  npm install @auto-canary/brew@9.27.3-canary.1152.14958.0
  npm install @auto-canary/chrome@9.27.3-canary.1152.14958.0
  npm install @auto-canary/cocoapods@9.27.3-canary.1152.14958.0
  npm install @auto-canary/conventional-commits@9.27.3-canary.1152.14958.0
  npm install @auto-canary/crates@9.27.3-canary.1152.14958.0
  npm install @auto-canary/exec@9.27.3-canary.1152.14958.0
  npm install @auto-canary/first-time-contributor@9.27.3-canary.1152.14958.0
  npm install @auto-canary/gh-pages@9.27.3-canary.1152.14958.0
  npm install @auto-canary/git-tag@9.27.3-canary.1152.14958.0
  npm install @auto-canary/gradle@9.27.3-canary.1152.14958.0
  npm install @auto-canary/jira@9.27.3-canary.1152.14958.0
  npm install @auto-canary/maven@9.27.3-canary.1152.14958.0
  npm install @auto-canary/npm@9.27.3-canary.1152.14958.0
  npm install @auto-canary/omit-commits@9.27.3-canary.1152.14958.0
  npm install @auto-canary/omit-release-notes@9.27.3-canary.1152.14958.0
  npm install @auto-canary/released@9.27.3-canary.1152.14958.0
  npm install @auto-canary/s3@9.27.3-canary.1152.14958.0
  npm install @auto-canary/slack@9.27.3-canary.1152.14958.0
  npm install @auto-canary/twitter@9.27.3-canary.1152.14958.0
  npm install @auto-canary/upload-assets@9.27.3-canary.1152.14958.0
  # or 
  yarn add @auto-canary/bot-list@9.27.3-canary.1152.14958.0
  yarn add @auto-canary/auto@9.27.3-canary.1152.14958.0
  yarn add @auto-canary/core@9.27.3-canary.1152.14958.0
  yarn add @auto-canary/all-contributors@9.27.3-canary.1152.14958.0
  yarn add @auto-canary/brew@9.27.3-canary.1152.14958.0
  yarn add @auto-canary/chrome@9.27.3-canary.1152.14958.0
  yarn add @auto-canary/cocoapods@9.27.3-canary.1152.14958.0
  yarn add @auto-canary/conventional-commits@9.27.3-canary.1152.14958.0
  yarn add @auto-canary/crates@9.27.3-canary.1152.14958.0
  yarn add @auto-canary/exec@9.27.3-canary.1152.14958.0
  yarn add @auto-canary/first-time-contributor@9.27.3-canary.1152.14958.0
  yarn add @auto-canary/gh-pages@9.27.3-canary.1152.14958.0
  yarn add @auto-canary/git-tag@9.27.3-canary.1152.14958.0
  yarn add @auto-canary/gradle@9.27.3-canary.1152.14958.0
  yarn add @auto-canary/jira@9.27.3-canary.1152.14958.0
  yarn add @auto-canary/maven@9.27.3-canary.1152.14958.0
  yarn add @auto-canary/npm@9.27.3-canary.1152.14958.0
  yarn add @auto-canary/omit-commits@9.27.3-canary.1152.14958.0
  yarn add @auto-canary/omit-release-notes@9.27.3-canary.1152.14958.0
  yarn add @auto-canary/released@9.27.3-canary.1152.14958.0
  yarn add @auto-canary/s3@9.27.3-canary.1152.14958.0
  yarn add @auto-canary/slack@9.27.3-canary.1152.14958.0
  yarn add @auto-canary/twitter@9.27.3-canary.1152.14958.0
  yarn add @auto-canary/upload-assets@9.27.3-canary.1152.14958.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
