### PR TITLE
add test that ensure bundled auto still works

### DIFF
--- a/packages/cli/__tests__/__snapshots__/bundle.test.ts.snap
+++ b/packages/cli/__tests__/__snapshots__/bundle.test.ts.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`bundle should function 1`] = `
+"
+create-labels
+
+  Create your project's labels on github. If labels exist it will update them. 
+
+Options
+
+  -d, --dry-run    Report what command will do but do not actually do anything 
+
+Global Options
+
+  -V, --version         Display auto's version                                  
+  -v, --verbose         Show some more logs. Pass -vv for very verbose logs.    
+  --repo string         The repo to set the status on. Defaults to looking in   
+                        the package definition for the platform                 
+  --owner string        The owner of the GitHub repo. Defaults to reading from  
+                        the package definition for the platform                 
+  --github-api string   GitHub API to use                                       
+  --plugins string[]    Plugins to load auto with. (defaults to just npm)       
+  -h, --help            Display the help output                                 
+
+Examples
+
+  $ auto create-labels 
+
+"
+`;

--- a/packages/cli/__tests__/bundle.test.ts
+++ b/packages/cli/__tests__/bundle.test.ts
@@ -2,18 +2,22 @@ import path from "path";
 import { execSync } from "child_process";
 
 test("bundle should function", () => {
-  const binary =
+  const type =
     (process.platform === "win32" && "win.exe") ||
     (process.platform === "darwin" && "macos") ||
     "linux";
+  const zip = path.join(__dirname, `../binary/auto-${type}`);
+  const binary = path.join(__dirname, "../auto");
 
-  // Using this command because it is unlikely to change very much
+  execSync(`gunzip -c ${zip} > ${binary}`);
+  execSync(`chmod +x ${binary}`);
+
   expect(
-    execSync(
-      path.join(__dirname, `../binary/auto-${binary} create-labels --help`),
-      {
-        encoding: "utf8",
-      }
-    )
+    // Using this command because it is unlikely to change very much
+    execSync(`${binary} create-labels --help`, {
+      encoding: "utf8",
+    })
   ).toMatchSnapshot();
+
+  execSync(`rm ${binary}`);
 });

--- a/packages/cli/__tests__/bundle.test.ts
+++ b/packages/cli/__tests__/bundle.test.ts
@@ -1,0 +1,19 @@
+import path from "path";
+import { execSync } from "child_process";
+
+test("bundle should function", () => {
+  const binary =
+    (process.platform === "win32" && "win.exe") ||
+    (process.platform === "darwin" && "macos") ||
+    "linux";
+
+  // Using this command because it is unlikely to change very much
+  expect(
+    execSync(
+      path.join(__dirname, `../binary/auto-${binary} create-labels --help`),
+      {
+        encoding: "utf8",
+      }
+    )
+  ).toMatchSnapshot();
+});


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.33.3-canary.1226.15777.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.33.3-canary.1226.15777.0
  npm install @auto-canary/auto@9.33.3-canary.1226.15777.0
  npm install @auto-canary/core@9.33.3-canary.1226.15777.0
  npm install @auto-canary/all-contributors@9.33.3-canary.1226.15777.0
  npm install @auto-canary/brew@9.33.3-canary.1226.15777.0
  npm install @auto-canary/chrome@9.33.3-canary.1226.15777.0
  npm install @auto-canary/cocoapods@9.33.3-canary.1226.15777.0
  npm install @auto-canary/conventional-commits@9.33.3-canary.1226.15777.0
  npm install @auto-canary/crates@9.33.3-canary.1226.15777.0
  npm install @auto-canary/exec@9.33.3-canary.1226.15777.0
  npm install @auto-canary/first-time-contributor@9.33.3-canary.1226.15777.0
  npm install @auto-canary/gem@9.33.3-canary.1226.15777.0
  npm install @auto-canary/gh-pages@9.33.3-canary.1226.15777.0
  npm install @auto-canary/git-tag@9.33.3-canary.1226.15777.0
  npm install @auto-canary/gradle@9.33.3-canary.1226.15777.0
  npm install @auto-canary/jira@9.33.3-canary.1226.15777.0
  npm install @auto-canary/maven@9.33.3-canary.1226.15777.0
  npm install @auto-canary/npm@9.33.3-canary.1226.15777.0
  npm install @auto-canary/omit-commits@9.33.3-canary.1226.15777.0
  npm install @auto-canary/omit-release-notes@9.33.3-canary.1226.15777.0
  npm install @auto-canary/released@9.33.3-canary.1226.15777.0
  npm install @auto-canary/s3@9.33.3-canary.1226.15777.0
  npm install @auto-canary/slack@9.33.3-canary.1226.15777.0
  npm install @auto-canary/twitter@9.33.3-canary.1226.15777.0
  npm install @auto-canary/upload-assets@9.33.3-canary.1226.15777.0
  # or 
  yarn add @auto-canary/bot-list@9.33.3-canary.1226.15777.0
  yarn add @auto-canary/auto@9.33.3-canary.1226.15777.0
  yarn add @auto-canary/core@9.33.3-canary.1226.15777.0
  yarn add @auto-canary/all-contributors@9.33.3-canary.1226.15777.0
  yarn add @auto-canary/brew@9.33.3-canary.1226.15777.0
  yarn add @auto-canary/chrome@9.33.3-canary.1226.15777.0
  yarn add @auto-canary/cocoapods@9.33.3-canary.1226.15777.0
  yarn add @auto-canary/conventional-commits@9.33.3-canary.1226.15777.0
  yarn add @auto-canary/crates@9.33.3-canary.1226.15777.0
  yarn add @auto-canary/exec@9.33.3-canary.1226.15777.0
  yarn add @auto-canary/first-time-contributor@9.33.3-canary.1226.15777.0
  yarn add @auto-canary/gem@9.33.3-canary.1226.15777.0
  yarn add @auto-canary/gh-pages@9.33.3-canary.1226.15777.0
  yarn add @auto-canary/git-tag@9.33.3-canary.1226.15777.0
  yarn add @auto-canary/gradle@9.33.3-canary.1226.15777.0
  yarn add @auto-canary/jira@9.33.3-canary.1226.15777.0
  yarn add @auto-canary/maven@9.33.3-canary.1226.15777.0
  yarn add @auto-canary/npm@9.33.3-canary.1226.15777.0
  yarn add @auto-canary/omit-commits@9.33.3-canary.1226.15777.0
  yarn add @auto-canary/omit-release-notes@9.33.3-canary.1226.15777.0
  yarn add @auto-canary/released@9.33.3-canary.1226.15777.0
  yarn add @auto-canary/s3@9.33.3-canary.1226.15777.0
  yarn add @auto-canary/slack@9.33.3-canary.1226.15777.0
  yarn add @auto-canary/twitter@9.33.3-canary.1226.15777.0
  yarn add @auto-canary/upload-assets@9.33.3-canary.1226.15777.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
