### PR TITLE
fix automated old branch creation

### DIFF
--- a/packages/core/src/__tests__/major-version-branches.test.ts
+++ b/packages/core/src/__tests__/major-version-branches.test.ts
@@ -1,0 +1,92 @@
+import Auto from "../auto";
+import SEMVER from "../semver";
+import execPromise from "../utils/exec-promise";
+
+const execSpy = execPromise as jest.Mock;
+jest.mock("../utils/exec-promise");
+
+const search = jest.fn();
+jest.mock("cosmiconfig", () => ({
+  cosmiconfig: () => ({
+    search,
+  }),
+}));
+
+jest.mock("@octokit/rest", () => {
+  const Octokit = class MockOctokit {
+    static plugin = () => Octokit;
+
+    authenticate = () => undefined;
+
+    search = {
+      issuesAndPullRequests: () => ({ data: { items: [] } }),
+    };
+
+    repos = {
+      get: jest.fn().mockReturnValueOnce({}),
+    };
+
+    hook = {
+      error: () => undefined,
+    };
+  };
+
+  return { Octokit };
+});
+
+const defaults = {
+  owner: "foo",
+  repo: "bar",
+};
+
+describe("Old Version Branches", () => {
+  beforeEach(() => {
+    search.mockClear();
+    execSpy.mockClear();
+  });
+
+  test("should not create old version branches", async () => {
+    search.mockReturnValueOnce({});
+    execSpy.mockResolvedValueOnce(undefined);
+
+    const auto = new Auto({ ...defaults, plugins: [] });
+    await auto.loadConfig();
+
+    auto.hooks.getPreviousVersion.tap("test", () => "1.0.0");
+    await auto.hooks.beforeCommitChangelog.promise({
+      bump: SEMVER.major,
+    } as any);
+
+    expect(execSpy).not.toHaveBeenCalledWith();
+  });
+
+  test("create old version branches", async () => {
+    search.mockReturnValueOnce({ config: { versionBranches: true } });
+    execSpy.mockResolvedValueOnce(undefined);
+
+    const auto = new Auto({ ...defaults, plugins: [] });
+    await auto.loadConfig();
+
+    auto.hooks.getPreviousVersion.tap("test", () => "1.0.0");
+    await auto.hooks.beforeCommitChangelog.promise({
+      bump: SEMVER.major,
+    } as any);
+
+    expect(execSpy).toHaveBeenCalledWith("git", ["branch", "version-1"]);
+  });
+
+  test("should be able to customize old version branches", async () => {
+    search.mockReturnValueOnce({ config: { versionBranches: "v" } });
+    execSpy.mockResolvedValueOnce(undefined);
+
+    const auto = new Auto({ ...defaults, plugins: [] });
+    await auto.loadConfig();
+
+    auto.hooks.getPreviousVersion.tap("test", () => "1.0.0");
+    await auto.hooks.beforeCommitChangelog.promise({
+      bump: SEMVER.major,
+    } as any);
+
+    expect(execSpy).toHaveBeenCalledWith("git", ["branch", "v1"]);
+  });
+});

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -372,10 +372,8 @@ export default class Auto {
             await this.hooks.getPreviousVersion.promise()
           )}`;
 
-          await execPromise("git", [
-            "branch",
-            await this.git?.getLatestTagInBranch(),
-          ]);
+          await execPromise("git", ["branch", branch]);
+          this.logger.log.success(`Created old version branch: ${branch}`)
           await execPromise("git", ["push", this.remote, branch]);
         }
       }

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -90,7 +90,7 @@ export default class Config {
       labels,
       prereleaseBranches: rawConfig.prereleaseBranches || ["next"],
       versionBranches:
-        typeof rawConfig.versionBranches === "boolean"
+        typeof rawConfig.versionBranches === "boolean" && rawConfig.versionBranches
           ? "version-"
           : rawConfig.versionBranches,
     };


### PR DESCRIPTION
# What Changed

Fix branch creation for old majors

# Why

closes #1270

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.38.3-canary.1278.16275.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @auto-canary/bot-list@9.38.3-canary.1278.16275.0
  npm install @auto-canary/auto@9.38.3-canary.1278.16275.0
  npm install @auto-canary/core@9.38.3-canary.1278.16275.0
  npm install @auto-canary/all-contributors@9.38.3-canary.1278.16275.0
  npm install @auto-canary/brew@9.38.3-canary.1278.16275.0
  npm install @auto-canary/chrome@9.38.3-canary.1278.16275.0
  npm install @auto-canary/cocoapods@9.38.3-canary.1278.16275.0
  npm install @auto-canary/conventional-commits@9.38.3-canary.1278.16275.0
  npm install @auto-canary/crates@9.38.3-canary.1278.16275.0
  npm install @auto-canary/exec@9.38.3-canary.1278.16275.0
  npm install @auto-canary/first-time-contributor@9.38.3-canary.1278.16275.0
  npm install @auto-canary/gem@9.38.3-canary.1278.16275.0
  npm install @auto-canary/gh-pages@9.38.3-canary.1278.16275.0
  npm install @auto-canary/git-tag@9.38.3-canary.1278.16275.0
  npm install @auto-canary/gradle@9.38.3-canary.1278.16275.0
  npm install @auto-canary/jira@9.38.3-canary.1278.16275.0
  npm install @auto-canary/maven@9.38.3-canary.1278.16275.0
  npm install @auto-canary/npm@9.38.3-canary.1278.16275.0
  npm install @auto-canary/omit-commits@9.38.3-canary.1278.16275.0
  npm install @auto-canary/omit-release-notes@9.38.3-canary.1278.16275.0
  npm install @auto-canary/released@9.38.3-canary.1278.16275.0
  npm install @auto-canary/s3@9.38.3-canary.1278.16275.0
  npm install @auto-canary/slack@9.38.3-canary.1278.16275.0
  npm install @auto-canary/twitter@9.38.3-canary.1278.16275.0
  npm install @auto-canary/upload-assets@9.38.3-canary.1278.16275.0
  # or 
  yarn add @auto-canary/bot-list@9.38.3-canary.1278.16275.0
  yarn add @auto-canary/auto@9.38.3-canary.1278.16275.0
  yarn add @auto-canary/core@9.38.3-canary.1278.16275.0
  yarn add @auto-canary/all-contributors@9.38.3-canary.1278.16275.0
  yarn add @auto-canary/brew@9.38.3-canary.1278.16275.0
  yarn add @auto-canary/chrome@9.38.3-canary.1278.16275.0
  yarn add @auto-canary/cocoapods@9.38.3-canary.1278.16275.0
  yarn add @auto-canary/conventional-commits@9.38.3-canary.1278.16275.0
  yarn add @auto-canary/crates@9.38.3-canary.1278.16275.0
  yarn add @auto-canary/exec@9.38.3-canary.1278.16275.0
  yarn add @auto-canary/first-time-contributor@9.38.3-canary.1278.16275.0
  yarn add @auto-canary/gem@9.38.3-canary.1278.16275.0
  yarn add @auto-canary/gh-pages@9.38.3-canary.1278.16275.0
  yarn add @auto-canary/git-tag@9.38.3-canary.1278.16275.0
  yarn add @auto-canary/gradle@9.38.3-canary.1278.16275.0
  yarn add @auto-canary/jira@9.38.3-canary.1278.16275.0
  yarn add @auto-canary/maven@9.38.3-canary.1278.16275.0
  yarn add @auto-canary/npm@9.38.3-canary.1278.16275.0
  yarn add @auto-canary/omit-commits@9.38.3-canary.1278.16275.0
  yarn add @auto-canary/omit-release-notes@9.38.3-canary.1278.16275.0
  yarn add @auto-canary/released@9.38.3-canary.1278.16275.0
  yarn add @auto-canary/s3@9.38.3-canary.1278.16275.0
  yarn add @auto-canary/slack@9.38.3-canary.1278.16275.0
  yarn add @auto-canary/twitter@9.38.3-canary.1278.16275.0
  yarn add @auto-canary/upload-assets@9.38.3-canary.1278.16275.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
