### PR TITLE
if canary --force provided default to patch

### DIFF
--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -1178,6 +1178,28 @@ describe("Auto", () => {
       await auto.canary();
       expect(canary).not.toHaveBeenCalled();
     });
+
+    test("should publish with --force and skip-release label", async () => {
+      const auto = new Auto({ ...defaults, plugins: [] });
+      // @ts-ignore
+      auto.checkClean = () => Promise.resolve(true);
+      auto.logger = dummyLog();
+      await auto.loadConfig();
+
+      auto.git!.getSha = () => Promise.resolve("abcd");
+      auto.git!.getLatestRelease = () => Promise.resolve("1.2.3");
+      auto.release!.getCommitsInRelease = () =>
+        Promise.resolve([
+          makeCommitFromMsg("Test Commit", {
+            labels: ["skip-release"],
+          }),
+        ]);
+      const canary = jest.fn();
+      auto.hooks.canary.tap("test", canary);
+
+      await auto.canary({ force: true });
+      expect(canary).toHaveBeenCalledWith(SEMVER.patch, "canary.abcd");
+    });
   });
 
   describe("next", () => {

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1084,17 +1084,17 @@ export default class Auto {
     const from = (await this.git.shaExists("HEAD^")) ? "HEAD^" : "HEAD";
     const head = await this.release.getCommitsInRelease(from);
     const labels = head.map((commit) => commit.labels);
-    const version = calculateSemVerBump(
-      labels,
-      this.semVerLabels!,
-      this.config
-    );
+    let version = calculateSemVerBump(labels, this.semVerLabels!, this.config);
 
-    if (version === SEMVER.noVersion && !options.force) {
-      this.logger.log.info(
-        "Skipping canary release due to PR being specifying no release. Use `auto canary --force` to override this setting"
-      );
-      return;
+    if (version === SEMVER.noVersion) {
+      if (options.force) {
+        version = SEMVER.patch;
+      } else {
+        this.logger.log.info(
+          "Skipping canary release due to PR being specifying no release. Use `auto canary --force` to override this setting"
+        );
+        return;
+      }
     }
 
     let canaryVersion = "";


### PR DESCRIPTION
# What Changed

If --force is provided ensure that bump is provided to the `canary` hook.

# Why

closes #1274 

Todo:

- [x] Add tests


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.38.2-canary.1275.16238.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.38.2-canary.1275.16238.0
  npm install @auto-canary/auto@9.38.2-canary.1275.16238.0
  npm install @auto-canary/core@9.38.2-canary.1275.16238.0
  npm install @auto-canary/all-contributors@9.38.2-canary.1275.16238.0
  npm install @auto-canary/brew@9.38.2-canary.1275.16238.0
  npm install @auto-canary/chrome@9.38.2-canary.1275.16238.0
  npm install @auto-canary/cocoapods@9.38.2-canary.1275.16238.0
  npm install @auto-canary/conventional-commits@9.38.2-canary.1275.16238.0
  npm install @auto-canary/crates@9.38.2-canary.1275.16238.0
  npm install @auto-canary/exec@9.38.2-canary.1275.16238.0
  npm install @auto-canary/first-time-contributor@9.38.2-canary.1275.16238.0
  npm install @auto-canary/gem@9.38.2-canary.1275.16238.0
  npm install @auto-canary/gh-pages@9.38.2-canary.1275.16238.0
  npm install @auto-canary/git-tag@9.38.2-canary.1275.16238.0
  npm install @auto-canary/gradle@9.38.2-canary.1275.16238.0
  npm install @auto-canary/jira@9.38.2-canary.1275.16238.0
  npm install @auto-canary/maven@9.38.2-canary.1275.16238.0
  npm install @auto-canary/npm@9.38.2-canary.1275.16238.0
  npm install @auto-canary/omit-commits@9.38.2-canary.1275.16238.0
  npm install @auto-canary/omit-release-notes@9.38.2-canary.1275.16238.0
  npm install @auto-canary/released@9.38.2-canary.1275.16238.0
  npm install @auto-canary/s3@9.38.2-canary.1275.16238.0
  npm install @auto-canary/slack@9.38.2-canary.1275.16238.0
  npm install @auto-canary/twitter@9.38.2-canary.1275.16238.0
  npm install @auto-canary/upload-assets@9.38.2-canary.1275.16238.0
  # or 
  yarn add @auto-canary/bot-list@9.38.2-canary.1275.16238.0
  yarn add @auto-canary/auto@9.38.2-canary.1275.16238.0
  yarn add @auto-canary/core@9.38.2-canary.1275.16238.0
  yarn add @auto-canary/all-contributors@9.38.2-canary.1275.16238.0
  yarn add @auto-canary/brew@9.38.2-canary.1275.16238.0
  yarn add @auto-canary/chrome@9.38.2-canary.1275.16238.0
  yarn add @auto-canary/cocoapods@9.38.2-canary.1275.16238.0
  yarn add @auto-canary/conventional-commits@9.38.2-canary.1275.16238.0
  yarn add @auto-canary/crates@9.38.2-canary.1275.16238.0
  yarn add @auto-canary/exec@9.38.2-canary.1275.16238.0
  yarn add @auto-canary/first-time-contributor@9.38.2-canary.1275.16238.0
  yarn add @auto-canary/gem@9.38.2-canary.1275.16238.0
  yarn add @auto-canary/gh-pages@9.38.2-canary.1275.16238.0
  yarn add @auto-canary/git-tag@9.38.2-canary.1275.16238.0
  yarn add @auto-canary/gradle@9.38.2-canary.1275.16238.0
  yarn add @auto-canary/jira@9.38.2-canary.1275.16238.0
  yarn add @auto-canary/maven@9.38.2-canary.1275.16238.0
  yarn add @auto-canary/npm@9.38.2-canary.1275.16238.0
  yarn add @auto-canary/omit-commits@9.38.2-canary.1275.16238.0
  yarn add @auto-canary/omit-release-notes@9.38.2-canary.1275.16238.0
  yarn add @auto-canary/released@9.38.2-canary.1275.16238.0
  yarn add @auto-canary/s3@9.38.2-canary.1275.16238.0
  yarn add @auto-canary/slack@9.38.2-canary.1275.16238.0
  yarn add @auto-canary/twitter@9.38.2-canary.1275.16238.0
  yarn add @auto-canary/upload-assets@9.38.2-canary.1275.16238.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
