### PR TITLE
Remove maven release plugin requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.27",
     "@fortawesome/free-solid-svg-icons": "^5.12.1",
     "@fortawesome/react-fontawesome": "^0.1.9",
+    "@types/jest": "^26.0.0",
     "@types/parse-github-url": "1.0.0",
     "@typescript-eslint/eslint-plugin": "^2.7.0",
     "@typescript-eslint/parser": "^2.7.0",
@@ -61,6 +62,7 @@
     "husky": "^4.0.7",
     "ignite": "1.11.2",
     "jest": "~25.5.4",
+    "jest-circus": "^26.0.1",
     "jest-serializer-path": "^0.1.15",
     "jest-snapshot-serializer-ansi": "^1.0.0",
     "lerna": "^3.13.4",
@@ -102,6 +104,7 @@
       "!**/dist/**/*",
       "!**/scripts/template-plugin/**/*"
     ],
+    "testRunner": "jest-circus/runner",
     "snapshotSerializers": [
       "jest-serializer-path",
       "jest-snapshot-serializer-ansi"

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -134,7 +134,7 @@ export interface IAutoHooks {
   /** Validate what is in the config. You must return the config in this hook. */
   validateConfig: ValidatePluginHook;
   /** Happens before anything is done. This is a great place to check for platform specific secrets. */
-  beforeRun: SyncHook<[LoadedAutoRc]>;
+  beforeRun: AsyncSeriesHook<[LoadedAutoRc]>;
   /** Happens before `shipit` is run. This is a great way to throw an error if a token or key is not present. */
   beforeShipIt: AsyncSeriesHook<[BeforeShipitContext]>;
   /** Ran before the `changelog` command commits the new release notes to `CHANGELOG.md`. */
@@ -373,7 +373,7 @@ export default class Auto {
           )}`;
 
           await execPromise("git", ["branch", branch]);
-          this.logger.log.success(`Created old version branch: ${branch}`)
+          this.logger.log.success(`Created old version branch: ${branch}`);
           await execPromise("git", ["push", this.remote, branch]);
         }
       }
@@ -485,7 +485,7 @@ export default class Auto {
     this.config = this.hooks.modifyConfig.call(this.config!);
     this.labels = this.config.labels;
     this.semVerLabels = getVersionMap(this.config.labels);
-    this.hooks.beforeRun.call(this.config);
+    await this.hooks.beforeRun.promise(this.config);
 
     const errors = [
       ...(await validateAutoRc(this.config)),

--- a/packages/core/src/utils/make-hooks.ts
+++ b/packages/core/src/utils/make-hooks.ts
@@ -14,7 +14,7 @@ import { InteractiveInitHooks } from "../init";
 
 /** Make the hooks for "auto" */
 export const makeHooks = (): IAutoHooks => ({
-  beforeRun: new SyncHook(["config"]),
+  beforeRun: new AsyncSeriesHook(["config"]),
   modifyConfig: new SyncWaterfallHook(["config"]),
   validateConfig: new AsyncSeriesBailHook(["name", "options"]),
   beforeShipIt: new AsyncSeriesHook(["context"]),

--- a/plugins/exec/__tests__/exec.test.ts
+++ b/plugins/exec/__tests__/exec.test.ts
@@ -31,12 +31,12 @@ describe("Exec Plugin", () => {
     ).toMatchSnapshot();
   });
 
-  test("should handle SyncHook hooks", () => {
+  test("should handle SyncHook hooks", async () => {
     const plugins = new Exec({ beforeRun: "echo foo" });
     const hooks = makeHooks();
 
     plugins.apply({ hooks } as Auto);
-    hooks.beforeRun.call({} as any);
+    await hooks.beforeRun.promise({} as any);
 
     expect(execSpy).toHaveBeenCalledWith("echo foo", expect.anything());
   });

--- a/plugins/maven/README.md
+++ b/plugins/maven/README.md
@@ -80,6 +80,10 @@ formatter with the following default settings:
 | `MAVEN_USERNAME`      | (DEPRECATED IN 9.38.0 ) The deploy username used to login to the repository. | `null`                      |
 | `MAVEN_PASSWORD`      | (DEPRECATED IN 9.38.0 ) The deploy password used to login to the repository. | `null`                      |
 
+**NOTE:** The MAVEN_USERNAME and MAVEN_PASSWORD environment variables are still supported, and have their counterparts as configuration
+options, but should are deprecated, and will be removed in a later release. This is because MAVEN_SETTINGS or MAVEN_OPTIONS can do the
+same work, but provide a much more flexible solution.
+
 ## Maven Project Configuration
 
 You will need all the following configuration blocks for all parts of `auto` to function:

--- a/plugins/maven/README.md
+++ b/plugins/maven/README.md
@@ -14,6 +14,12 @@ yarn add -D @auto-it/maven
 
 ## Usage
 
+This plugin makes recursive changes to all `pom.xml` files in the project, with the following assumptions:
+a. The project is a multi-module project.
+b. The parent `pom.xml` file is located in the root directory of the repo.
+c. The parent `pom.xml` contains the version.
+d. Sub-modules have the same version as the parent `pom.xml`.
+
 `auto` will detect if the parent `pom.xml` file has the [`versions-maven-plugin`][versions-maven-plugin] configured, and
 if so, use it to set the version on the parent and all child `pom.xml` files. If not, then `auto` will modify the parent
 and all child `pom.xml` files using a DOM parser and XML serializer. This has the effect of losing formatting. Therefore

--- a/plugins/maven/README.md
+++ b/plugins/maven/README.md
@@ -80,9 +80,9 @@ formatter with the following default settings:
 | `MAVEN_USERNAME`      | (DEPRECATED IN 9.38.0 ) The deploy username used to login to the repository. | `null`                      |
 | `MAVEN_PASSWORD`      | (DEPRECATED IN 9.38.0 ) The deploy password used to login to the repository. | `null`                      |
 
-**NOTE:** The MAVEN_USERNAME and MAVEN_PASSWORD environment variables are still supported, and have their counterparts as configuration
-options, but should are deprecated, and will be removed in a later release. This is because MAVEN_SETTINGS or MAVEN_OPTIONS can do the
-same work, but provide a much more flexible solution.
+**NOTE:** The `MAVEN_USERNAME` and `MAVEN_PASSWORD` environment variables are still supported, and have their
+counterparts as configuration options, but should be deprecated, and will be removed in a later release. This is because
+`MAVEN_SETTINGS` or `MAVEN_OPTIONS` can do the same work, but provide a much more flexible solution.
 
 ## Maven Project Configuration
 

--- a/plugins/maven/README.md
+++ b/plugins/maven/README.md
@@ -1,6 +1,6 @@
 # Maven Plugin
 
-Release a Java project to a [maven](https://maven.apache.org/) repository.
+Release a Java project to a [maven][maven] repository.
 
 ## Installation
 
@@ -13,6 +13,18 @@ yarn add -D @auto-it/maven
 ```
 
 ## Usage
+
+`auto` will detect if the parent `pom.xml` file has the [`versions-maven-plugin`][versions-maven-plugin] configured, and
+if so, use it to set the version on the parent and all child `pom.xml` files. If not, then `auto` will modify the parent
+and all child `pom.xml` files using a DOM parser and XML serializer. This has the effect of losing formatting. Therefore
+it then runs the serialized XML through the `prettier` "html" pretty-printer.
+
+This means that if the `versions-maven-plugin` isn't available, the `pom.xml` files will be pretty-printed using `prettier`
+formatter with the following default settings:
+
+- `printWidth: 120` (configurable - see below)
+- `tabWidth: 4` (configurable - see below)
+- `parser: "html"`
 
 ```jsonc
 {
@@ -35,7 +47,15 @@ yarn add -D @auto-it/maven
 
         // An optional path to a maven settings.xml file
         // @default ""
-        "mavenSettings": "./.github/maven/settings.xml"
+        "mavenSettings": "./.github/maven/settings.xml",
+
+        // An optional printWidth for the prettier pretty-printer
+        // @default 120
+        "printWidth": 80,
+
+        // An optional tabWidth for the prettier pretty-printer
+        // @default 4
+        "tabWidth": 4
       }
     ]
     // other plugins
@@ -62,10 +82,10 @@ You will need all the following configuration blocks for all parts of `auto` to 
 
 ```xml
 <developers>
- <developer>
-   <name>Andrew Lisowski</name>
-   <email>test@email.com</email>
- </developer>
+    <developer>
+        <name>Andrew Lisowski</name>
+        <email>test@email.com</email>
+    </developer>
 </developers>
 ```
 
@@ -73,11 +93,23 @@ You will need all the following configuration blocks for all parts of `auto` to 
 
 ```xml
 <scm>
- <connection>scm:git:https://${env.GH_USER}:${env.GH_TOKEN}@github.com/Fuego-Tools/java-test-project.git</connection>
- <developerConnection>scm:git:https://${env.GH_USER}:${env.GH_TOKEN}@github.com/Fuego-Tools/java-test-project.git</developerConnection>
- <url>https://github.com/Fuego-Tools/java-test-project</url>
- <tag>HEAD</tag>
+    <connection
+  >scm:git:https://${env.GH_USER}:${env.GH_TOKEN}@github.com/Fuego-Tools/java-test-project.git</connection>
+    <developerConnection
+  >scm:git:https://${env.GH_USER}:${env.GH_TOKEN}@github.com/Fuego-Tools/java-test-project.git</developerConnection>
+    <url>https://github.com/Fuego-Tools/java-test-project</url>
+    <tag>HEAD</tag>
 </scm>
+```
+
+3. Versions Maven Plugin **RECOMMENDED** (Optional)
+
+```xml
+<plugin>
+    <groupId>org.codehaus.mojo</groupId>
+    <artifactId>versions-maven-plugin</artifactId>
+    <version>2.7</version>
+</plugin>
 ```
 
 > :warning: Don't forget to set enviornment variables `GH_USER`, `GH_TOKEN`
@@ -87,3 +119,6 @@ You will need all the following configuration blocks for all parts of `auto` to 
 ```xml
 <version>1.0.0-SNAPSHOT</version>
 ```
+
+[maven]: https://maven.apache.org/
+[versions-maven-plugin]: https://www.mojohaus.org/versions-maven-plugin/

--- a/plugins/maven/README.md
+++ b/plugins/maven/README.md
@@ -114,7 +114,7 @@ You will need all the following configuration blocks for all parts of `auto` to 
 
 > :warning: Don't forget to set enviornment variables `GH_USER`, `GH_TOKEN`
 
-3. Version
+4. Version
 
 ```xml
 <version>1.0.0-SNAPSHOT</version>

--- a/plugins/maven/README.md
+++ b/plugins/maven/README.md
@@ -1,6 +1,6 @@
 # Maven Plugin
 
-Release a Java project to a [maven](https://maven.apache.org/) instance.
+Release a Java project to a [maven](https://maven.apache.org/) repository.
 
 ## Installation
 
@@ -14,38 +14,49 @@ yarn add -D @auto-it/maven
 
 ## Usage
 
-```json
+```jsonc
 {
-  "plugins": ["maven"]
+  "plugins": [
+    [
+      "maven",
+      {
+        // An optional maven binary cmd/path
+        // @default /usr/bin/mvn
+        "mavenCommand": "mvn",
+
+        // An optional maven argument list - e.g. any maven option allowed for the version
+        // of maven you're using
+        // @default []
+        "mavenOptions": ["-DskipTests", "-P some-profile"],
+
+        // An optional set of goals to execute for release
+        // @default ["deploy", "site-deploy"]
+        "mavenReleaseGoals": ["deploy"],
+
+        // An optional path to a maven settings.xml file
+        // @default ""
+        "mavenSettings": "./.github/maven/settings.xml"
+      }
+    ]
+    // other plugins
+  ]
 }
 ```
 
 ## Environment Variables
 
-| Name                    | Description                                                                                      | Default value  |
-| ----------------------- | ------------------------------------------------------------------------------------------------ | -------------- |
-| `MAVEN_USERNAME`        | The deploy username used to login to the repository.                                             | `null`         |
-| `MAVEN_PASSWORD`        | The deploy password used to login to the repository.                                             | `null`         |
-| `MAVEN_SETTINGS`        | The maven `settings.xml` file used by maven.                                                     | `null`         |
-| `MAVEN_SNAPSHOT_BRANCH` | The branch on which the `SNAPSHOT` version lives. Must be different than the Auto "base branch." | `dev-snapshot` |
+| Name                  | Description                                                                  | Default value               |
+| --------------------- | ---------------------------------------------------------------------------- | --------------------------- |
+| `MAVEN_COMMAND`       | The Maven command to use.                                                    | `/usr/bin/mvn`              |
+| `MAVEN_OPTIONS`       | A list of maven command customizations to pass to maven.                     | `null`                      |
+| `MAVEN_RELEASE_GOALS` | A list of maven goals to pass to maven for release.                          | `["deploy", "site-deploy"]` |
+| `MAVEN_SETTINGS`      | The maven `settings.xml` file used by maven.                                 | `null`                      |
+| `MAVEN_USERNAME`      | (DEPRECATED IN 9.38.0 ) The deploy username used to login to the repository. | `null`                      |
+| `MAVEN_PASSWORD`      | (DEPRECATED IN 9.38.0 ) The deploy password used to login to the repository. | `null`                      |
 
 ## Maven Project Configuration
 
-Your project must be using the maven release plugin. Make sure the the latest `maven-release-plugin` is in your `pom.xml`.
-
-```xml
-<plugin>
-  <groupId>org.apache.maven.plugins</groupId>
-  <artifactId>maven-release-plugin</artifactId>
-  <version>3.0.0-M1</version>
-  <configuration>
-    <preparationGoals>initialize</preparationGoals>
-    <goals>deploy</goals>
-  </configuration>
-</plugin>
-```
-
-You will also need all the following configuration blocks for all parts of `auto` to function:
+You will need all the following configuration blocks for all parts of `auto` to function:
 
 1. Author
 

--- a/plugins/maven/__tests__/maven.test.ts
+++ b/plugins/maven/__tests__/maven.test.ts
@@ -1,22 +1,55 @@
-import fs from "fs";
-
 import * as Auto from "@auto-it/core";
 import { dummyLog } from "@auto-it/core/dist/utils/logger";
 import { makeHooks } from "@auto-it/core/dist/utils/make-hooks";
 import MavenPlugin, { IMavenPluginOptions } from "../src";
+import { execSync } from "child_process";
+import * as glob from "fast-glob";
 
 const exec = jest.fn();
+const existsSync = jest.fn();
+const mkdirSync = jest.fn();
+const readFile = jest.fn();
+const readFileSync = jest.fn();
+const writeFile = jest.fn();
+const writeFileSync = jest.fn();
+
+jest.mock("fs", () => ({
+  // @ts-ignore
+  existsSync: (...args) => existsSync(...args),
+  // @ts-ignore
+  mkdirSync: (...args) => mkdirSync(...args),
+  // @ts-ignore
+  readFileSync: (...args) => readFileSync(...args),
+  // @ts-ignore
+  writeFileSync: (...args) => writeFileSync(...args),
+  // @ts-ignore
+  readFile: (...args) => readFile(...args),
+  // @ts-ignore
+  writeFile: (...args) => writeFile(...args),
+  ReadStream: function () {},
+  WriteStream: function () {},
+  // @ts-ignore
+  closeSync: () => undefined,
+}));
+
+jest.mock("child_process");
+jest.mock("fast-glob");
+
+const mockGlob = (result: string[]) =>
+  jest.spyOn(glob, "sync").mockImplementation(() => result);
+
+const mockReadFile = (result: string) =>
+  readFile.mockImplementation((path, options, callback) =>
+    callback(undefined, result)
+  );
+
+// @ts-ignore
+execSync.mockImplementation(exec);
 
 jest.mock("../../../packages/core/dist/utils/exec-promise", () => ({
   // @ts-ignore
   default: (...args) => exec(...args),
 }));
-
-const mockRead = (result: string) =>
-  jest
-    .spyOn(fs, "readFile")
-    // @ts-ignore
-    .mockImplementationOnce((a, b, cb) => cb(undefined, result));
 
 describe("maven", () => {
   let hooks: Auto.IAutoHooks;
@@ -26,7 +59,7 @@ describe("maven", () => {
   const options: IMavenPluginOptions = {};
 
   beforeEach(() => {
-    exec.mockClear();
+    jest.clearAllMocks();
     const plugin = new MavenPlugin(options);
     hooks = makeHooks();
     plugin.apply({ hooks, logger: dummyLog(), prefixRelease } as Auto.Auto);
@@ -34,7 +67,7 @@ describe("maven", () => {
 
   describe("getAuthor", () => {
     test("should get author from pom.xml", async () => {
-      mockRead(`
+      mockReadFile(`
         <project
           xmlns="http://maven.apache.org/POM/4.0.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -59,7 +92,7 @@ describe("maven", () => {
     });
 
     test("should support multiple developers", async () => {
-      mockRead(`
+      mockReadFile(`
         <project
           xmlns="http://maven.apache.org/POM/4.0.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -87,8 +120,8 @@ describe("maven", () => {
       );
     });
 
-    test("should get author from pom.xml - simple", async () => {
-      mockRead(`
+    test("author should be undefined if not found in pom.xml", async () => {
+      mockReadFile(`
         <project
           xmlns="http://maven.apache.org/POM/4.0.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -104,18 +137,18 @@ describe("maven", () => {
 
   describe("getRepository", () => {
     test("should get repo from pom.xml", async () => {
-      mockRead(`
-        <project
-          xmlns="http://maven.apache.org/POM/4.0.0"
-          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-          <scm>
-            <connection>scm:git:https://github.com/Fuego-Tools/java-test-project.git</connection>
-            <url>https://github.com/Fuego-Tools/java-test-project</url>
-            <tag>HEAD</tag>
-          </scm>
-        </project>
-      `);
+      mockReadFile(`
+                <project
+                  xmlns="http://maven.apache.org/POM/4.0.0"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+                  <scm>
+                    <connection>scm:git:https://github.com/Fuego-Tools/java-test-project.git</connection>
+                    <url>https://github.com/Fuego-Tools/java-test-project</url>
+                    <tag>HEAD</tag>
+                  </scm>
+                </project>
+            `);
 
       await hooks.beforeRun.promise({} as any);
 
@@ -128,7 +161,7 @@ describe("maven", () => {
     });
 
     test("should be undefined if no repo found", async () => {
-      mockRead(`
+      mockReadFile(`
         <project
           xmlns="http://maven.apache.org/POM/4.0.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -147,7 +180,7 @@ describe("maven", () => {
     });
 
     test("should be undefined if cannot find github URL", async () => {
-      mockRead(`
+      mockReadFile(`
         <project
           xmlns="http://maven.apache.org/POM/4.0.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -171,7 +204,7 @@ describe("maven", () => {
     });
 
     test("should be undefined if cannot parse github URL", async () => {
-      mockRead(`
+      mockReadFile(`
         <project
           xmlns="http://maven.apache.org/POM/4.0.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -197,14 +230,14 @@ describe("maven", () => {
 
   describe("getPreviousVersion", () => {
     test("should get previous version from pom.xml", async () => {
-      mockRead(`
-        <project
-          xmlns="http://maven.apache.org/POM/4.0.0"
-          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-          <version>1.0.0-SNAPSHOT</version>
-        </project>
-      `);
+      mockReadFile(`
+          <project
+            xmlns="http://maven.apache.org/POM/4.0.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+            <version>1.0.0-SNAPSHOT</version>
+          </project>
+        `);
 
       await hooks.beforeRun.promise({} as any);
 
@@ -212,41 +245,185 @@ describe("maven", () => {
     });
 
     test("should be undefined when no version in pom.xml", async () => {
-      mockRead("");
-      expect(await hooks.getPreviousVersion.promise()).toBe("v0.0.0.0");
+      mockReadFile("");
+      expect(await hooks.getPreviousVersion.promise()).toBe("v0.0.0");
     });
   });
 
   describe("version", () => {
     test("should version release - not versioned because of pre-patched snapshot", async () => {
-      mockRead(`
-        <project
-          xmlns="http://maven.apache.org/POM/4.0.0"
-          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-          <version>1.0.0-SNAPSHOT</version>
-        </project>
-      `);
+      mockReadFile(`
+          <project
+            xmlns="http://maven.apache.org/POM/4.0.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+            <version>1.0.0-SNAPSHOT</version>
+          </project>
+        `);
 
       await hooks.beforeRun.promise({} as any);
 
       await hooks.version.promise(Auto.SEMVER.patch);
 
-      const call = exec.mock.calls[1][1];
+      const call = exec.mock.calls[0][1];
       expect(call).toContain("tag");
       expect(call).toContain("v1.0.0");
+      expect(call).toContain('"Update version to v1.0.0"');
+    });
+
+    test("should version release", async () => {
+      mockReadFile(`
+          <project
+            xmlns="http://maven.apache.org/POM/4.0.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+            <version>1.0.0</version>
+          </project>
+        `);
+
+      await hooks.beforeRun.promise({} as any);
+
+      await hooks.version.promise(Auto.SEMVER.patch);
+
+      const call = exec.mock.calls[0][1];
+      expect(call).toContain("tag");
+      expect(call).toContain("v1.0.1");
       expect(call).toContain('"Update version to v1.0.1"');
     });
 
+    test("should replace the previousVersion with the newVersion", async () => {
+      const oldPomXml = `<project
+                  xmlns="http://maven.apache.org/POM/4.0.0"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+                  <version>1.0.0-SNAPSHOT</version>
+                </project>`;
+      const newPomXml = `<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"
+>
+    <version>1.0.0</version>
+</project>
+`;
+
+      mockGlob(["pom.xml"]);
+      mockReadFile(oldPomXml);
+
+      await hooks.beforeRun.promise({} as any);
+      await hooks.version.promise(Auto.SEMVER.patch);
+
+      expect(await readFile).toHaveBeenCalledTimes(3);
+      expect(await readFile).toHaveBeenLastCalledWith(
+        "pom.xml",
+        { encoding: "utf8" },
+        expect.anything()
+      );
+      expect(await writeFile).toHaveBeenCalledWith(
+        "pom.xml",
+        newPomXml,
+        { encoding: "utf8" },
+        expect.anything()
+      );
+    });
+
+    test("should detect the versions-maven-plugin and use the newVersion", async () => {
+      mockReadFile(`<project
+                  xmlns="http://maven.apache.org/POM/4.0.0"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+                  <version>1.0.0-SNAPSHOT</version>
+                  <build>
+                    <plugins>
+                      <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>versions-maven-plugin</artifactId>
+                        <version>2.7</version>
+                      </plugin>
+                    </plugins>
+                  </build>
+                </project>`);
+
+      await hooks.beforeRun.promise({} as any);
+      await hooks.version.promise(Auto.SEMVER.patch);
+
+      expect(await readFile).toHaveBeenCalledTimes(2);
+      expect(await readFile).toHaveBeenLastCalledWith(
+        "pom.xml",
+        { encoding: "utf8" },
+        expect.anything()
+      );
+
+      const call = exec.mock.calls[0][1];
+      expect(call).toContain("versions:set");
+      expect(call).toContain("-DgenerateBackupPoms=false");
+      expect(call).toContain("-DnewVersion=1.0.0");
+    });
+
+    test("should replace the parent previousVersion with the newVersion", async () => {
+      const oldParentPomXml = `<project
+                  xmlns="http://maven.apache.org/POM/4.0.0"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+                  <version>1.0.0-SNAPSHOT</version>
+                </project>`;
+
+      const oldChildPomXml = `<project
+                  xmlns="http://maven.apache.org/POM/4.0.0"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+                  <parent>
+                    <version>1.0.0-SNAPSHOT</version>
+                  </parent>
+                </project>`;
+
+      const newPomXml = `<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"
+>
+    <parent>
+        <version>1.0.0</version>
+    </parent>
+</project>
+`;
+
+      mockGlob(["pom.xml", "child/pom.xml"]);
+      readFile.mockImplementation((path, options, callback) => {
+        if (path === "pom.xml") {
+          callback(undefined, oldParentPomXml);
+        } else if (path === "child/pom.xml") {
+          callback(undefined, oldChildPomXml);
+        }
+      });
+
+      await hooks.beforeRun.promise({} as any);
+      await hooks.version.promise(Auto.SEMVER.patch);
+
+      expect(await readFile).toHaveBeenCalledTimes(4);
+      expect(await readFile).toHaveBeenLastCalledWith(
+        "child/pom.xml",
+        { encoding: "utf8" },
+        expect.anything()
+      );
+      expect(await writeFile).toHaveBeenCalledTimes(2);
+      expect(await writeFile).toHaveBeenLastCalledWith(
+        "child/pom.xml",
+        newPomXml,
+        { encoding: "utf8" },
+        expect.anything()
+      );
+    });
+
     test("should be undefined when failing to increment previous version", async () => {
-      mockRead(`
-        <project
-          xmlns="http://maven.apache.org/POM/4.0.0"
-          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-          <version>1.0.a-SNAPSHOT</version>
-        </project>
-      `);
+      mockReadFile(`
+          <project
+            xmlns="http://maven.apache.org/POM/4.0.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+            <version>1.0.a-SNAPSHOT</version>
+          </project>
+        `);
 
       await hooks.beforeRun.promise({} as any);
 
@@ -256,11 +433,35 @@ describe("maven", () => {
 
   describe("publish", () => {
     test("should publish release", async () => {
+      mockReadFile(`
+        <project
+          xmlns="http://maven.apache.org/POM/4.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+          <version>1.0.0-SNAPSHOT</version>
+          <developers>
+            <developer>
+              <name>Andrew Lisowski</name>
+              <email>test@email.com</email>
+            </developer>
+            <developer>
+              <name>Adam Dierkens</name>
+              <email>adam@dierkens.com</email>
+            </developer>
+          </developers>
+          <scm>
+            <connection>scm:git:https://foo.com</connection>
+            <url>https://foo.com</url>
+            <tag>HEAD</tag>
+          </scm>
+        </project>
+      `);
+
       await hooks.beforeRun.promise({} as any);
 
       await hooks.publish.promise(Auto.SEMVER.patch);
 
-      expect(exec.mock.calls[1][1]).toContain("deploy");
+      expect(exec.mock.calls[0][1]).toContain("deploy");
     });
   });
 });

--- a/plugins/maven/package.json
+++ b/plugins/maven/package.json
@@ -39,12 +39,11 @@
   },
   "devDependencies": {
     "@auto-it/core": "link:../../packages/core",
-    "@types/xml2js": "^0.4.5",
     "fast-glob": "^3.1.1",
+    "jest-circus": "^25.5.4",
     "parse-github-url": "^1.0.2",
     "pom-parser": "^1.1.1",
-    "semver": "^7.0.0",
+
     "tslib": "2.0.0",
-    "xml2js": "^0.4.23"
   }
 }

--- a/plugins/maven/package.json
+++ b/plugins/maven/package.json
@@ -37,12 +37,14 @@
     "lint": "eslint src --ext .ts",
     "test": "jest --maxWorkers=2 --config ../../package.json"
   },
-  "dependencies": {
+  "devDependencies": {
     "@auto-it/core": "link:../../packages/core",
+    "@types/xml2js": "^0.4.5",
+    "fast-glob": "^3.1.1",
     "parse-github-url": "^1.0.2",
     "pom-parser": "^1.1.1",
     "semver": "^7.0.0",
     "tslib": "2.0.0",
-    "xml2js-es6-promise": "^1.1.1"
+    "xml2js": "^0.4.23"
   }
 }

--- a/plugins/maven/package.json
+++ b/plugins/maven/package.json
@@ -37,16 +37,18 @@
     "lint": "eslint src --ext .ts",
     "test": "jest --maxWorkers=2 --config ../../package.json"
   },
-  "devDependencies": {
+  "dependencies": {
     "@auto-it/core": "link:../../packages/core",
-    "@types/jest": "^25.2.3",
-    "@types/jsdom": "^16.2.3",
-    "@types/prettier": "^2.0.1",
     "fast-glob": "^3.1.1",
     "jsdom": "^16.2.2",
     "parse-github-url": "^1.0.2",
     "pom-parser": "^1.1.1",
-    "prettier": "^2.0.5",
+    "prettier": "^2.0.5"
+  },
+  "devDependencies": {
+    "@types/jest": "^25.2.3",
+    "@types/jsdom": "^16.2.3",
+    "@types/prettier": "^2.0.1",
     "ts-jest": "^25.5.1",
     "tslib": "2.0.0"
   }

--- a/plugins/maven/package.json
+++ b/plugins/maven/package.json
@@ -39,11 +39,15 @@
   },
   "devDependencies": {
     "@auto-it/core": "link:../../packages/core",
+    "@types/jest": "^25.2.3",
+    "@types/jsdom": "^16.2.3",
+    "@types/prettier": "^2.0.1",
     "fast-glob": "^3.1.1",
-    "jest-circus": "^25.5.4",
+    "jsdom": "^16.2.2",
     "parse-github-url": "^1.0.2",
     "pom-parser": "^1.1.1",
-
-    "tslib": "2.0.0",
+    "prettier": "^2.0.5",
+    "ts-jest": "^25.5.1",
+    "tslib": "2.0.0"
   }
 }

--- a/plugins/maven/src/index.ts
+++ b/plugins/maven/src/index.ts
@@ -124,7 +124,7 @@ export default class MavenPlugin implements IPlugin {
 
   /** Tap into auto plugin points. */
   apply(auto: Auto) {
-    auto.hooks.beforeRun.tap(this.name, async () => {
+    auto.hooks.beforeRun.tapPromise(this.name, async () => {
       auto.logger.verbose.warn(`Running "beforeRun"`);
       this.properties = await MavenPlugin.getProperties();
       const { version = "" } = this.properties;

--- a/plugins/maven/src/index.ts
+++ b/plugins/maven/src/index.ts
@@ -122,7 +122,7 @@ export default class MavenPlugin implements IPlugin {
       "/project/version",
       pomDom.documentElement,
       pomDom.createNSResolver(pomDom.documentElement),
-      9
+      9 // XPathResult.FIRST_ORDERED_NODE_TYPE
     );
 
     if (versionNode?.singleNodeValue) {
@@ -133,7 +133,7 @@ export default class MavenPlugin implements IPlugin {
       "/project/parent/version",
       pomDom.documentElement,
       pomDom.createNSResolver(pomDom.documentElement),
-      9
+      9 // XPathResult.FIRST_ORDERED_NODE_TYPE
     );
 
     if (parentVersionNode?.singleNodeValue) {
@@ -156,7 +156,7 @@ export default class MavenPlugin implements IPlugin {
       "/project/build/plugins/plugin/artifactId[normalize-space(text())='versions-maven-plugin']",
       pomDom.documentElement,
       pomDom.createNSResolver(pomDom.documentElement),
-      9
+      9 // XPathResult.FIRST_ORDERED_NODE_TYPE
     );
 
     if (versionsMavenPluginNode?.singleNodeValue) {
@@ -167,7 +167,7 @@ export default class MavenPlugin implements IPlugin {
       "/project/build/pluginManagement/plugins/plugin/artifactId[normalize-space(text())='versions-maven-plugin']",
       pomDom.documentElement,
       pomDom.createNSResolver(pomDom.documentElement),
-      9
+      9 // XPathResult.FIRST_ORDERED_NODE_TYPE
     );
 
     return Boolean(versionsMavenPluginManagementNode?.singleNodeValue);

--- a/plugins/maven/src/index.ts
+++ b/plugins/maven/src/index.ts
@@ -255,12 +255,12 @@ export default class MavenPlugin implements IPlugin {
           throw new Error(reason);
         });
 
-      await execPromise("git", [
-        "commit",
-        "-am",
-        `"update version: ${version} [skip ci]"`,
-        "--no-verify",
-      ]);
+      // await execPromise("git", [
+      //   "commit",
+      //   "-am",
+      //   `"update version: ${version} [skip ci]"`,
+      //   "--no-verify",
+      // ]);
     }
   }
 
@@ -387,15 +387,15 @@ export default class MavenPlugin implements IPlugin {
         await MavenPlugin.updatePoms(newVersion, this.options, auto);
       }
 
-      await execPromise("git", [
-        "push",
-        "--follow-tags",
-        "--set-upstream",
-        auto.remote,
-        auto.baseBranch,
-      ]);
-    });
-  }
+        await execPromise("mvn", [
+          "versions:set",
+          "-DgenerateBackupPoms=false",
+          `-DnewVersion=${newVersion}`,
+        ]);
+      } else {
+        auto.logger.verbose.warn("Using the auto maven plugin");
+        await MavenPlugin.updatePoms(newVersion, this.options, auto);
+      }
 
   /** Get the version from the current pom.xml **/
   private async getVersion(auto: Auto): Promise<string> {

--- a/plugins/maven/src/index.ts
+++ b/plugins/maven/src/index.ts
@@ -255,12 +255,12 @@ export default class MavenPlugin implements IPlugin {
           throw new Error(reason);
         });
 
-      // await execPromise("git", [
-      //   "commit",
-      //   "-am",
-      //   `"update version: ${version} [skip ci]"`,
-      //   "--no-verify",
-      // ]);
+      await execPromise("git", [
+        "commit",
+        "-am",
+        `"update version: ${version} [skip ci]"`,
+        "--no-verify",
+      ]);
     }
   }
 
@@ -354,13 +354,13 @@ export default class MavenPlugin implements IPlugin {
           : "",
       ]);
 
-      // await execPromise("git", [
-      //   "push",
-      //   "--follow-tags",
-      //   "--set-upstream",
-      //   auto.remote,
-      //   auto.baseBranch,
-      // ]);
+      await execPromise("git", [
+        "push",
+        "--follow-tags",
+        "--set-upstream",
+        auto.remote,
+        auto.baseBranch,
+      ]);
     });
 
     auto.hooks.afterShipIt.tapPromise(this.name, async () => {
@@ -387,13 +387,13 @@ export default class MavenPlugin implements IPlugin {
         await MavenPlugin.updatePoms(newVersion, this.options, auto);
       }
 
-      // await execPromise("git", [
-      //   "push",
-      //   "--follow-tags",
-      //   "--set-upstream",
-      //   auto.remote,
-      //   auto.baseBranch,
-      // ]);
+      await execPromise("git", [
+        "push",
+        "--follow-tags",
+        "--set-upstream",
+        auto.remote,
+        auto.baseBranch,
+      ]);
     });
   }
 

--- a/plugins/maven/src/index.ts
+++ b/plugins/maven/src/index.ts
@@ -1,13 +1,14 @@
 import { Auto, execPromise, IPlugin } from "@auto-it/core";
 import parseGitHubUrl from "parse-github-url";
-import path from "path";
 import { promisify } from "util";
 import * as t from "io-ts";
 import * as glob from "fast-glob";
 import { IDeveloper, parse } from "pom-parser";
 import { inc, ReleaseType } from "semver";
-import fs from "fs";
 import { validatePluginConfiguration } from "@auto-it/core/dist/auto";
+import * as fs from "fs";
+import * as jsdom from "jsdom";
+import * as prettier from "prettier";
 
 const snapshotSuffix = "-SNAPSHOT";
 
@@ -15,30 +16,9 @@ const snapshotSuffix = "-SNAPSHOT";
 const arrayify = <T>(arg: T | T[]): T[] => (Array.isArray(arg) ? arg : [arg]);
 /** Parse the pom.xml file **/
 const parsePom = promisify(parse);
-/** Write the pom.xml file **/
-const writeFile = promisify(fs.writeFile);
 
 /** Get the maven pom.xml for a project **/
-const getPom = async (filePath: string = path.join(process.cwd(), "pom.xml")) =>
-  parsePom({ filePath: filePath });
-
-/** Write the pom.xml file **/
-const writePom = async (
-  content: string,
-  filePath: string = path.join(process.cwd(), "pom.xml")
-) => writeFile(filePath, content);
-
-/** Get the pom.xml content with a new version **/
-const newVersionContent = (
-  content: string,
-  previousVersion: string,
-  version: string
-) => {
-  const escapedVersion = previousVersion.replace(/\./g, "\\.");
-  const versionReplace = `(\\s+<version>)(${escapedVersion})(<\\/version>)`;
-  const versionReplaceRegex = new RegExp(versionReplace, "gm");
-  return content.replace(versionReplaceRegex, `$1${version}$3`);
-};
+const getPom = async (filePath = "pom.xml") => parsePom({ filePath: filePath });
 
 const pluginOptions = t.partial({
   /** The maven binary to release the project with **/
@@ -52,6 +32,12 @@ const pluginOptions = t.partial({
 
   /** Path to maven settings file **/
   mavenSettings: t.string,
+
+  /** Print width for prettier formatting **/
+  printWidth: t.number,
+
+  /** Tab width for prettier formatting **/
+  tabWidth: t.number,
 
   /**
    * The username to use when deploying to the maven repository
@@ -98,6 +84,9 @@ export default class MavenPlugin implements IPlugin {
   /** should this release be a snapshot release **/
   private snapshotRelease = false;
 
+  /** should pom.xml versions be handled with the "versions-maven-plugin" **/
+  private versionsMavenPlugin = false;
+
   /** Initialize the plugin with its options **/
   constructor(options: IMavenPluginOptions = {}) {
     const {
@@ -118,21 +107,173 @@ export default class MavenPlugin implements IPlugin {
         (options?.mavenReleaseGoals
           ? options.mavenReleaseGoals
           : ["deploy", "site-deploy"]),
+      mavenSettings: MAVEN_SETTINGS || options.mavenSettings || "",
+      printWidth: options.printWidth || 120,
+      tabWidth: options.tabWidth || 4,
       mavenUsername: MAVEN_USERNAME || options.mavenUsername || "",
       mavenPassword: MAVEN_PASSWORD || options.mavenPassword || "",
-      mavenSettings: MAVEN_SETTINGS || options.mavenSettings || "",
     };
+  }
+
+  /** Update the version in the pom.xml file **/
+  private static async updatePomVersion(
+    content: string,
+    version: string,
+    options: IMavenPluginOptions
+  ): Promise<string> {
+    const dom = new jsdom.JSDOM(content, { contentType: "text/xml" });
+    const pomDom = dom.window.document;
+    const versionNode = pomDom.evaluate(
+      "/project/version",
+      pomDom.documentElement,
+      pomDom.createNSResolver(pomDom.documentElement),
+      9
+    );
+
+    if (versionNode?.singleNodeValue) {
+      versionNode.singleNodeValue.textContent = version;
+    }
+
+    const parentVersionNode = pomDom.evaluate(
+      "/project/parent/version",
+      pomDom.documentElement,
+      pomDom.createNSResolver(pomDom.documentElement),
+      9
+    );
+
+    if (parentVersionNode?.singleNodeValue) {
+      parentVersionNode.singleNodeValue.textContent = version;
+    }
+
+    return prettier.format(dom.serialize(), {
+      printWidth: options.printWidth,
+      tabWidth: options.tabWidth,
+      parser: "html",
+    });
+  }
+
+  /** Detect whether the parent pom.xml has the versions-maven-plugin **/
+  private static async detectVersionMavenPlugin(): Promise<boolean> {
+    const pom = await getPom();
+    const pomDom = new jsdom.JSDOM(pom.pomXml, { contentType: "text/xml" })
+      .window.document;
+    const versionsMavenPluginNode = pomDom.evaluate(
+      "/project/build/plugins/plugin/artifactId[normalize-space(text())='versions-maven-plugin']",
+      pomDom.documentElement,
+      pomDom.createNSResolver(pomDom.documentElement),
+      9
+    );
+
+    if (versionsMavenPluginNode?.singleNodeValue) {
+      return true;
+    }
+
+    const versionsMavenPluginManagementNode = pomDom.evaluate(
+      "/project/build/pluginManagement/plugins/plugin/artifactId[normalize-space(text())='versions-maven-plugin']",
+      pomDom.documentElement,
+      pomDom.createNSResolver(pomDom.documentElement),
+      9
+    );
+
+    return Boolean(versionsMavenPluginManagementNode?.singleNodeValue);
+  }
+
+  /** Get the properties from the pom.xml file **/
+  private static async getProperties(): Promise<IMavenProperties> {
+    const pom = await getPom();
+    const { scm } = pom.pomObject?.project || {};
+    let github;
+    let repoInfo;
+
+    if (scm) {
+      github = arrayify(scm).find((remote) =>
+        Boolean(remote.url.includes("github"))
+      );
+    }
+
+    if (github) {
+      repoInfo = parseGitHubUrl(github.url);
+    }
+
+    const developers = pom.pomObject?.project?.developers?.developer;
+    const developer = developers ? arrayify(developers)[0] : undefined;
+
+    return {
+      version: pom.pomObject?.project.version,
+      owner: repoInfo?.owner || undefined,
+      repo: repoInfo?.name || undefined,
+      developer: developer,
+    };
+  }
+
+  /** Update the pom.xml file with the new version **/
+  private static async updatePomFile(
+    pomFile: string,
+    version: string,
+    options: IMavenPluginOptions,
+    auto: Auto
+  ) {
+    auto.logger.verbose.info(`Updating: ${pomFile}`);
+    const pom = await getPom(pomFile);
+    const content = await MavenPlugin.updatePomVersion(
+      pom.pomXml,
+      version,
+      options
+    );
+    fs.writeFile(pomFile, content, { encoding: "utf8" }, (err) => {
+      if (err) throw err;
+    });
+  }
+
+  /** Find and update all pom.xml files with new versions, and then commit the changes **/
+  private static async updatePoms(
+    version: string,
+    options: IMavenPluginOptions,
+    auto: Auto
+  ) {
+    /** Get all the poms and update their versions **/
+    const pomFiles = await glob.sync("**/pom.xml");
+    if (pomFiles && pomFiles.length > 0) {
+      const updatedPoms = pomFiles.map((pomFile) => {
+        return MavenPlugin.updatePomFile(pomFile, version, options, auto);
+      });
+      await Promise.all(updatedPoms)
+        .then(() => {
+          auto.logger.verbose.info(
+            `Updated ${pomFiles.length} pom.xml files with version: ${version}`
+          );
+        })
+        .catch((reason: string) => {
+          auto.logger.verbose.error(
+            `There was an error modifying the pom files. Running 'git checkout -- .' to reset the clone.`
+          );
+          execPromise("git", ["checkout", "--", "."]).catch(
+            (reason: string) => {
+              throw new Error(reason);
+            }
+          );
+          throw new Error(reason);
+        });
+
+      // await execPromise("git", [
+      //   "commit",
+      //   "-am",
+      //   `"update version: ${version} [skip ci]"`,
+      //   "--no-verify",
+      // ]);
+    }
   }
 
   /** Tap into auto plugin points. */
   apply(auto: Auto) {
     auto.hooks.beforeRun.tapPromise(this.name, async () => {
-      auto.logger.verbose.warn(`Running "beforeRun"`);
       this.properties = await MavenPlugin.getProperties();
       const { version = "" } = this.properties;
       if (version?.endsWith(snapshotSuffix)) {
         this.snapshotRelease = true;
       }
+
+      this.versionsMavenPlugin = await MavenPlugin.detectVersionMavenPlugin();
     });
 
     auto.hooks.validateConfig.tapPromise(this.name, async (name, options) => {
@@ -146,7 +287,6 @@ export default class MavenPlugin implements IPlugin {
     );
 
     auto.hooks.getAuthor.tapPromise(this.name, async () => {
-      auto.logger.verbose.warn(`Running "getAuthor"`);
       const { developer } = this.properties;
       auto.logger.verbose.info(
         `Found author information in pom.xml: ${developer}`
@@ -155,7 +295,6 @@ export default class MavenPlugin implements IPlugin {
     });
 
     auto.hooks.getRepository.tapPromise(this.name, async () => {
-      auto.logger.verbose.warn(`Running "getRepository"`);
       const { owner, repo } = this.properties;
       auto.logger.verbose.info(
         `Found repo information in pom.xml: ${owner}/${repo}`
@@ -166,8 +305,7 @@ export default class MavenPlugin implements IPlugin {
       };
     });
 
-    auto.hooks.version.tapPromise(this.name, async (version) => {
-      auto.logger.verbose.warn(`Running "version"`);
+    auto.hooks.version.tapPromise(this.name, async (version: string) => {
       const previousVersion = await this.getVersion(auto);
       const releaseVersion =
         // After release we bump the version by a patch and add -SNAPSHOT
@@ -178,7 +316,17 @@ export default class MavenPlugin implements IPlugin {
           : inc(previousVersion, version as ReleaseType);
 
       if (releaseVersion) {
-        await this.updatePoms(previousVersion, releaseVersion, auto);
+        if (this.versionsMavenPlugin) {
+          auto.logger.verbose.warn("Using the versions-maven-plugin");
+          await execPromise("mvn", [
+            "versions:set",
+            "-DgenerateBackupPoms=false",
+            `-DnewVersion=${releaseVersion}`,
+          ]);
+        } else {
+          auto.logger.verbose.warn("Using the auto maven plugin");
+          await MavenPlugin.updatePoms(releaseVersion, this.options, auto);
+        }
 
         const newVersion = auto.prefixRelease(releaseVersion);
 
@@ -216,7 +364,6 @@ export default class MavenPlugin implements IPlugin {
     });
 
     auto.hooks.afterShipIt.tapPromise(this.name, async () => {
-      auto.logger.verbose.warn(`Running "afterShipIt"`);
       if (!this.snapshotRelease) {
         return;
       }
@@ -227,7 +374,18 @@ export default class MavenPlugin implements IPlugin {
       // then we need to set up snapshots on the next version
       const newVersion = `${inc(releaseVersion, "patch")}${snapshotSuffix}`;
 
-      await this.updatePoms(releaseVersion, newVersion, auto);
+      if (this.versionsMavenPlugin) {
+        auto.logger.verbose.warn("Using the versions-maven-plugin");
+
+        await execPromise("mvn", [
+          "versions:set",
+          "-DgenerateBackupPoms=false",
+          `-DnewVersion=${newVersion}`,
+        ]);
+      } else {
+        auto.logger.verbose.warn("Using the auto maven plugin");
+        await MavenPlugin.updatePoms(newVersion, this.options, auto);
+      }
 
       // await execPromise("git", [
       //   "push",
@@ -239,85 +397,6 @@ export default class MavenPlugin implements IPlugin {
     });
   }
 
-  /** Find and update all pom.xml files with new versions, and then commit the changes **/
-  private async updatePoms(
-    previousVersion: string,
-    releaseVersion: string,
-    auto: Auto
-  ) {
-    auto.logger.verbose.warn(
-      `Running "updatePoms". releaseVersion: ${releaseVersion}`
-    );
-    /** Get all the poms and update their versions **/
-    await Promise.all(
-      glob.sync("**/pom.xml").map((pomFile) =>
-        MavenPlugin.updatePomVersion(
-          pomFile,
-          previousVersion,
-          releaseVersion
-        ).catch((reason) => {
-          auto.logger.verbose.error(
-            `There was an error modifying the ${pomFile}: ${reason}`
-          );
-        })
-      )
-    ).catch((reason) => {
-      auto.logger.verbose.error(
-        `There was an error modifying the pom files. Running 'git checkout -- .' to reset the clone.`
-      );
-      execPromise("git", ["checkout", "--", "."]).catch((reason) => {
-        throw new Error(reason);
-      });
-      throw new Error(reason);
-    });
-
-    await execPromise("git", [
-      "commit",
-      "-am",
-      `"update version: ${releaseVersion} [skip ci]"`,
-      "--no-verify",
-    ]);
-  }
-
-  /** Update the version in the pom.xml file **/
-  private static async updatePomVersion(
-    pomFile: string,
-    previousVersion: string,
-    version: string
-  ) {
-    const pom = await getPom(pomFile);
-    const content = newVersionContent(pom.pomXml, previousVersion, version);
-    await writePom(content, pomFile);
-  }
-
-  /** Get the properties from the pom.xml file **/
-  private static async getProperties(): Promise<IMavenProperties> {
-    const pom = await getPom();
-    const { scm } = pom.pomObject?.project || {};
-    let github;
-    let repoInfo;
-
-    if (scm) {
-      github = arrayify(scm).find((remote) =>
-        Boolean(remote.url.includes("github"))
-      );
-    }
-
-    if (github) {
-      repoInfo = parseGitHubUrl(github.url);
-    }
-
-    const developers = pom.pomObject?.project?.developers?.developer;
-    const developer = developers ? arrayify(developers)[0] : undefined;
-
-    return {
-      version: pom.pomObject?.project.version,
-      owner: repoInfo?.owner || undefined,
-      repo: repoInfo?.name || undefined,
-      developer: developer,
-    };
-  }
-
   /** Get the version from the current pom.xml **/
   private async getVersion(auto: Auto): Promise<string> {
     const { version } = this.properties;
@@ -327,6 +406,6 @@ export default class MavenPlugin implements IPlugin {
       return version.replace(snapshotSuffix, "");
     }
 
-    return "0.0.0.0";
+    return "0.0.0";
   }
 }

--- a/plugins/maven/src/index.ts
+++ b/plugins/maven/src/index.ts
@@ -2,183 +2,327 @@ import { Auto, execPromise, IPlugin } from "@auto-it/core";
 import parseGitHubUrl from "parse-github-url";
 import path from "path";
 import { promisify } from "util";
-
-import { parse } from "pom-parser";
+import * as t from "io-ts";
+import * as glob from "fast-glob";
+import { IDeveloper, parse } from "pom-parser";
 import { inc, ReleaseType } from "semver";
+import fs from "fs";
+import * as xml2js from "xml2js";
+import { validatePluginConfiguration } from "@auto-it/core/dist/auto";
 
-/** Ensure a value is an array */
+const snapshotSuffix = "-SNAPSHOT";
+
+/** Ensure a value is an array **/
 const arrayify = <T>(arg: T | T[]): T[] => (Array.isArray(arg) ? arg : [arg]);
+/** Parse the pom.xml file **/
 const parsePom = promisify(parse);
+/** Write the pom.xml file **/
+const writeFile = promisify(fs.writeFile);
 
-/** Get the maven pom.xml for a project */
-const getPom = async () =>
-  parsePom({ filePath: path.join(process.cwd(), "pom.xml") });
+/** Get the maven pom.xml for a project **/
+const getPom = async (filePath: string = path.join(process.cwd(), "pom.xml")) =>
+  parsePom({ filePath: filePath });
 
-/** Get the previous version from the pom.xml */
-async function getPreviousVersion(auto: Auto): Promise<string> {
-  const pom = await getPom();
-  const previousVersion = pom.pomObject?.project.version;
+/** Write the pom.xml file **/
+const writePom = async (
+  content: string,
+  filePath: string = path.join(process.cwd(), "pom.xml")
+) => writeFile(filePath, content);
 
-  if (!previousVersion) {
-    throw new Error("Cannot read version from the pom.xml.");
-  }
+/** Xml to Js **/
+const xmlToJs = (content: string) => xml2js.parseStringPromise(content);
 
-  auto.logger.verbose.info(
-    "Maven: Got previous version from pom.xml",
-    previousVersion
-  );
+/** Js to Xml **/
+const jsToXml = (content: string) => {
+  const builder = new xml2js.Builder();
+  return builder.buildObject(content);
+};
 
-  return previousVersion.replace("-SNAPSHOT", "");
+const pluginOptions = t.partial({
+  /** The maven binary to release the project with **/
+  mavenCommand: t.string,
+
+  /** A list of maven command customizations to pass to maven **/
+  mavenOptions: t.array(t.string),
+
+  /** A list of maven goals to pass to maven for release **/
+  mavenReleaseGoals: t.array(t.string),
+
+  /** Path to maven settings file **/
+  mavenSettings: t.string,
+
+  /**
+   * The username to use when deploying to the maven repository
+   *
+   * @deprecated since 9.38.0
+   **/
+  mavenUsername: t.string,
+
+  /**
+   * The password to use when deploying to the maven repository
+   *
+   * @deprecated since 9.38.0
+   **/
+  mavenPassword: t.string,
+});
+
+export type IMavenPluginOptions = t.TypeOf<typeof pluginOptions>;
+
+export interface IMavenProperties {
+  /** version **/
+  version?: string;
+
+  /** git repository owner **/
+  owner?: string;
+
+  /** git repository **/
+  repo?: string;
+
+  /** the author **/
+  developer?: IDeveloper;
 }
 
-/** Deploy project to maven */
+/** Deploy project to maven repository */
 export default class MavenPlugin implements IPlugin {
   /** The name of the plugin */
-  name = "maven";
+  readonly name = "maven";
+
+  /** The options of the plugin **/
+  private readonly options: Required<IMavenPluginOptions>;
+
+  /** cached properties **/
+  private properties: IMavenProperties = {};
+
+  /** should this release be a snapshot release **/
+  private snapshotRelease = false;
+
+  /** Initialize the plugin with its options **/
+  constructor(options: IMavenPluginOptions = {}) {
+    const {
+      MAVEN_COMMAND,
+      MAVEN_OPTIONS,
+      MAVEN_RELEASE_GOALS,
+      MAVEN_SETTINGS,
+      MAVEN_PASSWORD,
+      MAVEN_USERNAME,
+    } = process.env;
+    this.options = {
+      mavenCommand:
+        MAVEN_COMMAND ||
+        (options?.mavenCommand ? options.mavenCommand : "/usr/bin/mvn"),
+      mavenOptions: MAVEN_OPTIONS?.split(" ") || options.mavenOptions || [],
+      mavenReleaseGoals:
+        MAVEN_RELEASE_GOALS?.split(" ") ||
+        (options?.mavenReleaseGoals
+          ? options.mavenReleaseGoals
+          : ["deploy", "site-deploy"]),
+      mavenUsername: MAVEN_USERNAME || options.mavenUsername || "",
+      mavenPassword: MAVEN_PASSWORD || options.mavenPassword || "",
+      mavenSettings: MAVEN_SETTINGS || options.mavenSettings || "",
+    };
+  }
 
   /** Tap into auto plugin points. */
   apply(auto: Auto) {
-    auto.hooks.onCreateLogParse.tap(this.name, (logParse) => {
-      logParse.hooks.omitCommit.tap(this.name, (commit) => {
-        if (commit.subject.includes("[maven-release-plugin]")) {
-          return true;
-        }
-      });
-    });
-
     auto.hooks.beforeRun.tap(this.name, async () => {
-      const { MAVEN_PASSWORD, MAVEN_USERNAME, MAVEN_SETTINGS } = process.env;
-
-      if (!MAVEN_PASSWORD && !MAVEN_SETTINGS) {
-        auto.logger.log.warn(
-          "No password detected in the environment. You may need this to publish."
-        );
-      }
-
-      if (!MAVEN_USERNAME && !MAVEN_SETTINGS) {
-        auto.logger.log.warn(
-          "No username detected in the environment. You may need this to publish."
-        );
+      auto.logger.verbose.warn(`Running "beforeRun"`);
+      this.properties = await MavenPlugin.getProperties();
+      const { version = "" } = this.properties;
+      if (version?.endsWith(snapshotSuffix)) {
+        this.snapshotRelease = true;
       }
     });
 
-    auto.hooks.getRepository.tapPromise(this.name, async () => {
-      auto.logger.verbose.info("Maven: getting repo information from pom.xml");
-
-      const pom = await getPom();
-      const { scm } = pom.pomObject.project;
-
-      if (!scm) {
-        throw new Error(
-          "Could not find scm settings in pom.xml. Make sure you set one up that points to your project on GitHub or set owner+repo in your .autorc"
-        );
+    auto.hooks.validateConfig.tapPromise(this.name, async (name, options) => {
+      if (name === this.name || name === `@auto-it/${this.name}`) {
+        return validatePluginConfiguration(this.name, pluginOptions, options);
       }
-
-      const github = arrayify(pom.pomObject.project.scm).find((remote) =>
-        Boolean(remote.url.includes("github"))
-      );
-
-      if (!github) {
-        throw new Error(
-          "Could not find GitHub scm settings in pom.xml. Make sure you set one up that points to your project on GitHub or set owner+repo in your .autorc"
-        );
-      }
-
-      const repoInfo = parseGitHubUrl(github.url);
-
-      if (!repoInfo || !repoInfo.owner || !repoInfo.name) {
-        throw new Error(
-          "Cannot read owner and project name from GitHub URL in pom.xml"
-        );
-      }
-
-      return {
-        owner: repoInfo.owner,
-        repo: repoInfo.name,
-      };
-    });
-
-    auto.hooks.getAuthor.tapPromise(this.name, async () => {
-      auto.logger.verbose.info("Maven: Getting repo information from pom.xml");
-
-      const pom = await getPom();
-      const developers = pom.pomObject.project.developers?.developer;
-      const developer = developers ? arrayify(developers)[0] : undefined;
-
-      if (!developer || !developer.name || !developer.email) {
-        throw new Error(
-          "Cannot read author from the pom.xml. Please include at least 1 developer in the developers section."
-        );
-      }
-
-      return developer;
     });
 
     auto.hooks.getPreviousVersion.tapPromise(this.name, async () =>
-      auto.prefixRelease(await getPreviousVersion(auto))
+      auto.prefixRelease(await this.getVersion(auto))
     );
 
+    auto.hooks.getAuthor.tapPromise(this.name, async () => {
+      auto.logger.verbose.warn(`Running "getAuthor"`);
+      const { developer } = this.properties;
+      auto.logger.verbose.info(
+        `Found author information in pom.xml: ${developer}`
+      );
+      return developer;
+    });
+
+    auto.hooks.getRepository.tapPromise(this.name, async () => {
+      auto.logger.verbose.warn(`Running "getRepository"`);
+      const { owner, repo } = this.properties;
+      auto.logger.verbose.info(
+        `Found repo information in pom.xml: ${owner}/${repo}`
+      );
+      return {
+        owner: owner,
+        repo: repo,
+      };
+    });
+
     auto.hooks.version.tapPromise(this.name, async (version) => {
-      const { MAVEN_SNAPSHOT_BRANCH } = process.env;
-      const mavenSnapshotBranch = MAVEN_SNAPSHOT_BRANCH || "dev-snapshot";
-      const previousVersion = await getPreviousVersion(auto);
-      const newVersion =
+      auto.logger.verbose.warn(`Running "version"`);
+      const previousVersion = await this.getVersion(auto);
+      const releaseVersion =
         // After release we bump the version by a patch and add -SNAPSHOT
         // Given that we do not need to increment when versioning, since
         // it has already been done
-        version === "patch"
+        this.snapshotRelease && version === "patch"
           ? previousVersion
           : inc(previousVersion, version as ReleaseType);
 
-      if (!newVersion) {
-        throw new Error(
-          `Could not increment previous version: ${previousVersion}`
-        );
-      }
+      if (releaseVersion) {
+        await this.updatePoms(releaseVersion, auto);
 
-      await execPromise("mvn", ["clean"]);
-      await execPromise("mvn", [
-        "-B",
-        "release:prepare",
-        `-Dtag=${auto.prefixRelease(newVersion)}`,
-        `-DreleaseVersion=${newVersion}`,
-        "-DpushChanges=false",
-      ]);
-      await execPromise("git", ["checkout", "-b", mavenSnapshotBranch]);
-      await execPromise("git", ["checkout", auto.baseBranch]);
-      await execPromise("git", ["reset", "--hard", "HEAD~1"]);
+        const newVersion = auto.prefixRelease(releaseVersion);
+
+        // Ensure tag is on this commit, changelog will be added automatically
+        await execPromise("git", [
+          "tag",
+          newVersion,
+          "-m",
+          `"Update version to ${newVersion}"`,
+        ]);
+      }
     });
 
     auto.hooks.publish.tapPromise(this.name, async () => {
-      const { MAVEN_PASSWORD, MAVEN_USERNAME, MAVEN_SETTINGS } = process.env;
-
-      auto.logger.log.await("Performing maven release...");
-
-      await execPromise("git", [
-        "push",
-        "--follow-tags",
-        "--set-upstream",
-        auto.remote,
-        auto.baseBranch,
+      auto.logger.verbose.warn(`Running "publish"`);
+      await execPromise(this.options.mavenCommand, [
+        ...this.options.mavenOptions,
+        ...this.options.mavenReleaseGoals,
+        this.options?.mavenSettings ? `-s=${this.options.mavenSettings}` : "",
+        this.options?.mavenUsername
+          ? `-Dusername=${this.options.mavenUsername}`
+          : "",
+        this.options?.mavenPassword
+          ? `-Dpassword=${this.options.mavenPassword}`
+          : "",
       ]);
 
-      await execPromise("mvn", [
-        MAVEN_PASSWORD && `-Dpassword=${MAVEN_PASSWORD}`,
-        MAVEN_USERNAME && `-Dusername=${MAVEN_USERNAME}`,
-        MAVEN_SETTINGS && `-s=${MAVEN_SETTINGS}`,
-        "release:perform",
-      ]);
-
-      auto.logger.log.success("Published code to maven!");
+      // await execPromise("git", [
+      //   "push",
+      //   "--follow-tags",
+      //   "--set-upstream",
+      //   auto.remote,
+      //   auto.baseBranch,
+      // ]);
     });
 
     auto.hooks.afterShipIt.tapPromise(this.name, async () => {
-      const { MAVEN_SNAPSHOT_BRANCH } = process.env;
-      const mavenSnapshotBranch = MAVEN_SNAPSHOT_BRANCH || "dev-snapshot";
-      // prepare for next development iteration
-      await execPromise("git", ["reset", "--hard", mavenSnapshotBranch]);
-      await execPromise("git", ["branch", "-d", mavenSnapshotBranch]);
-      await execPromise("git", ["push", auto.remote, auto.baseBranch]);
+      auto.logger.verbose.warn(`Running "afterShipIt"`);
+      if (!this.snapshotRelease) {
+        return;
+      }
+
+      const releaseVersion = await this.getVersion(auto);
+
+      // snapshots precede releases, so if we had a minor/major release,
+      // then we need to set up snapshots on the next version
+      const newVersion = `${inc(releaseVersion, "patch")}${snapshotSuffix}`;
+
+      await this.updatePoms(newVersion, auto);
+
+      // await execPromise("git", [
+      //   "push",
+      //   "--follow-tags",
+      //   "--set-upstream",
+      //   auto.remote,
+      //   auto.baseBranch,
+      // ]);
     });
+  }
+
+  /** Find and update all pom.xml files with new versions, and then commit the changes **/
+  private async updatePoms(releaseVersion: string, auto: Auto) {
+    auto.logger.verbose.warn(
+      `Running "updatePoms". releaseVersion: ${releaseVersion}`
+    );
+    /** Get all the poms and update their versions **/
+    await Promise.all(
+      glob.sync("**/pom.xml").map((pomFile) =>
+        MavenPlugin.updatePomVersion(pomFile, releaseVersion).catch(
+          (reason) => {
+            auto.logger.verbose.error(
+              `There was an error modifying the ${pomFile}: ${reason}`
+            );
+          }
+        )
+      )
+    ).catch((reason) => {
+      auto.logger.verbose.error(
+        `There was an error modifying the pom files. Running 'git checkout -- .' to reset the clone.`
+      );
+      execPromise("git", ["checkout", "--", "."]).catch((reason) => {
+        throw new Error(reason);
+      });
+      throw new Error(reason);
+    });
+
+    await execPromise("git", [
+      "commit",
+      "-am",
+      `"update version: ${releaseVersion} [skip ci]"`,
+      "--no-verify",
+    ]);
+  }
+
+  /** Update the version in the pom.xml file **/
+  private static async updatePomVersion(pomFile: string, version: string) {
+    const pom = await getPom(pomFile);
+    const pomJson = await xmlToJs(pom.pomXml);
+    if (pomJson?.parent) {
+      pomJson.parent.version = version;
+    }
+
+    if (pomJson?.version) {
+      pomJson.version = version;
+    }
+
+    await writePom(jsToXml(pomJson), pomFile);
+  }
+
+  /** Get the properties from the pom.xml file **/
+  private static async getProperties(): Promise<IMavenProperties> {
+    const pom = await getPom();
+    const { scm } = pom.pomObject?.project || {};
+    let github;
+    let repoInfo;
+
+    if (scm) {
+      github = arrayify(scm).find((remote) =>
+        Boolean(remote.url.includes("github"))
+      );
+    }
+
+    if (github) {
+      repoInfo = parseGitHubUrl(github.url);
+    }
+
+    const developers = pom.pomObject?.project?.developers?.developer;
+    const developer = developers ? arrayify(developers)[0] : undefined;
+
+    return {
+      version: pom.pomObject?.project.version,
+      owner: repoInfo?.owner || undefined,
+      repo: repoInfo?.name || undefined,
+      developer: developer,
+    };
+  }
+
+  /** Get the version from the current pom.xml **/
+  private async getVersion(auto: Auto): Promise<string> {
+    const { version } = this.properties;
+
+    if (version) {
+      auto.logger.verbose.info(`Found version in pom.xml: ${version}`);
+      return version.replace(snapshotSuffix, "");
+    }
+
+    return "0.0.0.0";
   }
 }

--- a/plugins/s3/__tests__/s3.test.ts
+++ b/plugins/s3/__tests__/s3.test.ts
@@ -7,7 +7,7 @@ import S3, { IUploadAssetsPluginOptions } from "../src";
 jest.mock("aws-cli-js");
 
 describe("S3 Plugin", () => {
-  test("should warn about keys", () => {
+  test("should warn about keys", async () => {
     const options: IUploadAssetsPluginOptions = {
       bucket: "BUCKET_NAME",
       region: "us-west-2",
@@ -18,7 +18,7 @@ describe("S3 Plugin", () => {
     const checkEnv = jest.fn();
 
     plugin.apply({ checkEnv, hooks } as any);
-    hooks.beforeRun.call({} as any);
+    await hooks.beforeRun.promise({} as any);
 
     expect(checkEnv).toHaveBeenCalledTimes(3);
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs", // Resolve modules the node way
-    "lib": ["es2017"], // Use newest ecma script features
+    "lib": ["dom", "es2017"], // Use newest ecma script features
     /* Outputs: */
     "sourceMap": true,
     "declaration": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1716,6 +1716,17 @@
     jest-util "^25.5.0"
     slash "^3.0.0"
 
+"@jest/console@^26.0.1":
+  version "26.0.1"
+  resolved "https://registry.yarnpkg.com/@jest/console/-/console-26.0.1.tgz#62b3b2fa8990f3cbffbef695c42ae9ddbc8f4b39"
+  integrity sha512-9t1KUe/93coV1rBSxMmBAOIK3/HVpwxArCA1CxskKyRiv6o8J70V8C/V3OJminVCTa2M0hQI9AWRd5wxu2dAHw==
+  dependencies:
+    "@jest/types" "^26.0.1"
+    chalk "^4.0.0"
+    jest-message-util "^26.0.1"
+    jest-util "^26.0.1"
+    slash "^3.0.0"
+
 "@jest/core@^25.5.4":
   version "25.5.4"
   resolved "https://registry.yarnpkg.com/@jest/core/-/core-25.5.4.tgz#3ef7412f7339210f003cdf36646bbca786efe7b4"
@@ -1759,6 +1770,15 @@
     "@jest/types" "^25.5.0"
     jest-mock "^25.5.0"
 
+"@jest/environment@^26.0.1":
+  version "26.0.1"
+  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-26.0.1.tgz#82f519bba71959be9b483675ee89de8c8f72a5c8"
+  integrity sha512-xBDxPe8/nx251u0VJ2dFAFz2H23Y98qdIaNwnMK6dFQr05jc+Ne/2np73lOAx+5mSBO/yuQldRrQOf6hP1h92g==
+  dependencies:
+    "@jest/fake-timers" "^26.0.1"
+    "@jest/types" "^26.0.1"
+    jest-mock "^26.0.1"
+
 "@jest/fake-timers@^25.5.0":
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-25.5.0.tgz#46352e00533c024c90c2bc2ad9f2959f7f114185"
@@ -1770,6 +1790,17 @@
     jest-util "^25.5.0"
     lolex "^5.0.0"
 
+"@jest/fake-timers@^26.0.1":
+  version "26.0.1"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-26.0.1.tgz#f7aeff13b9f387e9d0cac9a8de3bba538d19d796"
+  integrity sha512-Oj/kCBnTKhm7CR+OJSjZty6N1bRDr9pgiYQr4wY221azLz5PHi08x/U+9+QpceAYOWheauLP8MhtSVFrqXQfhg==
+  dependencies:
+    "@jest/types" "^26.0.1"
+    "@sinonjs/fake-timers" "^6.0.1"
+    jest-message-util "^26.0.1"
+    jest-mock "^26.0.1"
+    jest-util "^26.0.1"
+
 "@jest/globals@^25.5.2":
   version "25.5.2"
   resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-25.5.2.tgz#5e45e9de8d228716af3257eeb3991cc2e162ca88"
@@ -1778,6 +1809,15 @@
     "@jest/environment" "^25.5.0"
     "@jest/types" "^25.5.0"
     expect "^25.5.0"
+
+"@jest/globals@^26.0.1":
+  version "26.0.1"
+  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-26.0.1.tgz#3f67b508a7ce62b6e6efc536f3d18ec9deb19a9c"
+  integrity sha512-iuucxOYB7BRCvT+TYBzUqUNuxFX1hqaR6G6IcGgEqkJ5x4htNKo1r7jk1ji9Zj8ZMiMw0oB5NaA7k5Tx6MVssA==
+  dependencies:
+    "@jest/environment" "^26.0.1"
+    "@jest/types" "^26.0.1"
+    expect "^26.0.1"
 
 "@jest/reporters@^25.5.1":
   version "25.5.1"
@@ -1820,6 +1860,15 @@
     graceful-fs "^4.2.4"
     source-map "^0.6.0"
 
+"@jest/source-map@^26.0.0":
+  version "26.0.0"
+  resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-26.0.0.tgz#fd7706484a7d3faf7792ae29783933bbf48a4749"
+  integrity sha512-S2Z+Aj/7KOSU2TfW0dyzBze7xr95bkm5YXNUqqCek+HE0VbNNSNzrRwfIi5lf7wvzDTSS0/ib8XQ1krFNyYgbQ==
+  dependencies:
+    callsites "^3.0.0"
+    graceful-fs "^4.2.4"
+    source-map "^0.6.0"
+
 "@jest/test-result@^25.5.0":
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-25.5.0.tgz#139a043230cdeffe9ba2d8341b27f2efc77ce87c"
@@ -1827,6 +1876,16 @@
   dependencies:
     "@jest/console" "^25.5.0"
     "@jest/types" "^25.5.0"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    collect-v8-coverage "^1.0.0"
+
+"@jest/test-result@^26.0.1":
+  version "26.0.1"
+  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-26.0.1.tgz#1ffdc1ba4bc289919e54b9414b74c9c2f7b2b718"
+  integrity sha512-oKwHvOI73ICSYRPe8WwyYPTtiuOAkLSbY8/MfWF3qDEd/sa8EDyZzin3BaXTqufir/O/Gzea4E8Zl14XU4Mlyg==
+  dependencies:
+    "@jest/console" "^26.0.1"
+    "@jest/types" "^26.0.1"
     "@types/istanbul-lib-coverage" "^2.0.0"
     collect-v8-coverage "^1.0.0"
 
@@ -1840,6 +1899,17 @@
     jest-haste-map "^25.5.1"
     jest-runner "^25.5.4"
     jest-runtime "^25.5.4"
+
+"@jest/test-sequencer@^26.0.1":
+  version "26.0.1"
+  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-26.0.1.tgz#b0563424728f3fe9e75d1442b9ae4c11da73f090"
+  integrity sha512-ssga8XlwfP8YjbDcmVhwNlrmblddMfgUeAkWIXts1V22equp2GMIHxm7cyeD5Q/B0ZgKPK/tngt45sH99yLLGg==
+  dependencies:
+    "@jest/test-result" "^26.0.1"
+    graceful-fs "^4.2.4"
+    jest-haste-map "^26.0.1"
+    jest-runner "^26.0.1"
+    jest-runtime "^26.0.1"
 
 "@jest/transform@^25.5.1":
   version "25.5.1"
@@ -1863,6 +1933,27 @@
     source-map "^0.6.1"
     write-file-atomic "^3.0.0"
 
+"@jest/transform@^26.0.1":
+  version "26.0.1"
+  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-26.0.1.tgz#0e3ecbb34a11cd4b2080ed0a9c4856cf0ceb0639"
+  integrity sha512-pPRkVkAQ91drKGbzCfDOoHN838+FSbYaEAvBXvKuWeeRRUD8FjwXkqfUNUZL6Ke48aA/1cqq/Ni7kVMCoqagWA==
+  dependencies:
+    "@babel/core" "^7.1.0"
+    "@jest/types" "^26.0.1"
+    babel-plugin-istanbul "^6.0.0"
+    chalk "^4.0.0"
+    convert-source-map "^1.4.0"
+    fast-json-stable-stringify "^2.0.0"
+    graceful-fs "^4.2.4"
+    jest-haste-map "^26.0.1"
+    jest-regex-util "^26.0.0"
+    jest-util "^26.0.1"
+    micromatch "^4.0.2"
+    pirates "^4.0.1"
+    slash "^3.0.0"
+    source-map "^0.6.1"
+    write-file-atomic "^3.0.0"
+
 "@jest/types@^25.5.0":
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.5.0.tgz#4d6a4793f7b9599fc3680877b856a97dbccf2a9d"
@@ -1872,6 +1963,16 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
+
+"@jest/types@^26.0.1":
+  version "26.0.1"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.0.1.tgz#b78333fbd113fa7aec8d39de24f88de8686dac67"
+  integrity sha512-IbtjvqI9+eS1qFnOIEL7ggWmT+iK/U+Vde9cGWtYb/b6XgKb3X44ZAe/z9YZzoAAZ/E92m0DqrilF934IGNnQA==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^1.1.1"
+    "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
 
 "@jimp/bmp@^0.9.8":
   version "0.9.8"
@@ -3021,6 +3122,13 @@
   dependencies:
     type-detect "4.0.8"
 
+"@sinonjs/fake-timers@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz#293674fccb3262ac782c7aadfdeca86b10c75c40"
+  integrity sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
+
 "@tokenizer/token@^0.1.0", "@tokenizer/token@^0.1.1":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@tokenizer/token/-/token-0.1.1.tgz#f0d92c12f87079ddfd1b29f614758b9696bc29e3"
@@ -3154,10 +3262,18 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@~25.2.1":
+"@types/jest@^25.2.3", "@types/jest@~25.2.1":
   version "25.2.3"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-25.2.3.tgz#33d27e4c4716caae4eced355097a47ad363fdcaf"
   integrity sha512-JXc1nK/tXHiDhV55dvfzqtmP4S3sy3T3ouV2tkViZgxY/zeUkcpQcQPGRlgF4KmWzWW5oiWYSZwtCB+2RsE4Fw==
+  dependencies:
+    jest-diff "^25.2.1"
+    pretty-format "^25.2.1"
+
+"@types/jest@^26.0.0":
+  version "26.0.0"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.0.tgz#a6d7573dffa9c68cbbdf38f2e0de26f159e11134"
+  integrity sha512-/yeMsH9HQ1RLORlXAwoLXe8S98xxvhNtUz3yrgrwbaxYjT+6SFPZZRksmRKRA6L5vsUtSHeN71viDOTTyYAD+g==
   dependencies:
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
@@ -3166,6 +3282,15 @@
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-2.2.6.tgz#f1a1cb35aff47bc5cfb05cb0c441ca91e914c26f"
   integrity sha512-+oY0FDTO2GYKEV0YPvSshGq9t7YozVkgvXLty7zogQNuCxBhT9/3INX9Q7H1aRZ4SUDRXAKlJuA4EA5nTt7SNw==
+
+"@types/jsdom@^16.2.3":
+  version "16.2.3"
+  resolved "https://registry.yarnpkg.com/@types/jsdom/-/jsdom-16.2.3.tgz#c6feadfe0836389b27f9c911cde82cd32e91c537"
+  integrity sha512-BREatezSn74rmLIDksuqGNFUTi9HNAWWQXYpFBFLK9U6wlMCO4M0QCa8CMpDsZQuqxSO9XifVLT5Q1P0vgKLqw==
+  dependencies:
+    "@types/node" "*"
+    "@types/parse5" "*"
+    "@types/tough-cookie" "*"
 
 "@types/json-schema@^7.0.3":
   version "7.0.3"
@@ -3254,10 +3379,20 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
+"@types/parse5@*":
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/@types/parse5/-/parse5-5.0.3.tgz#e7b5aebbac150f8b5fdd4a46e7f0bd8e65e19109"
+  integrity sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==
+
 "@types/prettier@^1.19.0":
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-1.19.1.tgz#33509849f8e679e4add158959fdb086440e9553f"
   integrity sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==
+
+"@types/prettier@^2.0.0", "@types/prettier@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.0.1.tgz#b6e98083f13faa1e5231bfa3bdb1b0feff536b6d"
+  integrity sha512-boy4xPNEtiw6N3abRhBi/e7hNvy3Tt8E9ZRAQrwAGzoCGZS/1wjo9KY7JHhnfnEsG5wSjDbymCozUM9a3ea7OQ==
 
 "@types/prop-types@^15.5.3":
   version "15.7.3"
@@ -3302,6 +3437,11 @@
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/@types/tinycolor2/-/tinycolor2-1.4.2.tgz#721ca5c5d1a2988b4a886e35c2ffc5735b6afbdf"
   integrity sha512-PeHg/AtdW6aaIO2a+98Xj7rWY4KC1E6yOy7AFknJQ7VXUGNrMlyxDFxJo7HqLtjQms/ZhhQX52mLVW/EX3JGOw==
+
+"@types/tough-cookie@*":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.0.tgz#fef1904e4668b6e5ecee60c52cc6a078ffa6697d"
+  integrity sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==
 
 "@types/twitter-text@^2.0.0":
   version "2.0.0"
@@ -3350,13 +3490,6 @@
     "@types/uglify-js" "*"
     "@types/webpack-sources" "*"
     source-map "^0.6.0"
-
-"@types/xml2js@^0.4.5":
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/@types/xml2js/-/xml2js-0.4.5.tgz#d21759b056f282d9c7066f15bbf5c19b908f22fa"
-  integrity sha512-yohU3zMn0fkhlape1nxXG2bLEGZRc1FeqF80RoHaYXJN7uibaauXfhzhOJr1Xh36sn+/tx21QAOf07b/xYVk1w==
-  dependencies:
-    "@types/node" "*"
 
 "@types/yargs-parser@*":
   version "13.0.0"
@@ -3660,6 +3793,11 @@ abab@^2.0.0:
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.0.tgz#aba0ab4c5eee2d4c79d3487d85450fb2376ebb0f"
   integrity sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==
 
+abab@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.3.tgz#623e2075e02eb2d3f2475e49f99c91846467907a"
+  integrity sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -3680,6 +3818,14 @@ acorn-globals@^4.3.2:
   dependencies:
     acorn "^6.0.1"
     acorn-walk "^6.0.1"
+
+acorn-globals@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-6.0.0.tgz#46cdd39f0f8ff08a876619b55f5ac8a6dc770b45"
+  integrity sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==
+  dependencies:
+    acorn "^7.1.1"
+    acorn-walk "^7.1.1"
 
 acorn-jsx@^5.1.0:
   version "5.1.0"
@@ -4271,6 +4417,20 @@ babel-jest@^25.5.1:
     graceful-fs "^4.2.4"
     slash "^3.0.0"
 
+babel-jest@^26.0.1:
+  version "26.0.1"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-26.0.1.tgz#450139ce4b6c17174b136425bda91885c397bc46"
+  integrity sha512-Z4GGmSNQ8pX3WS1O+6v3fo41YItJJZsVxG5gIQ+HuB/iuAQBJxMTHTwz292vuYws1LnHfwSRgoqI+nxdy/pcvw==
+  dependencies:
+    "@jest/transform" "^26.0.1"
+    "@jest/types" "^26.0.1"
+    "@types/babel__core" "^7.1.7"
+    babel-plugin-istanbul "^6.0.0"
+    babel-preset-jest "^26.0.0"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.4"
+    slash "^3.0.0"
+
 babel-loader@8.0.4:
   version "8.0.4"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.0.4.tgz#7bbf20cbe4560629e2e41534147692d3fecbdce6"
@@ -4337,6 +4497,15 @@ babel-plugin-jest-hoist@^25.5.0:
     "@babel/types" "^7.3.3"
     "@types/babel__traverse" "^7.0.6"
 
+babel-plugin-jest-hoist@^26.0.0:
+  version "26.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.0.0.tgz#fd1d35f95cf8849fc65cb01b5e58aedd710b34a8"
+  integrity sha512-+AuoehOrjt9irZL7DOt2+4ZaTM6dlu1s5TTS46JBa0/qem4dy7VNW3tMb96qeEqcIh20LD73TVNtmVEeymTG7w==
+  dependencies:
+    "@babel/template" "^7.3.3"
+    "@babel/types" "^7.3.3"
+    "@types/babel__traverse" "^7.0.6"
+
 babel-plugin-syntax-jsx@6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
@@ -4382,6 +4551,14 @@ babel-preset-jest@^25.5.0:
   integrity sha512-8ZczygctQkBU+63DtSOKGh7tFL0CeCuz+1ieud9lJ1WPQ9O6A1a/r+LGn6Y705PA6whHQ3T1XuB/PmpfNYf8Fw==
   dependencies:
     babel-plugin-jest-hoist "^25.5.0"
+    babel-preset-current-node-syntax "^0.1.2"
+
+babel-preset-jest@^26.0.0:
+  version "26.0.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-26.0.0.tgz#1eac82f513ad36c4db2e9263d7c485c825b1faa6"
+  integrity sha512-9ce+DatAa31DpR4Uir8g4Ahxs5K4W4L8refzt+qHWQANb6LhGcAEfIFgLUwk67oya2cCUd6t4eUMtO/z64ocNw==
+  dependencies:
+    babel-plugin-jest-hoist "^26.0.0"
     babel-preset-current-node-syntax "^0.1.2"
 
 bail@^1.0.0:
@@ -4639,6 +4816,11 @@ browser-process-hrtime@^0.1.2:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz#616f00faef1df7ec1b5bf9cfe2bdc3170f26c7b4"
   integrity sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==
+
+browser-process-hrtime@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
+  integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
 
 browser-resolve@^1.11.3:
   version "1.11.3"
@@ -5041,6 +5223,11 @@ camelcase@^4.0.0, camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
+
+camelcase@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.0.0.tgz#5259f7c30e35e278f1bdc2a4d91230b37cad981e"
+  integrity sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==
 
 camelize@^1.0.0:
   version "1.0.0"
@@ -6392,7 +6579,7 @@ csso@^4.0.2:
   dependencies:
     css-tree "1.0.0-alpha.39"
 
-cssom@^0.4.1:
+cssom@^0.4.1, cssom@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.4.4.tgz#5a66cf93d2d0b661d80bf6a44fb65f5c2e4e0a10"
   integrity sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==
@@ -6406,6 +6593,13 @@ cssstyle@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-2.2.0.tgz#e4c44debccd6b7911ed617a4395e5754bba59992"
   integrity sha512-sEb3XFPx3jNnCAMtqrXPDeSgQr+jojtCeNf8cvMNMh1cG970+lljssvQDzPq6lmmJu2Vhqood/gtEomBiHOGnA==
+  dependencies:
+    cssom "~0.3.6"
+
+cssstyle@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-2.3.0.tgz#ff665a0ddbdc31864b09647f34163443d90b0852"
+  integrity sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
   dependencies:
     cssom "~0.3.6"
 
@@ -6471,6 +6665,15 @@ data-urls@^1.1.0:
     abab "^2.0.0"
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
+
+data-urls@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-2.0.0.tgz#156485a72963a970f5d5821aaf642bef2bf2db9b"
+  integrity sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==
+  dependencies:
+    abab "^2.0.3"
+    whatwg-mimetype "^2.3.0"
+    whatwg-url "^8.0.0"
 
 date-now@^0.1.4:
   version "0.1.4"
@@ -6539,6 +6742,11 @@ decamelize@^2.0.0:
   integrity sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==
   dependencies:
     xregexp "4.0.0"
+
+decimal.js@^10.2.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.2.0.tgz#39466113a9e036111d02f82489b5fd6b0b5ed231"
+  integrity sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw==
 
 decode-uri-component@^0.2.0:
   version "0.2.0"
@@ -6754,6 +6962,11 @@ diff-sequences@^25.2.6:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-25.2.6.tgz#5f467c00edd35352b7bca46d7927d60e687a76dd"
   integrity sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==
 
+diff-sequences@^26.0.0:
+  version "26.0.0"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.0.0.tgz#0760059a5c287637b842bd7085311db7060e88a6"
+  integrity sha512-JC/eHYEC3aSS0vZGjuoc4vHA0yAQTzhQQldXMeMF+JlxLGJlCO38Gma82NV9gk1jGFz8mDzUMeaKXvjRRdJ2dg==
+
 diffie-hellman@^5.0.0:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.3.tgz#40e8ee98f55a2149607146921c63e1ae5f3d2875"
@@ -6849,6 +7062,13 @@ domexception@^1.0.1:
   integrity sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==
   dependencies:
     webidl-conversions "^4.0.2"
+
+domexception@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/domexception/-/domexception-2.0.1.tgz#fb44aefba793e1574b0af6aed2801d057529f304"
+  integrity sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==
+  dependencies:
+    webidl-conversions "^5.0.0"
 
 domhandler@3.0.0, domhandler@^3.0.0:
   version "3.0.0"
@@ -7267,6 +7487,11 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+escape-string-regexp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
+  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
+
 escodegen@^1.11.1, escodegen@^1.14.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.1.tgz#ba01d0c8278b5e95a9a45350142026659027a457"
@@ -7654,6 +7879,18 @@ expect@^25.5.0:
     jest-matcher-utils "^25.5.0"
     jest-message-util "^25.5.0"
     jest-regex-util "^25.2.6"
+
+expect@^26.0.1:
+  version "26.0.1"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-26.0.1.tgz#18697b9611a7e2725e20ba3ceadda49bc9865421"
+  integrity sha512-QcCy4nygHeqmbw564YxNbHTJlXh47dVID2BUP52cZFpLU9zHViMFK6h07cC1wf7GYCTIigTdAXhVua8Yl1FkKg==
+  dependencies:
+    "@jest/types" "^26.0.1"
+    ansi-styles "^4.0.0"
+    jest-get-type "^26.0.0"
+    jest-matcher-utils "^26.0.1"
+    jest-message-util "^26.0.1"
+    jest-regex-util "^26.0.0"
 
 express@^4.16.3:
   version "4.17.1"
@@ -9114,6 +9351,13 @@ html-encoding-sniffer@^1.0.2:
   dependencies:
     whatwg-encoding "^1.0.1"
 
+html-encoding-sniffer@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz#42a6dc4fd33f00281176e8b23759ca4e4fa185f3"
+  integrity sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==
+  dependencies:
+    whatwg-encoding "^1.0.5"
+
 html-escaper@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.0.tgz#71e87f931de3fe09e56661ab9a29aadec707b491"
@@ -10109,6 +10353,11 @@ is-png@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-png/-/is-png-1.1.0.tgz#d574b12bf275c0350455570b0e5b57ab062077ce"
   integrity sha1-1XSxK/J1wDUEVVcLDltXqwYgd84=
 
+is-potential-custom-element-name@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz#0c52e54bcca391bb2c494b21e8626d7336c6e397"
+  integrity sha1-DFLlS8yjkbssSUsh6GJtczbG45c=
+
 is-promise@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
@@ -10343,6 +10592,30 @@ jest-changed-files@^25.5.0:
     execa "^3.2.0"
     throat "^5.0.0"
 
+jest-circus@^26.0.1:
+  version "26.0.1"
+  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-26.0.1.tgz#602c412ae8d31c5d436fa84c3a58944b166833fa"
+  integrity sha512-dp20V0Pi1N92Y7+ULPa3tNR9KCG0Sy19NiopyPmo5rNoQ4OGWmuzp1P0q1je2HV3fRD0BYE7wqh8aReGGENfUA==
+  dependencies:
+    "@babel/traverse" "^7.1.0"
+    "@jest/environment" "^26.0.1"
+    "@jest/test-result" "^26.0.1"
+    "@jest/types" "^26.0.1"
+    chalk "^4.0.0"
+    co "^4.6.0"
+    dedent "^0.7.0"
+    expect "^26.0.1"
+    is-generator-fn "^2.0.0"
+    jest-each "^26.0.1"
+    jest-matcher-utils "^26.0.1"
+    jest-message-util "^26.0.1"
+    jest-runtime "^26.0.1"
+    jest-snapshot "^26.0.1"
+    jest-util "^26.0.1"
+    pretty-format "^26.0.1"
+    stack-utils "^2.0.2"
+    throat "^5.0.0"
+
 jest-cli@^25.5.4:
   version "25.5.4"
   resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-25.5.4.tgz#b9f1a84d1301a92c5c217684cb79840831db9f0d"
@@ -10388,6 +10661,30 @@ jest-config@^25.5.4:
     pretty-format "^25.5.0"
     realpath-native "^2.0.0"
 
+jest-config@^26.0.1:
+  version "26.0.1"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-26.0.1.tgz#096a3d4150afadf719d1fab00e9a6fb2d6d67507"
+  integrity sha512-9mWKx2L1LFgOXlDsC4YSeavnblN6A4CPfXFiobq+YYLaBMymA/SczN7xYTSmLaEYHZOcB98UdoN4m5uNt6tztg==
+  dependencies:
+    "@babel/core" "^7.1.0"
+    "@jest/test-sequencer" "^26.0.1"
+    "@jest/types" "^26.0.1"
+    babel-jest "^26.0.1"
+    chalk "^4.0.0"
+    deepmerge "^4.2.2"
+    glob "^7.1.1"
+    graceful-fs "^4.2.4"
+    jest-environment-jsdom "^26.0.1"
+    jest-environment-node "^26.0.1"
+    jest-get-type "^26.0.0"
+    jest-jasmine2 "^26.0.1"
+    jest-regex-util "^26.0.0"
+    jest-resolve "^26.0.1"
+    jest-util "^26.0.1"
+    jest-validate "^26.0.1"
+    micromatch "^4.0.2"
+    pretty-format "^26.0.1"
+
 jest-diff@^25.2.1, jest-diff@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-25.5.0.tgz#1dd26ed64f96667c068cef026b677dfa01afcfa9"
@@ -10398,10 +10695,27 @@ jest-diff@^25.2.1, jest-diff@^25.5.0:
     jest-get-type "^25.2.6"
     pretty-format "^25.5.0"
 
+jest-diff@^26.0.1:
+  version "26.0.1"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.0.1.tgz#c44ab3cdd5977d466de69c46929e0e57f89aa1de"
+  integrity sha512-odTcHyl5X+U+QsczJmOjWw5tPvww+y9Yim5xzqxVl/R1j4z71+fHW4g8qu1ugMmKdFdxw+AtQgs5mupPnzcIBQ==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^26.0.0"
+    jest-get-type "^26.0.0"
+    pretty-format "^26.0.1"
+
 jest-docblock@^25.3.0:
   version "25.3.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-25.3.0.tgz#8b777a27e3477cd77a168c05290c471a575623ef"
   integrity sha512-aktF0kCar8+zxRHxQZwxMy70stc9R1mOmrLsT5VO3pIT0uzGRSDAXxSlz4NqQWpuLjPpuMhPRl7H+5FRsvIQAg==
+  dependencies:
+    detect-newline "^3.0.0"
+
+jest-docblock@^26.0.0:
+  version "26.0.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-26.0.0.tgz#3e2fa20899fc928cb13bd0ff68bd3711a36889b5"
+  integrity sha512-RDZ4Iz3QbtRWycd8bUEPxQsTlYazfYn/h5R65Fc6gOfwozFhoImx+affzky/FFBuqISPTqjXomoIGJVKBWoo0w==
   dependencies:
     detect-newline "^3.0.0"
 
@@ -10416,6 +10730,17 @@ jest-each@^25.5.0:
     jest-util "^25.5.0"
     pretty-format "^25.5.0"
 
+jest-each@^26.0.1:
+  version "26.0.1"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-26.0.1.tgz#633083061619302fc90dd8f58350f9d77d67be04"
+  integrity sha512-OTgJlwXCAR8NIWaXFL5DBbeS4QIYPuNASkzSwMCJO+ywo9BEa6TqkaSWsfR7VdbMLdgYJqSfQcIyjJCNwl5n4Q==
+  dependencies:
+    "@jest/types" "^26.0.1"
+    chalk "^4.0.0"
+    jest-get-type "^26.0.0"
+    jest-util "^26.0.1"
+    pretty-format "^26.0.1"
+
 jest-environment-jsdom@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-25.5.0.tgz#dcbe4da2ea997707997040ecf6e2560aec4e9834"
@@ -10427,6 +10752,18 @@ jest-environment-jsdom@^25.5.0:
     jest-mock "^25.5.0"
     jest-util "^25.5.0"
     jsdom "^15.2.1"
+
+jest-environment-jsdom@^26.0.1:
+  version "26.0.1"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-26.0.1.tgz#217690852e5bdd7c846a4e3b50c8ffd441dfd249"
+  integrity sha512-u88NJa3aptz2Xix2pFhihRBAatwZHWwSiRLBDBQE1cdJvDjPvv7ZGA0NQBxWwDDn7D0g1uHqxM8aGgfA9Bx49g==
+  dependencies:
+    "@jest/environment" "^26.0.1"
+    "@jest/fake-timers" "^26.0.1"
+    "@jest/types" "^26.0.1"
+    jest-mock "^26.0.1"
+    jest-util "^26.0.1"
+    jsdom "^16.2.2"
 
 jest-environment-node@^25.5.0:
   version "25.5.0"
@@ -10440,10 +10777,26 @@ jest-environment-node@^25.5.0:
     jest-util "^25.5.0"
     semver "^6.3.0"
 
+jest-environment-node@^26.0.1:
+  version "26.0.1"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-26.0.1.tgz#584a9ff623124ff6eeb49e0131b5f7612b310b13"
+  integrity sha512-4FRBWcSn5yVo0KtNav7+5NH5Z/tEgDLp7VRQVS5tCouWORxj+nI+1tOLutM07Zb2Qi7ja+HEDoOUkjBSWZg/IQ==
+  dependencies:
+    "@jest/environment" "^26.0.1"
+    "@jest/fake-timers" "^26.0.1"
+    "@jest/types" "^26.0.1"
+    jest-mock "^26.0.1"
+    jest-util "^26.0.1"
+
 jest-get-type@^25.2.6:
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-25.2.6.tgz#0b0a32fab8908b44d508be81681487dbabb8d877"
   integrity sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==
+
+jest-get-type@^26.0.0:
+  version "26.0.0"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.0.0.tgz#381e986a718998dbfafcd5ec05934be538db4039"
+  integrity sha512-zRc1OAPnnws1EVfykXOj19zo2EMw5Hi6HLbFCSjpuJiXtOWAYIjNsHVSbpQ8bDX7L5BGYGI8m+HmKdjHYFF0kg==
 
 jest-haste-map@^25.5.1:
   version "25.5.1"
@@ -10458,6 +10811,26 @@ jest-haste-map@^25.5.1:
     jest-serializer "^25.5.0"
     jest-util "^25.5.0"
     jest-worker "^25.5.0"
+    micromatch "^4.0.2"
+    sane "^4.0.3"
+    walker "^1.0.7"
+    which "^2.0.2"
+  optionalDependencies:
+    fsevents "^2.1.2"
+
+jest-haste-map@^26.0.1:
+  version "26.0.1"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-26.0.1.tgz#40dcc03c43ac94d25b8618075804d09cd5d49de7"
+  integrity sha512-J9kBl/EdjmDsvyv7CiyKY5+DsTvVOScenprz/fGqfLg/pm1gdjbwwQ98nW0t+OIt+f+5nAVaElvn/6wP5KO7KA==
+  dependencies:
+    "@jest/types" "^26.0.1"
+    "@types/graceful-fs" "^4.1.2"
+    anymatch "^3.0.3"
+    fb-watchman "^2.0.0"
+    graceful-fs "^4.2.4"
+    jest-serializer "^26.0.0"
+    jest-util "^26.0.1"
+    jest-worker "^26.0.0"
     micromatch "^4.0.2"
     sane "^4.0.3"
     walker "^1.0.7"
@@ -10488,6 +10861,29 @@ jest-jasmine2@^25.5.4:
     pretty-format "^25.5.0"
     throat "^5.0.0"
 
+jest-jasmine2@^26.0.1:
+  version "26.0.1"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-26.0.1.tgz#947c40ee816636ba23112af3206d6fa7b23c1c1c"
+  integrity sha512-ILaRyiWxiXOJ+RWTKupzQWwnPaeXPIoLS5uW41h18varJzd9/7I0QJGqg69fhTT1ev9JpSSo9QtalriUN0oqOg==
+  dependencies:
+    "@babel/traverse" "^7.1.0"
+    "@jest/environment" "^26.0.1"
+    "@jest/source-map" "^26.0.0"
+    "@jest/test-result" "^26.0.1"
+    "@jest/types" "^26.0.1"
+    chalk "^4.0.0"
+    co "^4.6.0"
+    expect "^26.0.1"
+    is-generator-fn "^2.0.0"
+    jest-each "^26.0.1"
+    jest-matcher-utils "^26.0.1"
+    jest-message-util "^26.0.1"
+    jest-runtime "^26.0.1"
+    jest-snapshot "^26.0.1"
+    jest-util "^26.0.1"
+    pretty-format "^26.0.1"
+    throat "^5.0.0"
+
 jest-leak-detector@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-25.5.0.tgz#2291c6294b0ce404241bb56fe60e2d0c3e34f0bb"
@@ -10495,6 +10891,14 @@ jest-leak-detector@^25.5.0:
   dependencies:
     jest-get-type "^25.2.6"
     pretty-format "^25.5.0"
+
+jest-leak-detector@^26.0.1:
+  version "26.0.1"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-26.0.1.tgz#79b19ab3f41170e0a78eb8fa754a116d3447fb8c"
+  integrity sha512-93FR8tJhaYIWrWsbmVN1pQ9ZNlbgRpfvrnw5LmgLRX0ckOJ8ut/I35CL7awi2ecq6Ca4lL59bEK9hr7nqoHWPA==
+  dependencies:
+    jest-get-type "^26.0.0"
+    pretty-format "^26.0.1"
 
 jest-matcher-utils@^25.5.0:
   version "25.5.0"
@@ -10505,6 +10909,16 @@ jest-matcher-utils@^25.5.0:
     jest-diff "^25.5.0"
     jest-get-type "^25.2.6"
     pretty-format "^25.5.0"
+
+jest-matcher-utils@^26.0.1:
+  version "26.0.1"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-26.0.1.tgz#12e1fc386fe4f14678f4cc8dbd5ba75a58092911"
+  integrity sha512-PUMlsLth0Azen8Q2WFTwnSkGh2JZ8FYuwijC8NR47vXKpsrKmA1wWvgcj1CquuVfcYiDEdj985u5Wmg7COEARw==
+  dependencies:
+    chalk "^4.0.0"
+    jest-diff "^26.0.1"
+    jest-get-type "^26.0.0"
+    pretty-format "^26.0.1"
 
 jest-message-util@^25.5.0:
   version "25.5.0"
@@ -10520,12 +10934,33 @@ jest-message-util@^25.5.0:
     slash "^3.0.0"
     stack-utils "^1.0.1"
 
+jest-message-util@^26.0.1:
+  version "26.0.1"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-26.0.1.tgz#07af1b42fc450b4cc8e90e4c9cef11b33ce9b0ac"
+  integrity sha512-CbK8uQREZ8umUfo8+zgIfEt+W7HAHjQCoRaNs4WxKGhAYBGwEyvxuK81FXa7VeB9pwDEXeeKOB2qcsNVCAvB7Q==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@jest/types" "^26.0.1"
+    "@types/stack-utils" "^1.0.1"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.4"
+    micromatch "^4.0.2"
+    slash "^3.0.0"
+    stack-utils "^2.0.2"
+
 jest-mock@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-25.5.0.tgz#a91a54dabd14e37ecd61665d6b6e06360a55387a"
   integrity sha512-eXWuTV8mKzp/ovHc5+3USJMYsTBhyQ+5A1Mak35dey/RG8GlM4YWVylZuGgVXinaW6tpvk/RSecmF37FKUlpXA==
   dependencies:
     "@jest/types" "^25.5.0"
+
+jest-mock@^26.0.1:
+  version "26.0.1"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-26.0.1.tgz#7fd1517ed4955397cf1620a771dc2d61fad8fd40"
+  integrity sha512-MpYTBqycuPYSY6xKJognV7Ja46/TeRbAZept987Zp+tuJvMN0YBWyyhG9mXyYQaU3SBI0TUlSaO5L3p49agw7Q==
+  dependencies:
+    "@jest/types" "^26.0.1"
 
 jest-pnp-resolver@^1.2.1:
   version "1.2.1"
@@ -10536,6 +10971,11 @@ jest-regex-util@^25.2.6:
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-25.2.6.tgz#d847d38ba15d2118d3b06390056028d0f2fd3964"
   integrity sha512-KQqf7a0NrtCkYmZZzodPftn7fL1cq3GQAFVMn5Hg8uKx/fIenLEobNanUxb7abQ1sjADHBseG/2FGpsv/wr+Qw==
+
+jest-regex-util@^26.0.0:
+  version "26.0.0"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-26.0.0.tgz#d25e7184b36e39fd466c3bc41be0971e821fee28"
+  integrity sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A==
 
 jest-resolve-dependencies@^25.5.4:
   version "25.5.4"
@@ -10561,6 +11001,20 @@ jest-resolve@^25.5.1:
     resolve "^1.17.0"
     slash "^3.0.0"
 
+jest-resolve@^26.0.1:
+  version "26.0.1"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-26.0.1.tgz#21d1ee06f9ea270a343a8893051aeed940cde736"
+  integrity sha512-6jWxk0IKZkPIVTvq6s72RH735P8f9eCJW3IM5CX/SJFeKq1p2cZx0U49wf/SdMlhaB/anann5J2nCJj6HrbezQ==
+  dependencies:
+    "@jest/types" "^26.0.1"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.4"
+    jest-pnp-resolver "^1.2.1"
+    jest-util "^26.0.1"
+    read-pkg-up "^7.0.1"
+    resolve "^1.17.0"
+    slash "^3.0.0"
+
 jest-runner@^25.5.4:
   version "25.5.4"
   resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-25.5.4.tgz#ffec5df3875da5f5c878ae6d0a17b8e4ecd7c71d"
@@ -10583,6 +11037,31 @@ jest-runner@^25.5.4:
     jest-runtime "^25.5.4"
     jest-util "^25.5.0"
     jest-worker "^25.5.0"
+    source-map-support "^0.5.6"
+    throat "^5.0.0"
+
+jest-runner@^26.0.1:
+  version "26.0.1"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-26.0.1.tgz#ea03584b7ae4bacfb7e533d680a575a49ae35d50"
+  integrity sha512-CApm0g81b49Znm4cZekYQK67zY7kkB4umOlI2Dx5CwKAzdgw75EN+ozBHRvxBzwo1ZLYZ07TFxkaPm+1t4d8jA==
+  dependencies:
+    "@jest/console" "^26.0.1"
+    "@jest/environment" "^26.0.1"
+    "@jest/test-result" "^26.0.1"
+    "@jest/types" "^26.0.1"
+    chalk "^4.0.0"
+    exit "^0.1.2"
+    graceful-fs "^4.2.4"
+    jest-config "^26.0.1"
+    jest-docblock "^26.0.0"
+    jest-haste-map "^26.0.1"
+    jest-jasmine2 "^26.0.1"
+    jest-leak-detector "^26.0.1"
+    jest-message-util "^26.0.1"
+    jest-resolve "^26.0.1"
+    jest-runtime "^26.0.1"
+    jest-util "^26.0.1"
+    jest-worker "^26.0.0"
     source-map-support "^0.5.6"
     throat "^5.0.0"
 
@@ -10618,6 +11097,38 @@ jest-runtime@^25.5.4:
     strip-bom "^4.0.0"
     yargs "^15.3.1"
 
+jest-runtime@^26.0.1:
+  version "26.0.1"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-26.0.1.tgz#a121a6321235987d294168e282d52b364d7d3f89"
+  integrity sha512-Ci2QhYFmANg5qaXWf78T2Pfo6GtmIBn2rRaLnklRyEucmPccmCKvS9JPljcmtVamsdMmkyNkVFb9pBTD6si9Lw==
+  dependencies:
+    "@jest/console" "^26.0.1"
+    "@jest/environment" "^26.0.1"
+    "@jest/fake-timers" "^26.0.1"
+    "@jest/globals" "^26.0.1"
+    "@jest/source-map" "^26.0.0"
+    "@jest/test-result" "^26.0.1"
+    "@jest/transform" "^26.0.1"
+    "@jest/types" "^26.0.1"
+    "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
+    collect-v8-coverage "^1.0.0"
+    exit "^0.1.2"
+    glob "^7.1.3"
+    graceful-fs "^4.2.4"
+    jest-config "^26.0.1"
+    jest-haste-map "^26.0.1"
+    jest-message-util "^26.0.1"
+    jest-mock "^26.0.1"
+    jest-regex-util "^26.0.0"
+    jest-resolve "^26.0.1"
+    jest-snapshot "^26.0.1"
+    jest-util "^26.0.1"
+    jest-validate "^26.0.1"
+    slash "^3.0.0"
+    strip-bom "^4.0.0"
+    yargs "^15.3.1"
+
 jest-serializer-path@^0.1.15:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/jest-serializer-path/-/jest-serializer-path-0.1.15.tgz#68528c98e3f8be652484f1c3876228f6864bd662"
@@ -10631,6 +11142,13 @@ jest-serializer@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-25.5.0.tgz#a993f484e769b4ed54e70e0efdb74007f503072b"
   integrity sha512-LxD8fY1lByomEPflwur9o4e2a5twSQ7TaVNLlFUuToIdoJuBt8tzHfCsZ42Ok6LkKXWzFWf3AGmheuLAA7LcCA==
+  dependencies:
+    graceful-fs "^4.2.4"
+
+jest-serializer@^26.0.0:
+  version "26.0.0"
+  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-26.0.0.tgz#f6c521ddb976943b93e662c0d4d79245abec72a3"
+  integrity sha512-sQGXLdEGWFAE4wIJ2ZaIDb+ikETlUirEOBsLXdoBbeLhTHkZUJwgk3+M8eyFizhM6le43PDCCKPA1hzkSDo4cQ==
   dependencies:
     graceful-fs "^4.2.4"
 
@@ -10663,6 +11181,27 @@ jest-snapshot@^25.5.1:
     pretty-format "^25.5.0"
     semver "^6.3.0"
 
+jest-snapshot@^26.0.1:
+  version "26.0.1"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-26.0.1.tgz#1baa942bd83d47b837a84af7fcf5fd4a236da399"
+  integrity sha512-jxd+cF7+LL+a80qh6TAnTLUZHyQoWwEHSUFJjkw35u3Gx+BZUNuXhYvDqHXr62UQPnWo2P6fvQlLjsU93UKyxA==
+  dependencies:
+    "@babel/types" "^7.0.0"
+    "@jest/types" "^26.0.1"
+    "@types/prettier" "^2.0.0"
+    chalk "^4.0.0"
+    expect "^26.0.1"
+    graceful-fs "^4.2.4"
+    jest-diff "^26.0.1"
+    jest-get-type "^26.0.0"
+    jest-matcher-utils "^26.0.1"
+    jest-message-util "^26.0.1"
+    jest-resolve "^26.0.1"
+    make-dir "^3.0.0"
+    natural-compare "^1.4.0"
+    pretty-format "^26.0.1"
+    semver "^7.3.2"
+
 jest-util@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-25.5.0.tgz#31c63b5d6e901274d264a4fec849230aa3fa35b0"
@@ -10670,6 +11209,17 @@ jest-util@^25.5.0:
   dependencies:
     "@jest/types" "^25.5.0"
     chalk "^3.0.0"
+    graceful-fs "^4.2.4"
+    is-ci "^2.0.0"
+    make-dir "^3.0.0"
+
+jest-util@^26.0.1:
+  version "26.0.1"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-26.0.1.tgz#72c4c51177b695fdd795ca072a6f94e3d7cef00a"
+  integrity sha512-byQ3n7ad1BO/WyFkYvlWQHTsomB6GIewBh8tlGtusiylAlaxQ1UpS0XYH0ngOyhZuHVLN79Qvl6/pMiDMSSG1g==
+  dependencies:
+    "@jest/types" "^26.0.1"
+    chalk "^4.0.0"
     graceful-fs "^4.2.4"
     is-ci "^2.0.0"
     make-dir "^3.0.0"
@@ -10685,6 +11235,18 @@ jest-validate@^25.5.0:
     jest-get-type "^25.2.6"
     leven "^3.1.0"
     pretty-format "^25.5.0"
+
+jest-validate@^26.0.1:
+  version "26.0.1"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-26.0.1.tgz#a62987e1da5b7f724130f904725e22f4e5b2e23c"
+  integrity sha512-u0xRc+rbmov/VqXnX3DlkxD74rHI/CfS5xaV2VpeaVySjbb1JioNVOyly5b56q2l9ZKe7bVG5qWmjfctkQb0bA==
+  dependencies:
+    "@jest/types" "^26.0.1"
+    camelcase "^6.0.0"
+    chalk "^4.0.0"
+    jest-get-type "^26.0.0"
+    leven "^3.1.0"
+    pretty-format "^26.0.1"
 
 jest-watcher@^25.5.0:
   version "25.5.0"
@@ -10710,6 +11272,14 @@ jest-worker@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-25.5.0.tgz#2611d071b79cea0f43ee57a3d118593ac1547db1"
   integrity sha512-/dsSmUkIy5EBGfv/IjjqmFxrNAUpBERfGs1oHROyD7yxjG/w+t0GOJDX8O1k32ySmd7+a5IhnJU2qQFcJ4n1vw==
+  dependencies:
+    merge-stream "^2.0.0"
+    supports-color "^7.0.0"
+
+jest-worker@^26.0.0:
+  version "26.0.0"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-26.0.0.tgz#4920c7714f0a96c6412464718d0c58a3df3fb066"
+  integrity sha512-pPaYa2+JnwmiZjK9x7p9BoZht+47ecFCDFA/CJxspHzeDvQcfVBLWzCiWyo+EGrSiQMWZtCFo9iSvMZnAAo8vw==
   dependencies:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
@@ -10839,6 +11409,38 @@ jsdom@^15.2.1:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^7.0.0"
     ws "^7.0.0"
+    xml-name-validator "^3.0.0"
+
+jsdom@^16.2.2:
+  version "16.2.2"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-16.2.2.tgz#76f2f7541646beb46a938f5dc476b88705bedf2b"
+  integrity sha512-pDFQbcYtKBHxRaP55zGXCJWgFHkDAYbKcsXEK/3Icu9nKYZkutUXfLBwbD+09XDutkYSHcgfQLZ0qvpAAm9mvg==
+  dependencies:
+    abab "^2.0.3"
+    acorn "^7.1.1"
+    acorn-globals "^6.0.0"
+    cssom "^0.4.4"
+    cssstyle "^2.2.0"
+    data-urls "^2.0.0"
+    decimal.js "^10.2.0"
+    domexception "^2.0.1"
+    escodegen "^1.14.1"
+    html-encoding-sniffer "^2.0.1"
+    is-potential-custom-element-name "^1.0.0"
+    nwsapi "^2.2.0"
+    parse5 "5.1.1"
+    request "^2.88.2"
+    request-promise-native "^1.0.8"
+    saxes "^5.0.0"
+    symbol-tree "^3.2.4"
+    tough-cookie "^3.0.1"
+    w3c-hr-time "^1.0.2"
+    w3c-xmlserializer "^2.0.0"
+    webidl-conversions "^6.0.0"
+    whatwg-encoding "^1.0.5"
+    whatwg-mimetype "^2.3.0"
+    whatwg-url "^8.0.0"
+    ws "^7.2.3"
     xml-name-validator "^3.0.0"
 
 jsesc@^2.5.1:
@@ -13453,17 +14055,17 @@ parse5@5.1.0:
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.0.tgz#c59341c9723f414c452975564c7c00a68d58acd2"
   integrity sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==
 
+parse5@5.1.1, parse5@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.1.tgz#f68e4e5ba1852ac2cadc00f4555fff6c2abb6178"
+  integrity sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==
+
 parse5@^3.0.1:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
   integrity sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==
   dependencies:
     "@types/node" "*"
-
-parse5@^5.0.0:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.1.tgz#f68e4e5ba1852ac2cadc00f4555fff6c2abb6178"
-  integrity sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==
 
 parseurl@^1.3.2, parseurl@~1.3.3:
   version "1.3.3"
@@ -14251,7 +14853,7 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.0.1:
+prettier@^2.0.1, prettier@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
   integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
@@ -14279,6 +14881,16 @@ pretty-format@^25.2.1, pretty-format@^25.5.0:
   integrity sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==
   dependencies:
     "@jest/types" "^25.5.0"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^16.12.0"
+
+pretty-format@^26.0.1:
+  version "26.0.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.0.1.tgz#a4fe54fe428ad2fd3413ca6bbd1ec8c2e277e197"
+  integrity sha512-SWxz6MbupT3ZSlL0Po4WF/KujhQaVehijR2blyRDCzk9e45EaYMVhMBn49fnRuHxtkSpXTes1GxNpVmH86Bxfw==
+  dependencies:
+    "@jest/types" "^26.0.1"
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
@@ -15276,7 +15888,7 @@ request-promise-core@1.1.3:
   dependencies:
     lodash "^4.17.15"
 
-request-promise-native@^1.0.7:
+request-promise-native@^1.0.7, request-promise-native@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.8.tgz#a455b960b826e44e2bf8999af64dff2bfe58cb36"
   integrity sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==
@@ -15295,7 +15907,7 @@ request-promise@4.2.2:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.3"
 
-request@^2.65.0, request@^2.83.0:
+request@^2.65.0, request@^2.83.0, request@^2.88.2:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
@@ -15672,6 +16284,13 @@ saxes@^3.1.9:
   integrity sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==
   dependencies:
     xmlchars "^2.1.1"
+
+saxes@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/saxes/-/saxes-5.0.1.tgz#eebab953fa3b7608dbe94e5dadb15c888fa6696d"
+  integrity sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==
+  dependencies:
+    xmlchars "^2.2.0"
 
 scheduler@^0.19.0, scheduler@^0.19.1:
   version "0.19.1"
@@ -16327,6 +16946,13 @@ stack-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
   integrity sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==
 
+stack-utils@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.2.tgz#5cf48b4557becb4638d0bc4f21d23f5d19586593"
+  integrity sha512-0H7QK2ECz3fyZMzQ8rH0j2ykpfbnd20BFtfg/SqVC2+sCTtcw0aDTGB7dk+de4U4uUeuz6nOtJcrkFFLG1B0Rg==
+  dependencies:
+    escape-string-regexp "^2.0.0"
+
 stackframe@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.2.0.tgz#52429492d63c62eb989804c11552e3d22e779303"
@@ -16878,6 +17504,11 @@ symbol-tree@^3.2.2:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
   integrity sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=
 
+symbol-tree@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
+  integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
+
 table-layout@^0.4.3:
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/table-layout/-/table-layout-0.4.5.tgz#d906de6a25fa09c0c90d1d08ecd833ecedcb7378"
@@ -17281,6 +17912,13 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
+tr46@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-2.0.2.tgz#03273586def1595ae08fedb38d7733cee91d2479"
+  integrity sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==
+  dependencies:
+    punycode "^2.1.1"
+
 transform-markdown-links@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/transform-markdown-links/-/transform-markdown-links-2.0.0.tgz#b79e9283d4474cb9b079899ae09152d4ec46325a"
@@ -17348,7 +17986,7 @@ ts-easing@^0.2.0:
   resolved "https://registry.yarnpkg.com/ts-easing/-/ts-easing-0.2.0.tgz#c8a8a35025105566588d87dbda05dd7fbfa5a4ec"
   integrity sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ==
 
-ts-jest@^25.0.0:
+ts-jest@^25.0.0, ts-jest@^25.5.1:
   version "25.5.1"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-25.5.1.tgz#2913afd08f28385d54f2f4e828be4d261f4337c7"
   integrity sha512-kHEUlZMK8fn8vkxDjwbHlxXRB9dHYpyzqKIGDNxbzs+Rz+ssNDSDNusEK8Fk/sDd4xE6iKoQLfFkFVaskmTJyw==
@@ -18103,6 +18741,13 @@ w3c-hr-time@^1.0.1:
   dependencies:
     browser-process-hrtime "^0.1.2"
 
+w3c-hr-time@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz#0a89cdf5cc15822df9c360543676963e0cc308cd"
+  integrity sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==
+  dependencies:
+    browser-process-hrtime "^1.0.0"
+
 w3c-xmlserializer@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-1.1.2.tgz#30485ca7d70a6fd052420a3d12fd90e6339ce794"
@@ -18110,6 +18755,13 @@ w3c-xmlserializer@^1.1.2:
   dependencies:
     domexception "^1.0.1"
     webidl-conversions "^4.0.2"
+    xml-name-validator "^3.0.0"
+
+w3c-xmlserializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz#3e7104a05b75146cc60f564380b7f683acf1020a"
+  integrity sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==
+  dependencies:
     xml-name-validator "^3.0.0"
 
 walker@^1.0.7, walker@~1.0.5:
@@ -18166,6 +18818,16 @@ webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
+
+webidl-conversions@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"
+  integrity sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==
+
+webidl-conversions@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-6.1.0.tgz#9111b4d7ea80acd40f5270d666621afa78b69514"
+  integrity sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
 
 webpack-bundle-analyzer@3.3.2:
   version "3.3.2"
@@ -18385,6 +19047,15 @@ whatwg-url@^7.0.0:
     lodash.sortby "^4.7.0"
     tr46 "^1.0.1"
     webidl-conversions "^4.0.2"
+
+whatwg-url@^8.0.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-8.1.0.tgz#c628acdcf45b82274ce7281ee31dd3c839791771"
+  integrity sha512-vEIkwNi9Hqt4TV9RdnaBPNt+E2Sgmo3gePebCRgZ1R7g6d23+53zCTnuB0amKI4AXq6VM8jj2DUAa0S1vjJxkw==
+  dependencies:
+    lodash.sortby "^4.7.0"
+    tr46 "^2.0.2"
+    webidl-conversions "^5.0.0"
 
 wheel@^1.0.0:
   version "1.0.0"
@@ -18608,6 +19279,11 @@ ws@^7.0.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.2.1.tgz#03ed52423cd744084b2cf42ed197c8b65a936b8e"
   integrity sha512-sucePNSafamSKoOqoNfBd8V0StlkzJKL2ZAhGQinCfNQ+oacw+Pk7lcdAElecBF2VkLNZRiIb5Oi1Q5lVUVt2A==
 
+ws@^7.2.3:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.3.0.tgz#4b2f7f219b3d3737bc1a2fbf145d825b94d38ffd"
+  integrity sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==
+
 xdg-basedir@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
@@ -18633,22 +19309,6 @@ xml-parse-from-string@^1.0.0:
   resolved "https://registry.yarnpkg.com/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz#a9029e929d3dbcded169f3c6e28238d95a5d5a28"
   integrity sha1-qQKekp09vN7RafPG4oI42VpdWig=
 
-xml2js@^0.4.23:
-  version "0.4.23"
-  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
-  integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==
-  dependencies:
-    sax ">=0.6.0"
-    xmlbuilder "~11.0.0"
-
-xml2js@^0.4.16, xml2js@^0.4.5, xml2js@^0.4.9:
-  version "0.4.19"
-  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
-  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
-  dependencies:
-    sax ">=0.6.0"
-    xmlbuilder "~9.0.1"
-
 xml2js@^0.4.5:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
@@ -18656,6 +19316,14 @@ xml2js@^0.4.5:
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~11.0.0"
+
+xml2js@^0.4.9:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
+  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~9.0.1"
 
 xmlbuilder@~11.0.0:
   version "11.0.1"
@@ -18667,7 +19335,7 @@ xmlbuilder@~9.0.1:
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
   integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
 
-xmlchars@^2.1.1:
+xmlchars@^2.1.1, xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -8421,9 +8421,9 @@ fragment-cache@^0.2.1:
     map-cache "^0.2.2"
 
 framer-motion@^1.11.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-1.11.0.tgz#9463a4d8e1be9f25d0f75712a4a835691c028d65"
-  integrity sha512-DkJFWAHIv57L4xu8Ufq9GMs9Ifqpgt5Yi55pc4NQos8TUGomgbLlnwpO1IXK85X5K1dVNKuTZMiqjWZLeOfG/A==
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-1.11.1.tgz#b031d1556a78854e0989b8c7e96418c6e15aa474"
+  integrity sha512-CP6aYLPSivAWkq9UoSurefHBggxG85IT8ObYyWYkcZppgtjHzpwRzhaA8P0ljMGRqtcpeQAIybiGgPioBPlOSw==
   dependencies:
     "@popmotion/easing" "^1.0.2"
     "@popmotion/popcorn" "^0.4.2"
@@ -12979,9 +12979,9 @@ nested-error-stacks@^2.0.0:
   integrity sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==
 
 next-ignite@^0.1.32:
-  version "0.1.32"
-  resolved "https://registry.yarnpkg.com/next-ignite/-/next-ignite-0.1.32.tgz#7df08e9940f5ddb2bc9afd3492a7c7eb059d6977"
-  integrity sha512-aewhQGk44tCxH+o5kb1DAIo2hBEbcjBfvXvgbA6nuF/OinOTUoeQoKtdJTvxlC4bUdhOTfNgr74WV1znoprxCQ==
+  version "0.1.33"
+  resolved "https://registry.yarnpkg.com/next-ignite/-/next-ignite-0.1.33.tgz#153f80a05e6438a848eb465125985657e3424a84"
+  integrity sha512-JYtne1+ofaVXkuZXfqVWQHHkBJWoO2qTddN17mgRqvrSnrYdPRkVpzeHhizbW5L4cmsSJqymo1vNczZvOwmP9g==
   dependencies:
     "@mapbox/rehype-prism" "^0.4.0"
     "@next/bundle-analyzer" "^9.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3351,6 +3351,13 @@
     "@types/webpack-sources" "*"
     source-map "^0.6.0"
 
+"@types/xml2js@^0.4.5":
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/@types/xml2js/-/xml2js-0.4.5.tgz#d21759b056f282d9c7066f15bbf5c19b908f22fa"
+  integrity sha512-yohU3zMn0fkhlape1nxXG2bLEGZRc1FeqF80RoHaYXJN7uibaauXfhzhOJr1Xh36sn+/tx21QAOf07b/xYVk1w==
+  dependencies:
+    "@types/node" "*"
+
 "@types/yargs-parser@*":
   version "13.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-13.0.0.tgz#453743c5bbf9f1bed61d959baab5b06be029b2d0"
@@ -18626,14 +18633,15 @@ xml-parse-from-string@^1.0.0:
   resolved "https://registry.yarnpkg.com/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz#a9029e929d3dbcded169f3c6e28238d95a5d5a28"
   integrity sha1-qQKekp09vN7RafPG4oI42VpdWig=
 
-xml2js-es6-promise@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/xml2js-es6-promise/-/xml2js-es6-promise-1.1.1.tgz#cd5688d9d6344e67c908f71e5b0a3d88d128e9a2"
-  integrity sha1-zVaI2dY0TmfJCPceWwo9iNEo6aI=
+xml2js@^0.4.23:
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
+  integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==
   dependencies:
-    xml2js "^0.4.16"
+    sax ">=0.6.0"
+    xmlbuilder "~11.0.0"
 
-xml2js@^0.4.16, xml2js@^0.4.9:
+xml2js@^0.4.16, xml2js@^0.4.5, xml2js@^0.4.9:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
   integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==


### PR DESCRIPTION
Fixes #1260

# Release Notes

This release removes the requirement for the `Maven Release Plugin` from maven projects. This is a breaking change but that maven plugin was quite experimental. This PR makes it a full featured `auto` experience. 

## Remove requirement for "maven-release-plugin" and other improvements

1. Remove requirement for "maven-release-plugin".
2. Support recursive changes to all `pom.xml` files in the project, with the following assumptions:
  a. The project is a multi-module project.
  b. The parent `pom.xml` file is located in the root directory of the repo.
  c. The parent `pom.xml` contains the version.
  d. Sub-modules have the same version as the parent `pom.xml`.
3. Support plugin options, with environment variable overrides:
  a. `MAVEN_COMMAND || mavenCommand` - the path to the maven executable to use. Defaults to `/usr/bin/mvn`.
  b. `MAVEN_OPTIONS || mavenOptions` - an array of arbitrary maven options, e.g. `-DskipTests -P some-profile`. No defaults.
  c. `MAVEN_RELEASE_GOALS || mavenReleaseGoals` - an array of maven goals to run when publishing. Defaults to `["deploy", "site-deploy"]`.
  d. `MAVEN_SETTINGS || mavenSettings` - the path to the maven settings file. No defaults.

**NOTE:** The `MAVEN_USERNAME` and `MAVEN_PASSWORD` environment variables are still supported, and have their counterparts as configuration options, but should are deprecated, and will be removed in a later release. This is because `MAVEN_SETTINGS` or `MAVEN_OPTIONS` can do the same work, but provide a much more flexible solution.

## Support both "versions-maven-plugin" and auto-native DOM/XML

`auto` will detect if the parent `pom.xml` file has the `versions-maven-plugin` configured, and if so, use it to set the version on the parent and all child `pom.xml` files. If not, then auto will modify the parent and all child `pom.xml` files using a DOM parser and XML serializer. This has the effect of losing formatting. Therefore it then runs the serialized XML through the `prettier` "html" pretty-printer.

This means that if the `versions-maven-plugin` isn't available, the `pom.xml` files will be pretty-printed using the `prettier` formatter with the following default settings:

* `printWidth: 120` (configurable - see below)
* `tabWidth: 4` (configurable - see below)
* `parser: "html"`

# Version

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.39.1-canary.1295.16583.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.39.1-canary.1295.16583.0
  npm install @auto-canary/auto@9.39.1-canary.1295.16583.0
  npm install @auto-canary/core@9.39.1-canary.1295.16583.0
  npm install @auto-canary/all-contributors@9.39.1-canary.1295.16583.0
  npm install @auto-canary/brew@9.39.1-canary.1295.16583.0
  npm install @auto-canary/chrome@9.39.1-canary.1295.16583.0
  npm install @auto-canary/cocoapods@9.39.1-canary.1295.16583.0
  npm install @auto-canary/conventional-commits@9.39.1-canary.1295.16583.0
  npm install @auto-canary/crates@9.39.1-canary.1295.16583.0
  npm install @auto-canary/exec@9.39.1-canary.1295.16583.0
  npm install @auto-canary/first-time-contributor@9.39.1-canary.1295.16583.0
  npm install @auto-canary/gem@9.39.1-canary.1295.16583.0
  npm install @auto-canary/gh-pages@9.39.1-canary.1295.16583.0
  npm install @auto-canary/git-tag@9.39.1-canary.1295.16583.0
  npm install @auto-canary/gradle@9.39.1-canary.1295.16583.0
  npm install @auto-canary/jira@9.39.1-canary.1295.16583.0
  npm install @auto-canary/maven@9.39.1-canary.1295.16583.0
  npm install @auto-canary/npm@9.39.1-canary.1295.16583.0
  npm install @auto-canary/omit-commits@9.39.1-canary.1295.16583.0
  npm install @auto-canary/omit-release-notes@9.39.1-canary.1295.16583.0
  npm install @auto-canary/released@9.39.1-canary.1295.16583.0
  npm install @auto-canary/s3@9.39.1-canary.1295.16583.0
  npm install @auto-canary/slack@9.39.1-canary.1295.16583.0
  npm install @auto-canary/twitter@9.39.1-canary.1295.16583.0
  npm install @auto-canary/upload-assets@9.39.1-canary.1295.16583.0
  # or 
  yarn add @auto-canary/bot-list@9.39.1-canary.1295.16583.0
  yarn add @auto-canary/auto@9.39.1-canary.1295.16583.0
  yarn add @auto-canary/core@9.39.1-canary.1295.16583.0
  yarn add @auto-canary/all-contributors@9.39.1-canary.1295.16583.0
  yarn add @auto-canary/brew@9.39.1-canary.1295.16583.0
  yarn add @auto-canary/chrome@9.39.1-canary.1295.16583.0
  yarn add @auto-canary/cocoapods@9.39.1-canary.1295.16583.0
  yarn add @auto-canary/conventional-commits@9.39.1-canary.1295.16583.0
  yarn add @auto-canary/crates@9.39.1-canary.1295.16583.0
  yarn add @auto-canary/exec@9.39.1-canary.1295.16583.0
  yarn add @auto-canary/first-time-contributor@9.39.1-canary.1295.16583.0
  yarn add @auto-canary/gem@9.39.1-canary.1295.16583.0
  yarn add @auto-canary/gh-pages@9.39.1-canary.1295.16583.0
  yarn add @auto-canary/git-tag@9.39.1-canary.1295.16583.0
  yarn add @auto-canary/gradle@9.39.1-canary.1295.16583.0
  yarn add @auto-canary/jira@9.39.1-canary.1295.16583.0
  yarn add @auto-canary/maven@9.39.1-canary.1295.16583.0
  yarn add @auto-canary/npm@9.39.1-canary.1295.16583.0
  yarn add @auto-canary/omit-commits@9.39.1-canary.1295.16583.0
  yarn add @auto-canary/omit-release-notes@9.39.1-canary.1295.16583.0
  yarn add @auto-canary/released@9.39.1-canary.1295.16583.0
  yarn add @auto-canary/s3@9.39.1-canary.1295.16583.0
  yarn add @auto-canary/slack@9.39.1-canary.1295.16583.0
  yarn add @auto-canary/twitter@9.39.1-canary.1295.16583.0
  yarn add @auto-canary/upload-assets@9.39.1-canary.1295.16583.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
