### PR TITLE
Update makeRelease to support 'from' and 'useVersion' options with build part of semver

### DIFF
--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -1019,6 +1019,45 @@ describe("Auto", () => {
         })
       );
     });
+
+    test("should publish with newVersion using useVersion option with semver build part", async () => {
+      const auto = new Auto({ ...defaults, plugins: [] });
+      auto.logger = dummyLog();
+      await auto.loadConfig();
+      auto.git!.getLatestRelease = () => Promise.resolve("1.2.3");
+
+      jest.spyOn(auto.git!, "publish").mockReturnValueOnce({ data: {} } as any);
+      jest
+        .spyOn(auto.release!, "generateReleaseNotes")
+        .mockImplementation(() => Promise.resolve("releaseNotes"));
+      auto.release!.getCommitsInRelease = () =>
+        Promise.resolve([makeCommitFromMsg("Test Commit")]);
+
+      auto.hooks.getPreviousVersion.tap("test", () => "1.2.4");
+      const afterRelease = jest.fn();
+      auto.hooks.afterRelease.tap("test", afterRelease);
+      jest.spyOn(auto.release!, "getCommits").mockImplementation();
+
+      await auto.runRelease({
+        useVersion: "1.2.3+1",
+      });
+      expect(auto.release!.generateReleaseNotes).toHaveBeenCalledWith(
+        "v1.2.3",
+        undefined,
+        undefined
+      );
+      expect(auto.git!.publish).toHaveBeenCalledWith(
+        "releaseNotes",
+        "v1.2.3+1",
+        false
+      );
+      expect(afterRelease).toHaveBeenCalledWith(
+        expect.objectContaining({
+          lastRelease: "v1.2.3",
+          newVersion: "v1.2.3+1",
+        })
+      );
+    });
   });
 
   describe("canary", () => {

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -6,7 +6,7 @@ import path from "path";
 import link from "terminal-link";
 import icons from "log-symbols";
 import chalk from "chalk";
-import { eq, gt, lte, inc, parse, ReleaseType, major } from "semver";
+import { gt, lte, compareBuild, inc, parse, ReleaseType, major } from "semver";
 import {
   AsyncParallelHook,
   AsyncSeriesBailHook,
@@ -373,7 +373,7 @@ export default class Auto {
           )}`;
 
           await execPromise("git", ["branch", branch]);
-          this.logger.log.success(`Created old version branch: ${branch}`)
+          this.logger.log.success(`Created old version branch: ${branch}`);
           await execPromise("git", ["push", this.remote, branch]);
         }
       }
@@ -1795,7 +1795,7 @@ export default class Auto {
       !dryRun &&
       parse(newVersion) &&
       parse(lastRelease) &&
-      eq(newVersion, lastRelease)
+      compareBuild(newVersion, lastRelease) === 0
     ) {
       this.logger.log.warn(
         `Nothing released to Github. Version to be released is the same as the latest release on Github: ${newVersion}`


### PR DESCRIPTION
# What Changed

- update makeRelease to check equality of previous and next version using `compareBuild` instead of `eq`
  - see https://github.com/npm/node-semver#comparison

# Why

- This pr will allow users to support previous versions via build part of semver when manually specifying versions
  - `eq` doesn't account for build part of semver when comparing... this means that if a user specifies `from=v1.2.3` & `userVersion=v1.2.3+1`, these would be treated as equal versions and the release would fail
  - `compareBuild` will account for the build part of semver when comparing, so the above scenario will succeed
- relates to #1054 

# Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.39.1-canary.1315.16593.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.39.1-canary.1315.16593.0
  npm install @auto-canary/auto@9.39.1-canary.1315.16593.0
  npm install @auto-canary/core@9.39.1-canary.1315.16593.0
  npm install @auto-canary/all-contributors@9.39.1-canary.1315.16593.0
  npm install @auto-canary/brew@9.39.1-canary.1315.16593.0
  npm install @auto-canary/chrome@9.39.1-canary.1315.16593.0
  npm install @auto-canary/cocoapods@9.39.1-canary.1315.16593.0
  npm install @auto-canary/conventional-commits@9.39.1-canary.1315.16593.0
  npm install @auto-canary/crates@9.39.1-canary.1315.16593.0
  npm install @auto-canary/exec@9.39.1-canary.1315.16593.0
  npm install @auto-canary/first-time-contributor@9.39.1-canary.1315.16593.0
  npm install @auto-canary/gem@9.39.1-canary.1315.16593.0
  npm install @auto-canary/gh-pages@9.39.1-canary.1315.16593.0
  npm install @auto-canary/git-tag@9.39.1-canary.1315.16593.0
  npm install @auto-canary/gradle@9.39.1-canary.1315.16593.0
  npm install @auto-canary/jira@9.39.1-canary.1315.16593.0
  npm install @auto-canary/maven@9.39.1-canary.1315.16593.0
  npm install @auto-canary/npm@9.39.1-canary.1315.16593.0
  npm install @auto-canary/omit-commits@9.39.1-canary.1315.16593.0
  npm install @auto-canary/omit-release-notes@9.39.1-canary.1315.16593.0
  npm install @auto-canary/released@9.39.1-canary.1315.16593.0
  npm install @auto-canary/s3@9.39.1-canary.1315.16593.0
  npm install @auto-canary/slack@9.39.1-canary.1315.16593.0
  npm install @auto-canary/twitter@9.39.1-canary.1315.16593.0
  npm install @auto-canary/upload-assets@9.39.1-canary.1315.16593.0
  # or 
  yarn add @auto-canary/bot-list@9.39.1-canary.1315.16593.0
  yarn add @auto-canary/auto@9.39.1-canary.1315.16593.0
  yarn add @auto-canary/core@9.39.1-canary.1315.16593.0
  yarn add @auto-canary/all-contributors@9.39.1-canary.1315.16593.0
  yarn add @auto-canary/brew@9.39.1-canary.1315.16593.0
  yarn add @auto-canary/chrome@9.39.1-canary.1315.16593.0
  yarn add @auto-canary/cocoapods@9.39.1-canary.1315.16593.0
  yarn add @auto-canary/conventional-commits@9.39.1-canary.1315.16593.0
  yarn add @auto-canary/crates@9.39.1-canary.1315.16593.0
  yarn add @auto-canary/exec@9.39.1-canary.1315.16593.0
  yarn add @auto-canary/first-time-contributor@9.39.1-canary.1315.16593.0
  yarn add @auto-canary/gem@9.39.1-canary.1315.16593.0
  yarn add @auto-canary/gh-pages@9.39.1-canary.1315.16593.0
  yarn add @auto-canary/git-tag@9.39.1-canary.1315.16593.0
  yarn add @auto-canary/gradle@9.39.1-canary.1315.16593.0
  yarn add @auto-canary/jira@9.39.1-canary.1315.16593.0
  yarn add @auto-canary/maven@9.39.1-canary.1315.16593.0
  yarn add @auto-canary/npm@9.39.1-canary.1315.16593.0
  yarn add @auto-canary/omit-commits@9.39.1-canary.1315.16593.0
  yarn add @auto-canary/omit-release-notes@9.39.1-canary.1315.16593.0
  yarn add @auto-canary/released@9.39.1-canary.1315.16593.0
  yarn add @auto-canary/s3@9.39.1-canary.1315.16593.0
  yarn add @auto-canary/slack@9.39.1-canary.1315.16593.0
  yarn add @auto-canary/twitter@9.39.1-canary.1315.16593.0
  yarn add @auto-canary/upload-assets@9.39.1-canary.1315.16593.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
