### PR TITLE
Add `--exists $LABEL` to label command

### DIFF
--- a/docs/pages/blog/using-shipit.mdx
+++ b/docs/pages/blog/using-shipit.mdx
@@ -58,7 +58,7 @@ For example,. the following will only run the test:visual script when the PR has
 ```bash
 export PATH=$(npm bin):$PATH
 
-if [ `auto label --pr $PR_NUMBER | grep -c '^Visual'` -ne 0 ];
+if auto label --pr $PR_NUMBER --exists Visual;
 then
     npm run test:visual
 fi

--- a/docs/pages/docs/extras/label.md
+++ b/docs/pages/docs/extras/label.md
@@ -6,7 +6,7 @@ The following will only run the test:visual script when the PR has has the
 ```bash
 export PATH=$(npm bin):$PATH
 
-if [ auto label --pr $PR_NUMBER | grep -c '^Visual' -ne 0 ];
+if auto label --pr $PR_NUMBER --exists Visual;
 then
   npm run test:visual
 fi

--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -272,6 +272,12 @@ export const commands: AutoCommand[] = [
       "Get the labels for a pull request. Doesn't do much, but the return value lets you write you own scripts based off of the PR labels!",
     options: [
       { ...pr, description: `${pr.description} (defaults to last merged PR)` },
+      {
+        name: "exists",
+        type: String,
+        group: "main",
+        description: "Checks for existence of a specific label",
+      },
     ],
     examples: ["{green $} auto label --pr 123"],
   },

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -15,6 +15,7 @@ import Auto, {
   IShipItOptions,
   IVersionOptions,
   INextOptions,
+  LabelExistsError,
 } from "@auto-it/core";
 import endent from "endent";
 import on from "await-to-js";
@@ -115,7 +116,7 @@ export async function run(command: string, args: ApiOptions) {
       `);
       console.log("");
       auto.logger.verbose.error(error);
-    } else {
+    } else if (!(error instanceof LabelExistsError)) {
       console.log(error);
     }
 

--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -314,6 +314,33 @@ describe("Auto", () => {
       expect(console.log).toHaveBeenCalledWith("foo");
     });
 
+    test("should check for a given label", async () => {
+      const auto = new Auto(defaults);
+      auto.logger = dummyLog();
+      await auto.loadConfig();
+
+      const getLabels = jest.fn();
+      auto.git!.getLabels = getLabels;
+      getLabels.mockReturnValueOnce(["foo"]);
+      jest.spyOn(console, "log").mockImplementation();
+
+      await auto.label({ pr: 13, exists: "foo" });
+      expect(console.log).toHaveBeenCalledWith("foo");
+    });
+
+    test("should throw if a check for a label fails", async () => {
+      const auto = new Auto(defaults);
+      auto.logger = dummyLog();
+      await auto.loadConfig();
+
+      const getLabels = jest.fn();
+      auto.git!.getLabels = getLabels;
+      getLabels.mockReturnValueOnce(["bar"]);
+      jest.spyOn(console, "log").mockImplementation();
+
+      await expect(auto.label({ pr: 13, exists: "foo" })).rejects.toThrow();
+    });
+
     test("should get labels for last merged PR", async () => {
       const auto = new Auto(defaults);
       auto.logger = dummyLog();

--- a/packages/core/src/auto-args.ts
+++ b/packages/core/src/auto-args.ts
@@ -14,6 +14,9 @@ export interface ICreateLabelsOptions {
 export interface ILabelOptions {
   /** PR to get the labels for */
   pr?: number;
+
+  /** Label to check for */
+  exists?: string;
 }
 
 export interface IPRCheckOptions {


### PR DESCRIPTION
# What Changed

This allows CI builds to check for existence of a label without
grepping for text in the label output.

# Why

Most of our CI pipelines follow the same format, which is "run this command if it's a patch release". Those checks usually follow the form of `auto label | grep patch`. This just simplifies that to checking for label existence and setting the exit code to 1 if the label doesn't exist.

Todo:

- [x] Add tests
- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.46.1-canary.1383.17400.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.46.1-canary.1383.17400.0
  npm install @auto-canary/auto@9.46.1-canary.1383.17400.0
  npm install @auto-canary/core@9.46.1-canary.1383.17400.0
  npm install @auto-canary/all-contributors@9.46.1-canary.1383.17400.0
  npm install @auto-canary/brew@9.46.1-canary.1383.17400.0
  npm install @auto-canary/chrome@9.46.1-canary.1383.17400.0
  npm install @auto-canary/cocoapods@9.46.1-canary.1383.17400.0
  npm install @auto-canary/conventional-commits@9.46.1-canary.1383.17400.0
  npm install @auto-canary/crates@9.46.1-canary.1383.17400.0
  npm install @auto-canary/exec@9.46.1-canary.1383.17400.0
  npm install @auto-canary/first-time-contributor@9.46.1-canary.1383.17400.0
  npm install @auto-canary/gem@9.46.1-canary.1383.17400.0
  npm install @auto-canary/gh-pages@9.46.1-canary.1383.17400.0
  npm install @auto-canary/git-tag@9.46.1-canary.1383.17400.0
  npm install @auto-canary/gradle@9.46.1-canary.1383.17400.0
  npm install @auto-canary/jira@9.46.1-canary.1383.17400.0
  npm install @auto-canary/maven@9.46.1-canary.1383.17400.0
  npm install @auto-canary/npm@9.46.1-canary.1383.17400.0
  npm install @auto-canary/omit-commits@9.46.1-canary.1383.17400.0
  npm install @auto-canary/omit-release-notes@9.46.1-canary.1383.17400.0
  npm install @auto-canary/released@9.46.1-canary.1383.17400.0
  npm install @auto-canary/s3@9.46.1-canary.1383.17400.0
  npm install @auto-canary/slack@9.46.1-canary.1383.17400.0
  npm install @auto-canary/twitter@9.46.1-canary.1383.17400.0
  npm install @auto-canary/upload-assets@9.46.1-canary.1383.17400.0
  # or 
  yarn add @auto-canary/bot-list@9.46.1-canary.1383.17400.0
  yarn add @auto-canary/auto@9.46.1-canary.1383.17400.0
  yarn add @auto-canary/core@9.46.1-canary.1383.17400.0
  yarn add @auto-canary/all-contributors@9.46.1-canary.1383.17400.0
  yarn add @auto-canary/brew@9.46.1-canary.1383.17400.0
  yarn add @auto-canary/chrome@9.46.1-canary.1383.17400.0
  yarn add @auto-canary/cocoapods@9.46.1-canary.1383.17400.0
  yarn add @auto-canary/conventional-commits@9.46.1-canary.1383.17400.0
  yarn add @auto-canary/crates@9.46.1-canary.1383.17400.0
  yarn add @auto-canary/exec@9.46.1-canary.1383.17400.0
  yarn add @auto-canary/first-time-contributor@9.46.1-canary.1383.17400.0
  yarn add @auto-canary/gem@9.46.1-canary.1383.17400.0
  yarn add @auto-canary/gh-pages@9.46.1-canary.1383.17400.0
  yarn add @auto-canary/git-tag@9.46.1-canary.1383.17400.0
  yarn add @auto-canary/gradle@9.46.1-canary.1383.17400.0
  yarn add @auto-canary/jira@9.46.1-canary.1383.17400.0
  yarn add @auto-canary/maven@9.46.1-canary.1383.17400.0
  yarn add @auto-canary/npm@9.46.1-canary.1383.17400.0
  yarn add @auto-canary/omit-commits@9.46.1-canary.1383.17400.0
  yarn add @auto-canary/omit-release-notes@9.46.1-canary.1383.17400.0
  yarn add @auto-canary/released@9.46.1-canary.1383.17400.0
  yarn add @auto-canary/s3@9.46.1-canary.1383.17400.0
  yarn add @auto-canary/slack@9.46.1-canary.1383.17400.0
  yarn add @auto-canary/twitter@9.46.1-canary.1383.17400.0
  yarn add @auto-canary/upload-assets@9.46.1-canary.1383.17400.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
