### PR TITLE
check for autoPublishRepo before trying to add it

### DIFF
--- a/plugins/cocoapods/README.md
+++ b/plugins/cocoapods/README.md
@@ -36,8 +36,8 @@ yarn add -D @auto-it/cocoapods
 ### General
 
 - The machine running this plugin must have the [CocoaPods](https://cocoapods.org/) `pod` CLI installed already.
-
 - Your `podspec` file must pass `pod lib lint` in order for publishing to a Specs repository to work.
+  - All warnings and errors must be addressed before attempting to push to a Specs repository.
 
 ### Pushing to the CocoaPods Trunk
 
@@ -46,3 +46,6 @@ If a `specsRepo` is not provided in the plugin options, this plugin will push to
 ### Pushing to a private specs repo
 
 If `specsRepo` is provided in the configuration, this plugin will add that repo under a temporary name, push to it, and remove the repo from the CocoaPods installation on the machine. The machine that is running the plugin must have the appropriate git credentials to push to that repository.
+
+#### Note
+When pushing to a private Specs repo, this plugin will temporarily create a repository with the name `autoPublishRepo` using `pod repo add`, and will remove it when the release has completed.

--- a/plugins/cocoapods/__tests__/cocoapods.test.ts
+++ b/plugins/cocoapods/__tests__/cocoapods.test.ts
@@ -250,7 +250,7 @@ describe("Cocoapods Plugin", () => {
       mockPodspec(specWithVersion("0.0.1"));
 
       exec = jest.fn().mockImplementation((...args) => {
-        if (args && args[1] && args[1][1] === 'list') {
+        if (args[1]?.[1] === 'list') {
           return `
 autoPublishRepo
 - Type: git (master)

--- a/plugins/cocoapods/src/index.ts
+++ b/plugins/cocoapods/src/index.ts
@@ -167,6 +167,23 @@ export default class CocoapodsPlugin implements IPlugin {
       }
 
       try {
+        const existingRepos = await execPromise("pod", [
+          "repo",
+          "list"
+        ]);
+        if (existingRepos.indexOf('autoPublishRepo') !== -1) {
+          auto.logger.log.info('Removing existing autoPublishRepo')
+          await execPromise("pod", [
+            "repo",
+            "remove",
+            "autoPublishRepo"
+          ])
+        }
+      } catch (error) {
+        auto.logger.log.warn(`Error Checking for existing Specs repositories: ${error}`)
+      }
+
+      try {
         await execPromise("pod", [
           "repo",
           "add",


### PR DESCRIPTION
# What Changed
- Some Readme updates for clarity
- check for existence of temporary repository before attempting to add it to ensure publish is always a clean slate
# Why
In some cases if the build is interrupted, or `pod lib lint` fails during the push portion, `autoPublishRepo` would still exist for the next build. I was working around this with
```sh
> pod repo remove autoPublishRepo || true
> auto shipit
```
but really, users shouldnt need to worry about it
Todo:

- [x] Add tests
- [x] Add docs
