### PR TITLE
add .autorc "author" option that combines email + name

### DIFF
--- a/docs/pages/docs/configuration/autorc.mdx
+++ b/docs/pages/docs/configuration/autorc.mdx
@@ -78,9 +78,32 @@ If you are using enterprise github and your company hosts the graphql at some ot
 }
 ```
 
+### author
+
+The name and email to use with git.
+
+```json
+{
+  "author": "Joe Schmo <joe@schmo.com>"
+}
+```
+
+or
+
+```json
+{
+  "author": {
+    "name": "Joe Schmo",
+    "email": "joe@schmo.com"
+  }
+}
+```
+
 ### name
 
 Name to use with git.
+
+> NOTE: Will be deprecated in v10
 
 ```json
 {
@@ -91,6 +114,8 @@ Name to use with git.
 ### email
 
 Email to use with git.
+
+> NOTE: Will be deprecated in v10
 
 ```json
 {

--- a/docs/pages/docs/configuration/non-npm.mdx
+++ b/docs/pages/docs/configuration/non-npm.mdx
@@ -46,8 +46,7 @@ Using `auto` with any other package manager than [npm](https://npmjs.com) requir
 
    ```json
    {
-     "name": "Andrew Lisowski",
-     "email": "lisowski54@gmail.com",
+     "author": "Andrew Lisowski <lisowski54@gmail.com>",
      "plugins": []
    }
    ```
@@ -56,13 +55,12 @@ Using `auto` with any other package manager than [npm](https://npmjs.com) requir
 
    ```json
    {
-     "name": "Andrew Lisowski",
-     "email": "lisowski54@gmail.com",
+     "author": "Andrew Lisowski <lisowski54@gmail.com>",
      "plugins": ["git-tag"]
    }
    ```
 
-3. `.autorc` - With package manager plugin. [`shipit`](https://intuit.github.io/auto/pages/generated/shipit.html) works, some configuration picked up from package manager package definition files. In the following `repo`, `owner`, `name`, and `email` are picked up from the `pom.xml`
+3. `.autorc` - With package manager plugin. [`shipit`](https://intuit.github.io/auto/pages/generated/shipit.html) works, some configuration picked up from package manager package definition files. In the following `repo`, `owner`, and `author` are picked up from the `pom.xml`
 
    ```json
    {

--- a/packages/cli/__tests__/main.test.ts
+++ b/packages/cli/__tests__/main.test.ts
@@ -6,7 +6,8 @@ test("throws error for unknown args", async () => {
   process.exit = jest.fn() as any;
   console.log = jest.fn() as any;
 
-  await run("foo", {});
+  // @ts-ignore
+  await run("foo", { foo: 123 });
 
   expect(process.exit).toHaveBeenCalledWith(1);
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -62,6 +62,7 @@
     "lodash.chunk": "^4.2.0",
     "log-symbols": "^4.0.0",
     "node-fetch": "2.6.0",
+    "parse-author": "^2.0.0",
     "parse-github-url": "1.0.2",
     "semver": "^7.0.0",
     "signale": "^1.4.0",

--- a/packages/core/src/__tests__/auto-git-user-in-ci.test.ts
+++ b/packages/core/src/__tests__/auto-git-user-in-ci.test.ts
@@ -1,0 +1,46 @@
+import Auto from "../auto";
+import execPromise from "../utils/exec-promise";
+
+const exec = jest.fn();
+jest.mock("../utils/exec-promise");
+// @ts-ignore
+execPromise.mockImplementation(exec);
+exec.mockImplementation(() => {
+  throw new Error();
+});
+
+jest.mock("env-ci", () => () => ({
+  isCi: true,
+}));
+
+const defaults = {
+  owner: "foo",
+  repo: "bar",
+};
+
+test("parses string author in config", async () => {
+  const auto = new Auto({ ...defaults, plugins: [] });
+
+  // @ts-ignore
+  auto.config = { author: "Andrew <andrew@mail.com>" };
+
+  // @ts-ignore
+  expect(await auto.getGitUser()).toStrictEqual({
+    name: "Andrew",
+    email: "andrew@mail.com",
+  });
+});
+
+test("parses object author in config", async () => {
+  const auto = new Auto({ ...defaults, plugins: [] });
+  const author = {
+    name: "Andrew",
+    email: "andrew@mail.com",
+  };
+
+  // @ts-ignore
+  auto.config = { author };
+
+  // @ts-ignore
+  expect(await auto.getGitUser()).toStrictEqual(author);
+});

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -6,6 +6,7 @@ import path from "path";
 import link from "terminal-link";
 import icons from "log-symbols";
 import chalk from "chalk";
+import parseAuthor from "parse-author";
 import { gt, lte, compareBuild, inc, parse, ReleaseType, major } from "semver";
 import {
   AsyncParallelHook,
@@ -1876,11 +1877,35 @@ export default class Auto {
         "Could not find git user or email configured in git config"
       );
 
-      if (!this.release) {
-        return;
+      const { author } = this.config || {};
+      let { email, name } = this.config || {};
+
+      if (author) {
+        const parsedAuthor =
+          typeof author === "string" ? parseAuthor(author) : author;
+
+        if (
+          typeof parsedAuthor === "object" &&
+          parsedAuthor.email &&
+          parsedAuthor.name
+        ) {
+          ({ name, email } = parsedAuthor);
+        } else {
+          this.logger.log.error(endent`
+            .autorc author parsing failed!
+  
+            The author must either be in one of the following formats:
+  
+            1. Your Name <your_email@mail.com>
+            2. An object with "name" and "email"
+  
+            But you supplied:
+  
+            ${author}
+          `);
+        }
       }
 
-      let { email, name } = this.release.config;
       this.logger.verbose.warn(
         `Got author from options: email: ${email}, name ${name}`
       );

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -3,6 +3,8 @@ import * as t from "io-ts";
 import { labelDefinition } from "./release";
 
 const author = t.partial({
+  /** The name and email of the author to make commits with */
+  author: t.string,
   /** The name of the author to make commits with */
   name: t.string,
   /** The email of the author to make commits with */


### PR DESCRIPTION
# What Changed

Add a new config option to replace `email` and `name`.

Thinking about deprecating `email` and `name` in v10 #1156 

# Why

Every time I see `email` and `name` in an `.autorc` I cringe. an `author` field is better DX. having these options in the autorc is a remnant of the past when an `.autorc` could have any flag at the root of the object

Todo:

- [ ] Add tests
- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.43.3-canary.1370.17258.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.43.3-canary.1370.17258.0
  npm install @auto-canary/auto@9.43.3-canary.1370.17258.0
  npm install @auto-canary/core@9.43.3-canary.1370.17258.0
  npm install @auto-canary/all-contributors@9.43.3-canary.1370.17258.0
  npm install @auto-canary/brew@9.43.3-canary.1370.17258.0
  npm install @auto-canary/chrome@9.43.3-canary.1370.17258.0
  npm install @auto-canary/cocoapods@9.43.3-canary.1370.17258.0
  npm install @auto-canary/conventional-commits@9.43.3-canary.1370.17258.0
  npm install @auto-canary/crates@9.43.3-canary.1370.17258.0
  npm install @auto-canary/exec@9.43.3-canary.1370.17258.0
  npm install @auto-canary/first-time-contributor@9.43.3-canary.1370.17258.0
  npm install @auto-canary/gem@9.43.3-canary.1370.17258.0
  npm install @auto-canary/gh-pages@9.43.3-canary.1370.17258.0
  npm install @auto-canary/git-tag@9.43.3-canary.1370.17258.0
  npm install @auto-canary/gradle@9.43.3-canary.1370.17258.0
  npm install @auto-canary/jira@9.43.3-canary.1370.17258.0
  npm install @auto-canary/maven@9.43.3-canary.1370.17258.0
  npm install @auto-canary/npm@9.43.3-canary.1370.17258.0
  npm install @auto-canary/omit-commits@9.43.3-canary.1370.17258.0
  npm install @auto-canary/omit-release-notes@9.43.3-canary.1370.17258.0
  npm install @auto-canary/released@9.43.3-canary.1370.17258.0
  npm install @auto-canary/s3@9.43.3-canary.1370.17258.0
  npm install @auto-canary/slack@9.43.3-canary.1370.17258.0
  npm install @auto-canary/twitter@9.43.3-canary.1370.17258.0
  npm install @auto-canary/upload-assets@9.43.3-canary.1370.17258.0
  # or 
  yarn add @auto-canary/bot-list@9.43.3-canary.1370.17258.0
  yarn add @auto-canary/auto@9.43.3-canary.1370.17258.0
  yarn add @auto-canary/core@9.43.3-canary.1370.17258.0
  yarn add @auto-canary/all-contributors@9.43.3-canary.1370.17258.0
  yarn add @auto-canary/brew@9.43.3-canary.1370.17258.0
  yarn add @auto-canary/chrome@9.43.3-canary.1370.17258.0
  yarn add @auto-canary/cocoapods@9.43.3-canary.1370.17258.0
  yarn add @auto-canary/conventional-commits@9.43.3-canary.1370.17258.0
  yarn add @auto-canary/crates@9.43.3-canary.1370.17258.0
  yarn add @auto-canary/exec@9.43.3-canary.1370.17258.0
  yarn add @auto-canary/first-time-contributor@9.43.3-canary.1370.17258.0
  yarn add @auto-canary/gem@9.43.3-canary.1370.17258.0
  yarn add @auto-canary/gh-pages@9.43.3-canary.1370.17258.0
  yarn add @auto-canary/git-tag@9.43.3-canary.1370.17258.0
  yarn add @auto-canary/gradle@9.43.3-canary.1370.17258.0
  yarn add @auto-canary/jira@9.43.3-canary.1370.17258.0
  yarn add @auto-canary/maven@9.43.3-canary.1370.17258.0
  yarn add @auto-canary/npm@9.43.3-canary.1370.17258.0
  yarn add @auto-canary/omit-commits@9.43.3-canary.1370.17258.0
  yarn add @auto-canary/omit-release-notes@9.43.3-canary.1370.17258.0
  yarn add @auto-canary/released@9.43.3-canary.1370.17258.0
  yarn add @auto-canary/s3@9.43.3-canary.1370.17258.0
  yarn add @auto-canary/slack@9.43.3-canary.1370.17258.0
  yarn add @auto-canary/twitter@9.43.3-canary.1370.17258.0
  yarn add @auto-canary/upload-assets@9.43.3-canary.1370.17258.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
