### PR TITLE
catch errors when finding tags on next

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1279,10 +1279,18 @@ export default class Auto {
     );
     const lastRelease =
       initialForkCommit || (await this.git.getLatestRelease());
+
+    const [, lastTagNotInBaseBranch] = await on(
+      this.git.getLastTagNotInBaseBranch(currentBranch!)
+    );
+    const [, latestTagInBranch] = await on(
+      this.git.getLatestTagInBranch(currentBranch)
+    );
     const lastTag =
-      (await this.git.getLastTagNotInBaseBranch(currentBranch!)) ||
-      (await this.git.getLatestTagInBranch(currentBranch)) ||
+      lastTagNotInBaseBranch ||
+      latestTagInBranch ||
       (await this.git.getFirstCommit());
+
     const fullReleaseNotes = await this.release.generateReleaseNotes(
       lastRelease
     );


### PR DESCRIPTION
# What Changed

Add error handling when getting tags

# Why

closes #1401 

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.48.2-canary.1402.17571.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.48.2-canary.1402.17571.0
  npm install @auto-canary/auto@9.48.2-canary.1402.17571.0
  npm install @auto-canary/core@9.48.2-canary.1402.17571.0
  npm install @auto-canary/all-contributors@9.48.2-canary.1402.17571.0
  npm install @auto-canary/brew@9.48.2-canary.1402.17571.0
  npm install @auto-canary/chrome@9.48.2-canary.1402.17571.0
  npm install @auto-canary/cocoapods@9.48.2-canary.1402.17571.0
  npm install @auto-canary/conventional-commits@9.48.2-canary.1402.17571.0
  npm install @auto-canary/crates@9.48.2-canary.1402.17571.0
  npm install @auto-canary/exec@9.48.2-canary.1402.17571.0
  npm install @auto-canary/first-time-contributor@9.48.2-canary.1402.17571.0
  npm install @auto-canary/gem@9.48.2-canary.1402.17571.0
  npm install @auto-canary/gh-pages@9.48.2-canary.1402.17571.0
  npm install @auto-canary/git-tag@9.48.2-canary.1402.17571.0
  npm install @auto-canary/gradle@9.48.2-canary.1402.17571.0
  npm install @auto-canary/jira@9.48.2-canary.1402.17571.0
  npm install @auto-canary/maven@9.48.2-canary.1402.17571.0
  npm install @auto-canary/npm@9.48.2-canary.1402.17571.0
  npm install @auto-canary/omit-commits@9.48.2-canary.1402.17571.0
  npm install @auto-canary/omit-release-notes@9.48.2-canary.1402.17571.0
  npm install @auto-canary/released@9.48.2-canary.1402.17571.0
  npm install @auto-canary/s3@9.48.2-canary.1402.17571.0
  npm install @auto-canary/slack@9.48.2-canary.1402.17571.0
  npm install @auto-canary/twitter@9.48.2-canary.1402.17571.0
  npm install @auto-canary/upload-assets@9.48.2-canary.1402.17571.0
  # or 
  yarn add @auto-canary/bot-list@9.48.2-canary.1402.17571.0
  yarn add @auto-canary/auto@9.48.2-canary.1402.17571.0
  yarn add @auto-canary/core@9.48.2-canary.1402.17571.0
  yarn add @auto-canary/all-contributors@9.48.2-canary.1402.17571.0
  yarn add @auto-canary/brew@9.48.2-canary.1402.17571.0
  yarn add @auto-canary/chrome@9.48.2-canary.1402.17571.0
  yarn add @auto-canary/cocoapods@9.48.2-canary.1402.17571.0
  yarn add @auto-canary/conventional-commits@9.48.2-canary.1402.17571.0
  yarn add @auto-canary/crates@9.48.2-canary.1402.17571.0
  yarn add @auto-canary/exec@9.48.2-canary.1402.17571.0
  yarn add @auto-canary/first-time-contributor@9.48.2-canary.1402.17571.0
  yarn add @auto-canary/gem@9.48.2-canary.1402.17571.0
  yarn add @auto-canary/gh-pages@9.48.2-canary.1402.17571.0
  yarn add @auto-canary/git-tag@9.48.2-canary.1402.17571.0
  yarn add @auto-canary/gradle@9.48.2-canary.1402.17571.0
  yarn add @auto-canary/jira@9.48.2-canary.1402.17571.0
  yarn add @auto-canary/maven@9.48.2-canary.1402.17571.0
  yarn add @auto-canary/npm@9.48.2-canary.1402.17571.0
  yarn add @auto-canary/omit-commits@9.48.2-canary.1402.17571.0
  yarn add @auto-canary/omit-release-notes@9.48.2-canary.1402.17571.0
  yarn add @auto-canary/released@9.48.2-canary.1402.17571.0
  yarn add @auto-canary/s3@9.48.2-canary.1402.17571.0
  yarn add @auto-canary/slack@9.48.2-canary.1402.17571.0
  yarn add @auto-canary/twitter@9.48.2-canary.1402.17571.0
  yarn add @auto-canary/upload-assets@9.48.2-canary.1402.17571.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
