### PR TITLE
fix upload-assets plugin

### DIFF
--- a/plugins/upload-assets/src/index.ts
+++ b/plugins/upload-assets/src/index.ts
@@ -67,7 +67,7 @@ export default class UploadAssetsPlugin implements IPlugin {
           const type = await FileType.fromBuffer(file);
 
           const options = {
-            data: file.toString(),
+            data: file as any,
             name: path.basename(asset),
             owner: auto.git.options.owner,
             repo: auto.git.options.repo,


### PR DESCRIPTION
This was changed because of types, I think it's a bug in the octokit types
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.33.2-canary.1227.15752.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.33.2-canary.1227.15752.0
  npm install @auto-canary/auto@9.33.2-canary.1227.15752.0
  npm install @auto-canary/core@9.33.2-canary.1227.15752.0
  npm install @auto-canary/all-contributors@9.33.2-canary.1227.15752.0
  npm install @auto-canary/brew@9.33.2-canary.1227.15752.0
  npm install @auto-canary/chrome@9.33.2-canary.1227.15752.0
  npm install @auto-canary/cocoapods@9.33.2-canary.1227.15752.0
  npm install @auto-canary/conventional-commits@9.33.2-canary.1227.15752.0
  npm install @auto-canary/crates@9.33.2-canary.1227.15752.0
  npm install @auto-canary/exec@9.33.2-canary.1227.15752.0
  npm install @auto-canary/first-time-contributor@9.33.2-canary.1227.15752.0
  npm install @auto-canary/gem@9.33.2-canary.1227.15752.0
  npm install @auto-canary/gh-pages@9.33.2-canary.1227.15752.0
  npm install @auto-canary/git-tag@9.33.2-canary.1227.15752.0
  npm install @auto-canary/gradle@9.33.2-canary.1227.15752.0
  npm install @auto-canary/jira@9.33.2-canary.1227.15752.0
  npm install @auto-canary/maven@9.33.2-canary.1227.15752.0
  npm install @auto-canary/npm@9.33.2-canary.1227.15752.0
  npm install @auto-canary/omit-commits@9.33.2-canary.1227.15752.0
  npm install @auto-canary/omit-release-notes@9.33.2-canary.1227.15752.0
  npm install @auto-canary/released@9.33.2-canary.1227.15752.0
  npm install @auto-canary/s3@9.33.2-canary.1227.15752.0
  npm install @auto-canary/slack@9.33.2-canary.1227.15752.0
  npm install @auto-canary/twitter@9.33.2-canary.1227.15752.0
  npm install @auto-canary/upload-assets@9.33.2-canary.1227.15752.0
  # or 
  yarn add @auto-canary/bot-list@9.33.2-canary.1227.15752.0
  yarn add @auto-canary/auto@9.33.2-canary.1227.15752.0
  yarn add @auto-canary/core@9.33.2-canary.1227.15752.0
  yarn add @auto-canary/all-contributors@9.33.2-canary.1227.15752.0
  yarn add @auto-canary/brew@9.33.2-canary.1227.15752.0
  yarn add @auto-canary/chrome@9.33.2-canary.1227.15752.0
  yarn add @auto-canary/cocoapods@9.33.2-canary.1227.15752.0
  yarn add @auto-canary/conventional-commits@9.33.2-canary.1227.15752.0
  yarn add @auto-canary/crates@9.33.2-canary.1227.15752.0
  yarn add @auto-canary/exec@9.33.2-canary.1227.15752.0
  yarn add @auto-canary/first-time-contributor@9.33.2-canary.1227.15752.0
  yarn add @auto-canary/gem@9.33.2-canary.1227.15752.0
  yarn add @auto-canary/gh-pages@9.33.2-canary.1227.15752.0
  yarn add @auto-canary/git-tag@9.33.2-canary.1227.15752.0
  yarn add @auto-canary/gradle@9.33.2-canary.1227.15752.0
  yarn add @auto-canary/jira@9.33.2-canary.1227.15752.0
  yarn add @auto-canary/maven@9.33.2-canary.1227.15752.0
  yarn add @auto-canary/npm@9.33.2-canary.1227.15752.0
  yarn add @auto-canary/omit-commits@9.33.2-canary.1227.15752.0
  yarn add @auto-canary/omit-release-notes@9.33.2-canary.1227.15752.0
  yarn add @auto-canary/released@9.33.2-canary.1227.15752.0
  yarn add @auto-canary/s3@9.33.2-canary.1227.15752.0
  yarn add @auto-canary/slack@9.33.2-canary.1227.15752.0
  yarn add @auto-canary/twitter@9.33.2-canary.1227.15752.0
  yarn add @auto-canary/upload-assets@9.33.2-canary.1227.15752.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
