### PR TITLE
allow default SEMVER label to be configured

### DIFF
--- a/docs/pages/docs/configuration/autorc.mdx
+++ b/docs/pages/docs/configuration/autorc.mdx
@@ -243,6 +243,7 @@ You can customize everything about a label
 - `overwrite` - Overwrite the default label(s) associated with the `releaseType`. (default: `false`)
 - `changelogTitle` - The title to use in the changelog
 - `description` - The description to use when creating the label
+- `default` - Marks this label as the default label for unlabelled PRs (`patch` is the default "default label")
 - `color` - The color of the label. Can be specified as a string in any of [these](https://github.com/bgrins/TinyColor#accepted-string-input) ways. If not specified the color is random
 
 ```json

--- a/packages/core/src/__tests__/__snapshots__/changelog.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/changelog.test.ts.snap
@@ -192,6 +192,17 @@ exports[`generateReleaseNotes should include PR-less commits as patches 1`] = `
 - Adam Dierkens (adam@dierkens.com)"
 `;
 
+exports[`generateReleaseNotes should include PR-less commits as the default label 1`] = `
+"#### 🚀 Enhancement
+
+- I was a push to master (adam@dierkens.com)
+- First Feature [#1235](https://github.custom.com/foobar/auto/pull/1235) (adam@dierkens.com)
+
+#### Authors: 1
+
+- Adam Dierkens (adam@dierkens.com)"
+`;
+
 exports[`generateReleaseNotes should include prs with released label 1`] = `
 "#### 🐛 Bug Fix
 

--- a/packages/core/src/__tests__/changelog.test.ts
+++ b/packages/core/src/__tests__/changelog.test.ts
@@ -1,11 +1,10 @@
 import endent from "endent";
 import Changelog, { IGenerateReleaseNotesOptions } from "../changelog";
 import LogParse from "../log-parse";
-import { defaultLabels } from "../release";
 import { dummyLog } from "../utils/logger";
 
 import makeCommitFromMsg from "./make-commit-from-msg";
-import SEMVER from "../semver";
+import SEMVER, { defaultLabels } from "../semver";
 import { getCurrentBranch } from "../utils/get-current-branch";
 
 const currentBranchSpy = getCurrentBranch as jest.Mock;
@@ -348,6 +347,36 @@ describe("generateReleaseNotes", () => {
         authorEmail: "adam@dierkens.com",
         subject: "I was a push to master\n\nfoo bar",
         labels: ["pushToBaseBranch"],
+      },
+      {
+        hash: "2",
+        files: [],
+        authorName: "Adam Dierkens",
+        authorEmail: "adam@dierkens.com",
+        subject: "First Feature (#1235)",
+        labels: ["minor"],
+      },
+    ]);
+
+    expect(await changelog.generateReleaseNotes(commits)).toMatchSnapshot();
+  });
+
+  test("should include PR-less commits as the default label", async () => {
+    const options = testOptions();
+    options.labels[1] = {
+      ...options.labels[1],
+      default: true,
+    };
+    const changelog = new Changelog(dummyLog(), options);
+    changelog.loadDefaultHooks();
+
+    const commits = await logParse.normalizeCommits([
+      {
+        hash: "1",
+        files: [],
+        authorName: "Adam Dierkens",
+        authorEmail: "adam@dierkens.com",
+        subject: "I was a push to master\n\nfoo bar",
       },
       {
         hash: "2",

--- a/packages/core/src/__tests__/config.test.ts
+++ b/packages/core/src/__tests__/config.test.ts
@@ -1,7 +1,6 @@
 import Config, { normalizeLabel, normalizeLabels } from "../config";
 import { dummyLog } from "../utils/logger";
-import SEMVER from "../semver";
-import { ILabelDefinition } from "../release";
+import SEMVER, { ILabelDefinition } from "../semver";
 
 const fetchSpy = jest.fn();
 

--- a/packages/core/src/__tests__/release.test.ts
+++ b/packages/core/src/__tests__/release.test.ts
@@ -1,11 +1,7 @@
 import Git from "../git";
 import LogParse from "../log-parse";
-import Release, {
-  defaultLabels,
-  getVersionMap,
-  ILabelDefinition,
-} from "../release";
-import SEMVER from "../semver";
+import Release, { getVersionMap } from "../release";
+import SEMVER, { defaultLabels, ILabelDefinition } from "../semver";
 import { dummyLog } from "../utils/logger";
 import makeCommitFromMsg from "./make-commit-from-msg";
 import child from "child_process";

--- a/packages/core/src/__tests__/semver.test.ts
+++ b/packages/core/src/__tests__/semver.test.ts
@@ -1,5 +1,9 @@
-import { getVersionMap, defaultLabels } from "../release";
-import SEMVER, { calculateSemVerBump, getHigherSemverTag } from "../semver";
+import { getVersionMap } from "../release";
+import SEMVER, {
+  calculateSemVerBump,
+  getHigherSemverTag,
+  defaultLabels,
+} from "../semver";
 
 const semverMap = getVersionMap([
   ...defaultLabels,
@@ -42,6 +46,14 @@ describe("calculateSemVerBump", () => {
     expect(calculateSemVerBump([[], ["documentation"]], semverMap)).toBe(
       SEMVER.patch
     );
+  });
+
+  test("should be able to configure default label", () => {
+    expect(
+      calculateSemVerBump([[], ["documentation"]], semverMap, {
+        labels: [{ default: true, name: "minor", releaseType: SEMVER.minor }],
+      })
+    ).toBe(SEMVER.minor);
   });
 
   test("should not skip things before none", () => {

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -43,8 +43,12 @@ import Config from "./config";
 import Git, { IGitOptions, IPRInfo } from "./git";
 import InteractiveInit from "./init";
 import LogParse, { IExtendedCommit } from "./log-parse";
-import Release, { getVersionMap, ILabelDefinition } from "./release";
-import SEMVER, { calculateSemVerBump, IVersionLabels } from "./semver";
+import Release, { getVersionMap } from "./release";
+import SEMVER, {
+  calculateSemVerBump,
+  IVersionLabels,
+  ILabelDefinition,
+} from "./semver";
 import execPromise from "./utils/exec-promise";
 import { loadPlugin, IPlugin, listPlugins } from "./utils/load-plugins";
 import createLog, { ILogger, setLogLevel } from "./utils/logger";
@@ -2099,8 +2103,7 @@ export { IPlugin } from "./utils/load-plugins";
 export { ICommitAuthor, IExtendedCommit } from "./log-parse";
 
 export { default as Auto } from "./auto";
-export { default as SEMVER } from "./semver";
+export { default as SEMVER, VersionLabel } from "./semver";
 export { default as execPromise } from "./utils/exec-promise";
 export { default as getLernaPackages } from "./utils/get-lerna-packages";
 export { default as inFolder } from "./utils/in-folder";
-export { VersionLabel } from "./release";

--- a/packages/core/src/changelog.ts
+++ b/packages/core/src/changelog.ts
@@ -4,7 +4,7 @@ import join from "url-join";
 import botList from "@auto-it/bot-list";
 
 import { ICommitAuthor, IExtendedCommit } from "./log-parse";
-import { ILabelDefinition } from "./release";
+import { ILabelDefinition } from "./semver";
 import { ILogger } from "./utils/logger";
 import { makeChangelogHooks } from "./utils/make-hooks";
 import { getCurrentBranch } from "./utils/get-current-branch";
@@ -208,10 +208,10 @@ export default class Changelog {
       })
       .reduce<ILabelDefinition[]>((acc, item) => [...acc, item], []);
 
-    const defaultPatchLabelName = this.getFirstLabelNameFromLabelKey(
-      this.options.labels,
-      "patch"
-    );
+    const defaultPatchLabelName =
+      this.options.labels.find((l) => l.default)?.name ||
+      this.options.labels.find((l) => l.releaseType === "patch")?.name ||
+      "patch";
 
     commits
       .filter(
@@ -236,14 +236,6 @@ export default class Changelog {
           : { [label.name]: matchedCommits };
       })
     );
-  }
-
-  /** Get the default label for a label key */
-  private getFirstLabelNameFromLabelKey(
-    labels: ILabelDefinition[],
-    labelKey: string
-  ) {
-    return labels.find((l) => l.releaseType === labelKey)?.name || labelKey;
   }
 
   /** Create a list of users */

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -3,10 +3,11 @@ import merge from "deepmerge";
 import fetch from "node-fetch";
 import * as path from "path";
 
-import { defaultLabels, getVersionMap, ILabelDefinition } from "./release";
+import { getVersionMap } from "./release";
 import { ILogger } from "./utils/logger";
 import tryRequire from "./utils/try-require";
 import endent from "endent";
+import { ILabelDefinition, defaultLabels } from "./semver";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ConfigObject = any;
@@ -90,7 +91,8 @@ export default class Config {
       labels,
       prereleaseBranches: rawConfig.prereleaseBranches || ["next"],
       versionBranches:
-        typeof rawConfig.versionBranches === "boolean" && rawConfig.versionBranches
+        typeof rawConfig.versionBranches === "boolean" &&
+        rawConfig.versionBranches
           ? "version-"
           : rawConfig.versionBranches,
     };

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -10,14 +10,14 @@ import tinyColor from "tinycolor2";
 import endent from "endent";
 import on from "await-to-js";
 import join from "url-join";
+import { gt, lt } from "semver";
 
 import { Memoize as memoize } from "typescript-memoize";
 
-import { ILabelDefinition } from "./release";
+import { ILabelDefinition } from "./semver";
 import verifyAuth from "./utils/verify-auth";
 import execPromise from "./utils/exec-promise";
 import { dummyLog, ILogger } from "./utils/logger";
-import { gt, lt } from "semver";
 import { ICommit } from "./log-parse";
 import { buildSearchQuery, ISearchQuery } from "./match-sha-to-pr";
 

--- a/packages/core/src/init.ts
+++ b/packages/core/src/init.ts
@@ -5,8 +5,7 @@ import { prompt } from "enquirer";
 import { AsyncSeriesBailHook, AsyncSeriesWaterfallHook } from "tapable";
 
 import { makeInteractiveInitHooks } from "./utils/make-hooks";
-import { defaultLabels, ILabelDefinition } from "./release";
-import SEMVER from "./semver";
+import SEMVER, { defaultLabels, ILabelDefinition } from "./semver";
 import { loadPlugin } from "./utils/load-plugins";
 import { ILogger } from "./utils/logger";
 import { readFileSync, writeFileSync } from "fs";

--- a/packages/core/src/match-sha-to-pr.ts
+++ b/packages/core/src/match-sha-to-pr.ts
@@ -1,7 +1,7 @@
 import endent from "endent";
 
 import { IExtendedCommit } from "./log-parse";
-import { ILabelDefinition } from "./release";
+import { ILabelDefinition } from "./semver";
 
 interface ISearchEdge {
   /** Graphql search node */

--- a/packages/core/src/release.ts
+++ b/packages/core/src/release.ts
@@ -4,7 +4,6 @@ import * as fs from "fs";
 import chunk from "lodash.chunk";
 import { inc, ReleaseType } from "semver";
 import { promisify } from "util";
-import * as t from "io-ts";
 
 import { AsyncSeriesBailHook, SyncHook } from "tapable";
 import { Memoize as memoize } from "typescript-memoize";
@@ -12,7 +11,13 @@ import { ICreateLabelsOptions } from "./auto-args";
 import Changelog from "./changelog";
 import Git from "./git";
 import LogParse, { ICommitAuthor, IExtendedCommit } from "./log-parse";
-import SEMVER, { calculateSemVerBump, IVersionLabels } from "./semver";
+import SEMVER, {
+  calculateSemVerBump,
+  IVersionLabels,
+  isVersionLabel,
+  ILabelDefinition,
+  defaultLabels,
+} from "./semver";
 import execPromise from "./utils/exec-promise";
 import { dummyLog, ILogger } from "./utils/logger";
 import { makeReleaseHooks } from "./utils/make-hooks";
@@ -24,124 +29,6 @@ import {
   ISearchQuery,
 } from "./match-sha-to-pr";
 import { LoadedAutoRc } from "./types";
-
-export type VersionLabel =
-  | SEMVER.major
-  | SEMVER.minor
-  | SEMVER.patch
-  | "skip"
-  | "release";
-
-export const releaseLabels: VersionLabel[] = [
-  SEMVER.major,
-  SEMVER.minor,
-  SEMVER.patch,
-  "skip",
-  "release",
-];
-
-/** Determine if a label is a label used for versioning */
-export const isVersionLabel = (label: string): label is VersionLabel =>
-  releaseLabels.includes(label as VersionLabel);
-
-const labelDefinitionRequired = t.type({
-  /** The label text */
-  name: t.string,
-});
-
-const labelDefinitionOptional = t.partial({
-  /** A title to put in the changelog for the label */
-  changelogTitle: t.string,
-  /** The color of the label */
-  color: t.string,
-  /** The description of the label */
-  description: t.string,
-  /** What type of release this label signifies */
-  releaseType: t.union([
-    t.literal("none"),
-    t.literal("skip"),
-    ...releaseLabels.map((l) => t.literal(l)),
-  ]),
-  /** Whether to overwrite the base label */
-  overwrite: t.boolean,
-});
-
-export const labelDefinition = t.intersection([
-  labelDefinitionOptional,
-  labelDefinitionRequired,
-]);
-export type ILabelDefinition = t.TypeOf<typeof labelDefinition>;
-
-export const defaultLabels: ILabelDefinition[] = [
-  {
-    name: "major",
-    changelogTitle: "💥 Breaking Change",
-    description: "Increment the major version when merged",
-    releaseType: SEMVER.major,
-    color: "#C5000B",
-  },
-  {
-    name: "minor",
-    changelogTitle: "🚀 Enhancement",
-    description: "Increment the minor version when merged",
-    releaseType: SEMVER.minor,
-    color: "#F1A60E",
-  },
-  {
-    name: "patch",
-    changelogTitle: "🐛 Bug Fix",
-    description: "Increment the patch version when merged",
-    releaseType: SEMVER.patch,
-    color: "#870048",
-  },
-  {
-    name: "skip-release",
-    description: "Preserve the current version when merged",
-    releaseType: "skip",
-    color: "#bf5416",
-  },
-  {
-    name: "release",
-    description: "Create a release when this pr is merged",
-    releaseType: "release",
-    color: "#007f70",
-  },
-  {
-    name: "internal",
-    changelogTitle: "🏠 Internal",
-    description: "Changes only affect the internal API",
-    releaseType: "none",
-    color: "#696969",
-  },
-  {
-    name: "documentation",
-    changelogTitle: "📝 Documentation",
-    description: "Changes only affect the documentation",
-    releaseType: "none",
-    color: "#cfd3d7",
-  },
-  {
-    name: "tests",
-    changelogTitle: "🧪 Tests",
-    description: "Add or improve existing tests",
-    releaseType: "none",
-    color: "#ffd3cc",
-  },
-  {
-    name: "dependencies",
-    changelogTitle: "🔩 Dependency Updates",
-    description: "Update one or more dependencies version",
-    releaseType: "none",
-    color: "#8732bc",
-  },
-  {
-    name: "performance",
-    changelogTitle: "🏎 Performance",
-    description: "Improve performance of an existing feature",
-    releaseType: SEMVER.patch,
-    color: "#f4b2d8",
-  },
-];
 
 /** Construct a map of label => semver label */
 export const getVersionMap = (labels = defaultLabels) =>
@@ -528,7 +415,10 @@ export default class Release {
       options,
     });
 
-    const result = calculateSemVerBump(labels, this.versionLabels, options);
+    const result = calculateSemVerBump(labels, this.versionLabels, {
+      ...this.config,
+      ...options,
+    });
 
     this.logger.verbose.success("Calculated SEMVER bump:", result);
 

--- a/packages/core/src/semver.ts
+++ b/packages/core/src/semver.ts
@@ -1,5 +1,12 @@
-import { VersionLabel } from "./release";
 import { ReleaseCalculationOptions } from "./types";
+import * as t from "io-ts";
+
+export type VersionLabel =
+  | SEMVER.major
+  | SEMVER.minor
+  | SEMVER.patch
+  | "skip"
+  | "release";
 
 enum SEMVER {
   major = "major",
@@ -21,6 +28,119 @@ export type IVersionLabels = Map<VersionLabel | "none", string[]>;
 
 export default SEMVER;
 
+export const releaseLabels: VersionLabel[] = [
+  SEMVER.major,
+  SEMVER.minor,
+  SEMVER.patch,
+  "skip",
+  "release",
+];
+
+/** Determine if a label is a label used for versioning */
+export const isVersionLabel = (label: string): label is VersionLabel =>
+  releaseLabels.includes(label as VersionLabel);
+
+const labelDefinitionRequired = t.type({
+  /** The label text */
+  name: t.string,
+});
+
+const labelDefinitionOptional = t.partial({
+  /** A title to put in the changelog for the label */
+  changelogTitle: t.string,
+  /** The color of the label */
+  color: t.string,
+  /** The description of the label */
+  description: t.string,
+  /** What type of release this label signifies */
+  releaseType: t.union([
+    t.literal("none"),
+    t.literal("skip"),
+    ...releaseLabels.map((l) => t.literal(l)),
+  ]),
+  /** Whether to overwrite the base label */
+  overwrite: t.boolean,
+  /** Marks this label as the default label for unlabelled PRs */
+  default: t.boolean,
+});
+
+export const labelDefinition = t.intersection([
+  labelDefinitionOptional,
+  labelDefinitionRequired,
+]);
+export type ILabelDefinition = t.TypeOf<typeof labelDefinition>;
+
+export const defaultLabels: ILabelDefinition[] = [
+  {
+    name: "major",
+    changelogTitle: "💥 Breaking Change",
+    description: "Increment the major version when merged",
+    releaseType: SEMVER.major,
+    color: "#C5000B",
+  },
+  {
+    name: "minor",
+    changelogTitle: "🚀 Enhancement",
+    description: "Increment the minor version when merged",
+    releaseType: SEMVER.minor,
+    color: "#F1A60E",
+  },
+  {
+    name: "patch",
+    changelogTitle: "🐛 Bug Fix",
+    description: "Increment the patch version when merged",
+    releaseType: SEMVER.patch,
+    color: "#870048",
+  },
+  {
+    name: "skip-release",
+    description: "Preserve the current version when merged",
+    releaseType: "skip",
+    color: "#bf5416",
+  },
+  {
+    name: "release",
+    description: "Create a release when this pr is merged",
+    releaseType: "release",
+    color: "#007f70",
+  },
+  {
+    name: "internal",
+    changelogTitle: "🏠 Internal",
+    description: "Changes only affect the internal API",
+    releaseType: "none",
+    color: "#696969",
+  },
+  {
+    name: "documentation",
+    changelogTitle: "📝 Documentation",
+    description: "Changes only affect the documentation",
+    releaseType: "none",
+    color: "#cfd3d7",
+  },
+  {
+    name: "tests",
+    changelogTitle: "🧪 Tests",
+    description: "Add or improve existing tests",
+    releaseType: "none",
+    color: "#ffd3cc",
+  },
+  {
+    name: "dependencies",
+    changelogTitle: "🔩 Dependency Updates",
+    description: "Update one or more dependencies version",
+    releaseType: "none",
+    color: "#8732bc",
+  },
+  {
+    name: "performance",
+    changelogTitle: "🏎 Performance",
+    description: "Improve performance of an existing feature",
+    releaseType: SEMVER.patch,
+    color: "#f4b2d8",
+  },
+];
+
 /** Given two labels determine the next SEMVER bump. */
 export function getHigherSemverTag(left: SEMVER, right: string): SEMVER {
   if (left === SEMVER.major || right === SEMVER.major) {
@@ -40,17 +160,25 @@ export function getHigherSemverTag(left: SEMVER, right: string): SEMVER {
  * strategy.
  */
 export function calculateSemVerBump(
-  labels: string[][],
+  prLabels: string[][],
   labelMap: IVersionLabels,
-  { onlyPublishWithReleaseLabel }: ReleaseCalculationOptions = {}
+  {
+    onlyPublishWithReleaseLabel,
+    labels = defaultLabels,
+  }: ReleaseCalculationOptions & {
+    /** The project's labels */
+    labels?: ILabelDefinition[];
+  } = {}
 ) {
+  const defaultLabel =
+    labels.find((l) => l.default)?.releaseType || SEMVER.patch;
   const labelSet = new Set<string>();
   const skipReleaseLabels = labelMap.get("skip") || [];
 
-  labels.forEach((pr, index) => {
+  prLabels.forEach((pr, index) => {
     // If the head pr has no labels we default to a patch
     if (pr.length === 0 && index === 0) {
-      labelSet.add(SEMVER.patch);
+      labelSet.add(defaultLabel);
     }
 
     pr.forEach((label) => {
@@ -64,7 +192,7 @@ export function calculateSemVerBump(
     });
   });
 
-  const lastMergedCommitLabels = labels[0] || [];
+  const lastMergedCommitLabels = prLabels[0] || [];
   const releaseLabels = labelMap.get("release") || [];
   const skipRelease = onlyPublishWithReleaseLabel
     ? !lastMergedCommitLabels.some((label) => releaseLabels.includes(label))

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,6 +1,6 @@
 import * as t from "io-ts";
 
-import { labelDefinition } from "./release";
+import { labelDefinition } from "./semver";
 
 const author = t.partial({
   /** The name and email of the author to make commits with */

--- a/plugins/conventional-commits/__tests__/conventional-commits.test.ts
+++ b/plugins/conventional-commits/__tests__/conventional-commits.test.ts
@@ -2,10 +2,8 @@ import Auto from "@auto-it/core";
 import makeCommitFromMsg from "@auto-it/core/dist/__tests__/make-commit-from-msg";
 import Git from "@auto-it/core/dist/git";
 import LogParse from "@auto-it/core/dist/log-parse";
-import Release, {
-  defaultLabels,
-  getVersionMap,
-} from "@auto-it/core/dist/release";
+import Release, { getVersionMap } from "@auto-it/core/dist/release";
+import { defaultLabels } from "@auto-it/core/dist/semver";
 import { dummyLog } from "@auto-it/core/dist/utils/logger";
 import {
   makeHooks,

--- a/plugins/jira/__tests__/jira.test.ts
+++ b/plugins/jira/__tests__/jira.test.ts
@@ -4,7 +4,7 @@ import Changelog, {
   IGenerateReleaseNotesOptions,
 } from "@auto-it/core/dist/changelog";
 import LogParse from "@auto-it/core/dist/log-parse";
-import { defaultLabels } from "@auto-it/core/dist/release";
+import { defaultLabels } from "@auto-it/core/dist/semver";
 import { dummyLog } from "@auto-it/core/dist/utils/logger";
 import {
   makeChangelogHooks,

--- a/plugins/npm/__tests__/monorepo-log.test.ts
+++ b/plugins/npm/__tests__/monorepo-log.test.ts
@@ -4,7 +4,7 @@ import * as Auto from "@auto-it/core";
 import makeCommitFromMsg from "@auto-it/core/dist/__tests__/make-commit-from-msg";
 import Changelog from "@auto-it/core/dist/changelog";
 import LogParse from "@auto-it/core/dist/log-parse";
-import { defaultLabels } from "@auto-it/core/dist/release";
+import { defaultLabels } from "@auto-it/core/dist/semver";
 import { dummyLog } from "@auto-it/core/dist/utils/logger";
 import { makeHooks } from "@auto-it/core/dist/utils/make-hooks";
 

--- a/plugins/released/__tests__/released-label.test.ts
+++ b/plugins/released/__tests__/released-label.test.ts
@@ -2,7 +2,7 @@ import Auto from "@auto-it/core";
 import makeCommitFromMsg from "@auto-it/core/dist/__tests__/make-commit-from-msg";
 import Git from "@auto-it/core/dist/git";
 import LogParse from "@auto-it/core/dist/log-parse";
-import { defaultLabels } from "@auto-it/core/dist/release";
+import { defaultLabels } from "@auto-it/core/dist/semver";
 import { dummyLog } from "@auto-it/core/dist/utils/logger";
 import {
   makeHooks,

--- a/plugins/slack/__tests__/slack.test.ts
+++ b/plugins/slack/__tests__/slack.test.ts
@@ -2,7 +2,7 @@ import Auto from "@auto-it/core";
 import makeCommitFromMsg from "@auto-it/core/src/__tests__/make-commit-from-msg";
 import { dummyLog } from "@auto-it/core/src/utils/logger";
 import { makeHooks } from "@auto-it/core/src/utils/make-hooks";
-import { defaultLabels } from "@auto-it/core/dist/release";
+import { defaultLabels } from "@auto-it/core/dist/semver";
 import { execSync } from "child_process";
 
 import SlackPlugin from "../src";
@@ -31,10 +31,10 @@ const nextBranch = execSync("git rev-parse --abbrev-ref HEAD", {
   encoding: "utf8",
 }).trim();
 
-const mockAuto = ({
+const mockAuto = {
   git: {},
   logger: dummyLog(),
-} as any) ;
+} as any;
 
 describe("postToSlack", () => {
   test("doesn't post with no new version", async () => {


### PR DESCRIPTION
# Release Notes

Previously `auto` would mark unlabelled PRs as `patch`. You can now configure what label will be applied as the `default` when calculating SEMVER bumps and adding PRs to changelogs.

To configure a default label add the `default` property and set it to `true`.

```json
{
  "labels": [
    {
      "name": "Version: Minor",
      "releaseType": "minor",
      "default": true
    }
  ]
}
```

# Why

A team asked me if they could change the default label to `minor` to fit their release strategy.

Todo:

- [x] Add tests
- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.44.1-canary.1371.17274.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.44.1-canary.1371.17274.0
  npm install @auto-canary/auto@9.44.1-canary.1371.17274.0
  npm install @auto-canary/core@9.44.1-canary.1371.17274.0
  npm install @auto-canary/all-contributors@9.44.1-canary.1371.17274.0
  npm install @auto-canary/brew@9.44.1-canary.1371.17274.0
  npm install @auto-canary/chrome@9.44.1-canary.1371.17274.0
  npm install @auto-canary/cocoapods@9.44.1-canary.1371.17274.0
  npm install @auto-canary/conventional-commits@9.44.1-canary.1371.17274.0
  npm install @auto-canary/crates@9.44.1-canary.1371.17274.0
  npm install @auto-canary/exec@9.44.1-canary.1371.17274.0
  npm install @auto-canary/first-time-contributor@9.44.1-canary.1371.17274.0
  npm install @auto-canary/gem@9.44.1-canary.1371.17274.0
  npm install @auto-canary/gh-pages@9.44.1-canary.1371.17274.0
  npm install @auto-canary/git-tag@9.44.1-canary.1371.17274.0
  npm install @auto-canary/gradle@9.44.1-canary.1371.17274.0
  npm install @auto-canary/jira@9.44.1-canary.1371.17274.0
  npm install @auto-canary/maven@9.44.1-canary.1371.17274.0
  npm install @auto-canary/npm@9.44.1-canary.1371.17274.0
  npm install @auto-canary/omit-commits@9.44.1-canary.1371.17274.0
  npm install @auto-canary/omit-release-notes@9.44.1-canary.1371.17274.0
  npm install @auto-canary/released@9.44.1-canary.1371.17274.0
  npm install @auto-canary/s3@9.44.1-canary.1371.17274.0
  npm install @auto-canary/slack@9.44.1-canary.1371.17274.0
  npm install @auto-canary/twitter@9.44.1-canary.1371.17274.0
  npm install @auto-canary/upload-assets@9.44.1-canary.1371.17274.0
  # or 
  yarn add @auto-canary/bot-list@9.44.1-canary.1371.17274.0
  yarn add @auto-canary/auto@9.44.1-canary.1371.17274.0
  yarn add @auto-canary/core@9.44.1-canary.1371.17274.0
  yarn add @auto-canary/all-contributors@9.44.1-canary.1371.17274.0
  yarn add @auto-canary/brew@9.44.1-canary.1371.17274.0
  yarn add @auto-canary/chrome@9.44.1-canary.1371.17274.0
  yarn add @auto-canary/cocoapods@9.44.1-canary.1371.17274.0
  yarn add @auto-canary/conventional-commits@9.44.1-canary.1371.17274.0
  yarn add @auto-canary/crates@9.44.1-canary.1371.17274.0
  yarn add @auto-canary/exec@9.44.1-canary.1371.17274.0
  yarn add @auto-canary/first-time-contributor@9.44.1-canary.1371.17274.0
  yarn add @auto-canary/gem@9.44.1-canary.1371.17274.0
  yarn add @auto-canary/gh-pages@9.44.1-canary.1371.17274.0
  yarn add @auto-canary/git-tag@9.44.1-canary.1371.17274.0
  yarn add @auto-canary/gradle@9.44.1-canary.1371.17274.0
  yarn add @auto-canary/jira@9.44.1-canary.1371.17274.0
  yarn add @auto-canary/maven@9.44.1-canary.1371.17274.0
  yarn add @auto-canary/npm@9.44.1-canary.1371.17274.0
  yarn add @auto-canary/omit-commits@9.44.1-canary.1371.17274.0
  yarn add @auto-canary/omit-release-notes@9.44.1-canary.1371.17274.0
  yarn add @auto-canary/released@9.44.1-canary.1371.17274.0
  yarn add @auto-canary/s3@9.44.1-canary.1371.17274.0
  yarn add @auto-canary/slack@9.44.1-canary.1371.17274.0
  yarn add @auto-canary/twitter@9.44.1-canary.1371.17274.0
  yarn add @auto-canary/upload-assets@9.44.1-canary.1371.17274.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
