### PR TITLE
fix Chrome manifest copy to build folder

### DIFF
--- a/plugins/chrome/src/index.ts
+++ b/plugins/chrome/src/index.ts
@@ -5,6 +5,7 @@ import {
   validatePluginConfiguration,
 } from "@auto-it/core";
 import * as fs from "fs";
+import * as path from "path";
 import { inc, ReleaseType, gte } from "semver";
 import { promisify } from "util";
 import * as t from "io-ts";
@@ -164,7 +165,10 @@ export default class ChromeWebStorePlugin implements IPlugin {
         JSON.stringify(manifest, undefined, 2)
       );
 
-      await copyFile(this.options.manifest, this.options.build);
+      await copyFile(
+        this.options.manifest,
+        path.join(this.options.build, "manifest.json")
+      );
 
       // commit new version
       await execPromise("git", ["add", this.options.manifest]);


### PR DESCRIPTION
# What Changed

Add filename when copying `manifest.json` to the `build` folder

# Why

One of the steps of the Chrome Web Store Plugin is copying the `manifest.json` to the `build` folder. This used to work but now it throws the following error:

```
{ [Error: EISDIR: illegal operation on a directory, copyfile './manifest.json' -> './build']
  errno: -21,
  code: 'EISDIR',
  syscall: 'copyfile',
  path: './manifest.json',
  dest: './build' }
```

The reason seems to be that, according to [fs.copyFile Documentation](https://nodejs.org/api/fs.html#fs_fs_copyfile_src_dest_mode_callback) the destination filename should be specified. Not sure why this used to work in previous versions. 

Here is a repo with the bug: https://github.com/lucascurti/fs-copy-file-error. (Just run `npm start`)


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.47.2-canary.1395.17526.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.47.2-canary.1395.17526.0
  npm install @auto-canary/auto@9.47.2-canary.1395.17526.0
  npm install @auto-canary/core@9.47.2-canary.1395.17526.0
  npm install @auto-canary/all-contributors@9.47.2-canary.1395.17526.0
  npm install @auto-canary/brew@9.47.2-canary.1395.17526.0
  npm install @auto-canary/chrome@9.47.2-canary.1395.17526.0
  npm install @auto-canary/cocoapods@9.47.2-canary.1395.17526.0
  npm install @auto-canary/conventional-commits@9.47.2-canary.1395.17526.0
  npm install @auto-canary/crates@9.47.2-canary.1395.17526.0
  npm install @auto-canary/exec@9.47.2-canary.1395.17526.0
  npm install @auto-canary/first-time-contributor@9.47.2-canary.1395.17526.0
  npm install @auto-canary/gem@9.47.2-canary.1395.17526.0
  npm install @auto-canary/gh-pages@9.47.2-canary.1395.17526.0
  npm install @auto-canary/git-tag@9.47.2-canary.1395.17526.0
  npm install @auto-canary/gradle@9.47.2-canary.1395.17526.0
  npm install @auto-canary/jira@9.47.2-canary.1395.17526.0
  npm install @auto-canary/maven@9.47.2-canary.1395.17526.0
  npm install @auto-canary/npm@9.47.2-canary.1395.17526.0
  npm install @auto-canary/omit-commits@9.47.2-canary.1395.17526.0
  npm install @auto-canary/omit-release-notes@9.47.2-canary.1395.17526.0
  npm install @auto-canary/released@9.47.2-canary.1395.17526.0
  npm install @auto-canary/s3@9.47.2-canary.1395.17526.0
  npm install @auto-canary/slack@9.47.2-canary.1395.17526.0
  npm install @auto-canary/twitter@9.47.2-canary.1395.17526.0
  npm install @auto-canary/upload-assets@9.47.2-canary.1395.17526.0
  # or 
  yarn add @auto-canary/bot-list@9.47.2-canary.1395.17526.0
  yarn add @auto-canary/auto@9.47.2-canary.1395.17526.0
  yarn add @auto-canary/core@9.47.2-canary.1395.17526.0
  yarn add @auto-canary/all-contributors@9.47.2-canary.1395.17526.0
  yarn add @auto-canary/brew@9.47.2-canary.1395.17526.0
  yarn add @auto-canary/chrome@9.47.2-canary.1395.17526.0
  yarn add @auto-canary/cocoapods@9.47.2-canary.1395.17526.0
  yarn add @auto-canary/conventional-commits@9.47.2-canary.1395.17526.0
  yarn add @auto-canary/crates@9.47.2-canary.1395.17526.0
  yarn add @auto-canary/exec@9.47.2-canary.1395.17526.0
  yarn add @auto-canary/first-time-contributor@9.47.2-canary.1395.17526.0
  yarn add @auto-canary/gem@9.47.2-canary.1395.17526.0
  yarn add @auto-canary/gh-pages@9.47.2-canary.1395.17526.0
  yarn add @auto-canary/git-tag@9.47.2-canary.1395.17526.0
  yarn add @auto-canary/gradle@9.47.2-canary.1395.17526.0
  yarn add @auto-canary/jira@9.47.2-canary.1395.17526.0
  yarn add @auto-canary/maven@9.47.2-canary.1395.17526.0
  yarn add @auto-canary/npm@9.47.2-canary.1395.17526.0
  yarn add @auto-canary/omit-commits@9.47.2-canary.1395.17526.0
  yarn add @auto-canary/omit-release-notes@9.47.2-canary.1395.17526.0
  yarn add @auto-canary/released@9.47.2-canary.1395.17526.0
  yarn add @auto-canary/s3@9.47.2-canary.1395.17526.0
  yarn add @auto-canary/slack@9.47.2-canary.1395.17526.0
  yarn add @auto-canary/twitter@9.47.2-canary.1395.17526.0
  yarn add @auto-canary/upload-assets@9.47.2-canary.1395.17526.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
