### PR TITLE
fix: prioritize base branch head ref

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -397,7 +397,7 @@ export default class Auto {
         this.logger.verbose.info("Branch:", currentBranch);
         this.logger.verbose.info("HEADs:", heads);
         const baseBranchHeadRef = new RegExp(
-          `^(w+)refs/heads/${this.baseBranch}$`
+          `^(\\w+)\\s+refs/heads/${this.baseBranch}$`
         );
         const [, remoteHead] = heads.match(baseBranchHeadRef) || [];
 

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -396,7 +396,10 @@ export default class Auto {
         ]);
         this.logger.verbose.info("Branch:", currentBranch);
         this.logger.verbose.info("HEADs:", heads);
-        const [, remoteHead] = heads.match(/^(\w+)?/) || [];
+        const baseBranchHeadRef = new RegExp(
+          `^(w+)refs/heads/${this.baseBranch}$`
+        );
+        const [, remoteHead] = heads.match(baseBranchHeadRef) || [];
 
         if (remoteHead) {
           // This will throw if the branch is ahead of the current branch


### PR DESCRIPTION
# What Changed

The regex was modified for searching for head branches in comparing if the current commit was the latest.

# Why

The current Regex would just grab the first head (`(\w+)`), regardless of it being a part of the base branch. This results in all commits being considered out-of-date if the HEAD ref chosen is not the base branch.

Todo:

- [ ] Add tests
- [ ] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.43.1-canary.1363.17210.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.43.1-canary.1363.17210.0
  npm install @auto-canary/auto@9.43.1-canary.1363.17210.0
  npm install @auto-canary/core@9.43.1-canary.1363.17210.0
  npm install @auto-canary/all-contributors@9.43.1-canary.1363.17210.0
  npm install @auto-canary/brew@9.43.1-canary.1363.17210.0
  npm install @auto-canary/chrome@9.43.1-canary.1363.17210.0
  npm install @auto-canary/cocoapods@9.43.1-canary.1363.17210.0
  npm install @auto-canary/conventional-commits@9.43.1-canary.1363.17210.0
  npm install @auto-canary/crates@9.43.1-canary.1363.17210.0
  npm install @auto-canary/exec@9.43.1-canary.1363.17210.0
  npm install @auto-canary/first-time-contributor@9.43.1-canary.1363.17210.0
  npm install @auto-canary/gem@9.43.1-canary.1363.17210.0
  npm install @auto-canary/gh-pages@9.43.1-canary.1363.17210.0
  npm install @auto-canary/git-tag@9.43.1-canary.1363.17210.0
  npm install @auto-canary/gradle@9.43.1-canary.1363.17210.0
  npm install @auto-canary/jira@9.43.1-canary.1363.17210.0
  npm install @auto-canary/maven@9.43.1-canary.1363.17210.0
  npm install @auto-canary/npm@9.43.1-canary.1363.17210.0
  npm install @auto-canary/omit-commits@9.43.1-canary.1363.17210.0
  npm install @auto-canary/omit-release-notes@9.43.1-canary.1363.17210.0
  npm install @auto-canary/released@9.43.1-canary.1363.17210.0
  npm install @auto-canary/s3@9.43.1-canary.1363.17210.0
  npm install @auto-canary/slack@9.43.1-canary.1363.17210.0
  npm install @auto-canary/twitter@9.43.1-canary.1363.17210.0
  npm install @auto-canary/upload-assets@9.43.1-canary.1363.17210.0
  # or 
  yarn add @auto-canary/bot-list@9.43.1-canary.1363.17210.0
  yarn add @auto-canary/auto@9.43.1-canary.1363.17210.0
  yarn add @auto-canary/core@9.43.1-canary.1363.17210.0
  yarn add @auto-canary/all-contributors@9.43.1-canary.1363.17210.0
  yarn add @auto-canary/brew@9.43.1-canary.1363.17210.0
  yarn add @auto-canary/chrome@9.43.1-canary.1363.17210.0
  yarn add @auto-canary/cocoapods@9.43.1-canary.1363.17210.0
  yarn add @auto-canary/conventional-commits@9.43.1-canary.1363.17210.0
  yarn add @auto-canary/crates@9.43.1-canary.1363.17210.0
  yarn add @auto-canary/exec@9.43.1-canary.1363.17210.0
  yarn add @auto-canary/first-time-contributor@9.43.1-canary.1363.17210.0
  yarn add @auto-canary/gem@9.43.1-canary.1363.17210.0
  yarn add @auto-canary/gh-pages@9.43.1-canary.1363.17210.0
  yarn add @auto-canary/git-tag@9.43.1-canary.1363.17210.0
  yarn add @auto-canary/gradle@9.43.1-canary.1363.17210.0
  yarn add @auto-canary/jira@9.43.1-canary.1363.17210.0
  yarn add @auto-canary/maven@9.43.1-canary.1363.17210.0
  yarn add @auto-canary/npm@9.43.1-canary.1363.17210.0
  yarn add @auto-canary/omit-commits@9.43.1-canary.1363.17210.0
  yarn add @auto-canary/omit-release-notes@9.43.1-canary.1363.17210.0
  yarn add @auto-canary/released@9.43.1-canary.1363.17210.0
  yarn add @auto-canary/s3@9.43.1-canary.1363.17210.0
  yarn add @auto-canary/slack@9.43.1-canary.1363.17210.0
  yarn add @auto-canary/twitter@9.43.1-canary.1363.17210.0
  yarn add @auto-canary/upload-assets@9.43.1-canary.1363.17210.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
