### PR TITLE
fix npm canary release w/o any tags

### DIFF
--- a/packages/core/src/utils/exec-promise.ts
+++ b/packages/core/src/utils/exec-promise.ts
@@ -59,14 +59,13 @@ export default async function execPromise(
         appendedStdErr += allStdout.length ? `\n\n${allStdout}` : "";
         appendedStdErr += allStderr.length ? `\n\n${allStderr}` : "";
 
-        reject(
-          new Error(
-            `Running command '${cmd}' with args [${args.join(
-              ", "
-            )}] failed${appendedStdErr}`
-          )
+        const error = new Error(
+          `Running command '${cmd}' with args [${args.join(
+            ", "
+          )}] failed${appendedStdErr}`
         );
-        log.verbose.error("Called from:", callSite);
+        error.stack = (error.stack || "") + callSite;
+        reject(error);
       } else {
         // Tools can occasionally print to stderr but not fail, so print that just in case.
         if (allStderr.length) {

--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -757,7 +757,35 @@ describe("canary", () => {
       getCurrentVersion: () => "1.2.3",
       git: {
         getLatestRelease: () => "1.2.3",
-        getLatestTagInBranch: () => "1.2.3",
+        getLatestTagInBranch: () => Promise.resolve("1.2.3"),
+      },
+    } as unknown) as Auto.Auto);
+
+    readResult = `
+      {
+        "name": "test"
+      }
+    `;
+
+    await hooks.canary.promise(Auto.SEMVER.patch, "canary.123.1");
+    expect(execPromise.mock.calls[0]).toContain("npm");
+    expect(execPromise.mock.calls[0][1]).toContain("1.2.4-canary.123.1.0");
+  });
+
+  test("use handles repos with no tags", async () => {
+    const plugin = new NPMPlugin();
+    const hooks = makeHooks();
+
+    plugin.apply(({
+      config: { prereleaseBranches: ["next"] },
+      hooks,
+      remote: "origin",
+      baseBranch: "master",
+      logger: dummyLog(),
+      getCurrentVersion: () => "1.2.3",
+      git: {
+        getLatestRelease: () => "1.2.3",
+        getLatestTagInBranch: () => Promise.reject(new Error()),
       },
     } as unknown) as Auto.Auto);
 
@@ -784,7 +812,7 @@ describe("canary", () => {
       logger: dummyLog(),
       git: {
         getLatestRelease: () => Promise.resolve("1.2.3"),
-        getLatestTagInBranch: () => "1.2.3",
+        getLatestTagInBranch: () => Promise.resolve("1.2.3"),
       },
     } as any);
     existsSync.mockReturnValueOnce(true);
@@ -828,7 +856,7 @@ describe("canary", () => {
       logger: dummyLog(),
       git: {
         getLatestRelease: () => Promise.resolve("1.2.3"),
-        getLatestTagInBranch: () => "1.2.3",
+        getLatestTagInBranch: () => Promise.resolve("1.2.3"),
       },
     } as any);
     existsSync.mockReturnValueOnce(true);
@@ -922,7 +950,7 @@ describe("canary", () => {
       logger: dummyLog(),
       git: {
         getLatestRelease: () => Promise.resolve("@foo/lib:1.1.0"),
-        getLatestTagInBranch: () => "1.2.3",
+        getLatestTagInBranch: () => Promise.resolve("1.2.3"),
       },
     } as any);
     existsSync.mockReturnValueOnce(true);
@@ -964,7 +992,7 @@ describe("canary", () => {
       logger: dummyLog(),
       git: {
         getLatestRelease: () => Promise.resolve("@foo/lib:1.1.0"),
-        getLatestTagInBranch: () => "1.2.3",
+        getLatestTagInBranch: () => Promise.resolve("1.2.3"),
       },
     } as any);
     existsSync.mockReturnValueOnce(true);

--- a/plugins/npm/package.json
+++ b/plugins/npm/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@auto-it/core": "link:../../packages/core",
+    "await-to-js": "^2.1.1",
     "env-ci": "^5.0.1",
     "fp-ts": "^2.5.3",
     "get-monorepo-packages": "^1.1.0",

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -6,6 +6,7 @@ import { Memoize as memoize } from "typescript-memoize";
 import { Octokit } from "@octokit/rest";
 import * as t from "io-ts";
 import { execSync } from "child_process";
+import on from "await-to-js";
 
 import {
   Auto,
@@ -665,7 +666,9 @@ export default class NPMPlugin implements IPlugin {
       }
 
       const lastRelease = await auto.git!.getLatestRelease();
-      const latestTag = (await auto.git?.getLatestTagInBranch()) || lastRelease;
+      const [, latestTag = lastRelease] = await on(
+        auto.git!.getLatestTagInBranch()
+      );
       const inPrerelease = prereleaseBranches.some((b) =>
         latestTag.includes(`-${b}.`)
       );


### PR DESCRIPTION
# What Changed

Catch the error when there are no tags

# Why

closes #1187 

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.30.4-canary.1188.15307.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.30.4-canary.1188.15307.0
  npm install @auto-canary/auto@9.30.4-canary.1188.15307.0
  npm install @auto-canary/core@9.30.4-canary.1188.15307.0
  npm install @auto-canary/all-contributors@9.30.4-canary.1188.15307.0
  npm install @auto-canary/brew@9.30.4-canary.1188.15307.0
  npm install @auto-canary/chrome@9.30.4-canary.1188.15307.0
  npm install @auto-canary/cocoapods@9.30.4-canary.1188.15307.0
  npm install @auto-canary/conventional-commits@9.30.4-canary.1188.15307.0
  npm install @auto-canary/crates@9.30.4-canary.1188.15307.0
  npm install @auto-canary/exec@9.30.4-canary.1188.15307.0
  npm install @auto-canary/first-time-contributor@9.30.4-canary.1188.15307.0
  npm install @auto-canary/gh-pages@9.30.4-canary.1188.15307.0
  npm install @auto-canary/git-tag@9.30.4-canary.1188.15307.0
  npm install @auto-canary/gradle@9.30.4-canary.1188.15307.0
  npm install @auto-canary/jira@9.30.4-canary.1188.15307.0
  npm install @auto-canary/maven@9.30.4-canary.1188.15307.0
  npm install @auto-canary/npm@9.30.4-canary.1188.15307.0
  npm install @auto-canary/omit-commits@9.30.4-canary.1188.15307.0
  npm install @auto-canary/omit-release-notes@9.30.4-canary.1188.15307.0
  npm install @auto-canary/released@9.30.4-canary.1188.15307.0
  npm install @auto-canary/s3@9.30.4-canary.1188.15307.0
  npm install @auto-canary/slack@9.30.4-canary.1188.15307.0
  npm install @auto-canary/twitter@9.30.4-canary.1188.15307.0
  npm install @auto-canary/upload-assets@9.30.4-canary.1188.15307.0
  # or 
  yarn add @auto-canary/bot-list@9.30.4-canary.1188.15307.0
  yarn add @auto-canary/auto@9.30.4-canary.1188.15307.0
  yarn add @auto-canary/core@9.30.4-canary.1188.15307.0
  yarn add @auto-canary/all-contributors@9.30.4-canary.1188.15307.0
  yarn add @auto-canary/brew@9.30.4-canary.1188.15307.0
  yarn add @auto-canary/chrome@9.30.4-canary.1188.15307.0
  yarn add @auto-canary/cocoapods@9.30.4-canary.1188.15307.0
  yarn add @auto-canary/conventional-commits@9.30.4-canary.1188.15307.0
  yarn add @auto-canary/crates@9.30.4-canary.1188.15307.0
  yarn add @auto-canary/exec@9.30.4-canary.1188.15307.0
  yarn add @auto-canary/first-time-contributor@9.30.4-canary.1188.15307.0
  yarn add @auto-canary/gh-pages@9.30.4-canary.1188.15307.0
  yarn add @auto-canary/git-tag@9.30.4-canary.1188.15307.0
  yarn add @auto-canary/gradle@9.30.4-canary.1188.15307.0
  yarn add @auto-canary/jira@9.30.4-canary.1188.15307.0
  yarn add @auto-canary/maven@9.30.4-canary.1188.15307.0
  yarn add @auto-canary/npm@9.30.4-canary.1188.15307.0
  yarn add @auto-canary/omit-commits@9.30.4-canary.1188.15307.0
  yarn add @auto-canary/omit-release-notes@9.30.4-canary.1188.15307.0
  yarn add @auto-canary/released@9.30.4-canary.1188.15307.0
  yarn add @auto-canary/s3@9.30.4-canary.1188.15307.0
  yarn add @auto-canary/slack@9.30.4-canary.1188.15307.0
  yarn add @auto-canary/twitter@9.30.4-canary.1188.15307.0
  yarn add @auto-canary/upload-assets@9.30.4-canary.1188.15307.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
