### PR TITLE
fix reduce without initial value

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -46,6 +46,7 @@
     "@typescript-eslint/no-this-alias": 2,
     "@typescript-eslint/no-useless-constructor": 2,
     "@typescript-eslint/no-floating-promises": 2,
+    "@typescript-eslint/prefer-reduce-type-parameter": 2,
     "@typescript-eslint/prefer-as-const": 2,
     "@typescript-eslint/prefer-for-of": 2,
     "@typescript-eslint/prefer-optional-chain": 2,

--- a/packages/core/src/__tests__/git.test.ts
+++ b/packages/core/src/__tests__/git.test.ts
@@ -127,10 +127,12 @@ describe("github", () => {
   });
 
   describe("getTagNotInBaseBranch", () => {
-    test("works with no tags", async () => {
+    test("works with no tags, defaults to first commit", async () => {
       const gh = new Git(options);
       gh.getTags = () => Promise.resolve([]);
-      expect(await gh.getTagNotInBaseBranch("branch")).toBeUndefined();
+      expect(await gh.getTagNotInBaseBranch("branch")).toBe(
+        "0b2af75d8b55c8869cda93d0e5589ad9f2677e18"
+      );
     });
 
     test("finds greatest tag not in base branch", async () => {

--- a/packages/core/src/__tests__/git.test.ts
+++ b/packages/core/src/__tests__/git.test.ts
@@ -126,6 +126,56 @@ describe("github", () => {
     });
   });
 
+  describe("getTagNotInBaseBranch", () => {
+    test("works with no tags", async () => {
+      const gh = new Git(options);
+      gh.getTags = () => Promise.resolve([]);
+      expect(await gh.getTagNotInBaseBranch("branch")).toBeUndefined();
+    });
+
+    test("finds greatest tag not in base branch", async () => {
+      const gh = new Git(options);
+
+      gh.getTags = (ref: string) => {
+        if (ref === "origin/master") {
+          return Promise.resolve(["1.0.0", "1.2.3", "1.4.0"]);
+        }
+
+        return Promise.resolve([
+          "1.0.0",
+          "1.2.3",
+          "1.4.0",
+          "1.4.0-next",
+          "1.4.1-next",
+        ]);
+      };
+
+      expect(await gh.getTagNotInBaseBranch("branch")).toBe("1.4.1-next");
+    });
+
+    test("finds first tag not in base branch", async () => {
+      const gh = new Git(options);
+
+      gh.getTags = (ref: string) => {
+        if (ref === "origin/master") {
+          return Promise.resolve(["1.0.0", "1.2.3", "1.4.0"]);
+        }
+
+        return Promise.resolve([
+          "1.0.0",
+          "1.2.3",
+          "1.4.0",
+          "1.4.0-next",
+          "1.4.1-next",
+        ]);
+      };
+
+      expect(await gh.getTagNotInBaseBranch("branch", { first: true })).toBe(
+        "1.4.0-next"
+      );
+    });
+  });
+
   test("publish", async () => {
     const gh = new Git(options);
 

--- a/packages/core/src/changelog.ts
+++ b/packages/core/src/changelog.ts
@@ -369,13 +369,16 @@ export default class Changelog {
 
   /** Create a section in the changelog to with all of the changelog notes organized by change type */
   private async createLabelSection(split: ICommitSplit, sections: string[]) {
-    const changelogTitles = this.options.labels.reduce((titles, label) => {
-      if (label.changelogTitle) {
-        titles[label.name] = label.changelogTitle;
-      }
+    const changelogTitles = this.options.labels.reduce<Record<string, string>>(
+      (titles, label) => {
+        if (label.changelogTitle) {
+          titles[label.name] = label.changelogTitle;
+        }
 
-      return titles;
-    }, {} as { [label: string]: string });
+        return titles;
+      },
+      {}
+    );
 
     const labelSections = await Promise.all(
       Object.entries(split).map(async ([label, labelCommits]) => {
@@ -415,12 +418,12 @@ export default class Changelog {
       })
     );
 
-    const mergedSections = labelSections.reduce(
+    const mergedSections = labelSections.reduce<Record<string, string[]>>(
       (acc, [title, commits]) => ({
         ...acc,
         [title]: [...(acc[title] || []), ...commits],
       }),
-      {} as Record<string, string[]>
+      {}
     );
 
     Object.entries(mergedSections)

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -873,7 +873,7 @@ export default class Git {
       firstGreatestUnique
     );
 
-    return firstGreatestUnique;
+    return firstGreatestUnique || this.getFirstCommit();
   }
 
   /** Get the last tag that isn't in the base branch */

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -346,7 +346,7 @@ export default class Git {
           subject: commit.rawBody!,
           files: (commit.files || []).map((file) => path.resolve(file)),
         }))
-        .reduce((all, commit) => {
+        .reduce<ICommit[]>((all, commit) => {
           // The -m option will list a commit for each merge parent. This
           // means two items will have the same hash. We are using -m to get all the changed files
           // in a merge commit. The following code combines these repeated hashes into
@@ -360,7 +360,7 @@ export default class Git {
           }
 
           return all;
-        }, [] as ICommit[]);
+        }, []);
     } catch (error) {
       console.log(error);
       const tag = error.match(/ambiguous argument '(\S+)\.\.\S+'/);
@@ -855,13 +855,16 @@ export default class Git {
     ).reverse();
     const branchTags = (await this.getTags(`heads/${branch}`)).reverse();
     const comparator = options.first ? lt : gt;
-    const firstGreatestUnique = branchTags.reduce((result, tag) => {
-      if (!baseTags.includes(tag) && (!result || comparator(tag, result))) {
-        return tag;
-      }
+    const firstGreatestUnique = branchTags.reduce<string | undefined>(
+      (result, tag) => {
+        if (!baseTags.includes(tag) && (!result || comparator(tag, result))) {
+          return tag;
+        }
 
-      return result;
-    });
+        return result;
+      },
+      undefined
+    );
 
     this.logger.verbose.info("Tags found in base branch:", baseTags);
     this.logger.verbose.info("Tags found in branch:", branchTags);

--- a/packages/core/src/release.ts
+++ b/packages/core/src/release.ts
@@ -134,14 +134,14 @@ export const defaultLabels: ILabelDefinition[] = [
 
 /** Construct a map of label => semver label */
 export const getVersionMap = (labels = defaultLabels) =>
-  labels.reduce((semVer, { releaseType: type, name }) => {
+  labels.reduce<IVersionLabels>((semVer, { releaseType: type, name }) => {
     if (type && (isVersionLabel(type) || type === "none")) {
       const list = semVer.get(type) || [];
       semVer.set(type, [...list, name]);
     }
 
     return semVer;
-  }, new Map() as IVersionLabels);
+  }, new Map());
 
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
@@ -239,9 +239,9 @@ export default class Release {
     );
     const allPrCommitHashes = allPrCommits
       .filter(Boolean)
-      .reduce(
+      .reduce<string[]>(
         (all, pr) => [...all, ...pr.map((subCommit) => subCommit.sha)],
-        [] as string[]
+        []
       );
     const uniqueCommits = allCommits.filter(
       (commit) =>

--- a/packages/core/src/validate-config.ts
+++ b/packages/core/src/validate-config.ts
@@ -77,19 +77,22 @@ function reporter<T>(validation: t.Validation<T>) {
   });
 
   const otherErrors: string[] = [];
-  const grouped = errors.reduce((acc, item) => {
-    if (typeof item === "string") {
-      otherErrors.push(item);
+  const grouped = errors.reduce<Record<string, ConfigOptionError[]>>(
+    (acc, item) => {
+      if (typeof item === "string") {
+        otherErrors.push(item);
+        return acc;
+      }
+
+      if (!acc[item.path]) {
+        acc[item.path] = [];
+      }
+
+      acc[item.path].push(item);
       return acc;
-    }
-
-    if (!acc[item.path]) {
-      acc[item.path] = [];
-    }
-
-    acc[item.path].push(item);
-    return acc;
-  }, {} as Record<string, ConfigOptionError[]>);
+    },
+    {}
+  );
   const paths = Object.keys(grouped);
 
   return [

--- a/plugins/all-contributors/src/index.ts
+++ b/plugins/all-contributors/src/index.ts
@@ -209,9 +209,9 @@ export default class AllContributorsPlugin implements IPlugin {
         return;
       }
 
-      const allContributions = Object.values(extra).reduce(
+      const allContributions = Object.values(extra).reduce<string[]>(
         (all, i) => [...all, ...i],
-        [] as string[]
+        []
       );
       const unknownTypes = allContributions.filter(
         (contribution) =>

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -143,23 +143,26 @@ export async function getChangedPackages({
 export function getMonorepoPackage() {
   const packages = getPackages(process.cwd());
 
-  return packages.reduce((greatest, subPackage) => {
-    if (subPackage.package.version) {
-      if (!greatest.version) {
-        return subPackage.package;
+  return packages.reduce<IPackageJSON>(
+    (greatest, subPackage) => {
+      if (subPackage.package.version) {
+        if (!greatest.version) {
+          return subPackage.package;
+        }
+
+        if (subPackage.package.private) {
+          return greatest;
+        }
+
+        return gt(greatest.version, subPackage.package.version)
+          ? greatest
+          : subPackage.package;
       }
 
-      if (subPackage.package.private) {
-        return greatest;
-      }
-
-      return gt(greatest.version, subPackage.package.version)
-        ? greatest
-        : subPackage.package;
-    }
-
-    return greatest;
-  }, {} as IPackageJSON);
+      return greatest;
+    },
+    { name: "initial" }
+  );
 }
 
 /** Get all of the packages+version in the lerna monorepo */

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -143,26 +143,29 @@ export async function getChangedPackages({
 export function getMonorepoPackage() {
   const packages = getPackages(process.cwd());
 
-  return packages.reduce<IPackageJSON>(
-    (greatest, subPackage) => {
-      if (subPackage.package.version) {
-        if (!greatest.version) {
-          return subPackage.package;
-        }
+  if (!packages.length) {
+    return {} as IPackageJSON;
+  }
 
-        if (subPackage.package.private) {
-          return greatest;
-        }
-
-        return gt(greatest.version, subPackage.package.version)
-          ? greatest
-          : subPackage.package;
+  const monorepoPackage = packages.reduce((greatest, subPackage) => {
+    if (subPackage.package.version) {
+      if (!greatest.package.version) {
+        return subPackage;
       }
 
-      return greatest;
-    },
-    { name: "initial" }
-  );
+      if (subPackage.package.private) {
+        return greatest;
+      }
+
+      return gt(greatest.package.version, subPackage.package.version)
+        ? greatest
+        : subPackage;
+    }
+
+    return greatest;
+  });
+
+  return monorepoPackage.package;
 }
 
 /** Get all of the packages+version in the lerna monorepo */


### PR DESCRIPTION
# What Changed

One reduce didn't have an initial value, failing the release.

# Why

https://circleci.com/gh/jpaulobneto/lerna-auto-publish/19?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

@jpaulobneto this should fix your build on that repo


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.36.1-canary.1249.16001.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.36.1-canary.1249.16001.0
  npm install @auto-canary/auto@9.36.1-canary.1249.16001.0
  npm install @auto-canary/core@9.36.1-canary.1249.16001.0
  npm install @auto-canary/all-contributors@9.36.1-canary.1249.16001.0
  npm install @auto-canary/brew@9.36.1-canary.1249.16001.0
  npm install @auto-canary/chrome@9.36.1-canary.1249.16001.0
  npm install @auto-canary/cocoapods@9.36.1-canary.1249.16001.0
  npm install @auto-canary/conventional-commits@9.36.1-canary.1249.16001.0
  npm install @auto-canary/crates@9.36.1-canary.1249.16001.0
  npm install @auto-canary/exec@9.36.1-canary.1249.16001.0
  npm install @auto-canary/first-time-contributor@9.36.1-canary.1249.16001.0
  npm install @auto-canary/gem@9.36.1-canary.1249.16001.0
  npm install @auto-canary/gh-pages@9.36.1-canary.1249.16001.0
  npm install @auto-canary/git-tag@9.36.1-canary.1249.16001.0
  npm install @auto-canary/gradle@9.36.1-canary.1249.16001.0
  npm install @auto-canary/jira@9.36.1-canary.1249.16001.0
  npm install @auto-canary/maven@9.36.1-canary.1249.16001.0
  npm install @auto-canary/npm@9.36.1-canary.1249.16001.0
  npm install @auto-canary/omit-commits@9.36.1-canary.1249.16001.0
  npm install @auto-canary/omit-release-notes@9.36.1-canary.1249.16001.0
  npm install @auto-canary/released@9.36.1-canary.1249.16001.0
  npm install @auto-canary/s3@9.36.1-canary.1249.16001.0
  npm install @auto-canary/slack@9.36.1-canary.1249.16001.0
  npm install @auto-canary/twitter@9.36.1-canary.1249.16001.0
  npm install @auto-canary/upload-assets@9.36.1-canary.1249.16001.0
  # or 
  yarn add @auto-canary/bot-list@9.36.1-canary.1249.16001.0
  yarn add @auto-canary/auto@9.36.1-canary.1249.16001.0
  yarn add @auto-canary/core@9.36.1-canary.1249.16001.0
  yarn add @auto-canary/all-contributors@9.36.1-canary.1249.16001.0
  yarn add @auto-canary/brew@9.36.1-canary.1249.16001.0
  yarn add @auto-canary/chrome@9.36.1-canary.1249.16001.0
  yarn add @auto-canary/cocoapods@9.36.1-canary.1249.16001.0
  yarn add @auto-canary/conventional-commits@9.36.1-canary.1249.16001.0
  yarn add @auto-canary/crates@9.36.1-canary.1249.16001.0
  yarn add @auto-canary/exec@9.36.1-canary.1249.16001.0
  yarn add @auto-canary/first-time-contributor@9.36.1-canary.1249.16001.0
  yarn add @auto-canary/gem@9.36.1-canary.1249.16001.0
  yarn add @auto-canary/gh-pages@9.36.1-canary.1249.16001.0
  yarn add @auto-canary/git-tag@9.36.1-canary.1249.16001.0
  yarn add @auto-canary/gradle@9.36.1-canary.1249.16001.0
  yarn add @auto-canary/jira@9.36.1-canary.1249.16001.0
  yarn add @auto-canary/maven@9.36.1-canary.1249.16001.0
  yarn add @auto-canary/npm@9.36.1-canary.1249.16001.0
  yarn add @auto-canary/omit-commits@9.36.1-canary.1249.16001.0
  yarn add @auto-canary/omit-release-notes@9.36.1-canary.1249.16001.0
  yarn add @auto-canary/released@9.36.1-canary.1249.16001.0
  yarn add @auto-canary/s3@9.36.1-canary.1249.16001.0
  yarn add @auto-canary/slack@9.36.1-canary.1249.16001.0
  yarn add @auto-canary/twitter@9.36.1-canary.1249.16001.0
  yarn add @auto-canary/upload-assets@9.36.1-canary.1249.16001.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
