### PR TITLE
fix(shipit): correct variable name isBaseBranch

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1394,7 +1394,7 @@ export default class Auto {
     // env-ci sets branch to target branch (ex: master) in some CI services.
     // so we should make sure we aren't in a PR just to be safe
     const currentBranch = getCurrentBranch();
-    const isBaseBrach = !isPR && currentBranch === this.baseBranch;
+    const isBaseBranch = !isPR && currentBranch === this.baseBranch;
     const shouldGraduate =
       !options.onlyGraduateWithReleaseLabel ||
       (options.onlyGraduateWithReleaseLabel &&
@@ -1411,7 +1411,7 @@ export default class Auto {
 
     this.logger.veryVerbose.info({
       currentBranch,
-      isBaseBrach,
+      isBaseBranch,
       isPR,
       shouldGraduate,
       isPrereleaseBranch,
@@ -1421,7 +1421,7 @@ export default class Auto {
 
     let releaseType: ShipitRelease = "canary";
 
-    if (isBaseBrach && shouldGraduate) {
+    if (isBaseBranch && shouldGraduate) {
       releaseType = "latest";
     } else if (this.inOldVersionBranch()) {
       releaseType = "old";


### PR DESCRIPTION
While reading the source I noticed this typo
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.32.4-canary.1223.15713.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.32.4-canary.1223.15713.0
  npm install @auto-canary/auto@9.32.4-canary.1223.15713.0
  npm install @auto-canary/core@9.32.4-canary.1223.15713.0
  npm install @auto-canary/all-contributors@9.32.4-canary.1223.15713.0
  npm install @auto-canary/brew@9.32.4-canary.1223.15713.0
  npm install @auto-canary/chrome@9.32.4-canary.1223.15713.0
  npm install @auto-canary/cocoapods@9.32.4-canary.1223.15713.0
  npm install @auto-canary/conventional-commits@9.32.4-canary.1223.15713.0
  npm install @auto-canary/crates@9.32.4-canary.1223.15713.0
  npm install @auto-canary/exec@9.32.4-canary.1223.15713.0
  npm install @auto-canary/first-time-contributor@9.32.4-canary.1223.15713.0
  npm install @auto-canary/gh-pages@9.32.4-canary.1223.15713.0
  npm install @auto-canary/git-tag@9.32.4-canary.1223.15713.0
  npm install @auto-canary/gradle@9.32.4-canary.1223.15713.0
  npm install @auto-canary/jira@9.32.4-canary.1223.15713.0
  npm install @auto-canary/maven@9.32.4-canary.1223.15713.0
  npm install @auto-canary/npm@9.32.4-canary.1223.15713.0
  npm install @auto-canary/omit-commits@9.32.4-canary.1223.15713.0
  npm install @auto-canary/omit-release-notes@9.32.4-canary.1223.15713.0
  npm install @auto-canary/released@9.32.4-canary.1223.15713.0
  npm install @auto-canary/s3@9.32.4-canary.1223.15713.0
  npm install @auto-canary/slack@9.32.4-canary.1223.15713.0
  npm install @auto-canary/twitter@9.32.4-canary.1223.15713.0
  npm install @auto-canary/upload-assets@9.32.4-canary.1223.15713.0
  # or 
  yarn add @auto-canary/bot-list@9.32.4-canary.1223.15713.0
  yarn add @auto-canary/auto@9.32.4-canary.1223.15713.0
  yarn add @auto-canary/core@9.32.4-canary.1223.15713.0
  yarn add @auto-canary/all-contributors@9.32.4-canary.1223.15713.0
  yarn add @auto-canary/brew@9.32.4-canary.1223.15713.0
  yarn add @auto-canary/chrome@9.32.4-canary.1223.15713.0
  yarn add @auto-canary/cocoapods@9.32.4-canary.1223.15713.0
  yarn add @auto-canary/conventional-commits@9.32.4-canary.1223.15713.0
  yarn add @auto-canary/crates@9.32.4-canary.1223.15713.0
  yarn add @auto-canary/exec@9.32.4-canary.1223.15713.0
  yarn add @auto-canary/first-time-contributor@9.32.4-canary.1223.15713.0
  yarn add @auto-canary/gh-pages@9.32.4-canary.1223.15713.0
  yarn add @auto-canary/git-tag@9.32.4-canary.1223.15713.0
  yarn add @auto-canary/gradle@9.32.4-canary.1223.15713.0
  yarn add @auto-canary/jira@9.32.4-canary.1223.15713.0
  yarn add @auto-canary/maven@9.32.4-canary.1223.15713.0
  yarn add @auto-canary/npm@9.32.4-canary.1223.15713.0
  yarn add @auto-canary/omit-commits@9.32.4-canary.1223.15713.0
  yarn add @auto-canary/omit-release-notes@9.32.4-canary.1223.15713.0
  yarn add @auto-canary/released@9.32.4-canary.1223.15713.0
  yarn add @auto-canary/s3@9.32.4-canary.1223.15713.0
  yarn add @auto-canary/slack@9.32.4-canary.1223.15713.0
  yarn add @auto-canary/twitter@9.32.4-canary.1223.15713.0
  yarn add @auto-canary/upload-assets@9.32.4-canary.1223.15713.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
