### PR TITLE
Next - Adds intermediary check for newest release before releasing entire history

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1254,6 +1254,7 @@ export default class Auto {
       initialForkCommit || (await this.git.getLatestRelease());
     const lastTag =
       (await this.git.getLastTagNotInBaseBranch(currentBranch!)) ||
+      (await this.git.getLatestTagInBranch(currentBranch)) ||
       (await this.git.getFirstCommit());
     const fullReleaseNotes = await this.release.generateReleaseNotes(
       lastRelease


### PR DESCRIPTION
> I'm realizing this sits humorously close to my [last contribution](https://github.com/10hendersonm/auto/commit/3f87c8afe99aad1a6fbd77d6de52ab8597c946c0#diff-54899627ccbe2e33cc90970d5e6d5191L1247)

I'm new to open source, so I'm not really sure the right workflow here. This could be an issue, but I have code that fixes it for _my_ use case. Let me know which/both you'd prefer to see in the future.

# What Changed

This PR adds a check to `next` where, should no tags be found different between the current and base branch, it'll attempt to take the latest tag before grabbing the first ever commit.

# Why

We're trying to push feature branches onto `next` and they are revving `major` no matter what the change is. This appears to be because, on merging the change into `next`, no tags exist on next that are unique from `master`, so it instead grabs the first commit, thus generating a changelog and selecting the version bump based on every commit ever, rather than the couple of ones currently sitting on `next`.

## Workflow

1. Create `some-feature-branch` from `next`, and apply some minor patch to it
1. PR `some-feature-branch` to `next` with the `patch` tag and merge it
1. Run `auto shipit`
   - `auto shipit` sees no unique tags between `next` and `master`, so it grabs the first ever commit and revs a `major`, ex. `3.0.0`
1. PR+merge `next` onto `master` with a `patch` label
1. Run `auto shipit`
   - `auto shipit` correctly revs a `patch` and publishes `2.0.1`
1. Commit features in and PR + merge to `next` again
1. Run `auto shipit`
   - `auto shipit` now fails because it again tries to `major` rev `2.0.1`, but this time because `3.0.0-beta.0` already existed (due to step **3**)


Todo:

- [ ] Add tests
- [ ] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.40.4-canary.1323.16757.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.40.4-canary.1323.16757.0
  npm install @auto-canary/auto@9.40.4-canary.1323.16757.0
  npm install @auto-canary/core@9.40.4-canary.1323.16757.0
  npm install @auto-canary/all-contributors@9.40.4-canary.1323.16757.0
  npm install @auto-canary/brew@9.40.4-canary.1323.16757.0
  npm install @auto-canary/chrome@9.40.4-canary.1323.16757.0
  npm install @auto-canary/cocoapods@9.40.4-canary.1323.16757.0
  npm install @auto-canary/conventional-commits@9.40.4-canary.1323.16757.0
  npm install @auto-canary/crates@9.40.4-canary.1323.16757.0
  npm install @auto-canary/exec@9.40.4-canary.1323.16757.0
  npm install @auto-canary/first-time-contributor@9.40.4-canary.1323.16757.0
  npm install @auto-canary/gem@9.40.4-canary.1323.16757.0
  npm install @auto-canary/gh-pages@9.40.4-canary.1323.16757.0
  npm install @auto-canary/git-tag@9.40.4-canary.1323.16757.0
  npm install @auto-canary/gradle@9.40.4-canary.1323.16757.0
  npm install @auto-canary/jira@9.40.4-canary.1323.16757.0
  npm install @auto-canary/maven@9.40.4-canary.1323.16757.0
  npm install @auto-canary/npm@9.40.4-canary.1323.16757.0
  npm install @auto-canary/omit-commits@9.40.4-canary.1323.16757.0
  npm install @auto-canary/omit-release-notes@9.40.4-canary.1323.16757.0
  npm install @auto-canary/released@9.40.4-canary.1323.16757.0
  npm install @auto-canary/s3@9.40.4-canary.1323.16757.0
  npm install @auto-canary/slack@9.40.4-canary.1323.16757.0
  npm install @auto-canary/twitter@9.40.4-canary.1323.16757.0
  npm install @auto-canary/upload-assets@9.40.4-canary.1323.16757.0
  # or 
  yarn add @auto-canary/bot-list@9.40.4-canary.1323.16757.0
  yarn add @auto-canary/auto@9.40.4-canary.1323.16757.0
  yarn add @auto-canary/core@9.40.4-canary.1323.16757.0
  yarn add @auto-canary/all-contributors@9.40.4-canary.1323.16757.0
  yarn add @auto-canary/brew@9.40.4-canary.1323.16757.0
  yarn add @auto-canary/chrome@9.40.4-canary.1323.16757.0
  yarn add @auto-canary/cocoapods@9.40.4-canary.1323.16757.0
  yarn add @auto-canary/conventional-commits@9.40.4-canary.1323.16757.0
  yarn add @auto-canary/crates@9.40.4-canary.1323.16757.0
  yarn add @auto-canary/exec@9.40.4-canary.1323.16757.0
  yarn add @auto-canary/first-time-contributor@9.40.4-canary.1323.16757.0
  yarn add @auto-canary/gem@9.40.4-canary.1323.16757.0
  yarn add @auto-canary/gh-pages@9.40.4-canary.1323.16757.0
  yarn add @auto-canary/git-tag@9.40.4-canary.1323.16757.0
  yarn add @auto-canary/gradle@9.40.4-canary.1323.16757.0
  yarn add @auto-canary/jira@9.40.4-canary.1323.16757.0
  yarn add @auto-canary/maven@9.40.4-canary.1323.16757.0
  yarn add @auto-canary/npm@9.40.4-canary.1323.16757.0
  yarn add @auto-canary/omit-commits@9.40.4-canary.1323.16757.0
  yarn add @auto-canary/omit-release-notes@9.40.4-canary.1323.16757.0
  yarn add @auto-canary/released@9.40.4-canary.1323.16757.0
  yarn add @auto-canary/s3@9.40.4-canary.1323.16757.0
  yarn add @auto-canary/slack@9.40.4-canary.1323.16757.0
  yarn add @auto-canary/twitter@9.40.4-canary.1323.16757.0
  yarn add @auto-canary/upload-assets@9.40.4-canary.1323.16757.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
