### PR TITLE
Maven plugin support for configurable SNAPSHOT branch

### DIFF
--- a/plugins/maven/README.md
+++ b/plugins/maven/README.md
@@ -6,7 +6,7 @@ Release a Java project to a [maven](https://maven.apache.org/) instance.
 
 This plugin is not included with the `auto` CLI installed via NPM. To install:
 
-```sh
+```shell script
 npm i --save-dev @auto-it/maven
 # or
 yarn add -D @auto-it/maven
@@ -19,6 +19,15 @@ yarn add -D @auto-it/maven
   "plugins": ["maven"]
 }
 ```
+
+## Environment Variables
+
+| Name                    | Description                                                                                      | Default value  |
+| ----------------------- | ------------------------------------------------------------------------------------------------ | -------------- |
+| `MAVEN_USERNAME`        | The deploy username used to login to the repository.                                             | `null`         |
+| `MAVEN_PASSWORD`        | The deploy password used to login to the repository.                                             | `null`         |
+| `MAVEN_SETTINGS`        | The maven `settings.xml` file used by maven.                                                     | `null`         |
+| `MAVEN_SNAPSHOT_BRANCH` | The branch on which the `SNAPSHOT` version lives. Must be different than the Auto "base branch." | `dev-snapshot` |
 
 ## Maven Project Configuration
 
@@ -33,39 +42,39 @@ Your project must be using the maven release plugin. Make sure the the latest `m
     <preparationGoals>initialize</preparationGoals>
     <goals>deploy</goals>
   </configuration>
-</plugin
+</plugin>
 ```
 
-You will also need all of the following configuration blocks for all parts of `auto` to function:
+You will also need all the following configuration blocks for all parts of `auto` to function:
 
 1. Author
 
-   ```xml
-   <developers>
-     <developer>
-       <name>Andrew Lisowski</name>
-       <email>test@email.com</email>
-     </developer>
-   </developers>
-   ```
+```xml
+<developers>
+ <developer>
+   <name>Andrew Lisowski</name>
+   <email>test@email.com</email>
+ </developer>
+</developers>
+```
 
 2. SCM
 
-   ```xml
-   <scm>
-     <connection>scm:git:https://${env.GH_USER}:${env.GH_TOKEN}@github.com/Fuego-Tools/java-test-project.git</connection>
-     <developerConnection>scm:git:https://${env.GH_USER}:${env.GH_TOKEN}@github.com/Fuego-Tools/java-test-project.git</developerConnection>
-     <url>https://github.com/Fuego-Tools/java-test-project</url>
-     <tag>HEAD</tag>
-   </scm>
-   ```
+```xml
+<scm>
+ <connection>scm:git:https://${env.GH_USER}:${env.GH_TOKEN}@github.com/Fuego-Tools/java-test-project.git</connection>
+ <developerConnection>scm:git:https://${env.GH_USER}:${env.GH_TOKEN}@github.com/Fuego-Tools/java-test-project.git</developerConnection>
+ <url>https://github.com/Fuego-Tools/java-test-project</url>
+ <tag>HEAD</tag>
+</scm>
+```
 
-   ::: message is-info
-   Don't forget to set enviornment variables `GH_USER`, `GH_TOKEN`
-   :::
+::: message is-info
+Don't forget to set enviornment variables `GH_USER`, `GH_TOKEN`
+:::
 
 3. Version
 
-   ```xml
-   <version>1.0.0-SNAPSHOT</version>
-   ```
+```xml
+<version>1.0.0-SNAPSHOT</version>
+```

--- a/plugins/maven/src/index.ts
+++ b/plugins/maven/src/index.ts
@@ -171,9 +171,11 @@ export default class MavenPlugin implements IPlugin {
     });
 
     auto.hooks.afterShipIt.tapPromise(this.name, async () => {
+      const { MAVEN_SNAPSHOT_BRANCH } = process.env;
+      const mavenSnapshotBranch = MAVEN_SNAPSHOT_BRANCH || "dev-snapshot";
       // prepare for next development iteration
-      await execPromise("git", ["reset", "--hard", "dev-snapshot"]);
-      await execPromise("git", ["branch", "-d", "dev-snapshot"]);
+      await execPromise("git", ["reset", "--hard", mavenSnapshotBranch]);
+      await execPromise("git", ["branch", "-d", mavenSnapshotBranch]);
       await execPromise("git", ["push", auto.remote, auto.baseBranch]);
     });
   }


### PR DESCRIPTION
# Why

Currently, the Maven plugin has an undocumented requirement for a "dev-snapshot" branch for committing the next SNAPSHOT version after release. Also, `MAVEN_USERNAME`, `MAVEN_PASSWORD`, and `MAVEN_SETTINGS` are undocumented environment variables.

# What Changed

1. Add a new environment variable `MAVEN_SNAPSHOT_BRANCH` that can be used to configure the SNAPSHOT branch.
2. Document all environment variables used by this plugin directly. *NOTE: environment variables used in a `pom.xml` or `settings.xml` or other Maven configuration files are NOT documented here.*

Todo:

- [x] Add tests
- [ ] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.34.2-canary.1241.15885.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.34.2-canary.1241.15885.0
  npm install @auto-canary/auto@9.34.2-canary.1241.15885.0
  npm install @auto-canary/core@9.34.2-canary.1241.15885.0
  npm install @auto-canary/all-contributors@9.34.2-canary.1241.15885.0
  npm install @auto-canary/brew@9.34.2-canary.1241.15885.0
  npm install @auto-canary/chrome@9.34.2-canary.1241.15885.0
  npm install @auto-canary/cocoapods@9.34.2-canary.1241.15885.0
  npm install @auto-canary/conventional-commits@9.34.2-canary.1241.15885.0
  npm install @auto-canary/crates@9.34.2-canary.1241.15885.0
  npm install @auto-canary/exec@9.34.2-canary.1241.15885.0
  npm install @auto-canary/first-time-contributor@9.34.2-canary.1241.15885.0
  npm install @auto-canary/gh-pages@9.34.2-canary.1241.15885.0
  npm install @auto-canary/git-tag@9.34.2-canary.1241.15885.0
  npm install @auto-canary/gradle@9.34.2-canary.1241.15885.0
  npm install @auto-canary/jira@9.34.2-canary.1241.15885.0
  npm install @auto-canary/maven@9.34.2-canary.1241.15885.0
  npm install @auto-canary/npm@9.34.2-canary.1241.15885.0
  npm install @auto-canary/omit-commits@9.34.2-canary.1241.15885.0
  npm install @auto-canary/omit-release-notes@9.34.2-canary.1241.15885.0
  npm install @auto-canary/released@9.34.2-canary.1241.15885.0
  npm install @auto-canary/s3@9.34.2-canary.1241.15885.0
  npm install @auto-canary/slack@9.34.2-canary.1241.15885.0
  npm install @auto-canary/twitter@9.34.2-canary.1241.15885.0
  npm install @auto-canary/upload-assets@9.34.2-canary.1241.15885.0
  # or 
  yarn add @auto-canary/bot-list@9.34.2-canary.1241.15885.0
  yarn add @auto-canary/auto@9.34.2-canary.1241.15885.0
  yarn add @auto-canary/core@9.34.2-canary.1241.15885.0
  yarn add @auto-canary/all-contributors@9.34.2-canary.1241.15885.0
  yarn add @auto-canary/brew@9.34.2-canary.1241.15885.0
  yarn add @auto-canary/chrome@9.34.2-canary.1241.15885.0
  yarn add @auto-canary/cocoapods@9.34.2-canary.1241.15885.0
  yarn add @auto-canary/conventional-commits@9.34.2-canary.1241.15885.0
  yarn add @auto-canary/crates@9.34.2-canary.1241.15885.0
  yarn add @auto-canary/exec@9.34.2-canary.1241.15885.0
  yarn add @auto-canary/first-time-contributor@9.34.2-canary.1241.15885.0
  yarn add @auto-canary/gh-pages@9.34.2-canary.1241.15885.0
  yarn add @auto-canary/git-tag@9.34.2-canary.1241.15885.0
  yarn add @auto-canary/gradle@9.34.2-canary.1241.15885.0
  yarn add @auto-canary/jira@9.34.2-canary.1241.15885.0
  yarn add @auto-canary/maven@9.34.2-canary.1241.15885.0
  yarn add @auto-canary/npm@9.34.2-canary.1241.15885.0
  yarn add @auto-canary/omit-commits@9.34.2-canary.1241.15885.0
  yarn add @auto-canary/omit-release-notes@9.34.2-canary.1241.15885.0
  yarn add @auto-canary/released@9.34.2-canary.1241.15885.0
  yarn add @auto-canary/s3@9.34.2-canary.1241.15885.0
  yarn add @auto-canary/slack@9.34.2-canary.1241.15885.0
  yarn add @auto-canary/twitter@9.34.2-canary.1241.15885.0
  yarn add @auto-canary/upload-assets@9.34.2-canary.1241.15885.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
