### PR TITLE
fix next release start commit calculation when tags are package@version

### DIFF
--- a/packages/core/src/__tests__/git.test.ts
+++ b/packages/core/src/__tests__/git.test.ts
@@ -168,6 +168,30 @@ describe("github", () => {
         "1.4.0-next"
       );
     });
+
+    test("handles tags with package names", async () => {
+      const baseTags = ["@monorepo/models@2.0.0", "@monorepo/core@2.0.0"];
+      const branchTags = [
+        "@monorepo/models@2.0.0",
+        "@monorepo/core@1.0.0",
+        "@monorepo/models@6.0.1-next.0",
+        "@monorepo/core@6.0.1-next.0",
+      ];
+
+      const gh = new Git(options);
+
+      gh.getTags = (ref: string) => {
+        if (ref === "origin/master") {
+          return Promise.resolve(baseTags);
+        }
+
+        return Promise.resolve(branchTags);
+      };
+
+      expect(await gh.getTagNotInBaseBranch("branch")).toBe(
+        "@monorepo/core@6.0.1-next.0"
+      );
+    });
   });
 
   test("publish", async () => {


### PR DESCRIPTION
# What Changed

This funciton would break with any `package@version` tags. This is how `independent` (through `lerna`) tags releases.

# Why

might close #1272

Todo:

- [x] Add tests


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.38.1-canary.1273.16223.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.38.1-canary.1273.16223.0
  npm install @auto-canary/auto@9.38.1-canary.1273.16223.0
  npm install @auto-canary/core@9.38.1-canary.1273.16223.0
  npm install @auto-canary/all-contributors@9.38.1-canary.1273.16223.0
  npm install @auto-canary/brew@9.38.1-canary.1273.16223.0
  npm install @auto-canary/chrome@9.38.1-canary.1273.16223.0
  npm install @auto-canary/cocoapods@9.38.1-canary.1273.16223.0
  npm install @auto-canary/conventional-commits@9.38.1-canary.1273.16223.0
  npm install @auto-canary/crates@9.38.1-canary.1273.16223.0
  npm install @auto-canary/exec@9.38.1-canary.1273.16223.0
  npm install @auto-canary/first-time-contributor@9.38.1-canary.1273.16223.0
  npm install @auto-canary/gem@9.38.1-canary.1273.16223.0
  npm install @auto-canary/gh-pages@9.38.1-canary.1273.16223.0
  npm install @auto-canary/git-tag@9.38.1-canary.1273.16223.0
  npm install @auto-canary/gradle@9.38.1-canary.1273.16223.0
  npm install @auto-canary/jira@9.38.1-canary.1273.16223.0
  npm install @auto-canary/maven@9.38.1-canary.1273.16223.0
  npm install @auto-canary/npm@9.38.1-canary.1273.16223.0
  npm install @auto-canary/omit-commits@9.38.1-canary.1273.16223.0
  npm install @auto-canary/omit-release-notes@9.38.1-canary.1273.16223.0
  npm install @auto-canary/released@9.38.1-canary.1273.16223.0
  npm install @auto-canary/s3@9.38.1-canary.1273.16223.0
  npm install @auto-canary/slack@9.38.1-canary.1273.16223.0
  npm install @auto-canary/twitter@9.38.1-canary.1273.16223.0
  npm install @auto-canary/upload-assets@9.38.1-canary.1273.16223.0
  # or 
  yarn add @auto-canary/bot-list@9.38.1-canary.1273.16223.0
  yarn add @auto-canary/auto@9.38.1-canary.1273.16223.0
  yarn add @auto-canary/core@9.38.1-canary.1273.16223.0
  yarn add @auto-canary/all-contributors@9.38.1-canary.1273.16223.0
  yarn add @auto-canary/brew@9.38.1-canary.1273.16223.0
  yarn add @auto-canary/chrome@9.38.1-canary.1273.16223.0
  yarn add @auto-canary/cocoapods@9.38.1-canary.1273.16223.0
  yarn add @auto-canary/conventional-commits@9.38.1-canary.1273.16223.0
  yarn add @auto-canary/crates@9.38.1-canary.1273.16223.0
  yarn add @auto-canary/exec@9.38.1-canary.1273.16223.0
  yarn add @auto-canary/first-time-contributor@9.38.1-canary.1273.16223.0
  yarn add @auto-canary/gem@9.38.1-canary.1273.16223.0
  yarn add @auto-canary/gh-pages@9.38.1-canary.1273.16223.0
  yarn add @auto-canary/git-tag@9.38.1-canary.1273.16223.0
  yarn add @auto-canary/gradle@9.38.1-canary.1273.16223.0
  yarn add @auto-canary/jira@9.38.1-canary.1273.16223.0
  yarn add @auto-canary/maven@9.38.1-canary.1273.16223.0
  yarn add @auto-canary/npm@9.38.1-canary.1273.16223.0
  yarn add @auto-canary/omit-commits@9.38.1-canary.1273.16223.0
  yarn add @auto-canary/omit-release-notes@9.38.1-canary.1273.16223.0
  yarn add @auto-canary/released@9.38.1-canary.1273.16223.0
  yarn add @auto-canary/s3@9.38.1-canary.1273.16223.0
  yarn add @auto-canary/slack@9.38.1-canary.1273.16223.0
  yarn add @auto-canary/twitter@9.38.1-canary.1273.16223.0
  yarn add @auto-canary/upload-assets@9.38.1-canary.1273.16223.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
