### PR TITLE
fallback to tag name when the release has no name

### DIFF
--- a/plugins/released/src/index.ts
+++ b/plugins/released/src/index.ts
@@ -194,7 +194,9 @@ export default class ReleasedLabelPlugin implements IPlugin {
     // leave a comment with the new version
     const urls = releases.map((release) =>
       this.options.message === defaultOptions.message
-        ? `[\`${release.data.name}\`](${release.data.html_url})`
+        ? `[\`${release.data.name || release.data.tag_name}\`](${
+            release.data.html_url
+          })`
         : release.data.name
     );
     const message = this.createReleasedComment(isIssue, urls.join(", "));

--- a/plugins/slack/src/index.ts
+++ b/plugins/slack/src/index.ts
@@ -150,7 +150,10 @@ export default class SlackPlugin implements IPlugin {
     const proxyUrl = process.env.https_proxy || process.env.http_proxy;
     const atTarget = this.options.atTarget;
     const urls = releases.map(
-      (release) => `*<${release.data.html_url}|${release.data.name}>*`
+      (release) =>
+        `*<${release.data.html_url}|${
+          release.data.name || release.data.tag_name
+        }>*`
     );
     const releaseUrl = urls.length ? urls.join(", ") : newVersion;
 


### PR DESCRIPTION
# What Changed

Sometime the GitHub API responds with a release that has no `name` even though it is definitely set. This code falls back to the `tag_name` (which should be the same value)  if no `name` is found.

# Why

A user was experiencing `null` releases in the `slack` plugin.
This might have been due to the use of an HttpProxy.

Todo:

- [ ] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.35.1-canary.1243.15909.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.35.1-canary.1243.15909.0
  npm install @auto-canary/auto@9.35.1-canary.1243.15909.0
  npm install @auto-canary/core@9.35.1-canary.1243.15909.0
  npm install @auto-canary/all-contributors@9.35.1-canary.1243.15909.0
  npm install @auto-canary/brew@9.35.1-canary.1243.15909.0
  npm install @auto-canary/chrome@9.35.1-canary.1243.15909.0
  npm install @auto-canary/cocoapods@9.35.1-canary.1243.15909.0
  npm install @auto-canary/conventional-commits@9.35.1-canary.1243.15909.0
  npm install @auto-canary/crates@9.35.1-canary.1243.15909.0
  npm install @auto-canary/exec@9.35.1-canary.1243.15909.0
  npm install @auto-canary/first-time-contributor@9.35.1-canary.1243.15909.0
  npm install @auto-canary/gem@9.35.1-canary.1243.15909.0
  npm install @auto-canary/gh-pages@9.35.1-canary.1243.15909.0
  npm install @auto-canary/git-tag@9.35.1-canary.1243.15909.0
  npm install @auto-canary/gradle@9.35.1-canary.1243.15909.0
  npm install @auto-canary/jira@9.35.1-canary.1243.15909.0
  npm install @auto-canary/maven@9.35.1-canary.1243.15909.0
  npm install @auto-canary/npm@9.35.1-canary.1243.15909.0
  npm install @auto-canary/omit-commits@9.35.1-canary.1243.15909.0
  npm install @auto-canary/omit-release-notes@9.35.1-canary.1243.15909.0
  npm install @auto-canary/released@9.35.1-canary.1243.15909.0
  npm install @auto-canary/s3@9.35.1-canary.1243.15909.0
  npm install @auto-canary/slack@9.35.1-canary.1243.15909.0
  npm install @auto-canary/twitter@9.35.1-canary.1243.15909.0
  npm install @auto-canary/upload-assets@9.35.1-canary.1243.15909.0
  # or 
  yarn add @auto-canary/bot-list@9.35.1-canary.1243.15909.0
  yarn add @auto-canary/auto@9.35.1-canary.1243.15909.0
  yarn add @auto-canary/core@9.35.1-canary.1243.15909.0
  yarn add @auto-canary/all-contributors@9.35.1-canary.1243.15909.0
  yarn add @auto-canary/brew@9.35.1-canary.1243.15909.0
  yarn add @auto-canary/chrome@9.35.1-canary.1243.15909.0
  yarn add @auto-canary/cocoapods@9.35.1-canary.1243.15909.0
  yarn add @auto-canary/conventional-commits@9.35.1-canary.1243.15909.0
  yarn add @auto-canary/crates@9.35.1-canary.1243.15909.0
  yarn add @auto-canary/exec@9.35.1-canary.1243.15909.0
  yarn add @auto-canary/first-time-contributor@9.35.1-canary.1243.15909.0
  yarn add @auto-canary/gem@9.35.1-canary.1243.15909.0
  yarn add @auto-canary/gh-pages@9.35.1-canary.1243.15909.0
  yarn add @auto-canary/git-tag@9.35.1-canary.1243.15909.0
  yarn add @auto-canary/gradle@9.35.1-canary.1243.15909.0
  yarn add @auto-canary/jira@9.35.1-canary.1243.15909.0
  yarn add @auto-canary/maven@9.35.1-canary.1243.15909.0
  yarn add @auto-canary/npm@9.35.1-canary.1243.15909.0
  yarn add @auto-canary/omit-commits@9.35.1-canary.1243.15909.0
  yarn add @auto-canary/omit-release-notes@9.35.1-canary.1243.15909.0
  yarn add @auto-canary/released@9.35.1-canary.1243.15909.0
  yarn add @auto-canary/s3@9.35.1-canary.1243.15909.0
  yarn add @auto-canary/slack@9.35.1-canary.1243.15909.0
  yarn add @auto-canary/twitter@9.35.1-canary.1243.15909.0
  yarn add @auto-canary/upload-assets@9.35.1-canary.1243.15909.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
