### PR TITLE
respect registry set at top level for lerna

### DIFF
--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -27,6 +27,7 @@ exec.mockReturnValue("");
 let readResult = "{}";
 readFileSync.mockReturnValue("{}");
 
+jest.mock("../src/set-npm-token.ts");
 jest.mock("../../../packages/core/dist/utils/exec-promise", () => ({
   // @ts-ignore
   default: (...args) => execPromise(...args),

--- a/plugins/npm/__tests__/set-npm-token.test.ts
+++ b/plugins/npm/__tests__/set-npm-token.test.ts
@@ -25,6 +25,7 @@ describe("set npm token", () => {
 
   test("should write a new npmrc", async () => {
     loadPackageJson.mockReturnValueOnce({ name: "test" });
+    loadPackageJson.mockReturnValueOnce({ name: "test" });
     await setNpmToken(dummyLog());
     expect(writeFile).toHaveBeenCalledWith(
       "/User/name/.npmrc",
@@ -40,8 +41,8 @@ describe("set npm token", () => {
     expect(writeFile).not.toHaveBeenCalled()
   });
 
-
   test("should write a npmrc for monorepo", async () => {
+    loadPackageJson.mockReturnValueOnce({ name: "test", private: true });
     loadPackageJson.mockReturnValueOnce({ name: "test", private: true });
     isMonorepo.mockReturnValueOnce(true);
 
@@ -51,6 +52,7 @@ describe("set npm token", () => {
 
   test("should write a new npmrc w/o name", async () => {
     loadPackageJson.mockReturnValueOnce({});
+    loadPackageJson.mockReturnValueOnce({});
     await setNpmToken(dummyLog());
     expect(writeFile).toHaveBeenCalledWith(
       "/User/name/.npmrc",
@@ -59,6 +61,10 @@ describe("set npm token", () => {
   });
 
   test("should use registry from packageJson", async () => {
+    loadPackageJson.mockReturnValueOnce({
+      name: "test",
+      publishConfig: { registry: "https://my-registry.com" },
+    });
     loadPackageJson.mockReturnValueOnce({
       name: "test",
       publishConfig: { registry: "https://my-registry.com" },
@@ -74,6 +80,9 @@ describe("set npm token", () => {
     loadPackageJson.mockReturnValueOnce({
       name: "@scope/test",
     });
+    loadPackageJson.mockReturnValueOnce({
+      name: "@scope/test",
+    });
     await setNpmToken(dummyLog());
     expect(writeFile).toHaveBeenCalledWith(
       "/User/name/.npmrc",
@@ -82,6 +91,10 @@ describe("set npm token", () => {
   });
 
   test("should not edit npmrc if it already has the token", async () => {
+    loadPackageJson.mockReturnValueOnce({
+      name: "test",
+      publishConfig: { registry: "https://my-registry.com" },
+    });
     loadPackageJson.mockReturnValueOnce({
       name: "test",
       publishConfig: { registry: "https://my-registry.com" },

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -211,7 +211,7 @@ function getLegacyAuthArgs(
 /** Get the args to set the registry. Only used with lerna */
 async function getRegistryArgs() {
   const registry = await getRegistry();
-  return registry === DEFAULT_REGISTRY ? [] : ["--registry", registry];
+  return registry === DEFAULT_REGISTRY || !registry ? [] : ["--registry", registry];
 }
 
 const pluginOptions = t.partial({

--- a/plugins/npm/src/set-npm-token.ts
+++ b/plugins/npm/src/set-npm-token.ts
@@ -9,16 +9,35 @@ import { loadPackageJson, readFile, writeFile, isMonorepo } from "./utils";
 
 const { isCi } = envCi();
 
+export const DEFAULT_REGISTRY = 'https://registry.npmjs.org';
+
+/** Get the registry for the project */
+export const getRegistry = async () => {
+  const { publishConfig = {}, name } = await loadPackageJson();
+  let registry;
+
+  if (publishConfig.registry) {
+    registry = publishConfig.registry;
+  } else if (name?.startsWith("@")) {
+    const scope = name.split(`/`)[0];
+    registry = registryUrl(scope);
+  } else {
+    registry = registryUrl();
+  }
+
+  return registry;
+};
+
 /** Set the .npmrc only when in a continuos integration environment */
 export default async function setTokenOnCI(logger: ILogger) {
   if (!isCi) {
     return;
   }
 
-  const { publishConfig = {}, name, private: isPrivate } = await loadPackageJson();
+  const { private: isPrivate } = await loadPackageJson();
 
   if (isPrivate && !isMonorepo()) {
-    logger.verbose.info('NPM token not set for private package.')
+    logger.verbose.info("NPM token not set for private package.");
     return;
   }
 
@@ -31,16 +50,7 @@ export default async function setTokenOnCI(logger: ILogger) {
     // No ~/.npmrc set up
   }
 
-  let registry;
-
-  if (publishConfig.registry) {
-    registry = publishConfig.registry;
-  } else if (name?.startsWith("@")) {
-    const scope = name.split(`/`)[0];
-    registry = registryUrl(scope);
-  } else {
-    registry = registryUrl();
-  }
+  const registry = await getRegistry();
 
   logger.verbose.note(`Using ${registry} registry for package`);
 


### PR DESCRIPTION
# What Changed

use lerna's --registry flag with whatever was set by the user.

# Why

I've encountered this countless times where it hard to get lerna to publish to a private registry. This change will make it match the registry set with the npm token

Todo:

- [ ] Add tests
- [ ] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.48.2-canary.1412.17656.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.48.2-canary.1412.17656.0
  npm install @auto-canary/auto@9.48.2-canary.1412.17656.0
  npm install @auto-canary/core@9.48.2-canary.1412.17656.0
  npm install @auto-canary/all-contributors@9.48.2-canary.1412.17656.0
  npm install @auto-canary/brew@9.48.2-canary.1412.17656.0
  npm install @auto-canary/chrome@9.48.2-canary.1412.17656.0
  npm install @auto-canary/cocoapods@9.48.2-canary.1412.17656.0
  npm install @auto-canary/conventional-commits@9.48.2-canary.1412.17656.0
  npm install @auto-canary/crates@9.48.2-canary.1412.17656.0
  npm install @auto-canary/exec@9.48.2-canary.1412.17656.0
  npm install @auto-canary/first-time-contributor@9.48.2-canary.1412.17656.0
  npm install @auto-canary/gem@9.48.2-canary.1412.17656.0
  npm install @auto-canary/gh-pages@9.48.2-canary.1412.17656.0
  npm install @auto-canary/git-tag@9.48.2-canary.1412.17656.0
  npm install @auto-canary/gradle@9.48.2-canary.1412.17656.0
  npm install @auto-canary/jira@9.48.2-canary.1412.17656.0
  npm install @auto-canary/maven@9.48.2-canary.1412.17656.0
  npm install @auto-canary/npm@9.48.2-canary.1412.17656.0
  npm install @auto-canary/omit-commits@9.48.2-canary.1412.17656.0
  npm install @auto-canary/omit-release-notes@9.48.2-canary.1412.17656.0
  npm install @auto-canary/released@9.48.2-canary.1412.17656.0
  npm install @auto-canary/s3@9.48.2-canary.1412.17656.0
  npm install @auto-canary/slack@9.48.2-canary.1412.17656.0
  npm install @auto-canary/twitter@9.48.2-canary.1412.17656.0
  npm install @auto-canary/upload-assets@9.48.2-canary.1412.17656.0
  # or 
  yarn add @auto-canary/bot-list@9.48.2-canary.1412.17656.0
  yarn add @auto-canary/auto@9.48.2-canary.1412.17656.0
  yarn add @auto-canary/core@9.48.2-canary.1412.17656.0
  yarn add @auto-canary/all-contributors@9.48.2-canary.1412.17656.0
  yarn add @auto-canary/brew@9.48.2-canary.1412.17656.0
  yarn add @auto-canary/chrome@9.48.2-canary.1412.17656.0
  yarn add @auto-canary/cocoapods@9.48.2-canary.1412.17656.0
  yarn add @auto-canary/conventional-commits@9.48.2-canary.1412.17656.0
  yarn add @auto-canary/crates@9.48.2-canary.1412.17656.0
  yarn add @auto-canary/exec@9.48.2-canary.1412.17656.0
  yarn add @auto-canary/first-time-contributor@9.48.2-canary.1412.17656.0
  yarn add @auto-canary/gem@9.48.2-canary.1412.17656.0
  yarn add @auto-canary/gh-pages@9.48.2-canary.1412.17656.0
  yarn add @auto-canary/git-tag@9.48.2-canary.1412.17656.0
  yarn add @auto-canary/gradle@9.48.2-canary.1412.17656.0
  yarn add @auto-canary/jira@9.48.2-canary.1412.17656.0
  yarn add @auto-canary/maven@9.48.2-canary.1412.17656.0
  yarn add @auto-canary/npm@9.48.2-canary.1412.17656.0
  yarn add @auto-canary/omit-commits@9.48.2-canary.1412.17656.0
  yarn add @auto-canary/omit-release-notes@9.48.2-canary.1412.17656.0
  yarn add @auto-canary/released@9.48.2-canary.1412.17656.0
  yarn add @auto-canary/s3@9.48.2-canary.1412.17656.0
  yarn add @auto-canary/slack@9.48.2-canary.1412.17656.0
  yarn add @auto-canary/twitter@9.48.2-canary.1412.17656.0
  yarn add @auto-canary/upload-assets@9.48.2-canary.1412.17656.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
