### PR TITLE
add more contextual information to next hook

### DIFF
--- a/packages/core/src/utils/make-hooks.ts
+++ b/packages/core/src/utils/make-hooks.ts
@@ -34,7 +34,7 @@ export const makeHooks = (): IAutoHooks => ({
   publish: new AsyncParallelHook(["version"]),
   afterPublish: new AsyncParallelHook(),
   canary: new AsyncSeriesBailHook(["canaryVersion", "postFix"]),
-  next: new AsyncSeriesWaterfallHook(["preReleaseVersions", "bump"]),
+  next: new AsyncSeriesWaterfallHook(["preReleaseVersions", "bump", "context"]),
 });
 
 /** Make the hooks for "Release" */

--- a/plugins/git-tag/__tests__/git-tag.test.ts
+++ b/plugins/git-tag/__tests__/git-tag.test.ts
@@ -85,7 +85,7 @@ describe("Git Tag Plugin", () => {
   describe("next", () => {
     test("should do nothing without git", async () => {
       const hooks = setup();
-      await hooks.next.promise([], Auto.SEMVER.patch);
+      await hooks.next.promise([], Auto.SEMVER.patch, {} as any);
       expect(exec).not.toHaveBeenCalled();
     });
 
@@ -95,7 +95,7 @@ describe("Git Tag Plugin", () => {
         getLastTagNotInBaseBranch: () => "v1.0.0",
       });
 
-      await hooks.next.promise([], Auto.SEMVER.patch);
+      await hooks.next.promise([], Auto.SEMVER.patch, {} as any);
 
       expect(exec).toHaveBeenCalledWith("git", [
         "tag",

--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -1075,9 +1075,9 @@ describe("next", () => {
       }
     `;
 
-    expect(await hooks.next.promise([], Auto.SEMVER.patch)).toStrictEqual([
-      "1.2.4-next.0",
-    ]);
+    expect(
+      await hooks.next.promise([], Auto.SEMVER.patch, {} as any)
+    ).toStrictEqual(["1.2.4-next.0"]);
 
     expect(execPromise).toHaveBeenCalledWith("npm", [
       "version",
@@ -1126,9 +1126,9 @@ describe("next", () => {
       },
     } as unknown) as Auto.Auto);
 
-    expect(await hooks.next.promise([], Auto.SEMVER.patch)).toStrictEqual([
-      "1.2.4-next.0",
-    ]);
+    expect(
+      await hooks.next.promise([], Auto.SEMVER.patch, {} as any)
+    ).toStrictEqual(["1.2.4-next.0"]);
 
     expect(execPromise).toHaveBeenCalledWith(
       "npx",
@@ -1164,10 +1164,9 @@ describe("next", () => {
       },
     } as unknown) as Auto.Auto);
 
-    expect(await hooks.next.promise([], Auto.SEMVER.patch)).toStrictEqual([
-      "@foo/1@1.0.0-next.0",
-      "@foo/2@2.0.0-next.0",
-    ]);
+    expect(
+      await hooks.next.promise([], Auto.SEMVER.patch, {} as any)
+    ).toStrictEqual(["@foo/1@1.0.0-next.0", "@foo/2@2.0.0-next.0"]);
 
     expect(execPromise).toHaveBeenCalledWith(
       "npx",


### PR DESCRIPTION
# What Changed

This info should just be available on every hook.

# Why

I needed to know the labels of the commits in the next hook

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.36.5-canary.1265.16182.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.36.5-canary.1265.16182.0
  npm install @auto-canary/auto@9.36.5-canary.1265.16182.0
  npm install @auto-canary/core@9.36.5-canary.1265.16182.0
  npm install @auto-canary/all-contributors@9.36.5-canary.1265.16182.0
  npm install @auto-canary/brew@9.36.5-canary.1265.16182.0
  npm install @auto-canary/chrome@9.36.5-canary.1265.16182.0
  npm install @auto-canary/cocoapods@9.36.5-canary.1265.16182.0
  npm install @auto-canary/conventional-commits@9.36.5-canary.1265.16182.0
  npm install @auto-canary/crates@9.36.5-canary.1265.16182.0
  npm install @auto-canary/exec@9.36.5-canary.1265.16182.0
  npm install @auto-canary/first-time-contributor@9.36.5-canary.1265.16182.0
  npm install @auto-canary/gem@9.36.5-canary.1265.16182.0
  npm install @auto-canary/gh-pages@9.36.5-canary.1265.16182.0
  npm install @auto-canary/git-tag@9.36.5-canary.1265.16182.0
  npm install @auto-canary/gradle@9.36.5-canary.1265.16182.0
  npm install @auto-canary/jira@9.36.5-canary.1265.16182.0
  npm install @auto-canary/maven@9.36.5-canary.1265.16182.0
  npm install @auto-canary/npm@9.36.5-canary.1265.16182.0
  npm install @auto-canary/omit-commits@9.36.5-canary.1265.16182.0
  npm install @auto-canary/omit-release-notes@9.36.5-canary.1265.16182.0
  npm install @auto-canary/released@9.36.5-canary.1265.16182.0
  npm install @auto-canary/s3@9.36.5-canary.1265.16182.0
  npm install @auto-canary/slack@9.36.5-canary.1265.16182.0
  npm install @auto-canary/twitter@9.36.5-canary.1265.16182.0
  npm install @auto-canary/upload-assets@9.36.5-canary.1265.16182.0
  # or 
  yarn add @auto-canary/bot-list@9.36.5-canary.1265.16182.0
  yarn add @auto-canary/auto@9.36.5-canary.1265.16182.0
  yarn add @auto-canary/core@9.36.5-canary.1265.16182.0
  yarn add @auto-canary/all-contributors@9.36.5-canary.1265.16182.0
  yarn add @auto-canary/brew@9.36.5-canary.1265.16182.0
  yarn add @auto-canary/chrome@9.36.5-canary.1265.16182.0
  yarn add @auto-canary/cocoapods@9.36.5-canary.1265.16182.0
  yarn add @auto-canary/conventional-commits@9.36.5-canary.1265.16182.0
  yarn add @auto-canary/crates@9.36.5-canary.1265.16182.0
  yarn add @auto-canary/exec@9.36.5-canary.1265.16182.0
  yarn add @auto-canary/first-time-contributor@9.36.5-canary.1265.16182.0
  yarn add @auto-canary/gem@9.36.5-canary.1265.16182.0
  yarn add @auto-canary/gh-pages@9.36.5-canary.1265.16182.0
  yarn add @auto-canary/git-tag@9.36.5-canary.1265.16182.0
  yarn add @auto-canary/gradle@9.36.5-canary.1265.16182.0
  yarn add @auto-canary/jira@9.36.5-canary.1265.16182.0
  yarn add @auto-canary/maven@9.36.5-canary.1265.16182.0
  yarn add @auto-canary/npm@9.36.5-canary.1265.16182.0
  yarn add @auto-canary/omit-commits@9.36.5-canary.1265.16182.0
  yarn add @auto-canary/omit-release-notes@9.36.5-canary.1265.16182.0
  yarn add @auto-canary/released@9.36.5-canary.1265.16182.0
  yarn add @auto-canary/s3@9.36.5-canary.1265.16182.0
  yarn add @auto-canary/slack@9.36.5-canary.1265.16182.0
  yarn add @auto-canary/twitter@9.36.5-canary.1265.16182.0
  yarn add @auto-canary/upload-assets@9.36.5-canary.1265.16182.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
