### PR TITLE
align octokit types

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,7 +41,8 @@
     "start": "npm run build -- -w",
     "lint": "eslint src --ext .ts",
     "test": "jest --maxWorkers=2",
-    "bundle": "rimraf binary && pkg . --out-path binary && yarn gzip",
+    "bundle": "yarn package && yarn gzip",
+    "package": "rimraf binary && pkg . --out-path binary",
     "gzip": "ls binary/auto* | xargs gzip"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2543,31 +2543,11 @@
     "@octokit/plugin-request-log" "^1.0.0"
     "@octokit/plugin-rest-endpoint-methods" "3.11.0"
 
-"@octokit/types@^2.0.0", "@octokit/types@^2.0.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-2.1.1.tgz#77e80d1b663c5f1f829e5377b728fa3c4fe5a97d"
-  integrity sha512-89LOYH+d/vsbDX785NOfLxTW88GjNd0lWRz1DVPVsZgg9Yett5O+3MOvwo7iHgvUwbFz0mf/yPIjBkUbs4kxoQ==
-  dependencies:
-    "@types/node" ">= 8"
 
-"@octokit/types@^2.12.1", "@octokit/types@^2.16.0":
+"@octokit/types@^2.8.2", "@octokit/types@^2.0.0", "@octokit/types@^2.0.1", "@octokit/types@^2.12.1", "@octokit/types@^2.16.0":
   version "2.16.2"
   resolved "https://registry.yarnpkg.com/@octokit/types/-/types-2.16.2.tgz#4c5f8da3c6fecf3da1811aef678fda03edac35d2"
   integrity sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==
-  dependencies:
-    "@types/node" ">= 8"
-
-"@octokit/types@^2.8.2":
-  version "2.8.2"
-  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-2.8.2.tgz#08d1165354637ef32c3134b4b39b7f17bdc17aef"
-  integrity sha512-8cs4DjRAzFoGo1ieUhDyrTdPK016V3JD/H00nbnojSCUYfOXnnJ1owUaAT/3OebTzp/tgdTG6M+8PdCTJzI+/w==
-  dependencies:
-    "@types/node" ">= 8"
-
-"@octokit/types@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-3.0.1.tgz#0706510a6a4edd1925a2ef539773b1b6bfd62d74"
-  integrity sha512-hSWiTHlXO66VVkZQRXr2Le7xeR29CxOsrKOpKlr6/Oua9vnGBncelaNSnS8Ybjbcy0NJD6QgooQWGsbNK4hl2g==
   dependencies:
     "@types/node" ">= 8"
 


### PR DESCRIPTION
# What Changed

Fix lock file and align `@octokit/types`.

# Why

The cross-platform `auto` binary wasn't being built in a useable way. This fixes that.



<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.33.1-canary.1225.15736.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.33.1-canary.1225.15736.0
  npm install @auto-canary/auto@9.33.1-canary.1225.15736.0
  npm install @auto-canary/core@9.33.1-canary.1225.15736.0
  npm install @auto-canary/all-contributors@9.33.1-canary.1225.15736.0
  npm install @auto-canary/brew@9.33.1-canary.1225.15736.0
  npm install @auto-canary/chrome@9.33.1-canary.1225.15736.0
  npm install @auto-canary/cocoapods@9.33.1-canary.1225.15736.0
  npm install @auto-canary/conventional-commits@9.33.1-canary.1225.15736.0
  npm install @auto-canary/crates@9.33.1-canary.1225.15736.0
  npm install @auto-canary/exec@9.33.1-canary.1225.15736.0
  npm install @auto-canary/first-time-contributor@9.33.1-canary.1225.15736.0
  npm install @auto-canary/gem@9.33.1-canary.1225.15736.0
  npm install @auto-canary/gh-pages@9.33.1-canary.1225.15736.0
  npm install @auto-canary/git-tag@9.33.1-canary.1225.15736.0
  npm install @auto-canary/gradle@9.33.1-canary.1225.15736.0
  npm install @auto-canary/jira@9.33.1-canary.1225.15736.0
  npm install @auto-canary/maven@9.33.1-canary.1225.15736.0
  npm install @auto-canary/npm@9.33.1-canary.1225.15736.0
  npm install @auto-canary/omit-commits@9.33.1-canary.1225.15736.0
  npm install @auto-canary/omit-release-notes@9.33.1-canary.1225.15736.0
  npm install @auto-canary/released@9.33.1-canary.1225.15736.0
  npm install @auto-canary/s3@9.33.1-canary.1225.15736.0
  npm install @auto-canary/slack@9.33.1-canary.1225.15736.0
  npm install @auto-canary/twitter@9.33.1-canary.1225.15736.0
  npm install @auto-canary/upload-assets@9.33.1-canary.1225.15736.0
  # or 
  yarn add @auto-canary/bot-list@9.33.1-canary.1225.15736.0
  yarn add @auto-canary/auto@9.33.1-canary.1225.15736.0
  yarn add @auto-canary/core@9.33.1-canary.1225.15736.0
  yarn add @auto-canary/all-contributors@9.33.1-canary.1225.15736.0
  yarn add @auto-canary/brew@9.33.1-canary.1225.15736.0
  yarn add @auto-canary/chrome@9.33.1-canary.1225.15736.0
  yarn add @auto-canary/cocoapods@9.33.1-canary.1225.15736.0
  yarn add @auto-canary/conventional-commits@9.33.1-canary.1225.15736.0
  yarn add @auto-canary/crates@9.33.1-canary.1225.15736.0
  yarn add @auto-canary/exec@9.33.1-canary.1225.15736.0
  yarn add @auto-canary/first-time-contributor@9.33.1-canary.1225.15736.0
  yarn add @auto-canary/gem@9.33.1-canary.1225.15736.0
  yarn add @auto-canary/gh-pages@9.33.1-canary.1225.15736.0
  yarn add @auto-canary/git-tag@9.33.1-canary.1225.15736.0
  yarn add @auto-canary/gradle@9.33.1-canary.1225.15736.0
  yarn add @auto-canary/jira@9.33.1-canary.1225.15736.0
  yarn add @auto-canary/maven@9.33.1-canary.1225.15736.0
  yarn add @auto-canary/npm@9.33.1-canary.1225.15736.0
  yarn add @auto-canary/omit-commits@9.33.1-canary.1225.15736.0
  yarn add @auto-canary/omit-release-notes@9.33.1-canary.1225.15736.0
  yarn add @auto-canary/released@9.33.1-canary.1225.15736.0
  yarn add @auto-canary/s3@9.33.1-canary.1225.15736.0
  yarn add @auto-canary/slack@9.33.1-canary.1225.15736.0
  yarn add @auto-canary/twitter@9.33.1-canary.1225.15736.0
  yarn add @auto-canary/upload-assets@9.33.1-canary.1225.15736.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
