### PR TITLE
Increase gitlog maximum buffer size to Infinity

### DIFF
--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -330,7 +330,7 @@ export default class Git {
         // If start === firstCommit then we want to include that commit in the changelog
         // Otherwise it was that last release and should not be included in the release.
         branch: first === startSha ? end : `${start.trim()}..${end.trim()}`,
-        execOptions: { maxBuffer: 1000 * 1024 },
+        execOptions: { maxBuffer: Infinity },
         includeMergeCommitFiles: true,
       });
 


### PR DESCRIPTION
# What Changed

Increased gitlog maximum buffer size to Infinity

# Why

The stdout maxBuffer exceeds when run on large projects.
See [https://github.com/domharrington/node-gitlog/issues/19](https://github.com/domharrington/node-gitlog/issues/19) for further explanation.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.32.1-canary.1212.15526.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.32.1-canary.1212.15526.0
  npm install @auto-canary/auto@9.32.1-canary.1212.15526.0
  npm install @auto-canary/core@9.32.1-canary.1212.15526.0
  npm install @auto-canary/all-contributors@9.32.1-canary.1212.15526.0
  npm install @auto-canary/brew@9.32.1-canary.1212.15526.0
  npm install @auto-canary/chrome@9.32.1-canary.1212.15526.0
  npm install @auto-canary/cocoapods@9.32.1-canary.1212.15526.0
  npm install @auto-canary/conventional-commits@9.32.1-canary.1212.15526.0
  npm install @auto-canary/crates@9.32.1-canary.1212.15526.0
  npm install @auto-canary/exec@9.32.1-canary.1212.15526.0
  npm install @auto-canary/first-time-contributor@9.32.1-canary.1212.15526.0
  npm install @auto-canary/gh-pages@9.32.1-canary.1212.15526.0
  npm install @auto-canary/git-tag@9.32.1-canary.1212.15526.0
  npm install @auto-canary/gradle@9.32.1-canary.1212.15526.0
  npm install @auto-canary/jira@9.32.1-canary.1212.15526.0
  npm install @auto-canary/maven@9.32.1-canary.1212.15526.0
  npm install @auto-canary/npm@9.32.1-canary.1212.15526.0
  npm install @auto-canary/omit-commits@9.32.1-canary.1212.15526.0
  npm install @auto-canary/omit-release-notes@9.32.1-canary.1212.15526.0
  npm install @auto-canary/released@9.32.1-canary.1212.15526.0
  npm install @auto-canary/s3@9.32.1-canary.1212.15526.0
  npm install @auto-canary/slack@9.32.1-canary.1212.15526.0
  npm install @auto-canary/twitter@9.32.1-canary.1212.15526.0
  npm install @auto-canary/upload-assets@9.32.1-canary.1212.15526.0
  # or 
  yarn add @auto-canary/bot-list@9.32.1-canary.1212.15526.0
  yarn add @auto-canary/auto@9.32.1-canary.1212.15526.0
  yarn add @auto-canary/core@9.32.1-canary.1212.15526.0
  yarn add @auto-canary/all-contributors@9.32.1-canary.1212.15526.0
  yarn add @auto-canary/brew@9.32.1-canary.1212.15526.0
  yarn add @auto-canary/chrome@9.32.1-canary.1212.15526.0
  yarn add @auto-canary/cocoapods@9.32.1-canary.1212.15526.0
  yarn add @auto-canary/conventional-commits@9.32.1-canary.1212.15526.0
  yarn add @auto-canary/crates@9.32.1-canary.1212.15526.0
  yarn add @auto-canary/exec@9.32.1-canary.1212.15526.0
  yarn add @auto-canary/first-time-contributor@9.32.1-canary.1212.15526.0
  yarn add @auto-canary/gh-pages@9.32.1-canary.1212.15526.0
  yarn add @auto-canary/git-tag@9.32.1-canary.1212.15526.0
  yarn add @auto-canary/gradle@9.32.1-canary.1212.15526.0
  yarn add @auto-canary/jira@9.32.1-canary.1212.15526.0
  yarn add @auto-canary/maven@9.32.1-canary.1212.15526.0
  yarn add @auto-canary/npm@9.32.1-canary.1212.15526.0
  yarn add @auto-canary/omit-commits@9.32.1-canary.1212.15526.0
  yarn add @auto-canary/omit-release-notes@9.32.1-canary.1212.15526.0
  yarn add @auto-canary/released@9.32.1-canary.1212.15526.0
  yarn add @auto-canary/s3@9.32.1-canary.1212.15526.0
  yarn add @auto-canary/slack@9.32.1-canary.1212.15526.0
  yarn add @auto-canary/twitter@9.32.1-canary.1212.15526.0
  yarn add @auto-canary/upload-assets@9.32.1-canary.1212.15526.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
