### PR TITLE
automatically update install version in docs

### DIFF
--- a/docs/pages/non-npm.md
+++ b/docs/pages/non-npm.md
@@ -11,7 +11,7 @@ Simply download the appropriate version for your operating system and make it ex
 
 ```sh
 # Download a platform specific version of auto
-curl -vkL -o - https://github.com/intuit/auto/releases/download/v7.2.0/auto-linux.gz | gunzip > ~/auto
+curl -vkL -o - https://github.com/intuit/auto/releases/download/v9.35.1/auto-linux.gz | gunzip > ~/auto
 # Make auto executable
 chmod a+x ~/auto
 ```

--- a/docs/update-curl-version.js
+++ b/docs/update-curl-version.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+const project = require("../lerna.json");
+
+const filename = path.join(__dirname, "./pages/non-npm.md");
+const nonNpmDocs = fs.readFileSync(filename, { encoding: "utf8" });
+
+fs.writeFileSync(
+  filename,
+  nonNpmDocs.replace(
+    /(download\/v)(\d+\.\d+\.\d+)(\/auto-linux\.gz)/,
+    `$1${project.version}$3`
+  )
+);

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "contributors:add": "all-contributors",
     "contributors:generate": "all-contributors generate",
     "docs": "yarn docs:build && ignite",
-    "docs:build": "./docs/generate-command-docs.js",
+    "docs:build": "./docs/generate-command-docs.js && ./docs/update-curl-version.js",
     "docs:watch": "yarn docs --watch",
     "docs:publish": "./scripts/publish-docs.sh",
     "create:plugin": "./scripts/create-plugin.js",


### PR DESCRIPTION
# What Changed

Update the curl version in the non-npm docs

# Why

It's been out of date for a long time.


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.35.2-canary.1244.15924.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.35.2-canary.1244.15924.0
  npm install @auto-canary/auto@9.35.2-canary.1244.15924.0
  npm install @auto-canary/core@9.35.2-canary.1244.15924.0
  npm install @auto-canary/all-contributors@9.35.2-canary.1244.15924.0
  npm install @auto-canary/brew@9.35.2-canary.1244.15924.0
  npm install @auto-canary/chrome@9.35.2-canary.1244.15924.0
  npm install @auto-canary/cocoapods@9.35.2-canary.1244.15924.0
  npm install @auto-canary/conventional-commits@9.35.2-canary.1244.15924.0
  npm install @auto-canary/crates@9.35.2-canary.1244.15924.0
  npm install @auto-canary/exec@9.35.2-canary.1244.15924.0
  npm install @auto-canary/first-time-contributor@9.35.2-canary.1244.15924.0
  npm install @auto-canary/gem@9.35.2-canary.1244.15924.0
  npm install @auto-canary/gh-pages@9.35.2-canary.1244.15924.0
  npm install @auto-canary/git-tag@9.35.2-canary.1244.15924.0
  npm install @auto-canary/gradle@9.35.2-canary.1244.15924.0
  npm install @auto-canary/jira@9.35.2-canary.1244.15924.0
  npm install @auto-canary/maven@9.35.2-canary.1244.15924.0
  npm install @auto-canary/npm@9.35.2-canary.1244.15924.0
  npm install @auto-canary/omit-commits@9.35.2-canary.1244.15924.0
  npm install @auto-canary/omit-release-notes@9.35.2-canary.1244.15924.0
  npm install @auto-canary/released@9.35.2-canary.1244.15924.0
  npm install @auto-canary/s3@9.35.2-canary.1244.15924.0
  npm install @auto-canary/slack@9.35.2-canary.1244.15924.0
  npm install @auto-canary/twitter@9.35.2-canary.1244.15924.0
  npm install @auto-canary/upload-assets@9.35.2-canary.1244.15924.0
  # or 
  yarn add @auto-canary/bot-list@9.35.2-canary.1244.15924.0
  yarn add @auto-canary/auto@9.35.2-canary.1244.15924.0
  yarn add @auto-canary/core@9.35.2-canary.1244.15924.0
  yarn add @auto-canary/all-contributors@9.35.2-canary.1244.15924.0
  yarn add @auto-canary/brew@9.35.2-canary.1244.15924.0
  yarn add @auto-canary/chrome@9.35.2-canary.1244.15924.0
  yarn add @auto-canary/cocoapods@9.35.2-canary.1244.15924.0
  yarn add @auto-canary/conventional-commits@9.35.2-canary.1244.15924.0
  yarn add @auto-canary/crates@9.35.2-canary.1244.15924.0
  yarn add @auto-canary/exec@9.35.2-canary.1244.15924.0
  yarn add @auto-canary/first-time-contributor@9.35.2-canary.1244.15924.0
  yarn add @auto-canary/gem@9.35.2-canary.1244.15924.0
  yarn add @auto-canary/gh-pages@9.35.2-canary.1244.15924.0
  yarn add @auto-canary/git-tag@9.35.2-canary.1244.15924.0
  yarn add @auto-canary/gradle@9.35.2-canary.1244.15924.0
  yarn add @auto-canary/jira@9.35.2-canary.1244.15924.0
  yarn add @auto-canary/maven@9.35.2-canary.1244.15924.0
  yarn add @auto-canary/npm@9.35.2-canary.1244.15924.0
  yarn add @auto-canary/omit-commits@9.35.2-canary.1244.15924.0
  yarn add @auto-canary/omit-release-notes@9.35.2-canary.1244.15924.0
  yarn add @auto-canary/released@9.35.2-canary.1244.15924.0
  yarn add @auto-canary/s3@9.35.2-canary.1244.15924.0
  yarn add @auto-canary/slack@9.35.2-canary.1244.15924.0
  yarn add @auto-canary/twitter@9.35.2-canary.1244.15924.0
  yarn add @auto-canary/upload-assets@9.35.2-canary.1244.15924.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
