### PR TITLE
return 0.0.0 as default when no version found in gradle properties

### DIFF
--- a/plugins/gradle/__tests__/gradle.test.ts
+++ b/plugins/gradle/__tests__/gradle.test.ts
@@ -37,13 +37,6 @@ describe("Gradle Plugin", () => {
       exec.mockReturnValueOnce("version: 1.0.0-SNAPSHOT");
       expect(await hooks.getPreviousVersion.promise()).toBe("v1.0.0");
     });
-
-    test("should throw when no version", async () => {
-      exec.mockReturnValueOnce("");
-      await expect(hooks.getPreviousVersion.promise()).rejects.toThrowError(
-        "No version was found in gradle properties."
-      );
-    });
   });
 
   describe("beforeRun & version", () => {

--- a/plugins/gradle/src/index.ts
+++ b/plugins/gradle/src/index.ts
@@ -69,15 +69,11 @@ async function getVersion(
   gradleOptions: string[]
 ): Promise<string> {
   const {
-    version,
+    version = "0.0.0",
     snapshotSuffix = defaultSnapshotSuffix,
   } = await getProperties(gradleCommand, gradleOptions);
 
-  if (version) {
-    return version.replace(snapshotSuffix, "");
-  }
-
-  throw new Error("No version was found in gradle properties.");
+  return version.replace(snapshotSuffix, "");
 }
 
 /** A plugin to release java projects with gradle */


### PR DESCRIPTION
Addressing #1276

To return 0.0.0 instead of throwing error when version is not found in default properties

Todo:

- [ ] Add tests
- [ ] Add docs
