### PR TITLE
allow more rc file types

### DIFF
--- a/docs/pages/autorc.md
+++ b/docs/pages/autorc.md
@@ -1,12 +1,13 @@
 # `auto` RC File
 
-`auto` uses [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) to find your config. This means you can define this file a variety of ways. Our `cosmiconfig` setup is custom and will start at the root of your project and start to search up the directory tree for the following:
+`auto` uses [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) to find your config.
+This means you can define this file a variety of ways.
+`cosmiconfig` will start at the root of your project and start to search up the directory tree for the following:
 
-- a JSON or YAML, extension-less "rc file"
-- an "rc file" with the extensions `.json`, `.yaml`, or `.yml`
 - a package.json property
-
-`auto` does not support writing configuration files in JavaScript.
+- a JSON or YAML, extension-less "rc file"
+- an "rc file" with the extensions `.json`, `.yaml`, `.yml`, or `.js`
+- a `.config.js` CommonJS module
 
 ## Initialization
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -63,15 +63,7 @@ export default class Config {
    * load the extends property, load the plugins and start the git remote interface.
    */
   async loadConfig() {
-    const explorer = cosmiconfig("auto", {
-      searchPlaces: [
-        `.autorc`,
-        `.autorc.json`,
-        `.autorc.yaml`,
-        `.autorc.yml`,
-        "package.json",
-      ],
-    });
+    const explorer = cosmiconfig("auto");
     const result = await explorer.search();
 
     let rawConfig: ConfigObject = {};


### PR DESCRIPTION
# What Changed

Allow `.autorc.js` and `auto.config.js` again.

# Why

closes #1234 

Todo:

- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.33.3-canary.1235.15828.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.33.3-canary.1235.15828.0
  npm install @auto-canary/auto@9.33.3-canary.1235.15828.0
  npm install @auto-canary/core@9.33.3-canary.1235.15828.0
  npm install @auto-canary/all-contributors@9.33.3-canary.1235.15828.0
  npm install @auto-canary/brew@9.33.3-canary.1235.15828.0
  npm install @auto-canary/chrome@9.33.3-canary.1235.15828.0
  npm install @auto-canary/cocoapods@9.33.3-canary.1235.15828.0
  npm install @auto-canary/conventional-commits@9.33.3-canary.1235.15828.0
  npm install @auto-canary/crates@9.33.3-canary.1235.15828.0
  npm install @auto-canary/exec@9.33.3-canary.1235.15828.0
  npm install @auto-canary/first-time-contributor@9.33.3-canary.1235.15828.0
  npm install @auto-canary/gem@9.33.3-canary.1235.15828.0
  npm install @auto-canary/gh-pages@9.33.3-canary.1235.15828.0
  npm install @auto-canary/git-tag@9.33.3-canary.1235.15828.0
  npm install @auto-canary/gradle@9.33.3-canary.1235.15828.0
  npm install @auto-canary/jira@9.33.3-canary.1235.15828.0
  npm install @auto-canary/maven@9.33.3-canary.1235.15828.0
  npm install @auto-canary/npm@9.33.3-canary.1235.15828.0
  npm install @auto-canary/omit-commits@9.33.3-canary.1235.15828.0
  npm install @auto-canary/omit-release-notes@9.33.3-canary.1235.15828.0
  npm install @auto-canary/released@9.33.3-canary.1235.15828.0
  npm install @auto-canary/s3@9.33.3-canary.1235.15828.0
  npm install @auto-canary/slack@9.33.3-canary.1235.15828.0
  npm install @auto-canary/twitter@9.33.3-canary.1235.15828.0
  npm install @auto-canary/upload-assets@9.33.3-canary.1235.15828.0
  # or 
  yarn add @auto-canary/bot-list@9.33.3-canary.1235.15828.0
  yarn add @auto-canary/auto@9.33.3-canary.1235.15828.0
  yarn add @auto-canary/core@9.33.3-canary.1235.15828.0
  yarn add @auto-canary/all-contributors@9.33.3-canary.1235.15828.0
  yarn add @auto-canary/brew@9.33.3-canary.1235.15828.0
  yarn add @auto-canary/chrome@9.33.3-canary.1235.15828.0
  yarn add @auto-canary/cocoapods@9.33.3-canary.1235.15828.0
  yarn add @auto-canary/conventional-commits@9.33.3-canary.1235.15828.0
  yarn add @auto-canary/crates@9.33.3-canary.1235.15828.0
  yarn add @auto-canary/exec@9.33.3-canary.1235.15828.0
  yarn add @auto-canary/first-time-contributor@9.33.3-canary.1235.15828.0
  yarn add @auto-canary/gem@9.33.3-canary.1235.15828.0
  yarn add @auto-canary/gh-pages@9.33.3-canary.1235.15828.0
  yarn add @auto-canary/git-tag@9.33.3-canary.1235.15828.0
  yarn add @auto-canary/gradle@9.33.3-canary.1235.15828.0
  yarn add @auto-canary/jira@9.33.3-canary.1235.15828.0
  yarn add @auto-canary/maven@9.33.3-canary.1235.15828.0
  yarn add @auto-canary/npm@9.33.3-canary.1235.15828.0
  yarn add @auto-canary/omit-commits@9.33.3-canary.1235.15828.0
  yarn add @auto-canary/omit-release-notes@9.33.3-canary.1235.15828.0
  yarn add @auto-canary/released@9.33.3-canary.1235.15828.0
  yarn add @auto-canary/s3@9.33.3-canary.1235.15828.0
  yarn add @auto-canary/slack@9.33.3-canary.1235.15828.0
  yarn add @auto-canary/twitter@9.33.3-canary.1235.15828.0
  yarn add @auto-canary/upload-assets@9.33.3-canary.1235.15828.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
