### PR TITLE
fix(docs): mention correct key within forcePublish

### DIFF
--- a/plugins/npm/README.md
+++ b/plugins/npm/README.md
@@ -57,7 +57,7 @@ When running the `shipit` command auto will try to set your `.npmrc` token while
 
 ### forcePublish
 
-By default `auto` will force publish all packages for monorepos. To disable this behavior you must set the `setRcToken` to false.
+By default `auto` will force publish all packages for monorepos. To disable this behavior you must set the `forcePublish` to false.
 
 ```json
 {


### PR DESCRIPTION
https://intuit.github.io/auto/plugins/npm/README.html has an incorrect reference at the `forcePublish` section. 

Expected Text:

"By default auto will force publish all packages for monorepos. To disable this behavior you must set the `forcePublish` to false."

Actual Text:

"By default auto will force publish all packages for monorepos. To disable this behavior you must set the `setRcToken` to false."
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.31.2-canary.1205.15454.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.31.2-canary.1205.15454.0
  npm install @auto-canary/auto@9.31.2-canary.1205.15454.0
  npm install @auto-canary/core@9.31.2-canary.1205.15454.0
  npm install @auto-canary/all-contributors@9.31.2-canary.1205.15454.0
  npm install @auto-canary/brew@9.31.2-canary.1205.15454.0
  npm install @auto-canary/chrome@9.31.2-canary.1205.15454.0
  npm install @auto-canary/cocoapods@9.31.2-canary.1205.15454.0
  npm install @auto-canary/conventional-commits@9.31.2-canary.1205.15454.0
  npm install @auto-canary/crates@9.31.2-canary.1205.15454.0
  npm install @auto-canary/exec@9.31.2-canary.1205.15454.0
  npm install @auto-canary/first-time-contributor@9.31.2-canary.1205.15454.0
  npm install @auto-canary/gh-pages@9.31.2-canary.1205.15454.0
  npm install @auto-canary/git-tag@9.31.2-canary.1205.15454.0
  npm install @auto-canary/gradle@9.31.2-canary.1205.15454.0
  npm install @auto-canary/jira@9.31.2-canary.1205.15454.0
  npm install @auto-canary/maven@9.31.2-canary.1205.15454.0
  npm install @auto-canary/npm@9.31.2-canary.1205.15454.0
  npm install @auto-canary/omit-commits@9.31.2-canary.1205.15454.0
  npm install @auto-canary/omit-release-notes@9.31.2-canary.1205.15454.0
  npm install @auto-canary/released@9.31.2-canary.1205.15454.0
  npm install @auto-canary/s3@9.31.2-canary.1205.15454.0
  npm install @auto-canary/slack@9.31.2-canary.1205.15454.0
  npm install @auto-canary/twitter@9.31.2-canary.1205.15454.0
  npm install @auto-canary/upload-assets@9.31.2-canary.1205.15454.0
  # or 
  yarn add @auto-canary/bot-list@9.31.2-canary.1205.15454.0
  yarn add @auto-canary/auto@9.31.2-canary.1205.15454.0
  yarn add @auto-canary/core@9.31.2-canary.1205.15454.0
  yarn add @auto-canary/all-contributors@9.31.2-canary.1205.15454.0
  yarn add @auto-canary/brew@9.31.2-canary.1205.15454.0
  yarn add @auto-canary/chrome@9.31.2-canary.1205.15454.0
  yarn add @auto-canary/cocoapods@9.31.2-canary.1205.15454.0
  yarn add @auto-canary/conventional-commits@9.31.2-canary.1205.15454.0
  yarn add @auto-canary/crates@9.31.2-canary.1205.15454.0
  yarn add @auto-canary/exec@9.31.2-canary.1205.15454.0
  yarn add @auto-canary/first-time-contributor@9.31.2-canary.1205.15454.0
  yarn add @auto-canary/gh-pages@9.31.2-canary.1205.15454.0
  yarn add @auto-canary/git-tag@9.31.2-canary.1205.15454.0
  yarn add @auto-canary/gradle@9.31.2-canary.1205.15454.0
  yarn add @auto-canary/jira@9.31.2-canary.1205.15454.0
  yarn add @auto-canary/maven@9.31.2-canary.1205.15454.0
  yarn add @auto-canary/npm@9.31.2-canary.1205.15454.0
  yarn add @auto-canary/omit-commits@9.31.2-canary.1205.15454.0
  yarn add @auto-canary/omit-release-notes@9.31.2-canary.1205.15454.0
  yarn add @auto-canary/released@9.31.2-canary.1205.15454.0
  yarn add @auto-canary/s3@9.31.2-canary.1205.15454.0
  yarn add @auto-canary/slack@9.31.2-canary.1205.15454.0
  yarn add @auto-canary/twitter@9.31.2-canary.1205.15454.0
  yarn add @auto-canary/upload-assets@9.31.2-canary.1205.15454.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
