### PR TITLE
chore: accurately name variable within inOldVersionBranch()

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -721,14 +721,14 @@ export default class Auto {
   /** Determine if the repo is currently in a old-version branch */
   inOldVersionBranch(): boolean {
     const branch = getCurrentBranch();
-    const prereleaseBranchPrefix = this.config?.versionBranches as
+    const oldVersionBranchPrefix = this.config?.versionBranches as
       | string
       | undefined;
 
     return Boolean(
-      prereleaseBranchPrefix &&
+      oldVersionBranchPrefix &&
         branch &&
-        new RegExp(`^${escapeRegExp(prereleaseBranchPrefix)}`).test(branch)
+        new RegExp(`^${escapeRegExp(oldVersionBranchPrefix)}`).test(branch)
     );
   }
 


### PR DESCRIPTION
# What Changed

Scoped variable within `inOldVersionBranch`

# Why

When reading this source code, it was confusing to see mention of prerelease - which is irrelevant.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.38.1-canary.1271.16211.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.38.1-canary.1271.16211.0
  npm install @auto-canary/auto@9.38.1-canary.1271.16211.0
  npm install @auto-canary/core@9.38.1-canary.1271.16211.0
  npm install @auto-canary/all-contributors@9.38.1-canary.1271.16211.0
  npm install @auto-canary/brew@9.38.1-canary.1271.16211.0
  npm install @auto-canary/chrome@9.38.1-canary.1271.16211.0
  npm install @auto-canary/cocoapods@9.38.1-canary.1271.16211.0
  npm install @auto-canary/conventional-commits@9.38.1-canary.1271.16211.0
  npm install @auto-canary/crates@9.38.1-canary.1271.16211.0
  npm install @auto-canary/exec@9.38.1-canary.1271.16211.0
  npm install @auto-canary/first-time-contributor@9.38.1-canary.1271.16211.0
  npm install @auto-canary/gem@9.38.1-canary.1271.16211.0
  npm install @auto-canary/gh-pages@9.38.1-canary.1271.16211.0
  npm install @auto-canary/git-tag@9.38.1-canary.1271.16211.0
  npm install @auto-canary/gradle@9.38.1-canary.1271.16211.0
  npm install @auto-canary/jira@9.38.1-canary.1271.16211.0
  npm install @auto-canary/maven@9.38.1-canary.1271.16211.0
  npm install @auto-canary/npm@9.38.1-canary.1271.16211.0
  npm install @auto-canary/omit-commits@9.38.1-canary.1271.16211.0
  npm install @auto-canary/omit-release-notes@9.38.1-canary.1271.16211.0
  npm install @auto-canary/released@9.38.1-canary.1271.16211.0
  npm install @auto-canary/s3@9.38.1-canary.1271.16211.0
  npm install @auto-canary/slack@9.38.1-canary.1271.16211.0
  npm install @auto-canary/twitter@9.38.1-canary.1271.16211.0
  npm install @auto-canary/upload-assets@9.38.1-canary.1271.16211.0
  # or 
  yarn add @auto-canary/bot-list@9.38.1-canary.1271.16211.0
  yarn add @auto-canary/auto@9.38.1-canary.1271.16211.0
  yarn add @auto-canary/core@9.38.1-canary.1271.16211.0
  yarn add @auto-canary/all-contributors@9.38.1-canary.1271.16211.0
  yarn add @auto-canary/brew@9.38.1-canary.1271.16211.0
  yarn add @auto-canary/chrome@9.38.1-canary.1271.16211.0
  yarn add @auto-canary/cocoapods@9.38.1-canary.1271.16211.0
  yarn add @auto-canary/conventional-commits@9.38.1-canary.1271.16211.0
  yarn add @auto-canary/crates@9.38.1-canary.1271.16211.0
  yarn add @auto-canary/exec@9.38.1-canary.1271.16211.0
  yarn add @auto-canary/first-time-contributor@9.38.1-canary.1271.16211.0
  yarn add @auto-canary/gem@9.38.1-canary.1271.16211.0
  yarn add @auto-canary/gh-pages@9.38.1-canary.1271.16211.0
  yarn add @auto-canary/git-tag@9.38.1-canary.1271.16211.0
  yarn add @auto-canary/gradle@9.38.1-canary.1271.16211.0
  yarn add @auto-canary/jira@9.38.1-canary.1271.16211.0
  yarn add @auto-canary/maven@9.38.1-canary.1271.16211.0
  yarn add @auto-canary/npm@9.38.1-canary.1271.16211.0
  yarn add @auto-canary/omit-commits@9.38.1-canary.1271.16211.0
  yarn add @auto-canary/omit-release-notes@9.38.1-canary.1271.16211.0
  yarn add @auto-canary/released@9.38.1-canary.1271.16211.0
  yarn add @auto-canary/s3@9.38.1-canary.1271.16211.0
  yarn add @auto-canary/slack@9.38.1-canary.1271.16211.0
  yarn add @auto-canary/twitter@9.38.1-canary.1271.16211.0
  yarn add @auto-canary/upload-assets@9.38.1-canary.1271.16211.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
