### PR TITLE
Slack Plugin HTTP Proxy support

### DIFF
--- a/plugins/slack/__tests__/__snapshots__/slack.test.ts.snap
+++ b/plugins/slack/__tests__/__snapshots__/slack.test.ts.snap
@@ -4,6 +4,10 @@ exports[`postToSlack should call slack api 1`] = `"{\\"text\\":\\"@channel: New 
 
 exports[`postToSlack should call slack api in env var 1`] = `"{\\"text\\":\\"@channel: New release *<https://git.hub/some/project/releases/v1.0.0|v1.0.0>*\\\\n* My Notes*\\\\n• PR <google.com|some link>\\",\\"link_names\\":1}"`;
 
+exports[`postToSlack should call slack api through http proxy 1`] = `"{\\"text\\":\\"@channel: New release *<https://git.hub/some/project/releases/v1.0.0|v1.0.0>*\\\\n* My Notes*\\\\n• PR <google.com|some link>\\",\\"link_names\\":1}"`;
+
+exports[`postToSlack should call slack api through https proxy 1`] = `"{\\"text\\":\\"@channel: New release *<https://git.hub/some/project/releases/v1.0.0|v1.0.0>*\\\\n* My Notes*\\\\n• PR <google.com|some link>\\",\\"link_names\\":1}"`;
+
 exports[`postToSlack should call slack api with custom atTarget 1`] = `"{\\"text\\":\\"@here: New release *<https://git.hub/some/project/releases/v1.0.0|v1.0.0>*\\\\n* My Notes*\\\\n• PR <google.com|some link>\\",\\"link_names\\":1}"`;
 
 exports[`postToSlack should call slack api with minimal config 1`] = `"{\\"text\\":\\"@channel: New release *<https://git.hub/some/project/releases/v1.0.0|v1.0.0>*\\\\n* My Notes*\\\\n• PR <google.com|some link>\\",\\"link_names\\":1}"`;

--- a/plugins/slack/__tests__/slack.test.ts
+++ b/plugins/slack/__tests__/slack.test.ts
@@ -231,6 +231,48 @@ describe("postToSlack", () => {
     expect(fetchSpy.mock.calls[0][0]).toBe(
       "https://custom-slack-url?token=MY_TOKEN"
     );
+    expect(fetchSpy.mock.calls[0][1].agent).toBeUndefined()
+    expect(fetchSpy.mock.calls[0][1].body).toMatchSnapshot();
+  });
+
+  test("should call slack api through http proxy", async () => {
+    const plugin = new SlackPlugin("https://custom-slack-url");
+    process.env.SLACK_TOKEN = "MY_TOKEN";
+    process.env.http_proxy = "http-proxy"
+
+    await plugin.postToSlack(
+      mockAuto,
+      "1.0.0",
+      "# My Notes\n- PR [some link](google.com)",
+      // @ts-ignore
+      mockResponse
+    );
+
+    expect(fetchSpy).toHaveBeenCalled();
+    expect(fetchSpy.mock.calls[0][0]).toBe(
+      "https://custom-slack-url?token=MY_TOKEN"
+    );
+    expect(fetchSpy.mock.calls[0][1].agent).not.toBeUndefined()
+    expect(fetchSpy.mock.calls[0][1].body).toMatchSnapshot();
+  });
+  test("should call slack api through https proxy", async () => {
+    const plugin = new SlackPlugin("https://custom-slack-url");
+    process.env.SLACK_TOKEN = "MY_TOKEN";
+    process.env.https_proxy = "https-proxy"
+
+    await plugin.postToSlack(
+      mockAuto,
+      "1.0.0",
+      "# My Notes\n- PR [some link](google.com)",
+      // @ts-ignore
+      mockResponse
+    );
+
+    expect(fetchSpy).toHaveBeenCalled();
+    expect(fetchSpy.mock.calls[0][0]).toBe(
+      "https://custom-slack-url?token=MY_TOKEN"
+    );
+    expect(fetchSpy.mock.calls[0][1].agent).not.toBeUndefined()
     expect(fetchSpy.mock.calls[0][1].body).toMatchSnapshot();
   });
 

--- a/plugins/slack/package.json
+++ b/plugins/slack/package.json
@@ -41,6 +41,7 @@
     "@auto-it/core": "link:../../packages/core",
     "@octokit/rest": "16.43.1",
     "fp-ts": "^2.5.3",
+    "https-proxy-agent": "^5.0.0",
     "io-ts": "^2.1.2",
     "node-fetch": "2.6.0",
     "tslib": "1.11.1"

--- a/plugins/slack/src/index.ts
+++ b/plugins/slack/src/index.ts
@@ -1,5 +1,6 @@
 import { githubToSlack } from "@atomist/slack-messages";
 import { Octokit } from "@octokit/rest";
+import createHttpsProxyAgent from "https-proxy-agent";
 
 import {
   Auto,
@@ -144,6 +145,7 @@ export default class SlackPlugin implements IPlugin {
 
     const body = sanitizeMarkdown(releaseNotes);
     const token = process.env.SLACK_TOKEN;
+    const proxyUrl = process.env.https_proxy || process.env.http_proxy;
     const atTarget = this.options.atTarget;
     const urls = releases.map(
       (release) => `*<${release.data.html_url}|${release.data.name}>*`
@@ -161,6 +163,7 @@ export default class SlackPlugin implements IPlugin {
         link_names: 1,
       }),
       headers: { "Content-Type": "application/json" },
+      agent: proxyUrl ? createHttpsProxyAgent(proxyUrl) : undefined
     });
 
     auto.logger.verbose.info("Posted release notes to slack.");

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,10 +8,10 @@
   integrity sha512-m2OzlTDbhvzK4hgswH9Lx0cdpq1AntXu53Klz5RGkFfuoDvKsnlU7tmtVfNWtUiP0zZbGtrb/BZYH7aB6TRnMA==
 
 "@auto-it/bot-list@link:packages/bot-list":
-  version "9.31.0"
+  version "9.31.2"
 
 "@auto-it/core@link:packages/core":
-  version "9.31.0"
+  version "9.31.2"
   dependencies:
     "@auto-it/bot-list" "link:packages/bot-list"
     "@octokit/core" "2.4.2"
@@ -50,7 +50,7 @@
     url-join "^4.0.0"
 
 "@auto-it/npm@link:plugins/npm":
-  version "9.31.0"
+  version "9.31.2"
   dependencies:
     "@auto-it/core" "link:packages/core"
     await-to-js "^2.1.1"
@@ -68,7 +68,7 @@
     user-home "^2.0.0"
 
 "@auto-it/released@link:plugins/released":
-  version "9.31.0"
+  version "9.31.2"
   dependencies:
     "@auto-it/core" "link:packages/core"
     deepmerge "^4.0.0"
@@ -2876,16 +2876,6 @@
     regexpp "^3.0.0"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@2.27.0":
-  version "2.27.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.27.0.tgz#801a952c10b58e486c9a0b36cf21e2aab1e9e01a"
-  integrity sha512-vOsYzjwJlY6E0NJRXPTeCGqjv5OHgRU1kzxHKWJVPjDYGbPgLudBXjIlc+OD1hDBZ4l1DLbOc5VjofKahsu9Jw==
-  dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.27.0"
-    eslint-scope "^5.0.0"
-    eslint-utils "^2.0.0"
-
 "@typescript-eslint/experimental-utils@2.31.0", "@typescript-eslint/experimental-utils@^2.5.0":
   version "2.31.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.31.0.tgz#a9ec514bf7fd5e5e82bc10dcb6a86d58baae9508"
@@ -2905,19 +2895,6 @@
     "@typescript-eslint/experimental-utils" "2.31.0"
     "@typescript-eslint/typescript-estree" "2.31.0"
     eslint-visitor-keys "^1.1.0"
-
-"@typescript-eslint/typescript-estree@2.27.0":
-  version "2.27.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.27.0.tgz#a288e54605412da8b81f1660b56c8b2e42966ce8"
-  integrity sha512-t2miCCJIb/FU8yArjAvxllxbTiyNqaXJag7UOpB5DVoM3+xnjeOngtqlJkLRnMtzaRcJhe3CIR9RmL40omubhg==
-  dependencies:
-    debug "^4.1.1"
-    eslint-visitor-keys "^1.1.0"
-    glob "^7.1.6"
-    is-glob "^4.0.1"
-    lodash "^4.17.15"
-    semver "^6.3.0"
-    tsutils "^3.17.1"
 
 "@typescript-eslint/typescript-estree@2.31.0":
   version "2.31.0"


### PR DESCRIPTION
# What Changed
Added support for `http_proxy` and `https_proxy` environment variables for using a tunnel, same way the core package does from #584
# Why
My current CI pipeline runs behind a proxy which works for releases but not for slack notifications
Todo:

- [x] Add tests
- [ ] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.31.3-canary.1210.15495.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.31.3-canary.1210.15495.0
  npm install @auto-canary/auto@9.31.3-canary.1210.15495.0
  npm install @auto-canary/core@9.31.3-canary.1210.15495.0
  npm install @auto-canary/all-contributors@9.31.3-canary.1210.15495.0
  npm install @auto-canary/brew@9.31.3-canary.1210.15495.0
  npm install @auto-canary/chrome@9.31.3-canary.1210.15495.0
  npm install @auto-canary/cocoapods@9.31.3-canary.1210.15495.0
  npm install @auto-canary/conventional-commits@9.31.3-canary.1210.15495.0
  npm install @auto-canary/crates@9.31.3-canary.1210.15495.0
  npm install @auto-canary/exec@9.31.3-canary.1210.15495.0
  npm install @auto-canary/first-time-contributor@9.31.3-canary.1210.15495.0
  npm install @auto-canary/gh-pages@9.31.3-canary.1210.15495.0
  npm install @auto-canary/git-tag@9.31.3-canary.1210.15495.0
  npm install @auto-canary/gradle@9.31.3-canary.1210.15495.0
  npm install @auto-canary/jira@9.31.3-canary.1210.15495.0
  npm install @auto-canary/maven@9.31.3-canary.1210.15495.0
  npm install @auto-canary/npm@9.31.3-canary.1210.15495.0
  npm install @auto-canary/omit-commits@9.31.3-canary.1210.15495.0
  npm install @auto-canary/omit-release-notes@9.31.3-canary.1210.15495.0
  npm install @auto-canary/released@9.31.3-canary.1210.15495.0
  npm install @auto-canary/s3@9.31.3-canary.1210.15495.0
  npm install @auto-canary/slack@9.31.3-canary.1210.15495.0
  npm install @auto-canary/twitter@9.31.3-canary.1210.15495.0
  npm install @auto-canary/upload-assets@9.31.3-canary.1210.15495.0
  # or 
  yarn add @auto-canary/bot-list@9.31.3-canary.1210.15495.0
  yarn add @auto-canary/auto@9.31.3-canary.1210.15495.0
  yarn add @auto-canary/core@9.31.3-canary.1210.15495.0
  yarn add @auto-canary/all-contributors@9.31.3-canary.1210.15495.0
  yarn add @auto-canary/brew@9.31.3-canary.1210.15495.0
  yarn add @auto-canary/chrome@9.31.3-canary.1210.15495.0
  yarn add @auto-canary/cocoapods@9.31.3-canary.1210.15495.0
  yarn add @auto-canary/conventional-commits@9.31.3-canary.1210.15495.0
  yarn add @auto-canary/crates@9.31.3-canary.1210.15495.0
  yarn add @auto-canary/exec@9.31.3-canary.1210.15495.0
  yarn add @auto-canary/first-time-contributor@9.31.3-canary.1210.15495.0
  yarn add @auto-canary/gh-pages@9.31.3-canary.1210.15495.0
  yarn add @auto-canary/git-tag@9.31.3-canary.1210.15495.0
  yarn add @auto-canary/gradle@9.31.3-canary.1210.15495.0
  yarn add @auto-canary/jira@9.31.3-canary.1210.15495.0
  yarn add @auto-canary/maven@9.31.3-canary.1210.15495.0
  yarn add @auto-canary/npm@9.31.3-canary.1210.15495.0
  yarn add @auto-canary/omit-commits@9.31.3-canary.1210.15495.0
  yarn add @auto-canary/omit-release-notes@9.31.3-canary.1210.15495.0
  yarn add @auto-canary/released@9.31.3-canary.1210.15495.0
  yarn add @auto-canary/s3@9.31.3-canary.1210.15495.0
  yarn add @auto-canary/slack@9.31.3-canary.1210.15495.0
  yarn add @auto-canary/twitter@9.31.3-canary.1210.15495.0
  yarn add @auto-canary/upload-assets@9.31.3-canary.1210.15495.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
