### PR TITLE
Include Chrome manifest in build folder + ensure correct version is used

### DIFF
--- a/plugins/chrome/src/index.ts
+++ b/plugins/chrome/src/index.ts
@@ -9,6 +9,7 @@ import { inc, ReleaseType, gte } from "semver";
 import { promisify } from "util";
 import * as t from "io-ts";
 
+const copyFile = promisify(fs.copyFile);
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
 
@@ -162,6 +163,8 @@ export default class ChromeWebStorePlugin implements IPlugin {
         this.options.manifest,
         JSON.stringify(manifest, undefined, 2)
       );
+
+      await copyFile(this.options.manifest, this.options.build);
 
       // commit new version
       await execPromise("git", ["add", this.options.manifest]);


### PR DESCRIPTION
# What Changed

The chrome plugin now checks that the manifest version is higher or equal to the last tag, if not the tag is used as the higher version.

We also now copy the versioned manifest to the build folder.

# Why

closes #1158 

Todo:

- [ ] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.29.1-canary.1171.15135.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.29.1-canary.1171.15135.0
  npm install @auto-canary/auto@9.29.1-canary.1171.15135.0
  npm install @auto-canary/core@9.29.1-canary.1171.15135.0
  npm install @auto-canary/all-contributors@9.29.1-canary.1171.15135.0
  npm install @auto-canary/brew@9.29.1-canary.1171.15135.0
  npm install @auto-canary/chrome@9.29.1-canary.1171.15135.0
  npm install @auto-canary/cocoapods@9.29.1-canary.1171.15135.0
  npm install @auto-canary/conventional-commits@9.29.1-canary.1171.15135.0
  npm install @auto-canary/crates@9.29.1-canary.1171.15135.0
  npm install @auto-canary/exec@9.29.1-canary.1171.15135.0
  npm install @auto-canary/first-time-contributor@9.29.1-canary.1171.15135.0
  npm install @auto-canary/gh-pages@9.29.1-canary.1171.15135.0
  npm install @auto-canary/git-tag@9.29.1-canary.1171.15135.0
  npm install @auto-canary/gradle@9.29.1-canary.1171.15135.0
  npm install @auto-canary/jira@9.29.1-canary.1171.15135.0
  npm install @auto-canary/maven@9.29.1-canary.1171.15135.0
  npm install @auto-canary/npm@9.29.1-canary.1171.15135.0
  npm install @auto-canary/omit-commits@9.29.1-canary.1171.15135.0
  npm install @auto-canary/omit-release-notes@9.29.1-canary.1171.15135.0
  npm install @auto-canary/released@9.29.1-canary.1171.15135.0
  npm install @auto-canary/s3@9.29.1-canary.1171.15135.0
  npm install @auto-canary/slack@9.29.1-canary.1171.15135.0
  npm install @auto-canary/twitter@9.29.1-canary.1171.15135.0
  npm install @auto-canary/upload-assets@9.29.1-canary.1171.15135.0
  # or 
  yarn add @auto-canary/bot-list@9.29.1-canary.1171.15135.0
  yarn add @auto-canary/auto@9.29.1-canary.1171.15135.0
  yarn add @auto-canary/core@9.29.1-canary.1171.15135.0
  yarn add @auto-canary/all-contributors@9.29.1-canary.1171.15135.0
  yarn add @auto-canary/brew@9.29.1-canary.1171.15135.0
  yarn add @auto-canary/chrome@9.29.1-canary.1171.15135.0
  yarn add @auto-canary/cocoapods@9.29.1-canary.1171.15135.0
  yarn add @auto-canary/conventional-commits@9.29.1-canary.1171.15135.0
  yarn add @auto-canary/crates@9.29.1-canary.1171.15135.0
  yarn add @auto-canary/exec@9.29.1-canary.1171.15135.0
  yarn add @auto-canary/first-time-contributor@9.29.1-canary.1171.15135.0
  yarn add @auto-canary/gh-pages@9.29.1-canary.1171.15135.0
  yarn add @auto-canary/git-tag@9.29.1-canary.1171.15135.0
  yarn add @auto-canary/gradle@9.29.1-canary.1171.15135.0
  yarn add @auto-canary/jira@9.29.1-canary.1171.15135.0
  yarn add @auto-canary/maven@9.29.1-canary.1171.15135.0
  yarn add @auto-canary/npm@9.29.1-canary.1171.15135.0
  yarn add @auto-canary/omit-commits@9.29.1-canary.1171.15135.0
  yarn add @auto-canary/omit-release-notes@9.29.1-canary.1171.15135.0
  yarn add @auto-canary/released@9.29.1-canary.1171.15135.0
  yarn add @auto-canary/s3@9.29.1-canary.1171.15135.0
  yarn add @auto-canary/slack@9.29.1-canary.1171.15135.0
  yarn add @auto-canary/twitter@9.29.1-canary.1171.15135.0
  yarn add @auto-canary/upload-assets@9.29.1-canary.1171.15135.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
