### PR TITLE
Updates afterRelease documented parameters

### DIFF
--- a/docs/pages/docs/plugins/release-lifecycle-hooks.mdx
+++ b/docs/pages/docs/plugins/release-lifecycle-hooks.mdx
@@ -267,8 +267,8 @@ _Other examples:_
 Ran after the `release` command has run, creating a new release on GitHub.
 This async hook gets the following arguments:
 
-- `lastVersion` - the version that existed prior to the current release
-- `nextVersion` - version that was just released
+- `lastRelease` - the version that existed prior to the current release
+- `newVersion` - version that was just released
 - `commits` - the commits in the release
 - `releaseNotes` - generated release notes for the release
 - `response` - the response returned from making the release
@@ -276,7 +276,7 @@ This async hook gets the following arguments:
 ```ts
 auto.hooks.afterRelease.tapPromise(
   "MyPlugin",
-  async ({ lastVersion, nextVersion, commits, releaseNotes, response }) => {
+  async ({ lastRelease, newVersion, commits, releaseNotes, response }) => {
     // do something
   }
 );


### PR DESCRIPTION
# What Changed

Updates documented `afterRelease` parameters.

# Why

The documented parameters `nextVersion` and `lastVersion` do not match the [in-code values of `newVersion` and `lastRelease`](https://github.com/intuit/auto/blob/master/packages/core/src/auto.ts#L162).

Todo:

- [ ] Add tests
- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.40.6-canary.1334.16877.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.40.6-canary.1334.16877.0
  npm install @auto-canary/auto@9.40.6-canary.1334.16877.0
  npm install @auto-canary/core@9.40.6-canary.1334.16877.0
  npm install @auto-canary/all-contributors@9.40.6-canary.1334.16877.0
  npm install @auto-canary/brew@9.40.6-canary.1334.16877.0
  npm install @auto-canary/chrome@9.40.6-canary.1334.16877.0
  npm install @auto-canary/cocoapods@9.40.6-canary.1334.16877.0
  npm install @auto-canary/conventional-commits@9.40.6-canary.1334.16877.0
  npm install @auto-canary/crates@9.40.6-canary.1334.16877.0
  npm install @auto-canary/exec@9.40.6-canary.1334.16877.0
  npm install @auto-canary/first-time-contributor@9.40.6-canary.1334.16877.0
  npm install @auto-canary/gem@9.40.6-canary.1334.16877.0
  npm install @auto-canary/gh-pages@9.40.6-canary.1334.16877.0
  npm install @auto-canary/git-tag@9.40.6-canary.1334.16877.0
  npm install @auto-canary/gradle@9.40.6-canary.1334.16877.0
  npm install @auto-canary/jira@9.40.6-canary.1334.16877.0
  npm install @auto-canary/maven@9.40.6-canary.1334.16877.0
  npm install @auto-canary/npm@9.40.6-canary.1334.16877.0
  npm install @auto-canary/omit-commits@9.40.6-canary.1334.16877.0
  npm install @auto-canary/omit-release-notes@9.40.6-canary.1334.16877.0
  npm install @auto-canary/released@9.40.6-canary.1334.16877.0
  npm install @auto-canary/s3@9.40.6-canary.1334.16877.0
  npm install @auto-canary/slack@9.40.6-canary.1334.16877.0
  npm install @auto-canary/twitter@9.40.6-canary.1334.16877.0
  npm install @auto-canary/upload-assets@9.40.6-canary.1334.16877.0
  # or 
  yarn add @auto-canary/bot-list@9.40.6-canary.1334.16877.0
  yarn add @auto-canary/auto@9.40.6-canary.1334.16877.0
  yarn add @auto-canary/core@9.40.6-canary.1334.16877.0
  yarn add @auto-canary/all-contributors@9.40.6-canary.1334.16877.0
  yarn add @auto-canary/brew@9.40.6-canary.1334.16877.0
  yarn add @auto-canary/chrome@9.40.6-canary.1334.16877.0
  yarn add @auto-canary/cocoapods@9.40.6-canary.1334.16877.0
  yarn add @auto-canary/conventional-commits@9.40.6-canary.1334.16877.0
  yarn add @auto-canary/crates@9.40.6-canary.1334.16877.0
  yarn add @auto-canary/exec@9.40.6-canary.1334.16877.0
  yarn add @auto-canary/first-time-contributor@9.40.6-canary.1334.16877.0
  yarn add @auto-canary/gem@9.40.6-canary.1334.16877.0
  yarn add @auto-canary/gh-pages@9.40.6-canary.1334.16877.0
  yarn add @auto-canary/git-tag@9.40.6-canary.1334.16877.0
  yarn add @auto-canary/gradle@9.40.6-canary.1334.16877.0
  yarn add @auto-canary/jira@9.40.6-canary.1334.16877.0
  yarn add @auto-canary/maven@9.40.6-canary.1334.16877.0
  yarn add @auto-canary/npm@9.40.6-canary.1334.16877.0
  yarn add @auto-canary/omit-commits@9.40.6-canary.1334.16877.0
  yarn add @auto-canary/omit-release-notes@9.40.6-canary.1334.16877.0
  yarn add @auto-canary/released@9.40.6-canary.1334.16877.0
  yarn add @auto-canary/s3@9.40.6-canary.1334.16877.0
  yarn add @auto-canary/slack@9.40.6-canary.1334.16877.0
  yarn add @auto-canary/twitter@9.40.6-canary.1334.16877.0
  yarn add @auto-canary/upload-assets@9.40.6-canary.1334.16877.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
