### PR TITLE
pass exact flag to publish too

### DIFF
--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -622,6 +622,18 @@ describe("publish", () => {
       '"Bump version to: %s [skip ci]"',
       "--exact",
     ]);
+
+    execPromise.mockClear();
+    existsSync.mockReturnValueOnce(true);
+
+    await hooks.publish.promise(Auto.SEMVER.patch);
+    expect(execPromise).toHaveBeenCalledWith("npx", [
+      "lerna",
+      "publish",
+      "--yes",
+      "from-package",
+      "--exact",
+    ]);
   });
 
   test("monorepo - should publish", async () => {
@@ -644,6 +656,7 @@ describe("publish", () => {
       "publish",
       "--yes",
       "from-package",
+      false,
     ]);
   });
 

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -927,6 +927,7 @@ export default class NPMPlugin implements IPlugin {
           // publish the changed package versions. from-git broke when HEAD
           // didn't contain the tags
           "from-package",
+          this.exact && "--exact",
           ...verboseArgs,
         ]);
       } else {


### PR DESCRIPTION
# What Changed

The versioning part of the npm plugin was already doing this. I think it was an oversight that this wasn't also in the publish portion before.

# Why

closes #1214 

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.32.2-canary.1215.15551.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.32.2-canary.1215.15551.0
  npm install @auto-canary/auto@9.32.2-canary.1215.15551.0
  npm install @auto-canary/core@9.32.2-canary.1215.15551.0
  npm install @auto-canary/all-contributors@9.32.2-canary.1215.15551.0
  npm install @auto-canary/brew@9.32.2-canary.1215.15551.0
  npm install @auto-canary/chrome@9.32.2-canary.1215.15551.0
  npm install @auto-canary/cocoapods@9.32.2-canary.1215.15551.0
  npm install @auto-canary/conventional-commits@9.32.2-canary.1215.15551.0
  npm install @auto-canary/crates@9.32.2-canary.1215.15551.0
  npm install @auto-canary/exec@9.32.2-canary.1215.15551.0
  npm install @auto-canary/first-time-contributor@9.32.2-canary.1215.15551.0
  npm install @auto-canary/gh-pages@9.32.2-canary.1215.15551.0
  npm install @auto-canary/git-tag@9.32.2-canary.1215.15551.0
  npm install @auto-canary/gradle@9.32.2-canary.1215.15551.0
  npm install @auto-canary/jira@9.32.2-canary.1215.15551.0
  npm install @auto-canary/maven@9.32.2-canary.1215.15551.0
  npm install @auto-canary/npm@9.32.2-canary.1215.15551.0
  npm install @auto-canary/omit-commits@9.32.2-canary.1215.15551.0
  npm install @auto-canary/omit-release-notes@9.32.2-canary.1215.15551.0
  npm install @auto-canary/released@9.32.2-canary.1215.15551.0
  npm install @auto-canary/s3@9.32.2-canary.1215.15551.0
  npm install @auto-canary/slack@9.32.2-canary.1215.15551.0
  npm install @auto-canary/twitter@9.32.2-canary.1215.15551.0
  npm install @auto-canary/upload-assets@9.32.2-canary.1215.15551.0
  # or 
  yarn add @auto-canary/bot-list@9.32.2-canary.1215.15551.0
  yarn add @auto-canary/auto@9.32.2-canary.1215.15551.0
  yarn add @auto-canary/core@9.32.2-canary.1215.15551.0
  yarn add @auto-canary/all-contributors@9.32.2-canary.1215.15551.0
  yarn add @auto-canary/brew@9.32.2-canary.1215.15551.0
  yarn add @auto-canary/chrome@9.32.2-canary.1215.15551.0
  yarn add @auto-canary/cocoapods@9.32.2-canary.1215.15551.0
  yarn add @auto-canary/conventional-commits@9.32.2-canary.1215.15551.0
  yarn add @auto-canary/crates@9.32.2-canary.1215.15551.0
  yarn add @auto-canary/exec@9.32.2-canary.1215.15551.0
  yarn add @auto-canary/first-time-contributor@9.32.2-canary.1215.15551.0
  yarn add @auto-canary/gh-pages@9.32.2-canary.1215.15551.0
  yarn add @auto-canary/git-tag@9.32.2-canary.1215.15551.0
  yarn add @auto-canary/gradle@9.32.2-canary.1215.15551.0
  yarn add @auto-canary/jira@9.32.2-canary.1215.15551.0
  yarn add @auto-canary/maven@9.32.2-canary.1215.15551.0
  yarn add @auto-canary/npm@9.32.2-canary.1215.15551.0
  yarn add @auto-canary/omit-commits@9.32.2-canary.1215.15551.0
  yarn add @auto-canary/omit-release-notes@9.32.2-canary.1215.15551.0
  yarn add @auto-canary/released@9.32.2-canary.1215.15551.0
  yarn add @auto-canary/s3@9.32.2-canary.1215.15551.0
  yarn add @auto-canary/slack@9.32.2-canary.1215.15551.0
  yarn add @auto-canary/twitter@9.32.2-canary.1215.15551.0
  yarn add @auto-canary/upload-assets@9.32.2-canary.1215.15551.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
