### PR TITLE
fix(git): Prevents getLastTagNotInBaseBranch from returning a commit hash

### DIFF
--- a/packages/core/src/__tests__/git.test.ts
+++ b/packages/core/src/__tests__/git.test.ts
@@ -127,14 +127,6 @@ describe("github", () => {
   });
 
   describe("getTagNotInBaseBranch", () => {
-    test("works with no tags, defaults to first commit", async () => {
-      const gh = new Git(options);
-      gh.getTags = () => Promise.resolve([]);
-      expect(await gh.getTagNotInBaseBranch("branch")).toBe(
-        "0b2af75d8b55c8869cda93d0e5589ad9f2677e18"
-      );
-    });
-
     test("finds greatest tag not in base branch", async () => {
       const gh = new Git(options);
 

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1244,7 +1244,9 @@ export default class Auto {
     ).slice(1);
     const lastRelease =
       initialForkCommit || (await this.git.getLatestRelease());
-    const lastTag = await this.git.getLastTagNotInBaseBranch(currentBranch!);
+    const lastTag =
+      (await this.git.getLastTagNotInBaseBranch(currentBranch!)) ||
+      (await this.git.getFirstCommit());
     const fullReleaseNotes = await this.release.generateReleaseNotes(
       lastRelease
     );

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -870,10 +870,10 @@ export default class Git {
     this.logger.verbose.info("Tags found in branch:", branchTags);
     this.logger.verbose.info(
       `${options.first ? "First" : "Latest"} tag in branch:`,
-      firstGreatestUnique
+      firstGreatestUnique || "Not Found"
     );
 
-    return firstGreatestUnique || this.getFirstCommit();
+    return firstGreatestUnique;
   }
 
   /** Get the last tag that isn't in the base branch */


### PR DESCRIPTION
closes #1261 

# What Changed

This PR removes functionality where `getLastTagNotInBaseBranch` would previously return the first commit on a branch if no tag was found.

# Why

`getLastTagNotInBaseBranch` is called [in the `npm` plugin](https://github.com/intuit/auto/blob/master/plugins/npm/src/index.ts#L817-L833), but the value is then passed to [`determineNextVersion`, where it attempts to run semver operations on the provided tag](https://github.com/intuit/auto/blob/9a3c6561453b881773316974f6adb0ed0df347d3/packages/core/src/auto.ts#L275). When the tag is instead a commit hash, the semver operations fail out gracelessly.

Within #1261, @hipstersmoothie suggests making `determineNextVersion` take optional `lastVersion?` and `currentVersion?`s with appropriate handling, however I'm unsure that's necessary given all calls or references to `getLastTagNotInBaseBranch` are currently piped over to some default value ([1](https://github.com/intuit/auto/blob/fa333d5ada74d521f1afd93d3dc062801223d86c/plugins/git-tag/src/index.ts#L72-L73), [2](https://github.com/intuit/auto/blob/2a47b73e61d1e3d8f49ed1f13cc7c7f72ad09381/docs/pages/plugins/release-lifecycle-hooks.md#next), [3](https://github.com/intuit/auto/blob/fa333d5ada74d521f1afd93d3dc062801223d86c/packages/core/src/auto.ts#L1247) - managed by this PR, [4](https://github.com/intuit/auto/blob/672874dcba5aa0f9aa11bf60a0b6aafc1326f496/plugins/npm/src/index.ts#L818-L819)).

Unfortunately, I'm having difficulty further validating, as my monorepo no longer falls into this state..

Todo:

- [ ] Add tests
- [ ] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.36.3-canary.1262.16149.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.36.3-canary.1262.16149.0
  npm install @auto-canary/auto@9.36.3-canary.1262.16149.0
  npm install @auto-canary/core@9.36.3-canary.1262.16149.0
  npm install @auto-canary/all-contributors@9.36.3-canary.1262.16149.0
  npm install @auto-canary/brew@9.36.3-canary.1262.16149.0
  npm install @auto-canary/chrome@9.36.3-canary.1262.16149.0
  npm install @auto-canary/cocoapods@9.36.3-canary.1262.16149.0
  npm install @auto-canary/conventional-commits@9.36.3-canary.1262.16149.0
  npm install @auto-canary/crates@9.36.3-canary.1262.16149.0
  npm install @auto-canary/exec@9.36.3-canary.1262.16149.0
  npm install @auto-canary/first-time-contributor@9.36.3-canary.1262.16149.0
  npm install @auto-canary/gem@9.36.3-canary.1262.16149.0
  npm install @auto-canary/gh-pages@9.36.3-canary.1262.16149.0
  npm install @auto-canary/git-tag@9.36.3-canary.1262.16149.0
  npm install @auto-canary/gradle@9.36.3-canary.1262.16149.0
  npm install @auto-canary/jira@9.36.3-canary.1262.16149.0
  npm install @auto-canary/maven@9.36.3-canary.1262.16149.0
  npm install @auto-canary/npm@9.36.3-canary.1262.16149.0
  npm install @auto-canary/omit-commits@9.36.3-canary.1262.16149.0
  npm install @auto-canary/omit-release-notes@9.36.3-canary.1262.16149.0
  npm install @auto-canary/released@9.36.3-canary.1262.16149.0
  npm install @auto-canary/s3@9.36.3-canary.1262.16149.0
  npm install @auto-canary/slack@9.36.3-canary.1262.16149.0
  npm install @auto-canary/twitter@9.36.3-canary.1262.16149.0
  npm install @auto-canary/upload-assets@9.36.3-canary.1262.16149.0
  # or 
  yarn add @auto-canary/bot-list@9.36.3-canary.1262.16149.0
  yarn add @auto-canary/auto@9.36.3-canary.1262.16149.0
  yarn add @auto-canary/core@9.36.3-canary.1262.16149.0
  yarn add @auto-canary/all-contributors@9.36.3-canary.1262.16149.0
  yarn add @auto-canary/brew@9.36.3-canary.1262.16149.0
  yarn add @auto-canary/chrome@9.36.3-canary.1262.16149.0
  yarn add @auto-canary/cocoapods@9.36.3-canary.1262.16149.0
  yarn add @auto-canary/conventional-commits@9.36.3-canary.1262.16149.0
  yarn add @auto-canary/crates@9.36.3-canary.1262.16149.0
  yarn add @auto-canary/exec@9.36.3-canary.1262.16149.0
  yarn add @auto-canary/first-time-contributor@9.36.3-canary.1262.16149.0
  yarn add @auto-canary/gem@9.36.3-canary.1262.16149.0
  yarn add @auto-canary/gh-pages@9.36.3-canary.1262.16149.0
  yarn add @auto-canary/git-tag@9.36.3-canary.1262.16149.0
  yarn add @auto-canary/gradle@9.36.3-canary.1262.16149.0
  yarn add @auto-canary/jira@9.36.3-canary.1262.16149.0
  yarn add @auto-canary/maven@9.36.3-canary.1262.16149.0
  yarn add @auto-canary/npm@9.36.3-canary.1262.16149.0
  yarn add @auto-canary/omit-commits@9.36.3-canary.1262.16149.0
  yarn add @auto-canary/omit-release-notes@9.36.3-canary.1262.16149.0
  yarn add @auto-canary/released@9.36.3-canary.1262.16149.0
  yarn add @auto-canary/s3@9.36.3-canary.1262.16149.0
  yarn add @auto-canary/slack@9.36.3-canary.1262.16149.0
  yarn add @auto-canary/twitter@9.36.3-canary.1262.16149.0
  yarn add @auto-canary/upload-assets@9.36.3-canary.1262.16149.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
