### PR TITLE
pass Gradle options to getProperties helper function

### DIFF
--- a/plugins/gradle/__tests__/gradle.test.ts
+++ b/plugins/gradle/__tests__/gradle.test.ts
@@ -213,14 +213,28 @@ describe("getProperties", () => {
       version: 1.0.0
       snapshotSuffix: :SNAPSHOT
     `);
-    expect(await getProperties("")).toStrictEqual({
+    expect(await getProperties("", [])).toStrictEqual({
       version: "1.0.0",
       snapshotSuffix: ":SNAPSHOT",
     });
   });
 
+  test("should read properties from file with options", async () => {
+    const spy = jest.fn(() => Promise.resolve("version: 1.0.0"));
+    jest.spyOn(Auto, "execPromise").mockImplementation(spy);
+
+    expect(await getProperties("gradle", ["-someOpt"])).toStrictEqual({
+      version: "1.0.0",
+    });
+    expect(spy).toHaveBeenCalledWith(expect.stringMatching("gradle"), [
+      "properties",
+      "-q",
+      `-someOpt`,
+    ]);
+  });
+
   test("should read nothing from empty file", async () => {
     mockProperties("");
-    expect(await getProperties("")).toStrictEqual({});
+    expect(await getProperties("", [])).toStrictEqual({});
   });
 });

--- a/plugins/gradle/__tests__/gradle.test.ts
+++ b/plugins/gradle/__tests__/gradle.test.ts
@@ -227,9 +227,9 @@ describe("getProperties", () => {
       version: "1.0.0",
     });
     expect(spy).toHaveBeenCalledWith(expect.stringMatching("gradle"), [
-      "properties",
       "-q",
-      `-someOpt`,
+      "properties",
+      "-someOpt",
     ]);
   });
 

--- a/plugins/gradle/src/index.ts
+++ b/plugins/gradle/src/index.ts
@@ -47,7 +47,7 @@ export async function getProperties(
   gradleOptions: string[]
 ): Promise<IGradleProperties> {
   const properties = (
-    await execPromise(gradleCommand, ["properties", "-q", ...gradleOptions])
+    await execPromise(gradleCommand, ["-q", "properties", ...gradleOptions])
   )
     .split("\n")
     .map((line) => /([^:\s]+):\s?(.+)/.exec(line) || [])

--- a/plugins/gradle/src/index.ts
+++ b/plugins/gradle/src/index.ts
@@ -39,12 +39,16 @@ export interface IGradleProperties {
  * Builds properties object from gradle properties command
  *
  * @param gradleCommand - base gradle command
+ * @param gradleOptions - options to pass to gradle command
  * @returns properties wrapped in a promise
  */
 export async function getProperties(
-  gradleCommand: string
+  gradleCommand: string,
+  gradleOptions: string[]
 ): Promise<IGradleProperties> {
-  const properties = (await execPromise(gradleCommand, ["properties", "-q"]))
+  const properties = (
+    await execPromise(gradleCommand, ["properties", "-q", ...gradleOptions])
+  )
     .split("\n")
     .map((line) => /([^:\s]+):\s?(.+)/.exec(line) || [])
     .map(([, key, value]) => key && value && { [key]: value })
@@ -57,13 +61,17 @@ export async function getProperties(
  * Retrieves version from gradle properties. Will throw error if version does not exist
  *
  * @param gradleCommand - base gradle command
+ * @param gradleOptions - options to pass to gradle command
  * @returns version wrapped in a promise
  */
-async function getVersion(gradleCommand: string): Promise<string> {
+async function getVersion(
+  gradleCommand: string,
+  gradleOptions: string[]
+): Promise<string> {
   const {
     version,
     snapshotSuffix = defaultSnapshotSuffix,
-  } = await getProperties(gradleCommand);
+  } = await getProperties(gradleCommand, gradleOptions);
 
   if (version) {
     return version.replace(snapshotSuffix, "");
@@ -141,7 +149,10 @@ export default class GradleReleasePluginPlugin implements IPlugin {
     auto.hooks.beforeRun.tap(this.name, async () => {
       auto.logger.log.warn(`${logPrefix} BeforeRun`);
 
-      this.properties = await getProperties(this.options.gradleCommand);
+      this.properties = await getProperties(
+        this.options.gradleCommand,
+        this.options.gradleOptions
+      );
       const {
         version = "",
         snapshotSuffix = defaultSnapshotSuffix,
@@ -160,11 +171,16 @@ export default class GradleReleasePluginPlugin implements IPlugin {
     });
 
     auto.hooks.getPreviousVersion.tapPromise(this.name, async () => {
-      return auto.prefixRelease(await getVersion(this.options.gradleCommand));
+      return auto.prefixRelease(
+        await getVersion(this.options.gradleCommand, this.options.gradleOptions)
+      );
     });
 
     auto.hooks.version.tapPromise(this.name, async (version: string) => {
-      const previousVersion = await getVersion(this.options.gradleCommand);
+      const previousVersion = await getVersion(
+        this.options.gradleCommand,
+        this.options.gradleOptions
+      );
 
       const releaseVersion =
         // After release we bump the version by a patch and add -SNAPSHOT
@@ -221,7 +237,10 @@ export default class GradleReleasePluginPlugin implements IPlugin {
       }
 
       const { snapshotSuffix = defaultSnapshotSuffix } = this.properties;
-      const releaseVersion = await getVersion(this.options.gradleCommand);
+      const releaseVersion = await getVersion(
+        this.options.gradleCommand,
+        this.options.gradleOptions
+      );
 
       // snapshots precede releases, so if we had a minor/major release,
       // then we need to set up snapshots on the next version


### PR DESCRIPTION
# What Changed

Pass Gradle options into `getProperties` helper function.

# Why

Gradle options should be used for any Gradle invocation.

Todo:

- [x] Add tests
- [ ] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.30.3-canary.1184.15235.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.30.3-canary.1184.15235.0
  npm install @auto-canary/auto@9.30.3-canary.1184.15235.0
  npm install @auto-canary/core@9.30.3-canary.1184.15235.0
  npm install @auto-canary/all-contributors@9.30.3-canary.1184.15235.0
  npm install @auto-canary/brew@9.30.3-canary.1184.15235.0
  npm install @auto-canary/chrome@9.30.3-canary.1184.15235.0
  npm install @auto-canary/cocoapods@9.30.3-canary.1184.15235.0
  npm install @auto-canary/conventional-commits@9.30.3-canary.1184.15235.0
  npm install @auto-canary/crates@9.30.3-canary.1184.15235.0
  npm install @auto-canary/exec@9.30.3-canary.1184.15235.0
  npm install @auto-canary/first-time-contributor@9.30.3-canary.1184.15235.0
  npm install @auto-canary/gh-pages@9.30.3-canary.1184.15235.0
  npm install @auto-canary/git-tag@9.30.3-canary.1184.15235.0
  npm install @auto-canary/gradle@9.30.3-canary.1184.15235.0
  npm install @auto-canary/jira@9.30.3-canary.1184.15235.0
  npm install @auto-canary/maven@9.30.3-canary.1184.15235.0
  npm install @auto-canary/npm@9.30.3-canary.1184.15235.0
  npm install @auto-canary/omit-commits@9.30.3-canary.1184.15235.0
  npm install @auto-canary/omit-release-notes@9.30.3-canary.1184.15235.0
  npm install @auto-canary/released@9.30.3-canary.1184.15235.0
  npm install @auto-canary/s3@9.30.3-canary.1184.15235.0
  npm install @auto-canary/slack@9.30.3-canary.1184.15235.0
  npm install @auto-canary/twitter@9.30.3-canary.1184.15235.0
  npm install @auto-canary/upload-assets@9.30.3-canary.1184.15235.0
  # or 
  yarn add @auto-canary/bot-list@9.30.3-canary.1184.15235.0
  yarn add @auto-canary/auto@9.30.3-canary.1184.15235.0
  yarn add @auto-canary/core@9.30.3-canary.1184.15235.0
  yarn add @auto-canary/all-contributors@9.30.3-canary.1184.15235.0
  yarn add @auto-canary/brew@9.30.3-canary.1184.15235.0
  yarn add @auto-canary/chrome@9.30.3-canary.1184.15235.0
  yarn add @auto-canary/cocoapods@9.30.3-canary.1184.15235.0
  yarn add @auto-canary/conventional-commits@9.30.3-canary.1184.15235.0
  yarn add @auto-canary/crates@9.30.3-canary.1184.15235.0
  yarn add @auto-canary/exec@9.30.3-canary.1184.15235.0
  yarn add @auto-canary/first-time-contributor@9.30.3-canary.1184.15235.0
  yarn add @auto-canary/gh-pages@9.30.3-canary.1184.15235.0
  yarn add @auto-canary/git-tag@9.30.3-canary.1184.15235.0
  yarn add @auto-canary/gradle@9.30.3-canary.1184.15235.0
  yarn add @auto-canary/jira@9.30.3-canary.1184.15235.0
  yarn add @auto-canary/maven@9.30.3-canary.1184.15235.0
  yarn add @auto-canary/npm@9.30.3-canary.1184.15235.0
  yarn add @auto-canary/omit-commits@9.30.3-canary.1184.15235.0
  yarn add @auto-canary/omit-release-notes@9.30.3-canary.1184.15235.0
  yarn add @auto-canary/released@9.30.3-canary.1184.15235.0
  yarn add @auto-canary/s3@9.30.3-canary.1184.15235.0
  yarn add @auto-canary/slack@9.30.3-canary.1184.15235.0
  yarn add @auto-canary/twitter@9.30.3-canary.1184.15235.0
  yarn add @auto-canary/upload-assets@9.30.3-canary.1184.15235.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
