### PR TITLE
stop parsing release notes when we hit an automated comment created by auto

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/changelog.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/changelog.test.ts.snap
@@ -231,6 +231,24 @@ exports[`generateReleaseNotes should merge sections with same changelog title 1`
 - Adam Dierkens (adam@dierkens.com)"
 `;
 
+exports[`generateReleaseNotes should not add automated comments to additional release notes 1`] = `
+"### Release Notes
+
+_From #1235_
+
+Here is how you upgrade
+
+---
+
+#### 🚀 Enhancement
+
+- First Feature [#1235](https://github.custom.com/foobar/auto/pull/1235) (adam@dierkens.com)
+
+#### Authors: 1
+
+- Adam Dierkens (adam@dierkens.com)"
+`;
+
 exports[`generateReleaseNotes should omit authors with invalid email addresses 1`] = `
 "#### 🚀 Enhancement
 

--- a/packages/core/src/__tests__/changelog.test.ts
+++ b/packages/core/src/__tests__/changelog.test.ts
@@ -669,6 +669,33 @@ describe("generateReleaseNotes", () => {
     expect(await changelog.generateReleaseNotes(commits)).toMatchSnapshot();
   });
 
+  test("should not add automated comments to additional release notes", async () => {
+    const changelog = new Changelog(dummyLog(), testOptions());
+    changelog.loadDefaultHooks();
+
+    const commits = await logParse.normalizeCommits([
+      {
+        hash: "2",
+        files: [],
+        authorName: "Adam Dierkens",
+        authorEmail: "adam@dierkens.com",
+        subject: "First Feature (#1235)",
+        labels: ["minor"],
+      },
+    ]);
+    commits[0].pullRequest!.body = endent`
+      ## Release Notes
+
+      Here is how you upgrade
+
+      <!-- GITHUB_RELEASE PR BODY: prerelease-version -->
+      Should not show up in notes
+      <!-- GITHUB_RELEASE PR BODY: prerelease-version -->
+    `;
+
+    expect(await changelog.generateReleaseNotes(commits)).toMatchSnapshot();
+  });
+
   test("additional release notes should be able to contain sub-headers", async () => {
     const changelog = new Changelog(dummyLog(), testOptions());
     changelog.loadDefaultHooks();

--- a/packages/core/src/changelog.ts
+++ b/packages/core/src/changelog.ts
@@ -9,6 +9,7 @@ import { ILogger } from "./utils/logger";
 import { makeChangelogHooks } from "./utils/make-hooks";
 import { getCurrentBranch } from "./utils/get-current-branch";
 import SEMVER from "./semver";
+import { automatedCommentIdentifier } from "./git";
 
 export interface IGenerateReleaseNotesOptions {
   /** Github repo owner (user) */
@@ -479,7 +480,10 @@ export default class Changelog {
         const line = lines[index];
         const isTitle = line.match(title);
 
-        if (line.startsWith("#") && getHeaderDepth(line) <= depth && !isTitle) {
+        if (
+          (line.startsWith("#") && getHeaderDepth(line) <= depth && !isTitle) ||
+          line.startsWith(automatedCommentIdentifier)
+        ) {
           break;
         }
 

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -78,9 +78,11 @@ function getVersionFromTag(tag: string) {
   return tag;
 }
 
+export const automatedCommentIdentifier = "<!-- GITHUB_RELEASE";
+
 /** Make a comment to build automation in PRs off of. */
 const makeIdentifier = (type: string, context: string) =>
-  `<!-- GITHUB_RELEASE ${type}: ${context} -->`;
+  `${automatedCommentIdentifier} ${type}: ${context} -->`;
 
 /** Make an identifier for `auto comment` */
 const makeCommentIdentifier = (context: string) =>


### PR DESCRIPTION
# What Changed

When `auto` hits an automated comment in a PR body it will not add it to the `Release Notes` section in changelogs.

# Why

It isn't rendered right, it's ugly, and it takes up valuable space!

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.40.2-canary.1320.16720.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.40.2-canary.1320.16720.0
  npm install @auto-canary/auto@9.40.2-canary.1320.16720.0
  npm install @auto-canary/core@9.40.2-canary.1320.16720.0
  npm install @auto-canary/all-contributors@9.40.2-canary.1320.16720.0
  npm install @auto-canary/brew@9.40.2-canary.1320.16720.0
  npm install @auto-canary/chrome@9.40.2-canary.1320.16720.0
  npm install @auto-canary/cocoapods@9.40.2-canary.1320.16720.0
  npm install @auto-canary/conventional-commits@9.40.2-canary.1320.16720.0
  npm install @auto-canary/crates@9.40.2-canary.1320.16720.0
  npm install @auto-canary/exec@9.40.2-canary.1320.16720.0
  npm install @auto-canary/first-time-contributor@9.40.2-canary.1320.16720.0
  npm install @auto-canary/gem@9.40.2-canary.1320.16720.0
  npm install @auto-canary/gh-pages@9.40.2-canary.1320.16720.0
  npm install @auto-canary/git-tag@9.40.2-canary.1320.16720.0
  npm install @auto-canary/gradle@9.40.2-canary.1320.16720.0
  npm install @auto-canary/jira@9.40.2-canary.1320.16720.0
  npm install @auto-canary/maven@9.40.2-canary.1320.16720.0
  npm install @auto-canary/npm@9.40.2-canary.1320.16720.0
  npm install @auto-canary/omit-commits@9.40.2-canary.1320.16720.0
  npm install @auto-canary/omit-release-notes@9.40.2-canary.1320.16720.0
  npm install @auto-canary/released@9.40.2-canary.1320.16720.0
  npm install @auto-canary/s3@9.40.2-canary.1320.16720.0
  npm install @auto-canary/slack@9.40.2-canary.1320.16720.0
  npm install @auto-canary/twitter@9.40.2-canary.1320.16720.0
  npm install @auto-canary/upload-assets@9.40.2-canary.1320.16720.0
  # or 
  yarn add @auto-canary/bot-list@9.40.2-canary.1320.16720.0
  yarn add @auto-canary/auto@9.40.2-canary.1320.16720.0
  yarn add @auto-canary/core@9.40.2-canary.1320.16720.0
  yarn add @auto-canary/all-contributors@9.40.2-canary.1320.16720.0
  yarn add @auto-canary/brew@9.40.2-canary.1320.16720.0
  yarn add @auto-canary/chrome@9.40.2-canary.1320.16720.0
  yarn add @auto-canary/cocoapods@9.40.2-canary.1320.16720.0
  yarn add @auto-canary/conventional-commits@9.40.2-canary.1320.16720.0
  yarn add @auto-canary/crates@9.40.2-canary.1320.16720.0
  yarn add @auto-canary/exec@9.40.2-canary.1320.16720.0
  yarn add @auto-canary/first-time-contributor@9.40.2-canary.1320.16720.0
  yarn add @auto-canary/gem@9.40.2-canary.1320.16720.0
  yarn add @auto-canary/gh-pages@9.40.2-canary.1320.16720.0
  yarn add @auto-canary/git-tag@9.40.2-canary.1320.16720.0
  yarn add @auto-canary/gradle@9.40.2-canary.1320.16720.0
  yarn add @auto-canary/jira@9.40.2-canary.1320.16720.0
  yarn add @auto-canary/maven@9.40.2-canary.1320.16720.0
  yarn add @auto-canary/npm@9.40.2-canary.1320.16720.0
  yarn add @auto-canary/omit-commits@9.40.2-canary.1320.16720.0
  yarn add @auto-canary/omit-release-notes@9.40.2-canary.1320.16720.0
  yarn add @auto-canary/released@9.40.2-canary.1320.16720.0
  yarn add @auto-canary/s3@9.40.2-canary.1320.16720.0
  yarn add @auto-canary/slack@9.40.2-canary.1320.16720.0
  yarn add @auto-canary/twitter@9.40.2-canary.1320.16720.0
  yarn add @auto-canary/upload-assets@9.40.2-canary.1320.16720.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
