### PR TITLE
set noVersionPrefix if tagVersionPrefix is set

### DIFF
--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -380,6 +380,77 @@ test("should use string semver if no published package", async () => {
   );
 });
 
+describe("modifyConfig", () => {
+  beforeEach(() => {
+    execPromise.mockClear();
+  });
+
+  test("should not modify config in single package", async () => {
+    const plugin = new NPMPlugin({ setRcToken: false });
+    const hooks = makeHooks();
+    const logger = dummyLog();
+
+    plugin.apply({
+      config: { prereleaseBranches: ["next"] },
+      hooks,
+      remote: "origin",
+      baseBranch: "master",
+      logger,
+    } as Auto.Auto);
+
+    expect(hooks.modifyConfig.call({} as any)).toStrictEqual({});
+  });
+
+  test("should not modify config when tagVersionPrefix is not set", async () => {
+    const plugin = new NPMPlugin({ setRcToken: false });
+    const hooks = makeHooks();
+    const logger = dummyLog();
+
+    plugin.apply({
+      config: { prereleaseBranches: ["next"] },
+      hooks,
+      remote: "origin",
+      baseBranch: "master",
+      logger,
+    } as Auto.Auto);
+
+    existsSync.mockReturnValueOnce(true);
+    readResult = `
+      {
+        "name": "test"
+      }
+    `;
+
+    expect(hooks.modifyConfig.call({} as any)).toStrictEqual({});
+  });
+
+  test("should modify config when tagVersionPrefix is set", async () => {
+    const plugin = new NPMPlugin({ setRcToken: false });
+    const hooks = makeHooks();
+    const logger = dummyLog();
+
+    existsSync.mockReturnValueOnce(true);
+    readFileSync.mockReturnValue(`
+      {
+        "name": "test",
+        "tagVersionPrefix": ""
+      }
+    `);
+
+    plugin.apply({
+      config: { prereleaseBranches: ["next"] },
+      hooks,
+      remote: "origin",
+      baseBranch: "master",
+      logger,
+    } as Auto.Auto);
+
+    expect(hooks.modifyConfig.call({} as any)).toStrictEqual({
+      noVersionPrefix: true,
+    });
+  });
+});
+
 describe("publish", () => {
   beforeEach(() => {
     execPromise.mockClear();

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -455,6 +455,21 @@ export default class NPMPlugin implements IPlugin {
       }
     });
 
+    auto.hooks.modifyConfig.tap(this.name, (config) => {
+      if (isMonorepo()) {
+        const lernaJson = getLernaJson();
+
+        if (lernaJson.tagVersionPrefix === "") {
+          return {
+            ...config,
+            noVersionPrefix: true,
+          };
+        }
+      }
+
+      return config;
+    });
+
     auto.hooks.beforeShipIt.tap(this.name, async () => {
       const isIndependent = getLernaJson().version === "independent";
 


### PR DESCRIPTION
# What Changed

If we are in a lerna project with tagVersionPrefix set to `""` then we also turn on `noVersionPrefix`

# Why

You would have to read the docs to know to do this. automated is better

Todo:

- [x] Add tests


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.28.4-canary.1170.15083.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.28.4-canary.1170.15083.0
  npm install @auto-canary/auto@9.28.4-canary.1170.15083.0
  npm install @auto-canary/core@9.28.4-canary.1170.15083.0
  npm install @auto-canary/all-contributors@9.28.4-canary.1170.15083.0
  npm install @auto-canary/brew@9.28.4-canary.1170.15083.0
  npm install @auto-canary/chrome@9.28.4-canary.1170.15083.0
  npm install @auto-canary/cocoapods@9.28.4-canary.1170.15083.0
  npm install @auto-canary/conventional-commits@9.28.4-canary.1170.15083.0
  npm install @auto-canary/crates@9.28.4-canary.1170.15083.0
  npm install @auto-canary/exec@9.28.4-canary.1170.15083.0
  npm install @auto-canary/first-time-contributor@9.28.4-canary.1170.15083.0
  npm install @auto-canary/gh-pages@9.28.4-canary.1170.15083.0
  npm install @auto-canary/git-tag@9.28.4-canary.1170.15083.0
  npm install @auto-canary/gradle@9.28.4-canary.1170.15083.0
  npm install @auto-canary/jira@9.28.4-canary.1170.15083.0
  npm install @auto-canary/maven@9.28.4-canary.1170.15083.0
  npm install @auto-canary/npm@9.28.4-canary.1170.15083.0
  npm install @auto-canary/omit-commits@9.28.4-canary.1170.15083.0
  npm install @auto-canary/omit-release-notes@9.28.4-canary.1170.15083.0
  npm install @auto-canary/released@9.28.4-canary.1170.15083.0
  npm install @auto-canary/s3@9.28.4-canary.1170.15083.0
  npm install @auto-canary/slack@9.28.4-canary.1170.15083.0
  npm install @auto-canary/twitter@9.28.4-canary.1170.15083.0
  npm install @auto-canary/upload-assets@9.28.4-canary.1170.15083.0
  # or 
  yarn add @auto-canary/bot-list@9.28.4-canary.1170.15083.0
  yarn add @auto-canary/auto@9.28.4-canary.1170.15083.0
  yarn add @auto-canary/core@9.28.4-canary.1170.15083.0
  yarn add @auto-canary/all-contributors@9.28.4-canary.1170.15083.0
  yarn add @auto-canary/brew@9.28.4-canary.1170.15083.0
  yarn add @auto-canary/chrome@9.28.4-canary.1170.15083.0
  yarn add @auto-canary/cocoapods@9.28.4-canary.1170.15083.0
  yarn add @auto-canary/conventional-commits@9.28.4-canary.1170.15083.0
  yarn add @auto-canary/crates@9.28.4-canary.1170.15083.0
  yarn add @auto-canary/exec@9.28.4-canary.1170.15083.0
  yarn add @auto-canary/first-time-contributor@9.28.4-canary.1170.15083.0
  yarn add @auto-canary/gh-pages@9.28.4-canary.1170.15083.0
  yarn add @auto-canary/git-tag@9.28.4-canary.1170.15083.0
  yarn add @auto-canary/gradle@9.28.4-canary.1170.15083.0
  yarn add @auto-canary/jira@9.28.4-canary.1170.15083.0
  yarn add @auto-canary/maven@9.28.4-canary.1170.15083.0
  yarn add @auto-canary/npm@9.28.4-canary.1170.15083.0
  yarn add @auto-canary/omit-commits@9.28.4-canary.1170.15083.0
  yarn add @auto-canary/omit-release-notes@9.28.4-canary.1170.15083.0
  yarn add @auto-canary/released@9.28.4-canary.1170.15083.0
  yarn add @auto-canary/s3@9.28.4-canary.1170.15083.0
  yarn add @auto-canary/slack@9.28.4-canary.1170.15083.0
  yarn add @auto-canary/twitter@9.28.4-canary.1170.15083.0
  yarn add @auto-canary/upload-assets@9.28.4-canary.1170.15083.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
