### PR TITLE
add --no-changelog option

### DIFF
--- a/docs/generate-command-docs.js
+++ b/docs/generate-command-docs.js
@@ -2,6 +2,7 @@
 
 const fs = require("fs");
 const path = require("path");
+const {camelCase} = require('change-case')
 const endent = require("endent").default;
 const docs = require("command-line-docs").default;
 const { commands } = require("../packages/cli/dist/parse-args");
@@ -76,7 +77,7 @@ commands.map((command) => {
                   (o.type === Number && 123);
               }
 
-              return `"${o.name}": ${value}`;
+              return `"${camelCase(o.name)}": ${value}`;
             })
             .join(",\n")}
         }

--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -208,6 +208,14 @@ const changelogCommitMessage: AutoOption = {
   config: true,
 };
 
+const noChangelog: AutoOption = {
+  name: "no-changelog",
+  type: Boolean,
+  group: "main",
+  description: "Skip creating the changelog",
+  config: true,
+};
+
 interface AutoCommand extends Command {
   /** Options for the command */
   options?: AutoOption[];
@@ -224,6 +232,7 @@ const latestCommandArgs: AutoOption[] = [
   changelogTitle,
   changelogCommitMessage,
   quiet,
+  noChangelog,
 ];
 
 export const commands: AutoCommand[] = [

--- a/packages/core/src/auto-args.ts
+++ b/packages/core/src/auto-args.ts
@@ -95,6 +95,8 @@ export type IChangelogOptions = BaseBranch &
     from?: string;
     /** Commit to start calculating the changelog to */
     to?: string;
+    /** Don't commit the changelog */
+    noCommit?: boolean;
   };
 
 export type IReleaseOptions = BaseBranch &
@@ -124,24 +126,28 @@ export type ICommentOptions = DryRun & {
 
 export type IPRBodyOptions = Omit<ICommentOptions, "edit" | "delete">;
 
-export type IShipItOptions = BaseBranch &
+export type ILatestOptions = BaseBranch &
+  DryRun &
+  Partial<AuthorInformation> &
   Prerelease &
   NoVersionPrefix &
-  ChangelogMessage &
   ChangelogTitle &
-  DryRun &
+  ChangelogMessage &
   Quiet &
-  Partial<AuthorInformation> &
-  Partial<RepoInformation> &
   ReleaseCalculationOptions & {
-    /**
-     * Make auto publish prerelease versions when merging to master.
-     * Only PRs merged with "release" label will generate a "latest" release.
-     * Only use this flag if you do not want to maintain a prerelease branch,
-     * and instead only want to use master.
-     */
-    onlyGraduateWithReleaseLabel?: boolean;
+    /** Skip creating the changelog */
+    noChangelog?: boolean;
   };
+
+export type IShipItOptions = ILatestOptions & {
+  /**
+   * Make auto publish prerelease versions when merging to master.
+   * Only PRs merged with "release" label will generate a "latest" release.
+   * Only use this flag if you do not want to maintain a prerelease branch,
+   * and instead only want to use master.
+   */
+  onlyGraduateWithReleaseLabel?: boolean;
+};
 
 export type ICanaryOptions = Quiet & {
   /** Do not actually do anything */
@@ -176,6 +182,7 @@ export type GlobalOptions = {
 
 export type ApiOptions = GlobalOptions &
   (
+    | ILatestOptions
     | IInfoOptions
     | ICreateLabelsOptions
     | ILabelOptions


### PR DESCRIPTION
# What Changed

Add a flag to `latest`/`shipit` to skip the creation of the changelog. This will still call the afterAddToChangelog hook. We plan to rename that hook to make it more descriptive of what it actually does.

# Why

closes #1192 

Todo:

- [x] Add tests
- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.30.6-canary.1193.15335.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.30.6-canary.1193.15335.0
  npm install @auto-canary/auto@9.30.6-canary.1193.15335.0
  npm install @auto-canary/core@9.30.6-canary.1193.15335.0
  npm install @auto-canary/all-contributors@9.30.6-canary.1193.15335.0
  npm install @auto-canary/brew@9.30.6-canary.1193.15335.0
  npm install @auto-canary/chrome@9.30.6-canary.1193.15335.0
  npm install @auto-canary/cocoapods@9.30.6-canary.1193.15335.0
  npm install @auto-canary/conventional-commits@9.30.6-canary.1193.15335.0
  npm install @auto-canary/crates@9.30.6-canary.1193.15335.0
  npm install @auto-canary/exec@9.30.6-canary.1193.15335.0
  npm install @auto-canary/first-time-contributor@9.30.6-canary.1193.15335.0
  npm install @auto-canary/gh-pages@9.30.6-canary.1193.15335.0
  npm install @auto-canary/git-tag@9.30.6-canary.1193.15335.0
  npm install @auto-canary/gradle@9.30.6-canary.1193.15335.0
  npm install @auto-canary/jira@9.30.6-canary.1193.15335.0
  npm install @auto-canary/maven@9.30.6-canary.1193.15335.0
  npm install @auto-canary/npm@9.30.6-canary.1193.15335.0
  npm install @auto-canary/omit-commits@9.30.6-canary.1193.15335.0
  npm install @auto-canary/omit-release-notes@9.30.6-canary.1193.15335.0
  npm install @auto-canary/released@9.30.6-canary.1193.15335.0
  npm install @auto-canary/s3@9.30.6-canary.1193.15335.0
  npm install @auto-canary/slack@9.30.6-canary.1193.15335.0
  npm install @auto-canary/twitter@9.30.6-canary.1193.15335.0
  npm install @auto-canary/upload-assets@9.30.6-canary.1193.15335.0
  # or 
  yarn add @auto-canary/bot-list@9.30.6-canary.1193.15335.0
  yarn add @auto-canary/auto@9.30.6-canary.1193.15335.0
  yarn add @auto-canary/core@9.30.6-canary.1193.15335.0
  yarn add @auto-canary/all-contributors@9.30.6-canary.1193.15335.0
  yarn add @auto-canary/brew@9.30.6-canary.1193.15335.0
  yarn add @auto-canary/chrome@9.30.6-canary.1193.15335.0
  yarn add @auto-canary/cocoapods@9.30.6-canary.1193.15335.0
  yarn add @auto-canary/conventional-commits@9.30.6-canary.1193.15335.0
  yarn add @auto-canary/crates@9.30.6-canary.1193.15335.0
  yarn add @auto-canary/exec@9.30.6-canary.1193.15335.0
  yarn add @auto-canary/first-time-contributor@9.30.6-canary.1193.15335.0
  yarn add @auto-canary/gh-pages@9.30.6-canary.1193.15335.0
  yarn add @auto-canary/git-tag@9.30.6-canary.1193.15335.0
  yarn add @auto-canary/gradle@9.30.6-canary.1193.15335.0
  yarn add @auto-canary/jira@9.30.6-canary.1193.15335.0
  yarn add @auto-canary/maven@9.30.6-canary.1193.15335.0
  yarn add @auto-canary/npm@9.30.6-canary.1193.15335.0
  yarn add @auto-canary/omit-commits@9.30.6-canary.1193.15335.0
  yarn add @auto-canary/omit-release-notes@9.30.6-canary.1193.15335.0
  yarn add @auto-canary/released@9.30.6-canary.1193.15335.0
  yarn add @auto-canary/s3@9.30.6-canary.1193.15335.0
  yarn add @auto-canary/slack@9.30.6-canary.1193.15335.0
  yarn add @auto-canary/twitter@9.30.6-canary.1193.15335.0
  yarn add @auto-canary/upload-assets@9.30.6-canary.1193.15335.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
