### PR TITLE
Slack code blocks

### DIFF
--- a/plugins/slack/__tests__/__snapshots__/slack.test.ts.snap
+++ b/plugins/slack/__tests__/__snapshots__/slack.test.ts.snap
@@ -12,4 +12,4 @@ exports[`postToSlack should call slack api with custom atTarget 1`] = `"{\\"text
 
 exports[`postToSlack should call slack api with minimal config 1`] = `"{\\"text\\":\\"@channel: New release *<https://git.hub/some/project/releases/v1.0.0|v1.0.0>*\\\\n* My Notes*\\\\n• PR <google.com|some link>\\",\\"link_names\\":1}"`;
 
-exports[`postToSlack should remove markdown code types from block 1`] = `"{\\"text\\":\\"@channel: New release *<https://git.hub/some/project/releases/v1.0.0|v1.0.0>*\\\\n* My Notes*\\\\n\`\`\`\\\\n{ \\\\\\"foo\\\\\\": \\\\\\"bar\\\\\\" }\`\`\`\\\\n• PR <google.com|some link>\\",\\"link_names\\":1}"`;
+exports[`postToSlack should remove markdown code types from block 1`] = `"{\\"text\\":\\"@channel: New release *<https://git.hub/some/project/releases/v1.0.0|v1.0.0>*\\\\n* My Notes*\\\\n\`json\`:\\\\n\\\\n\`\`\`\\\\n{ \\\\\\"foo\\\\\\": \\\\\\"bar\\\\\\" }\`\`\`\\\\n• PR <google.com|some link>\\",\\"link_names\\":1}"`;

--- a/plugins/slack/__tests__/__snapshots__/slack.test.ts.snap
+++ b/plugins/slack/__tests__/__snapshots__/slack.test.ts.snap
@@ -11,3 +11,5 @@ exports[`postToSlack should call slack api through https proxy 1`] = `"{\\"text\
 exports[`postToSlack should call slack api with custom atTarget 1`] = `"{\\"text\\":\\"@here: New release *<https://git.hub/some/project/releases/v1.0.0|v1.0.0>*\\\\n* My Notes*\\\\n• PR <google.com|some link>\\",\\"link_names\\":1}"`;
 
 exports[`postToSlack should call slack api with minimal config 1`] = `"{\\"text\\":\\"@channel: New release *<https://git.hub/some/project/releases/v1.0.0|v1.0.0>*\\\\n* My Notes*\\\\n• PR <google.com|some link>\\",\\"link_names\\":1}"`;
+
+exports[`postToSlack should remove markdown code types from block 1`] = `"{\\"text\\":\\"@channel: New release *<https://git.hub/some/project/releases/v1.0.0|v1.0.0>*\\\\n* My Notes*\\\\n\`\`\`\\\\n{ \\\\\\"foo\\\\\\": \\\\\\"bar\\\\\\" }\`\`\`\\\\n• PR <google.com|some link>\\",\\"link_names\\":1}"`;

--- a/plugins/slack/__tests__/slack.test.ts
+++ b/plugins/slack/__tests__/slack.test.ts
@@ -255,6 +255,22 @@ describe("postToSlack", () => {
     expect(fetchSpy.mock.calls[0][1].agent).not.toBeUndefined();
     expect(fetchSpy.mock.calls[0][1].body).toMatchSnapshot();
   });
+
+  test("should remove markdown code types from block", async () => {
+    const plugin = new SlackPlugin("https://custom-slack-url");
+    process.env.SLACK_TOKEN = "MY_TOKEN";
+
+    await plugin.postToSlack(
+      mockAuto,
+      "1.0.0",
+      `# My Notes\n\`\`\`json\n{ "foo": "bar" }\`\`\`\n- PR [some link](google.com)`,
+      // @ts-ignore
+      mockResponse
+    );
+
+    expect(fetchSpy.mock.calls[0][1].body).toMatchSnapshot();
+  });
+
   test("should call slack api through https proxy", async () => {
     const plugin = new SlackPlugin("https://custom-slack-url");
     process.env.SLACK_TOKEN = "MY_TOKEN";

--- a/plugins/slack/src/index.ts
+++ b/plugins/slack/src/index.ts
@@ -26,7 +26,7 @@ const sanitizeMarkdown = (markdown: string) =>
 
       // Strip markdown code block type. Slack does not render them correctly.
       if (line.match(MARKDOWN_LANGUAGE)) {
-        return line.replace(MARKDOWN_LANGUAGE, "$1");
+        return line.replace(MARKDOWN_LANGUAGE, "`$2`:\n\n$1");
       }
 
       return line;

--- a/plugins/slack/src/index.ts
+++ b/plugins/slack/src/index.ts
@@ -12,6 +12,8 @@ import {
 import fetch from "node-fetch";
 import * as t from "io-ts";
 
+const MARKDOWN_LANGUAGE = /^(```)(\S+)$/m;
+
 /** Transform markdown into slack friendly text */
 const sanitizeMarkdown = (markdown: string) =>
   githubToSlack(markdown)
@@ -20,6 +22,11 @@ const sanitizeMarkdown = (markdown: string) =>
       // Strip out the ### prefix and replace it with *<word>* to make it bold
       if (line.startsWith("#")) {
         return `*${line.replace(/^[#]+/, "")}*`;
+      }
+
+      // Strip markdown code block type. Slack does not render them correctly.
+      if (line.match(MARKDOWN_LANGUAGE)) {
+        return line.replace(MARKDOWN_LANGUAGE, "$1");
       }
 
       return line;


### PR DESCRIPTION
# What Changed

Remove markdown code type from block to before the code block.

# Why

Slack doesn't render GFM.

Todo:

- [x] Add tests


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.35.4-canary.1247.15971.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.35.4-canary.1247.15971.0
  npm install @auto-canary/auto@9.35.4-canary.1247.15971.0
  npm install @auto-canary/core@9.35.4-canary.1247.15971.0
  npm install @auto-canary/all-contributors@9.35.4-canary.1247.15971.0
  npm install @auto-canary/brew@9.35.4-canary.1247.15971.0
  npm install @auto-canary/chrome@9.35.4-canary.1247.15971.0
  npm install @auto-canary/cocoapods@9.35.4-canary.1247.15971.0
  npm install @auto-canary/conventional-commits@9.35.4-canary.1247.15971.0
  npm install @auto-canary/crates@9.35.4-canary.1247.15971.0
  npm install @auto-canary/exec@9.35.4-canary.1247.15971.0
  npm install @auto-canary/first-time-contributor@9.35.4-canary.1247.15971.0
  npm install @auto-canary/gem@9.35.4-canary.1247.15971.0
  npm install @auto-canary/gh-pages@9.35.4-canary.1247.15971.0
  npm install @auto-canary/git-tag@9.35.4-canary.1247.15971.0
  npm install @auto-canary/gradle@9.35.4-canary.1247.15971.0
  npm install @auto-canary/jira@9.35.4-canary.1247.15971.0
  npm install @auto-canary/maven@9.35.4-canary.1247.15971.0
  npm install @auto-canary/npm@9.35.4-canary.1247.15971.0
  npm install @auto-canary/omit-commits@9.35.4-canary.1247.15971.0
  npm install @auto-canary/omit-release-notes@9.35.4-canary.1247.15971.0
  npm install @auto-canary/released@9.35.4-canary.1247.15971.0
  npm install @auto-canary/s3@9.35.4-canary.1247.15971.0
  npm install @auto-canary/slack@9.35.4-canary.1247.15971.0
  npm install @auto-canary/twitter@9.35.4-canary.1247.15971.0
  npm install @auto-canary/upload-assets@9.35.4-canary.1247.15971.0
  # or 
  yarn add @auto-canary/bot-list@9.35.4-canary.1247.15971.0
  yarn add @auto-canary/auto@9.35.4-canary.1247.15971.0
  yarn add @auto-canary/core@9.35.4-canary.1247.15971.0
  yarn add @auto-canary/all-contributors@9.35.4-canary.1247.15971.0
  yarn add @auto-canary/brew@9.35.4-canary.1247.15971.0
  yarn add @auto-canary/chrome@9.35.4-canary.1247.15971.0
  yarn add @auto-canary/cocoapods@9.35.4-canary.1247.15971.0
  yarn add @auto-canary/conventional-commits@9.35.4-canary.1247.15971.0
  yarn add @auto-canary/crates@9.35.4-canary.1247.15971.0
  yarn add @auto-canary/exec@9.35.4-canary.1247.15971.0
  yarn add @auto-canary/first-time-contributor@9.35.4-canary.1247.15971.0
  yarn add @auto-canary/gem@9.35.4-canary.1247.15971.0
  yarn add @auto-canary/gh-pages@9.35.4-canary.1247.15971.0
  yarn add @auto-canary/git-tag@9.35.4-canary.1247.15971.0
  yarn add @auto-canary/gradle@9.35.4-canary.1247.15971.0
  yarn add @auto-canary/jira@9.35.4-canary.1247.15971.0
  yarn add @auto-canary/maven@9.35.4-canary.1247.15971.0
  yarn add @auto-canary/npm@9.35.4-canary.1247.15971.0
  yarn add @auto-canary/omit-commits@9.35.4-canary.1247.15971.0
  yarn add @auto-canary/omit-release-notes@9.35.4-canary.1247.15971.0
  yarn add @auto-canary/released@9.35.4-canary.1247.15971.0
  yarn add @auto-canary/s3@9.35.4-canary.1247.15971.0
  yarn add @auto-canary/slack@9.35.4-canary.1247.15971.0
  yarn add @auto-canary/twitter@9.35.4-canary.1247.15971.0
  yarn add @auto-canary/upload-assets@9.35.4-canary.1247.15971.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
