### PR TITLE
skip publish for private npm packages

### DIFF
--- a/plugins/npm/__tests__/set-npm-token.test.ts
+++ b/plugins/npm/__tests__/set-npm-token.test.ts
@@ -7,6 +7,7 @@ import * as utils from "../src/utils";
 const loadPackageJson = utils.loadPackageJson as jest.Mock;
 const readFile = utils.readFile as jest.Mock;
 const writeFile = utils.writeFile as jest.Mock;
+const isMonorepo = utils.isMonorepo as jest.Mock;
 
 jest.mock("../src/utils.ts");
 jest.mock("env-ci", () => () => ({
@@ -31,6 +32,23 @@ describe("set npm token", () => {
     );
   });
 
+  test("should not write a new npmrc for single private package", async () => {
+    loadPackageJson.mockReturnValueOnce({ name: "test", private: true });
+    isMonorepo.mockReturnValueOnce(false);
+
+    await setNpmToken(dummyLog());
+    expect(writeFile).not.toHaveBeenCalled()
+  });
+
+
+  test("should write a npmrc for monorepo", async () => {
+    loadPackageJson.mockReturnValueOnce({ name: "test", private: true });
+    isMonorepo.mockReturnValueOnce(true);
+
+    await setNpmToken(dummyLog());
+    expect(writeFile).toHaveBeenCalled()
+  });
+
   test("should write a new npmrc w/o name", async () => {
     loadPackageJson.mockReturnValueOnce({});
     await setNpmToken(dummyLog());
@@ -52,7 +70,7 @@ describe("set npm token", () => {
     );
   });
 
-  test("should use registry for scoped pacakged", async () => {
+  test("should use registry for scoped packaged", async () => {
     loadPackageJson.mockReturnValueOnce({
       name: "@scope/test",
     });

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -527,6 +527,12 @@ export default class NPMPlugin implements IPlugin {
         return;
       }
 
+      const { private: isPrivate } = await loadPackageJson();
+
+      if (isPrivate) {
+        return;
+      }
+
       auto.checkEnv(this.name, "NPM_TOKEN");
     });
 
@@ -814,8 +820,8 @@ export default class NPMPlugin implements IPlugin {
 
       if (isPrivate) {
         return {
-          error: 'Package private, cannot make canary release to npm.'
-        }
+          error: "Package private, cannot make canary release to npm.",
+        };
       }
 
       let canaryVersion = determineNextVersion(
@@ -957,7 +963,9 @@ export default class NPMPlugin implements IPlugin {
         ]);
 
         if (isPrivate) {
-          auto.logger.log.info(`Package private, skipping prerelease publish to npm.`);
+          auto.logger.log.info(
+            `Package private, skipping prerelease publish to npm.`
+          );
         } else {
           await execPromise("npm", [
             "publish",

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -26,13 +26,10 @@ import { gt, gte, inc, ReleaseType } from "semver";
 
 import getConfigFromPackageJson from "./package-config";
 import setTokenOnCI from "./set-npm-token";
-import { loadPackageJson, writeFile } from "./utils";
+import { loadPackageJson, writeFile, isMonorepo } from "./utils";
 
 const { isCi } = envCi();
 const VERSION_COMMIT_MESSAGE = '"Bump version to: %s [skip ci]"';
-
-/** Check if the project is a monorepo */
-const isMonorepo = () => fs.existsSync("lerna.json");
 
 /** Get the last published version for a npm package */
 async function getPublishedVersion(name: string) {

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -810,7 +810,14 @@ export default class NPMPlugin implements IPlugin {
 
       auto.logger.verbose.info("Detected single npm package");
       const current = await auto.getCurrentVersion(lastRelease);
-      const { name } = await loadPackageJson();
+      const { name, private: isPrivate } = await loadPackageJson();
+
+      if (isPrivate) {
+        return {
+          error: 'Package private, cannot make canary release to npm.'
+        }
+      }
+
       let canaryVersion = determineNextVersion(
         lastRelease,
         current,
@@ -941,7 +948,7 @@ export default class NPMPlugin implements IPlugin {
           ...verboseArgs,
         ]);
 
-        const { version } = await loadPackageJson();
+        const { version, private: isPrivate } = await loadPackageJson();
         await execPromise("git", [
           "tag",
           auto.prefixRelease(version!),
@@ -949,13 +956,17 @@ export default class NPMPlugin implements IPlugin {
           `"Update version to ${version}"`,
         ]);
 
-        await execPromise("npm", [
-          "publish",
-          "--tag",
-          prereleaseBranch,
-          ...verboseArgs,
-          ...getLegacyAuthArgs(this.legacyAuth),
-        ]);
+        if (isPrivate) {
+          auto.logger.log.info(`Package private, skipping prerelease publish to npm.`);
+        } else {
+          await execPromise("npm", [
+            "publish",
+            "--tag",
+            prereleaseBranch,
+            ...verboseArgs,
+            ...getLegacyAuthArgs(this.legacyAuth),
+          ]);
+        }
 
         auto.logger.verbose.info("Successfully published next version");
         preReleaseVersions.push(auto.prefixRelease(version!));
@@ -1005,12 +1016,18 @@ export default class NPMPlugin implements IPlugin {
           ...getLegacyAuthArgs(this.legacyAuth, { isMonorepo: true }),
         ]);
       } else {
-        await execPromise("npm", [
-          "publish",
-          ...tag,
-          ...verboseArgs,
-          ...getLegacyAuthArgs(this.legacyAuth),
-        ]);
+        const { private: isPrivate } = await loadPackageJson();
+
+        if (isPrivate) {
+          auto.logger.log.info(`Package private, skipping publish to npm.`);
+        } else {
+          await execPromise("npm", [
+            "publish",
+            ...tag,
+            ...verboseArgs,
+            ...getLegacyAuthArgs(this.legacyAuth),
+          ]);
+        }
       }
 
       await execPromise("git", [

--- a/plugins/npm/src/set-npm-token.ts
+++ b/plugins/npm/src/set-npm-token.ts
@@ -5,7 +5,7 @@ import registryUrl from "registry-url";
 import urlJoin from "url-join";
 import userHome from "user-home";
 
-import { loadPackageJson, readFile, writeFile } from "./utils";
+import { loadPackageJson, readFile, writeFile, isMonorepo } from "./utils";
 
 const { isCi } = envCi();
 
@@ -15,7 +15,13 @@ export default async function setTokenOnCI(logger: ILogger) {
     return;
   }
 
-  const { publishConfig = {}, name } = await loadPackageJson();
+  const { publishConfig = {}, name, private: isPrivate } = await loadPackageJson();
+
+  if (isPrivate && !isMonorepo()) {
+    logger.verbose.info('NPM token not set for private package.')
+    return;
+  }
+
   const rc = path.join(userHome, ".npmrc");
   let contents = "";
 

--- a/plugins/npm/src/utils.ts
+++ b/plugins/npm/src/utils.ts
@@ -9,3 +9,6 @@ export const writeFile = promisify(fs.writeFile);
 export async function loadPackageJson(root = "./"): Promise<IPackageJSON> {
   return JSON.parse(await readFile(path.join(root, "package.json"), "utf-8"));
 }
+
+/** Check if the project is a monorepo */
+export const isMonorepo = () => fs.existsSync("lerna.json");


### PR DESCRIPTION
# What Changed

In `canary`, `next`, and `publish` handle private npm packages.
All that is different is that the plugin will not call `npm publish`.
Everything else still happens.

Monorepos should already work with private packages.

# Why

Addresses [this comment](https://github.com/intuit/auto/issues/1365#issuecomment-662852061)

closes https://github.com/intuit/auto/issues/1398

Todo:

- [x] Add tests


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.47.3-canary.1397.17547.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.47.3-canary.1397.17547.0
  npm install @auto-canary/auto@9.47.3-canary.1397.17547.0
  npm install @auto-canary/core@9.47.3-canary.1397.17547.0
  npm install @auto-canary/all-contributors@9.47.3-canary.1397.17547.0
  npm install @auto-canary/brew@9.47.3-canary.1397.17547.0
  npm install @auto-canary/chrome@9.47.3-canary.1397.17547.0
  npm install @auto-canary/cocoapods@9.47.3-canary.1397.17547.0
  npm install @auto-canary/conventional-commits@9.47.3-canary.1397.17547.0
  npm install @auto-canary/crates@9.47.3-canary.1397.17547.0
  npm install @auto-canary/exec@9.47.3-canary.1397.17547.0
  npm install @auto-canary/first-time-contributor@9.47.3-canary.1397.17547.0
  npm install @auto-canary/gem@9.47.3-canary.1397.17547.0
  npm install @auto-canary/gh-pages@9.47.3-canary.1397.17547.0
  npm install @auto-canary/git-tag@9.47.3-canary.1397.17547.0
  npm install @auto-canary/gradle@9.47.3-canary.1397.17547.0
  npm install @auto-canary/jira@9.47.3-canary.1397.17547.0
  npm install @auto-canary/maven@9.47.3-canary.1397.17547.0
  npm install @auto-canary/npm@9.47.3-canary.1397.17547.0
  npm install @auto-canary/omit-commits@9.47.3-canary.1397.17547.0
  npm install @auto-canary/omit-release-notes@9.47.3-canary.1397.17547.0
  npm install @auto-canary/released@9.47.3-canary.1397.17547.0
  npm install @auto-canary/s3@9.47.3-canary.1397.17547.0
  npm install @auto-canary/slack@9.47.3-canary.1397.17547.0
  npm install @auto-canary/twitter@9.47.3-canary.1397.17547.0
  npm install @auto-canary/upload-assets@9.47.3-canary.1397.17547.0
  # or 
  yarn add @auto-canary/bot-list@9.47.3-canary.1397.17547.0
  yarn add @auto-canary/auto@9.47.3-canary.1397.17547.0
  yarn add @auto-canary/core@9.47.3-canary.1397.17547.0
  yarn add @auto-canary/all-contributors@9.47.3-canary.1397.17547.0
  yarn add @auto-canary/brew@9.47.3-canary.1397.17547.0
  yarn add @auto-canary/chrome@9.47.3-canary.1397.17547.0
  yarn add @auto-canary/cocoapods@9.47.3-canary.1397.17547.0
  yarn add @auto-canary/conventional-commits@9.47.3-canary.1397.17547.0
  yarn add @auto-canary/crates@9.47.3-canary.1397.17547.0
  yarn add @auto-canary/exec@9.47.3-canary.1397.17547.0
  yarn add @auto-canary/first-time-contributor@9.47.3-canary.1397.17547.0
  yarn add @auto-canary/gem@9.47.3-canary.1397.17547.0
  yarn add @auto-canary/gh-pages@9.47.3-canary.1397.17547.0
  yarn add @auto-canary/git-tag@9.47.3-canary.1397.17547.0
  yarn add @auto-canary/gradle@9.47.3-canary.1397.17547.0
  yarn add @auto-canary/jira@9.47.3-canary.1397.17547.0
  yarn add @auto-canary/maven@9.47.3-canary.1397.17547.0
  yarn add @auto-canary/npm@9.47.3-canary.1397.17547.0
  yarn add @auto-canary/omit-commits@9.47.3-canary.1397.17547.0
  yarn add @auto-canary/omit-release-notes@9.47.3-canary.1397.17547.0
  yarn add @auto-canary/released@9.47.3-canary.1397.17547.0
  yarn add @auto-canary/s3@9.47.3-canary.1397.17547.0
  yarn add @auto-canary/slack@9.47.3-canary.1397.17547.0
  yarn add @auto-canary/twitter@9.47.3-canary.1397.17547.0
  yarn add @auto-canary/upload-assets@9.47.3-canary.1397.17547.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
