### PR TITLE
add error message around mistmatched auto versions

### DIFF
--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+/* eslint-disable complexity */
+
 import Auto, {
   ApiOptions,
   IInfoOptions,
@@ -116,6 +118,19 @@ export async function run(command: string, args: ApiOptions) {
       `);
       console.log("");
       auto.logger.verbose.error(error);
+    } else if (error.message.includes("TypeError: Cannot read property 'tap")) {
+      auto.logger.log.error(endent`
+        One of the plugins you're using calls an unknown hook!
+
+        This usually because your project is trying to use mismatched plugin + core version.
+        
+        To fix this do one of the following:
+
+        1. Ensure that you have the same version of auto and it's plugins installed
+        2. Ensure that any non-official plugins use the same version of @auto-it/core
+        3. Ensure your environment's version of auto matches the plugins you're using
+      `);
+      auto.logger.log.error(error);
     } else if (!(error instanceof LabelExistsError)) {
       console.log(error);
     }


### PR DESCRIPTION
# What Changed

Add error message when we see this common error

# Why

I've probably seen this error from half a dozen different teams. This message should help them find the issue.



<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.48.1-canary.1399.17559.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.48.1-canary.1399.17559.0
  npm install @auto-canary/auto@9.48.1-canary.1399.17559.0
  npm install @auto-canary/core@9.48.1-canary.1399.17559.0
  npm install @auto-canary/all-contributors@9.48.1-canary.1399.17559.0
  npm install @auto-canary/brew@9.48.1-canary.1399.17559.0
  npm install @auto-canary/chrome@9.48.1-canary.1399.17559.0
  npm install @auto-canary/cocoapods@9.48.1-canary.1399.17559.0
  npm install @auto-canary/conventional-commits@9.48.1-canary.1399.17559.0
  npm install @auto-canary/crates@9.48.1-canary.1399.17559.0
  npm install @auto-canary/exec@9.48.1-canary.1399.17559.0
  npm install @auto-canary/first-time-contributor@9.48.1-canary.1399.17559.0
  npm install @auto-canary/gem@9.48.1-canary.1399.17559.0
  npm install @auto-canary/gh-pages@9.48.1-canary.1399.17559.0
  npm install @auto-canary/git-tag@9.48.1-canary.1399.17559.0
  npm install @auto-canary/gradle@9.48.1-canary.1399.17559.0
  npm install @auto-canary/jira@9.48.1-canary.1399.17559.0
  npm install @auto-canary/maven@9.48.1-canary.1399.17559.0
  npm install @auto-canary/npm@9.48.1-canary.1399.17559.0
  npm install @auto-canary/omit-commits@9.48.1-canary.1399.17559.0
  npm install @auto-canary/omit-release-notes@9.48.1-canary.1399.17559.0
  npm install @auto-canary/released@9.48.1-canary.1399.17559.0
  npm install @auto-canary/s3@9.48.1-canary.1399.17559.0
  npm install @auto-canary/slack@9.48.1-canary.1399.17559.0
  npm install @auto-canary/twitter@9.48.1-canary.1399.17559.0
  npm install @auto-canary/upload-assets@9.48.1-canary.1399.17559.0
  # or 
  yarn add @auto-canary/bot-list@9.48.1-canary.1399.17559.0
  yarn add @auto-canary/auto@9.48.1-canary.1399.17559.0
  yarn add @auto-canary/core@9.48.1-canary.1399.17559.0
  yarn add @auto-canary/all-contributors@9.48.1-canary.1399.17559.0
  yarn add @auto-canary/brew@9.48.1-canary.1399.17559.0
  yarn add @auto-canary/chrome@9.48.1-canary.1399.17559.0
  yarn add @auto-canary/cocoapods@9.48.1-canary.1399.17559.0
  yarn add @auto-canary/conventional-commits@9.48.1-canary.1399.17559.0
  yarn add @auto-canary/crates@9.48.1-canary.1399.17559.0
  yarn add @auto-canary/exec@9.48.1-canary.1399.17559.0
  yarn add @auto-canary/first-time-contributor@9.48.1-canary.1399.17559.0
  yarn add @auto-canary/gem@9.48.1-canary.1399.17559.0
  yarn add @auto-canary/gh-pages@9.48.1-canary.1399.17559.0
  yarn add @auto-canary/git-tag@9.48.1-canary.1399.17559.0
  yarn add @auto-canary/gradle@9.48.1-canary.1399.17559.0
  yarn add @auto-canary/jira@9.48.1-canary.1399.17559.0
  yarn add @auto-canary/maven@9.48.1-canary.1399.17559.0
  yarn add @auto-canary/npm@9.48.1-canary.1399.17559.0
  yarn add @auto-canary/omit-commits@9.48.1-canary.1399.17559.0
  yarn add @auto-canary/omit-release-notes@9.48.1-canary.1399.17559.0
  yarn add @auto-canary/released@9.48.1-canary.1399.17559.0
  yarn add @auto-canary/s3@9.48.1-canary.1399.17559.0
  yarn add @auto-canary/slack@9.48.1-canary.1399.17559.0
  yarn add @auto-canary/twitter@9.48.1-canary.1399.17559.0
  yarn add @auto-canary/upload-assets@9.48.1-canary.1399.17559.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
