### PR TITLE
Fixes baseBranch from config

### DIFF
--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -98,6 +98,32 @@ describe("Auto", () => {
     expect(auto.release).toBeDefined();
   });
 
+  test("should set default baseBranch", async () => {
+    search.mockReturnValueOnce({
+      config: defaults,
+    });
+
+    const auto = new Auto();
+    auto.logger = dummyLog();
+    await auto.loadConfig();
+    expect(auto.baseBranch).toBe("master");
+  });
+
+  test("should set custom baseBranch", async () => {
+    search.mockReturnValueOnce({
+      config: {
+        ...defaults,
+        baseBranch: "production",
+      },
+    });
+
+    const auto = new Auto();
+    auto.logger = dummyLog();
+    await auto.loadConfig();
+    expect(auto.baseBranch).toBe("production");
+    expect(auto.config?.baseBranch).toBe("production");
+  });
+
   test("should default to npm in non-pkg", async () => {
     search.mockReturnValueOnce({ config: defaults });
     // @ts-ignore

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -538,9 +538,10 @@ export default class Auto {
       // This Line overrides config with args
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ...omit(this.options, ["_command", "_all", "main"] as any),
-      baseBranch: this.baseBranch,
+      baseBranch: this.config.baseBranch || this.baseBranch,
     };
     this.config = config;
+    this.baseBranch = config.baseBranch;
     const repository = await this.getRepo(config);
     const token =
       repository?.token || process.env.GH_TOKEN || process.env.GITHUB_TOKEN;


### PR DESCRIPTION
# What Changed

This PR prevents `this.baseBranch` from overwriting a `config.baseBranch` value, which would force the value to stay as `master`. Additionally, `this.config.baseBranch` now writes back onto `this.baseBranch`.

I suppose one downside (?) in this is that there's now a hierarchy where an `autorc` `baseBranch` will override a passed argument.

# Why

I noticed after changing our master branch to `production` in config that my plugins (among other things) are still evaluating `auto.baseBranch` as `master`. It actually caused me a bug when it tries to `git rev-list --boundary beta...origin/master --left-only`, as well.

It looks like `this.baseBranch` is set from CLI arguments OR defaults to `master` early in the constructor. Later, when the config is loaded, it is overwritten with the value from `this.baseBranch` anyway, so `this.config.baseBranch` is also `master`.

Todo:

- [x] Add tests
- [ ] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.47.1-canary.1393.17453.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.47.1-canary.1393.17453.0
  npm install @auto-canary/auto@9.47.1-canary.1393.17453.0
  npm install @auto-canary/core@9.47.1-canary.1393.17453.0
  npm install @auto-canary/all-contributors@9.47.1-canary.1393.17453.0
  npm install @auto-canary/brew@9.47.1-canary.1393.17453.0
  npm install @auto-canary/chrome@9.47.1-canary.1393.17453.0
  npm install @auto-canary/cocoapods@9.47.1-canary.1393.17453.0
  npm install @auto-canary/conventional-commits@9.47.1-canary.1393.17453.0
  npm install @auto-canary/crates@9.47.1-canary.1393.17453.0
  npm install @auto-canary/exec@9.47.1-canary.1393.17453.0
  npm install @auto-canary/first-time-contributor@9.47.1-canary.1393.17453.0
  npm install @auto-canary/gem@9.47.1-canary.1393.17453.0
  npm install @auto-canary/gh-pages@9.47.1-canary.1393.17453.0
  npm install @auto-canary/git-tag@9.47.1-canary.1393.17453.0
  npm install @auto-canary/gradle@9.47.1-canary.1393.17453.0
  npm install @auto-canary/jira@9.47.1-canary.1393.17453.0
  npm install @auto-canary/maven@9.47.1-canary.1393.17453.0
  npm install @auto-canary/npm@9.47.1-canary.1393.17453.0
  npm install @auto-canary/omit-commits@9.47.1-canary.1393.17453.0
  npm install @auto-canary/omit-release-notes@9.47.1-canary.1393.17453.0
  npm install @auto-canary/released@9.47.1-canary.1393.17453.0
  npm install @auto-canary/s3@9.47.1-canary.1393.17453.0
  npm install @auto-canary/slack@9.47.1-canary.1393.17453.0
  npm install @auto-canary/twitter@9.47.1-canary.1393.17453.0
  npm install @auto-canary/upload-assets@9.47.1-canary.1393.17453.0
  # or 
  yarn add @auto-canary/bot-list@9.47.1-canary.1393.17453.0
  yarn add @auto-canary/auto@9.47.1-canary.1393.17453.0
  yarn add @auto-canary/core@9.47.1-canary.1393.17453.0
  yarn add @auto-canary/all-contributors@9.47.1-canary.1393.17453.0
  yarn add @auto-canary/brew@9.47.1-canary.1393.17453.0
  yarn add @auto-canary/chrome@9.47.1-canary.1393.17453.0
  yarn add @auto-canary/cocoapods@9.47.1-canary.1393.17453.0
  yarn add @auto-canary/conventional-commits@9.47.1-canary.1393.17453.0
  yarn add @auto-canary/crates@9.47.1-canary.1393.17453.0
  yarn add @auto-canary/exec@9.47.1-canary.1393.17453.0
  yarn add @auto-canary/first-time-contributor@9.47.1-canary.1393.17453.0
  yarn add @auto-canary/gem@9.47.1-canary.1393.17453.0
  yarn add @auto-canary/gh-pages@9.47.1-canary.1393.17453.0
  yarn add @auto-canary/git-tag@9.47.1-canary.1393.17453.0
  yarn add @auto-canary/gradle@9.47.1-canary.1393.17453.0
  yarn add @auto-canary/jira@9.47.1-canary.1393.17453.0
  yarn add @auto-canary/maven@9.47.1-canary.1393.17453.0
  yarn add @auto-canary/npm@9.47.1-canary.1393.17453.0
  yarn add @auto-canary/omit-commits@9.47.1-canary.1393.17453.0
  yarn add @auto-canary/omit-release-notes@9.47.1-canary.1393.17453.0
  yarn add @auto-canary/released@9.47.1-canary.1393.17453.0
  yarn add @auto-canary/s3@9.47.1-canary.1393.17453.0
  yarn add @auto-canary/slack@9.47.1-canary.1393.17453.0
  yarn add @auto-canary/twitter@9.47.1-canary.1393.17453.0
  yarn add @auto-canary/upload-assets@9.47.1-canary.1393.17453.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
