### PR TITLE
sub-package changelogs: Handle when no changes made to monorepo packages

### DIFF
--- a/plugins/npm/__tests__/monorepo-log.test.ts
+++ b/plugins/npm/__tests__/monorepo-log.test.ts
@@ -196,7 +196,7 @@ test("should create extra change logs for sub-packages", async () => {
       "packages/@foobar/release/README.md\npackages/@foobar/party/package.json"
   );
 
-  execPromise.mockReturnValueOnce('@foobar/release');
+  execPromise.mockResolvedValueOnce("@foobar/release");
 
   const plugin = new NpmPlugin();
   const hooks = makeHooks();

--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -1243,15 +1243,16 @@ describe("makeRelease", () => {
 describe("beforeCommitChangelog", () => {
   let updateChangelogFile: jest.Mock;
 
-  async function subPackageChangelogTest(options: INpmConfig = {}) {
+  async function subPackageChangelogTest(
+    options: INpmConfig = {},
+    changed = "@packages/a\n@packages/b"
+  ) {
     const plugin = new NPMPlugin(options);
     const hooks = makeHooks();
 
     // isMonorepo
-    execPromise.mockReturnValueOnce(
-      '@packages/a\n@packages/b'
-    );
-    execPromise.mockReturnValueOnce("@packages/a\n@packages/b");
+    execPromise.mockResolvedValue("@packages/a\n@packages/b");
+    execPromise.mockResolvedValue(changed);
     existsSync.mockReturnValueOnce(true);
     getLernaPackages.mockReturnValueOnce(monorepoPackagesResult);
 
@@ -1303,6 +1304,11 @@ describe("beforeCommitChangelog", () => {
 
   test("should not create sub-package changelogs ", async () => {
     await subPackageChangelogTest({ subPackageChangelogs: false });
+    expect(updateChangelogFile).not.toHaveBeenCalled();
+  });
+
+  test("should not create sub-package changelogs when nothing has changed", async () => {
+    await subPackageChangelogTest({}, "");
     expect(updateChangelogFile).not.toHaveBeenCalled();
   });
 });

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -581,9 +581,15 @@ export default class NPMPlugin implements IPlugin {
           return;
         }
 
-        const changedPackages = (
-          await execPromise("yarn", ["lerna", "changed"])
-        ).split("\n");
+        const [, changedPackagesResult = ""] = await on(
+          execPromise("yarn", ["lerna", "changed"])
+        );
+        const changedPackages = changedPackagesResult.split("\n");
+
+        if (!changedPackages.length) {
+          return;
+        }
+
         const lernaPackages = await getLernaPackages();
         const changelog = await auto.release.makeChangelog(bump);
 


### PR DESCRIPTION
# What Changed

Fix bug creating sub-package changelogs when no packages have changed.

# Why

It failed on of my releases

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.34.1-canary.1236.15840.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.34.1-canary.1236.15840.0
  npm install @auto-canary/auto@9.34.1-canary.1236.15840.0
  npm install @auto-canary/core@9.34.1-canary.1236.15840.0
  npm install @auto-canary/all-contributors@9.34.1-canary.1236.15840.0
  npm install @auto-canary/brew@9.34.1-canary.1236.15840.0
  npm install @auto-canary/chrome@9.34.1-canary.1236.15840.0
  npm install @auto-canary/cocoapods@9.34.1-canary.1236.15840.0
  npm install @auto-canary/conventional-commits@9.34.1-canary.1236.15840.0
  npm install @auto-canary/crates@9.34.1-canary.1236.15840.0
  npm install @auto-canary/exec@9.34.1-canary.1236.15840.0
  npm install @auto-canary/first-time-contributor@9.34.1-canary.1236.15840.0
  npm install @auto-canary/gem@9.34.1-canary.1236.15840.0
  npm install @auto-canary/gh-pages@9.34.1-canary.1236.15840.0
  npm install @auto-canary/git-tag@9.34.1-canary.1236.15840.0
  npm install @auto-canary/gradle@9.34.1-canary.1236.15840.0
  npm install @auto-canary/jira@9.34.1-canary.1236.15840.0
  npm install @auto-canary/maven@9.34.1-canary.1236.15840.0
  npm install @auto-canary/npm@9.34.1-canary.1236.15840.0
  npm install @auto-canary/omit-commits@9.34.1-canary.1236.15840.0
  npm install @auto-canary/omit-release-notes@9.34.1-canary.1236.15840.0
  npm install @auto-canary/released@9.34.1-canary.1236.15840.0
  npm install @auto-canary/s3@9.34.1-canary.1236.15840.0
  npm install @auto-canary/slack@9.34.1-canary.1236.15840.0
  npm install @auto-canary/twitter@9.34.1-canary.1236.15840.0
  npm install @auto-canary/upload-assets@9.34.1-canary.1236.15840.0
  # or 
  yarn add @auto-canary/bot-list@9.34.1-canary.1236.15840.0
  yarn add @auto-canary/auto@9.34.1-canary.1236.15840.0
  yarn add @auto-canary/core@9.34.1-canary.1236.15840.0
  yarn add @auto-canary/all-contributors@9.34.1-canary.1236.15840.0
  yarn add @auto-canary/brew@9.34.1-canary.1236.15840.0
  yarn add @auto-canary/chrome@9.34.1-canary.1236.15840.0
  yarn add @auto-canary/cocoapods@9.34.1-canary.1236.15840.0
  yarn add @auto-canary/conventional-commits@9.34.1-canary.1236.15840.0
  yarn add @auto-canary/crates@9.34.1-canary.1236.15840.0
  yarn add @auto-canary/exec@9.34.1-canary.1236.15840.0
  yarn add @auto-canary/first-time-contributor@9.34.1-canary.1236.15840.0
  yarn add @auto-canary/gem@9.34.1-canary.1236.15840.0
  yarn add @auto-canary/gh-pages@9.34.1-canary.1236.15840.0
  yarn add @auto-canary/git-tag@9.34.1-canary.1236.15840.0
  yarn add @auto-canary/gradle@9.34.1-canary.1236.15840.0
  yarn add @auto-canary/jira@9.34.1-canary.1236.15840.0
  yarn add @auto-canary/maven@9.34.1-canary.1236.15840.0
  yarn add @auto-canary/npm@9.34.1-canary.1236.15840.0
  yarn add @auto-canary/omit-commits@9.34.1-canary.1236.15840.0
  yarn add @auto-canary/omit-release-notes@9.34.1-canary.1236.15840.0
  yarn add @auto-canary/released@9.34.1-canary.1236.15840.0
  yarn add @auto-canary/s3@9.34.1-canary.1236.15840.0
  yarn add @auto-canary/slack@9.34.1-canary.1236.15840.0
  yarn add @auto-canary/twitter@9.34.1-canary.1236.15840.0
  yarn add @auto-canary/upload-assets@9.34.1-canary.1236.15840.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
