### PR TITLE
Fix missing use of MAVEN_SNAPSHOT_BRANCH

### DIFF
--- a/plugins/maven/src/index.ts
+++ b/plugins/maven/src/index.ts
@@ -145,7 +145,7 @@ export default class MavenPlugin implements IPlugin {
         "-DpushChanges=false",
       ]);
       await execPromise("git", ["checkout", "-b", mavenSnapshotBranch]);
-      await execPromise("git", ["checkout", "master"]);
+      await execPromise("git", ["checkout", auto.baseBranch]);
       await execPromise("git", ["reset", "--hard", "HEAD~1"]);
     });
 

--- a/plugins/maven/src/index.ts
+++ b/plugins/maven/src/index.ts
@@ -119,6 +119,8 @@ export default class MavenPlugin implements IPlugin {
     );
 
     auto.hooks.version.tapPromise(this.name, async (version) => {
+      const { MAVEN_SNAPSHOT_BRANCH } = process.env;
+      const mavenSnapshotBranch = MAVEN_SNAPSHOT_BRANCH || "dev-snapshot";
       const previousVersion = await getPreviousVersion(auto);
       const newVersion =
         // After release we bump the version by a patch and add -SNAPSHOT
@@ -142,7 +144,7 @@ export default class MavenPlugin implements IPlugin {
         `-DreleaseVersion=${newVersion}`,
         "-DpushChanges=false",
       ]);
-      await execPromise("git", ["checkout", "-b", "dev-snapshot"]);
+      await execPromise("git", ["checkout", "-b", mavenSnapshotBranch]);
       await execPromise("git", ["checkout", "master"]);
       await execPromise("git", ["reset", "--hard", "HEAD~1"]);
     });


### PR DESCRIPTION
Missed one other location where "dev-snapshot" is being used.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.35.1-canary.1242.15914.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.35.1-canary.1242.15914.0
  npm install @auto-canary/auto@9.35.1-canary.1242.15914.0
  npm install @auto-canary/core@9.35.1-canary.1242.15914.0
  npm install @auto-canary/all-contributors@9.35.1-canary.1242.15914.0
  npm install @auto-canary/brew@9.35.1-canary.1242.15914.0
  npm install @auto-canary/chrome@9.35.1-canary.1242.15914.0
  npm install @auto-canary/cocoapods@9.35.1-canary.1242.15914.0
  npm install @auto-canary/conventional-commits@9.35.1-canary.1242.15914.0
  npm install @auto-canary/crates@9.35.1-canary.1242.15914.0
  npm install @auto-canary/exec@9.35.1-canary.1242.15914.0
  npm install @auto-canary/first-time-contributor@9.35.1-canary.1242.15914.0
  npm install @auto-canary/gem@9.35.1-canary.1242.15914.0
  npm install @auto-canary/gh-pages@9.35.1-canary.1242.15914.0
  npm install @auto-canary/git-tag@9.35.1-canary.1242.15914.0
  npm install @auto-canary/gradle@9.35.1-canary.1242.15914.0
  npm install @auto-canary/jira@9.35.1-canary.1242.15914.0
  npm install @auto-canary/maven@9.35.1-canary.1242.15914.0
  npm install @auto-canary/npm@9.35.1-canary.1242.15914.0
  npm install @auto-canary/omit-commits@9.35.1-canary.1242.15914.0
  npm install @auto-canary/omit-release-notes@9.35.1-canary.1242.15914.0
  npm install @auto-canary/released@9.35.1-canary.1242.15914.0
  npm install @auto-canary/s3@9.35.1-canary.1242.15914.0
  npm install @auto-canary/slack@9.35.1-canary.1242.15914.0
  npm install @auto-canary/twitter@9.35.1-canary.1242.15914.0
  npm install @auto-canary/upload-assets@9.35.1-canary.1242.15914.0
  # or 
  yarn add @auto-canary/bot-list@9.35.1-canary.1242.15914.0
  yarn add @auto-canary/auto@9.35.1-canary.1242.15914.0
  yarn add @auto-canary/core@9.35.1-canary.1242.15914.0
  yarn add @auto-canary/all-contributors@9.35.1-canary.1242.15914.0
  yarn add @auto-canary/brew@9.35.1-canary.1242.15914.0
  yarn add @auto-canary/chrome@9.35.1-canary.1242.15914.0
  yarn add @auto-canary/cocoapods@9.35.1-canary.1242.15914.0
  yarn add @auto-canary/conventional-commits@9.35.1-canary.1242.15914.0
  yarn add @auto-canary/crates@9.35.1-canary.1242.15914.0
  yarn add @auto-canary/exec@9.35.1-canary.1242.15914.0
  yarn add @auto-canary/first-time-contributor@9.35.1-canary.1242.15914.0
  yarn add @auto-canary/gem@9.35.1-canary.1242.15914.0
  yarn add @auto-canary/gh-pages@9.35.1-canary.1242.15914.0
  yarn add @auto-canary/git-tag@9.35.1-canary.1242.15914.0
  yarn add @auto-canary/gradle@9.35.1-canary.1242.15914.0
  yarn add @auto-canary/jira@9.35.1-canary.1242.15914.0
  yarn add @auto-canary/maven@9.35.1-canary.1242.15914.0
  yarn add @auto-canary/npm@9.35.1-canary.1242.15914.0
  yarn add @auto-canary/omit-commits@9.35.1-canary.1242.15914.0
  yarn add @auto-canary/omit-release-notes@9.35.1-canary.1242.15914.0
  yarn add @auto-canary/released@9.35.1-canary.1242.15914.0
  yarn add @auto-canary/s3@9.35.1-canary.1242.15914.0
  yarn add @auto-canary/slack@9.35.1-canary.1242.15914.0
  yarn add @auto-canary/twitter@9.35.1-canary.1242.15914.0
  yarn add @auto-canary/upload-assets@9.35.1-canary.1242.15914.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
