### PR TITLE
exit in CI when no valid git email + name found

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1923,6 +1923,24 @@ export default class Auto {
         await execPromise("git", ["config", "user.name", `"${user.name}"`]);
         this.logger.verbose.warn(`Set git name to ${user.name}`);
       }
+
+      if (!user.name && !user.email) {
+        this.logger.log.error(
+          endent`
+            Could find a git name and email to commit with!
+
+            Name: ${user.name}
+            Email: ${user.email}
+  
+            You must do one of the following: 
+  
+            - configure the author for your package manager (ex: set "author" in package.json)
+            - Set "name" and "email in your .autorc
+          `,
+          ""
+        );
+        process.exit(1);
+      }
     }
   }
 

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -823,7 +823,7 @@ export default class Git {
     return result;
   }
 
-  /** Create a release for the GitHub projecct */
+  /** Create a release for the GitHub project */
   async publish(releaseNotes: string, tag: string, prerelease = false) {
     this.logger.verbose.info("Creating release on GitHub for tag:", tag);
 


### PR DESCRIPTION
# What Changed

See title

# Why

makes #1366 harder to happen

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.43.2-canary.1369.17241.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.43.2-canary.1369.17241.0
  npm install @auto-canary/auto@9.43.2-canary.1369.17241.0
  npm install @auto-canary/core@9.43.2-canary.1369.17241.0
  npm install @auto-canary/all-contributors@9.43.2-canary.1369.17241.0
  npm install @auto-canary/brew@9.43.2-canary.1369.17241.0
  npm install @auto-canary/chrome@9.43.2-canary.1369.17241.0
  npm install @auto-canary/cocoapods@9.43.2-canary.1369.17241.0
  npm install @auto-canary/conventional-commits@9.43.2-canary.1369.17241.0
  npm install @auto-canary/crates@9.43.2-canary.1369.17241.0
  npm install @auto-canary/exec@9.43.2-canary.1369.17241.0
  npm install @auto-canary/first-time-contributor@9.43.2-canary.1369.17241.0
  npm install @auto-canary/gem@9.43.2-canary.1369.17241.0
  npm install @auto-canary/gh-pages@9.43.2-canary.1369.17241.0
  npm install @auto-canary/git-tag@9.43.2-canary.1369.17241.0
  npm install @auto-canary/gradle@9.43.2-canary.1369.17241.0
  npm install @auto-canary/jira@9.43.2-canary.1369.17241.0
  npm install @auto-canary/maven@9.43.2-canary.1369.17241.0
  npm install @auto-canary/npm@9.43.2-canary.1369.17241.0
  npm install @auto-canary/omit-commits@9.43.2-canary.1369.17241.0
  npm install @auto-canary/omit-release-notes@9.43.2-canary.1369.17241.0
  npm install @auto-canary/released@9.43.2-canary.1369.17241.0
  npm install @auto-canary/s3@9.43.2-canary.1369.17241.0
  npm install @auto-canary/slack@9.43.2-canary.1369.17241.0
  npm install @auto-canary/twitter@9.43.2-canary.1369.17241.0
  npm install @auto-canary/upload-assets@9.43.2-canary.1369.17241.0
  # or 
  yarn add @auto-canary/bot-list@9.43.2-canary.1369.17241.0
  yarn add @auto-canary/auto@9.43.2-canary.1369.17241.0
  yarn add @auto-canary/core@9.43.2-canary.1369.17241.0
  yarn add @auto-canary/all-contributors@9.43.2-canary.1369.17241.0
  yarn add @auto-canary/brew@9.43.2-canary.1369.17241.0
  yarn add @auto-canary/chrome@9.43.2-canary.1369.17241.0
  yarn add @auto-canary/cocoapods@9.43.2-canary.1369.17241.0
  yarn add @auto-canary/conventional-commits@9.43.2-canary.1369.17241.0
  yarn add @auto-canary/crates@9.43.2-canary.1369.17241.0
  yarn add @auto-canary/exec@9.43.2-canary.1369.17241.0
  yarn add @auto-canary/first-time-contributor@9.43.2-canary.1369.17241.0
  yarn add @auto-canary/gem@9.43.2-canary.1369.17241.0
  yarn add @auto-canary/gh-pages@9.43.2-canary.1369.17241.0
  yarn add @auto-canary/git-tag@9.43.2-canary.1369.17241.0
  yarn add @auto-canary/gradle@9.43.2-canary.1369.17241.0
  yarn add @auto-canary/jira@9.43.2-canary.1369.17241.0
  yarn add @auto-canary/maven@9.43.2-canary.1369.17241.0
  yarn add @auto-canary/npm@9.43.2-canary.1369.17241.0
  yarn add @auto-canary/omit-commits@9.43.2-canary.1369.17241.0
  yarn add @auto-canary/omit-release-notes@9.43.2-canary.1369.17241.0
  yarn add @auto-canary/released@9.43.2-canary.1369.17241.0
  yarn add @auto-canary/s3@9.43.2-canary.1369.17241.0
  yarn add @auto-canary/slack@9.43.2-canary.1369.17241.0
  yarn add @auto-canary/twitter@9.43.2-canary.1369.17241.0
  yarn add @auto-canary/upload-assets@9.43.2-canary.1369.17241.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
