### PR TITLE
add --to flag to "auto release"

### DIFF
--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -462,6 +462,13 @@ export const commands: AutoCommand[] = [
           "Git revision (tag, commit sha, ...) to start release notes from. Defaults to latest tag.",
       },
       {
+        name: "to",
+        type: String,
+        group: "main",
+        description:
+          "Git revision (tag, commit sha, ...) to end release notes at. Defaults to HEAD",
+      },
+      {
         name: "use-version",
         type: String,
         group: "main",

--- a/packages/core/src/auto-args.ts
+++ b/packages/core/src/auto-args.ts
@@ -107,6 +107,8 @@ export type IReleaseOptions = BaseBranch &
   Partial<RepoInformation> & {
     /** Commit to start calculating the release from */
     from?: string;
+    /** Commit to calculate the release to */
+    to?: string;
     /** Override the version to release */
     useVersion?: string;
   };

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1724,7 +1724,7 @@ export default class Auto {
   /** Make a release over a range of commits */
   private async makeRelease(args: IReleaseOptions = {}) {
     const options = { ...this.getCommandDefault("release"), ...args };
-    const { dryRun, from, useVersion, prerelease = false } = options;
+    const { dryRun, from, to, useVersion, prerelease = false } = options;
 
     if (!this.release || !this.git) {
       throw this.createErrorMessage();
@@ -1766,11 +1766,12 @@ export default class Auto {
     this.logger.log.info('Current "Latest Release" on Github:', lastRelease);
 
     const commitsInRelease = await this.release.getCommitsInRelease(
-      lastRelease
+      lastRelease,
+      to
     );
     const releaseNotes = await this.release.generateReleaseNotes(
       lastRelease,
-      undefined,
+      to,
       this.versionBump
     );
 


### PR DESCRIPTION
# What Changed

Add the --to flag to "auto release"

# Why

It was asked for.

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.41.2-canary.1362.17187.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.41.2-canary.1362.17187.0
  npm install @auto-canary/auto@9.41.2-canary.1362.17187.0
  npm install @auto-canary/core@9.41.2-canary.1362.17187.0
  npm install @auto-canary/all-contributors@9.41.2-canary.1362.17187.0
  npm install @auto-canary/brew@9.41.2-canary.1362.17187.0
  npm install @auto-canary/chrome@9.41.2-canary.1362.17187.0
  npm install @auto-canary/cocoapods@9.41.2-canary.1362.17187.0
  npm install @auto-canary/conventional-commits@9.41.2-canary.1362.17187.0
  npm install @auto-canary/crates@9.41.2-canary.1362.17187.0
  npm install @auto-canary/exec@9.41.2-canary.1362.17187.0
  npm install @auto-canary/first-time-contributor@9.41.2-canary.1362.17187.0
  npm install @auto-canary/gem@9.41.2-canary.1362.17187.0
  npm install @auto-canary/gh-pages@9.41.2-canary.1362.17187.0
  npm install @auto-canary/git-tag@9.41.2-canary.1362.17187.0
  npm install @auto-canary/gradle@9.41.2-canary.1362.17187.0
  npm install @auto-canary/jira@9.41.2-canary.1362.17187.0
  npm install @auto-canary/maven@9.41.2-canary.1362.17187.0
  npm install @auto-canary/npm@9.41.2-canary.1362.17187.0
  npm install @auto-canary/omit-commits@9.41.2-canary.1362.17187.0
  npm install @auto-canary/omit-release-notes@9.41.2-canary.1362.17187.0
  npm install @auto-canary/released@9.41.2-canary.1362.17187.0
  npm install @auto-canary/s3@9.41.2-canary.1362.17187.0
  npm install @auto-canary/slack@9.41.2-canary.1362.17187.0
  npm install @auto-canary/twitter@9.41.2-canary.1362.17187.0
  npm install @auto-canary/upload-assets@9.41.2-canary.1362.17187.0
  # or 
  yarn add @auto-canary/bot-list@9.41.2-canary.1362.17187.0
  yarn add @auto-canary/auto@9.41.2-canary.1362.17187.0
  yarn add @auto-canary/core@9.41.2-canary.1362.17187.0
  yarn add @auto-canary/all-contributors@9.41.2-canary.1362.17187.0
  yarn add @auto-canary/brew@9.41.2-canary.1362.17187.0
  yarn add @auto-canary/chrome@9.41.2-canary.1362.17187.0
  yarn add @auto-canary/cocoapods@9.41.2-canary.1362.17187.0
  yarn add @auto-canary/conventional-commits@9.41.2-canary.1362.17187.0
  yarn add @auto-canary/crates@9.41.2-canary.1362.17187.0
  yarn add @auto-canary/exec@9.41.2-canary.1362.17187.0
  yarn add @auto-canary/first-time-contributor@9.41.2-canary.1362.17187.0
  yarn add @auto-canary/gem@9.41.2-canary.1362.17187.0
  yarn add @auto-canary/gh-pages@9.41.2-canary.1362.17187.0
  yarn add @auto-canary/git-tag@9.41.2-canary.1362.17187.0
  yarn add @auto-canary/gradle@9.41.2-canary.1362.17187.0
  yarn add @auto-canary/jira@9.41.2-canary.1362.17187.0
  yarn add @auto-canary/maven@9.41.2-canary.1362.17187.0
  yarn add @auto-canary/npm@9.41.2-canary.1362.17187.0
  yarn add @auto-canary/omit-commits@9.41.2-canary.1362.17187.0
  yarn add @auto-canary/omit-release-notes@9.41.2-canary.1362.17187.0
  yarn add @auto-canary/released@9.41.2-canary.1362.17187.0
  yarn add @auto-canary/s3@9.41.2-canary.1362.17187.0
  yarn add @auto-canary/slack@9.41.2-canary.1362.17187.0
  yarn add @auto-canary/twitter@9.41.2-canary.1362.17187.0
  yarn add @auto-canary/upload-assets@9.41.2-canary.1362.17187.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
