### PR TITLE
Fix PR detection bug

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -2010,9 +2010,12 @@ export default class Auto {
         const result = await this.git.graphql(query);
 
         if (result?.[`hash_${commit}`]) {
-          pr = String(
-            (result[`hash_${commit}`] as ISearchResult).edges[0]?.node?.number
-          );
+          const number = (result[`hash_${commit}`] as ISearchResult).edges[0]
+            ?.node?.number;
+
+          if (number) {
+            pr = String(number);
+          }
         }
       }
     }


### PR DESCRIPTION
# What Changed

make sure number exists to avoid "undefined" string as pr number

# Why

closes #1190 


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.30.5-canary.1191.15319.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.30.5-canary.1191.15319.0
  npm install @auto-canary/auto@9.30.5-canary.1191.15319.0
  npm install @auto-canary/core@9.30.5-canary.1191.15319.0
  npm install @auto-canary/all-contributors@9.30.5-canary.1191.15319.0
  npm install @auto-canary/brew@9.30.5-canary.1191.15319.0
  npm install @auto-canary/chrome@9.30.5-canary.1191.15319.0
  npm install @auto-canary/cocoapods@9.30.5-canary.1191.15319.0
  npm install @auto-canary/conventional-commits@9.30.5-canary.1191.15319.0
  npm install @auto-canary/crates@9.30.5-canary.1191.15319.0
  npm install @auto-canary/exec@9.30.5-canary.1191.15319.0
  npm install @auto-canary/first-time-contributor@9.30.5-canary.1191.15319.0
  npm install @auto-canary/gh-pages@9.30.5-canary.1191.15319.0
  npm install @auto-canary/git-tag@9.30.5-canary.1191.15319.0
  npm install @auto-canary/gradle@9.30.5-canary.1191.15319.0
  npm install @auto-canary/jira@9.30.5-canary.1191.15319.0
  npm install @auto-canary/maven@9.30.5-canary.1191.15319.0
  npm install @auto-canary/npm@9.30.5-canary.1191.15319.0
  npm install @auto-canary/omit-commits@9.30.5-canary.1191.15319.0
  npm install @auto-canary/omit-release-notes@9.30.5-canary.1191.15319.0
  npm install @auto-canary/released@9.30.5-canary.1191.15319.0
  npm install @auto-canary/s3@9.30.5-canary.1191.15319.0
  npm install @auto-canary/slack@9.30.5-canary.1191.15319.0
  npm install @auto-canary/twitter@9.30.5-canary.1191.15319.0
  npm install @auto-canary/upload-assets@9.30.5-canary.1191.15319.0
  # or 
  yarn add @auto-canary/bot-list@9.30.5-canary.1191.15319.0
  yarn add @auto-canary/auto@9.30.5-canary.1191.15319.0
  yarn add @auto-canary/core@9.30.5-canary.1191.15319.0
  yarn add @auto-canary/all-contributors@9.30.5-canary.1191.15319.0
  yarn add @auto-canary/brew@9.30.5-canary.1191.15319.0
  yarn add @auto-canary/chrome@9.30.5-canary.1191.15319.0
  yarn add @auto-canary/cocoapods@9.30.5-canary.1191.15319.0
  yarn add @auto-canary/conventional-commits@9.30.5-canary.1191.15319.0
  yarn add @auto-canary/crates@9.30.5-canary.1191.15319.0
  yarn add @auto-canary/exec@9.30.5-canary.1191.15319.0
  yarn add @auto-canary/first-time-contributor@9.30.5-canary.1191.15319.0
  yarn add @auto-canary/gh-pages@9.30.5-canary.1191.15319.0
  yarn add @auto-canary/git-tag@9.30.5-canary.1191.15319.0
  yarn add @auto-canary/gradle@9.30.5-canary.1191.15319.0
  yarn add @auto-canary/jira@9.30.5-canary.1191.15319.0
  yarn add @auto-canary/maven@9.30.5-canary.1191.15319.0
  yarn add @auto-canary/npm@9.30.5-canary.1191.15319.0
  yarn add @auto-canary/omit-commits@9.30.5-canary.1191.15319.0
  yarn add @auto-canary/omit-release-notes@9.30.5-canary.1191.15319.0
  yarn add @auto-canary/released@9.30.5-canary.1191.15319.0
  yarn add @auto-canary/s3@9.30.5-canary.1191.15319.0
  yarn add @auto-canary/slack@9.30.5-canary.1191.15319.0
  yarn add @auto-canary/twitter@9.30.5-canary.1191.15319.0
  yarn add @auto-canary/upload-assets@9.30.5-canary.1191.15319.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
