### PR TITLE
add legacyAuth option

### DIFF
--- a/plugins/npm/README.md
+++ b/plugins/npm/README.md
@@ -107,6 +107,28 @@ You can disable this behavior by using the `subPackageChangelogs` option.
 }
 ```
 
+### legacyAuth
+
+When publishing packages that require authentication but you are working with an internally hosted npm registry that only uses the legacy Base64 version of username:password.
+This is the same as the NPM publish \_auth flag.
+
+For security this option only accepts a boolean.
+When this option is set true `auto` will pass `--_auth $NPM_TOKEN` to the publish command.
+Set `$NPM_TOKEN` to the "Base64 version of username:password".
+
+```json
+{
+  "plugins": [
+    [
+      "npm",
+      {
+        "legacyAuth": true
+      }
+    ]
+  ]
+}
+```
+
 ### canaryScope
 
 Publishing canary versions comes with some security risks.

--- a/plugins/npm/__tests__/__snapshots__/npm.test.ts.snap
+++ b/plugins/npm/__tests__/__snapshots__/npm.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`canary dont force publish canaries 1`] = `
+exports[`canary don't force publish canaries 1`] = `
 Object {
   "details": ":sparkles: Test out this PR locally via:
 


### PR DESCRIPTION
# What Changed

Allow `legacyAuth` for NPM plugin

# Why

closes #1267

Todo:

- [x] Add tests
- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.37.1-canary.1268.16194.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.37.1-canary.1268.16194.0
  npm install @auto-canary/auto@9.37.1-canary.1268.16194.0
  npm install @auto-canary/core@9.37.1-canary.1268.16194.0
  npm install @auto-canary/all-contributors@9.37.1-canary.1268.16194.0
  npm install @auto-canary/brew@9.37.1-canary.1268.16194.0
  npm install @auto-canary/chrome@9.37.1-canary.1268.16194.0
  npm install @auto-canary/cocoapods@9.37.1-canary.1268.16194.0
  npm install @auto-canary/conventional-commits@9.37.1-canary.1268.16194.0
  npm install @auto-canary/crates@9.37.1-canary.1268.16194.0
  npm install @auto-canary/exec@9.37.1-canary.1268.16194.0
  npm install @auto-canary/first-time-contributor@9.37.1-canary.1268.16194.0
  npm install @auto-canary/gem@9.37.1-canary.1268.16194.0
  npm install @auto-canary/gh-pages@9.37.1-canary.1268.16194.0
  npm install @auto-canary/git-tag@9.37.1-canary.1268.16194.0
  npm install @auto-canary/gradle@9.37.1-canary.1268.16194.0
  npm install @auto-canary/jira@9.37.1-canary.1268.16194.0
  npm install @auto-canary/maven@9.37.1-canary.1268.16194.0
  npm install @auto-canary/npm@9.37.1-canary.1268.16194.0
  npm install @auto-canary/omit-commits@9.37.1-canary.1268.16194.0
  npm install @auto-canary/omit-release-notes@9.37.1-canary.1268.16194.0
  npm install @auto-canary/released@9.37.1-canary.1268.16194.0
  npm install @auto-canary/s3@9.37.1-canary.1268.16194.0
  npm install @auto-canary/slack@9.37.1-canary.1268.16194.0
  npm install @auto-canary/twitter@9.37.1-canary.1268.16194.0
  npm install @auto-canary/upload-assets@9.37.1-canary.1268.16194.0
  # or 
  yarn add @auto-canary/bot-list@9.37.1-canary.1268.16194.0
  yarn add @auto-canary/auto@9.37.1-canary.1268.16194.0
  yarn add @auto-canary/core@9.37.1-canary.1268.16194.0
  yarn add @auto-canary/all-contributors@9.37.1-canary.1268.16194.0
  yarn add @auto-canary/brew@9.37.1-canary.1268.16194.0
  yarn add @auto-canary/chrome@9.37.1-canary.1268.16194.0
  yarn add @auto-canary/cocoapods@9.37.1-canary.1268.16194.0
  yarn add @auto-canary/conventional-commits@9.37.1-canary.1268.16194.0
  yarn add @auto-canary/crates@9.37.1-canary.1268.16194.0
  yarn add @auto-canary/exec@9.37.1-canary.1268.16194.0
  yarn add @auto-canary/first-time-contributor@9.37.1-canary.1268.16194.0
  yarn add @auto-canary/gem@9.37.1-canary.1268.16194.0
  yarn add @auto-canary/gh-pages@9.37.1-canary.1268.16194.0
  yarn add @auto-canary/git-tag@9.37.1-canary.1268.16194.0
  yarn add @auto-canary/gradle@9.37.1-canary.1268.16194.0
  yarn add @auto-canary/jira@9.37.1-canary.1268.16194.0
  yarn add @auto-canary/maven@9.37.1-canary.1268.16194.0
  yarn add @auto-canary/npm@9.37.1-canary.1268.16194.0
  yarn add @auto-canary/omit-commits@9.37.1-canary.1268.16194.0
  yarn add @auto-canary/omit-release-notes@9.37.1-canary.1268.16194.0
  yarn add @auto-canary/released@9.37.1-canary.1268.16194.0
  yarn add @auto-canary/s3@9.37.1-canary.1268.16194.0
  yarn add @auto-canary/slack@9.37.1-canary.1268.16194.0
  yarn add @auto-canary/twitter@9.37.1-canary.1268.16194.0
  yarn add @auto-canary/upload-assets@9.37.1-canary.1268.16194.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
