### PR TITLE
attempt to construct the GitHub graphql root API endpoint if githubApi is provided

### DIFF
--- a/docs/pages/docs/configuration/autorc.mdx
+++ b/docs/pages/docs/configuration/autorc.mdx
@@ -69,11 +69,12 @@ If you are using enterprise github, `auto` lets you configure the github API URL
 
 This is used for doing some searches in `auto`.
 
-If you are using enterprise github and your company hosts the graphql at some other URL than the `githubApi`, you can use `githubGraphqlApi` to set the base path for `auto`. The `githubGraphqlApi` get merged with `/graphql` to build the final URL.
+The default behavior will construct the root API url for GitHub Enterprise.
+If you are using enterprise github and your company hosts the graphql at some other URL than the `githubApi`, you can use `githubGraphqlApi` to set the base path for `auto`.
 
 ```json
 {
-  "githubGraphqlApi": "https://github.mine.com/api/"
+  "githubGraphqlApi": "https://github.mine.com/other/api/"
 }
 ```
 

--- a/packages/core/src/__tests__/git.test.ts
+++ b/packages/core/src/__tests__/git.test.ts
@@ -202,6 +202,30 @@ describe("github", () => {
     expect(createRelease).toHaveBeenCalled();
   });
 
+  describe("Name of the group", () => {
+    test("default graphql API", async () => {
+      const gh = new Git(options);
+
+      await gh.publish("releaseNotes", "tag");
+
+      // @ts-ignore
+      expect(gh.baseUrl).toBe("https://api.github.com");
+      // @ts-ignore
+      expect(gh.graphqlBaseUrl).toBe("https://api.github.com");
+    });
+
+    test("override graphql API", async () => {
+      const gh = new Git({ ...options, baseUrl: "https://api.internal.com" });
+
+      await gh.publish("releaseNotes", "tag");
+
+      // @ts-ignore
+      expect(gh.baseUrl).toBe("https://api.internal.com");
+      // @ts-ignore
+      expect(gh.graphqlBaseUrl).toBe("https://api.internal.com/api");
+    });
+  });
+
   test("graphql", async () => {
     const gh = new Git(options);
     const result = await gh.graphql<{ data: any }>("{ someQuery }");

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -539,9 +539,8 @@ export default class Auto {
       ...repository,
       token,
       agent: proxyUrl ? createHttpsProxyAgent(proxyUrl) : undefined,
-      baseUrl: config.githubApi || "https://api.github.com",
-      graphqlBaseUrl:
-        config.githubGraphqlApi || config.githubApi || "https://api.github.com",
+      baseUrl: config.githubApi,
+      graphqlBaseUrl: config.githubGraphqlApi,
     };
 
     this.git = this.startGit(githubOptions as IGitOptions);

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -9,6 +9,7 @@ import { HttpsProxyAgent } from "https-proxy-agent";
 import tinyColor from "tinycolor2";
 import endent from "endent";
 import on from "await-to-js";
+import join from "url-join";
 
 import { Memoize as memoize } from "typescript-memoize";
 
@@ -123,7 +124,9 @@ export default class Git {
     this.logger = logger;
     this.options = options;
     this.baseUrl = this.options.baseUrl || "https://api.github.com";
-    this.graphqlBaseUrl = this.options.graphqlBaseUrl || this.baseUrl;
+    this.graphqlBaseUrl = this.options.baseUrl
+      ? this.options.graphqlBaseUrl || join(new URL(this.baseUrl).origin, "api")
+      : this.baseUrl;
     this.logger.veryVerbose.info(`Initializing GitHub with: ${this.baseUrl}`);
     const GitHub = Octokit.plugin(enterpriseCompatibility)
       .plugin(retry)
@@ -920,7 +923,7 @@ export default class Git {
     }
 
     const key = `hash_${sha}`;
-    const result = (await this.graphql<ISearchQuery>(query));
+    const result = await this.graphql<ISearchQuery>(query);
 
     if (!result || !result[key] || !result[key].edges[0]) {
       return;


### PR DESCRIPTION
# What Changed

If a githubApi URL is provided it is probably enterprise so we try to construct the URL

# Why

attempt to fix #1340 

Todo:

- [x] Add tests
- [x] Update docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.40.7-canary.1349.17053.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.40.7-canary.1349.17053.0
  npm install @auto-canary/auto@9.40.7-canary.1349.17053.0
  npm install @auto-canary/core@9.40.7-canary.1349.17053.0
  npm install @auto-canary/all-contributors@9.40.7-canary.1349.17053.0
  npm install @auto-canary/brew@9.40.7-canary.1349.17053.0
  npm install @auto-canary/chrome@9.40.7-canary.1349.17053.0
  npm install @auto-canary/cocoapods@9.40.7-canary.1349.17053.0
  npm install @auto-canary/conventional-commits@9.40.7-canary.1349.17053.0
  npm install @auto-canary/crates@9.40.7-canary.1349.17053.0
  npm install @auto-canary/exec@9.40.7-canary.1349.17053.0
  npm install @auto-canary/first-time-contributor@9.40.7-canary.1349.17053.0
  npm install @auto-canary/gem@9.40.7-canary.1349.17053.0
  npm install @auto-canary/gh-pages@9.40.7-canary.1349.17053.0
  npm install @auto-canary/git-tag@9.40.7-canary.1349.17053.0
  npm install @auto-canary/gradle@9.40.7-canary.1349.17053.0
  npm install @auto-canary/jira@9.40.7-canary.1349.17053.0
  npm install @auto-canary/maven@9.40.7-canary.1349.17053.0
  npm install @auto-canary/npm@9.40.7-canary.1349.17053.0
  npm install @auto-canary/omit-commits@9.40.7-canary.1349.17053.0
  npm install @auto-canary/omit-release-notes@9.40.7-canary.1349.17053.0
  npm install @auto-canary/released@9.40.7-canary.1349.17053.0
  npm install @auto-canary/s3@9.40.7-canary.1349.17053.0
  npm install @auto-canary/slack@9.40.7-canary.1349.17053.0
  npm install @auto-canary/twitter@9.40.7-canary.1349.17053.0
  npm install @auto-canary/upload-assets@9.40.7-canary.1349.17053.0
  # or 
  yarn add @auto-canary/bot-list@9.40.7-canary.1349.17053.0
  yarn add @auto-canary/auto@9.40.7-canary.1349.17053.0
  yarn add @auto-canary/core@9.40.7-canary.1349.17053.0
  yarn add @auto-canary/all-contributors@9.40.7-canary.1349.17053.0
  yarn add @auto-canary/brew@9.40.7-canary.1349.17053.0
  yarn add @auto-canary/chrome@9.40.7-canary.1349.17053.0
  yarn add @auto-canary/cocoapods@9.40.7-canary.1349.17053.0
  yarn add @auto-canary/conventional-commits@9.40.7-canary.1349.17053.0
  yarn add @auto-canary/crates@9.40.7-canary.1349.17053.0
  yarn add @auto-canary/exec@9.40.7-canary.1349.17053.0
  yarn add @auto-canary/first-time-contributor@9.40.7-canary.1349.17053.0
  yarn add @auto-canary/gem@9.40.7-canary.1349.17053.0
  yarn add @auto-canary/gh-pages@9.40.7-canary.1349.17053.0
  yarn add @auto-canary/git-tag@9.40.7-canary.1349.17053.0
  yarn add @auto-canary/gradle@9.40.7-canary.1349.17053.0
  yarn add @auto-canary/jira@9.40.7-canary.1349.17053.0
  yarn add @auto-canary/maven@9.40.7-canary.1349.17053.0
  yarn add @auto-canary/npm@9.40.7-canary.1349.17053.0
  yarn add @auto-canary/omit-commits@9.40.7-canary.1349.17053.0
  yarn add @auto-canary/omit-release-notes@9.40.7-canary.1349.17053.0
  yarn add @auto-canary/released@9.40.7-canary.1349.17053.0
  yarn add @auto-canary/s3@9.40.7-canary.1349.17053.0
  yarn add @auto-canary/slack@9.40.7-canary.1349.17053.0
  yarn add @auto-canary/twitter@9.40.7-canary.1349.17053.0
  yarn add @auto-canary/upload-assets@9.40.7-canary.1349.17053.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
