### PR TITLE
Implement full maven release workflow

### DIFF
--- a/plugins/maven/__tests__/maven.test.ts
+++ b/plugins/maven/__tests__/maven.test.ts
@@ -313,7 +313,7 @@ describe("maven", () => {
       await hooks.beforeRun.promise({} as any);
       await hooks.version.promise(Auto.SEMVER.patch);
 
-      expect(await readFile).toHaveBeenCalledTimes(3);
+      expect(await readFile).toHaveBeenCalledTimes(4);
       expect(await readFile).toHaveBeenLastCalledWith(
         "pom.xml",
         { encoding: "utf8" },
@@ -347,7 +347,7 @@ describe("maven", () => {
       await hooks.beforeRun.promise({} as any);
       await hooks.version.promise(Auto.SEMVER.patch);
 
-      expect(await readFile).toHaveBeenCalledTimes(2);
+      expect(await readFile).toHaveBeenCalledTimes(3);
       expect(await readFile).toHaveBeenLastCalledWith(
         "pom.xml",
         { encoding: "utf8" },
@@ -400,7 +400,7 @@ describe("maven", () => {
       await hooks.beforeRun.promise({} as any);
       await hooks.version.promise(Auto.SEMVER.patch);
 
-      expect(await readFile).toHaveBeenCalledTimes(4);
+      expect(await readFile).toHaveBeenCalledTimes(5);
       expect(await readFile).toHaveBeenLastCalledWith(
         "child/pom.xml",
         { encoding: "utf8" },

--- a/plugins/maven/src/maven.ts
+++ b/plugins/maven/src/maven.ts
@@ -1,0 +1,22 @@
+import { Auto, execPromise } from "@auto-it/core";
+import { IMavenPluginOptions } from "./index";
+
+/** Update the pom with maven */
+export async function updatePoms(
+  version: string,
+  options: IMavenPluginOptions,
+  auto: Auto,
+  message: string
+) {
+  auto.logger.verbose.info(
+    `Using the versions-maven-plugin to set version = ${version}`
+  );
+
+  await execPromise("mvn", [
+    "versions:set",
+    "-DgenerateBackupPoms=false",
+    `-DnewVersion=${version}`,
+  ]);
+
+  await execPromise("git", ["commit", "-am", message, "--no-verify"]);
+}

--- a/plugins/maven/src/maven.ts
+++ b/plugins/maven/src/maven.ts
@@ -1,6 +1,35 @@
 import { Auto, execPromise } from "@auto-it/core";
 import { IMavenPluginOptions } from "./index";
 
+const mavenDefaults = {
+  mavenCommand: "/usr/bin/mvn",
+  mavenOptions: [],
+  mavenReleaseGoals: ["deploy", "site-deploy"],
+};
+
+/** executes a maven command with all the options */
+async function executeMaven(options: IMavenPluginOptions, goals: string[]) {
+  const settingsParams = [
+    options?.mavenSettings ? `-s=${options.mavenSettings}` : "",
+    options?.mavenUsername ? `-Dusername=${options.mavenUsername}` : "",
+    options?.mavenPassword ? `-Dpassword=${options.mavenPassword}` : "",
+  ];
+
+  return execPromise(options.mavenCommand || mavenDefaults.mavenCommand, [
+    ...(options.mavenOptions || mavenDefaults.mavenOptions),
+    ...goals,
+    ...settingsParams,
+  ]);
+}
+
+/** execute the built in release goals */
+export async function executeReleaseGoals(options: IMavenPluginOptions) {
+  return executeMaven(
+    options,
+    options.mavenReleaseGoals || mavenDefaults.mavenReleaseGoals
+  );
+}
+
 /** Update the pom with maven */
 export async function updatePoms(
   version: string,
@@ -12,7 +41,7 @@ export async function updatePoms(
     `Using the versions-maven-plugin to set version = ${version}`
   );
 
-  await execPromise("mvn", [
+  await executeMaven(options, [
     "versions:set",
     "-DgenerateBackupPoms=false",
     `-DnewVersion=${version}`,

--- a/plugins/maven/src/native-version-update.ts
+++ b/plugins/maven/src/native-version-update.ts
@@ -1,0 +1,96 @@
+import { Auto, execPromise } from "@auto-it/core";
+import * as glob from "fast-glob";
+import * as fs from "fs";
+import * as jsdom from "jsdom";
+import * as prettier from "prettier";
+import { IMavenPluginOptions, getPom } from "./index";
+
+/** Update the version in the pom.xml file **/
+export async function updatePomVersion(
+  content: string,
+  version: string,
+  options: IMavenPluginOptions
+): Promise<string> {
+  const dom = new jsdom.JSDOM(content, { contentType: "text/xml" });
+  const pomDom = dom.window.document;
+  const versionNode = pomDom.evaluate(
+    "/project/version",
+    pomDom.documentElement,
+    pomDom.createNSResolver(pomDom.documentElement),
+    9 // XPathResult.FIRST_ORDERED_NODE_TYPE
+  );
+
+  if (versionNode?.singleNodeValue) {
+    versionNode.singleNodeValue.textContent = version;
+  }
+
+  const parentVersionNode = pomDom.evaluate(
+    "/project/parent/version",
+    pomDom.documentElement,
+    pomDom.createNSResolver(pomDom.documentElement),
+    9 // XPathResult.FIRST_ORDERED_NODE_TYPE
+  );
+
+  if (parentVersionNode?.singleNodeValue) {
+    parentVersionNode.singleNodeValue.textContent = version;
+  }
+
+  return prettier.format(dom.serialize(), {
+    printWidth: options.printWidth,
+    tabWidth: options.tabWidth,
+    parser: "html",
+  });
+}
+
+/** Update the pom.xml file with the new version **/
+export async function updatePomFile(
+  pomFile: string,
+  version: string,
+  options: IMavenPluginOptions,
+  auto: Auto
+) {
+  auto.logger.verbose.info(`Updating: ${pomFile}`);
+  const pom = await getPom(pomFile);
+  const content = await updatePomVersion(pom.pomXml, version, options);
+  fs.writeFile(pomFile, content, { encoding: "utf8" }, (err) => {
+    if (err) throw err;
+  });
+}
+
+/** Find and update all pom.xml files with new versions, and then commit the changes **/
+export async function updatePoms(
+  version: string,
+  options: IMavenPluginOptions,
+  auto: Auto
+) {
+  auto.logger.verbose.info("Using the auto maven plugin");
+  /** Get all the poms and update their versions **/
+  const pomFiles = await glob.sync("**/pom.xml");
+  if (pomFiles && pomFiles.length > 0) {
+    const updatedPoms = pomFiles.map((pomFile) => {
+      return updatePomFile(pomFile, version, options, auto);
+    });
+    await Promise.all(updatedPoms)
+      .then(() => {
+        auto.logger.verbose.info(
+          `Updated ${pomFiles.length} pom.xml files with version: ${version}`
+        );
+      })
+      .catch((reason: string) => {
+        auto.logger.verbose.error(
+          `There was an error modifying the pom files. Running 'git checkout -- .' to reset the clone.`
+        );
+        execPromise("git", ["checkout", "--", "."]).catch((reason: string) => {
+          throw new Error(reason);
+        });
+        throw new Error(reason);
+      });
+
+    await execPromise("git", [
+      "commit",
+      "-am",
+      `"update version: ${version} [skip ci]"`,
+      "--no-verify",
+    ]);
+  }
+}


### PR DESCRIPTION
# What Changed

Add commits back in the case of using the versions plugin

# Why

Because otherwise the repo is messed up.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.48.4-canary.1413.17702.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.48.4-canary.1413.17702.0
  npm install @auto-canary/auto@9.48.4-canary.1413.17702.0
  npm install @auto-canary/core@9.48.4-canary.1413.17702.0
  npm install @auto-canary/all-contributors@9.48.4-canary.1413.17702.0
  npm install @auto-canary/brew@9.48.4-canary.1413.17702.0
  npm install @auto-canary/chrome@9.48.4-canary.1413.17702.0
  npm install @auto-canary/cocoapods@9.48.4-canary.1413.17702.0
  npm install @auto-canary/conventional-commits@9.48.4-canary.1413.17702.0
  npm install @auto-canary/crates@9.48.4-canary.1413.17702.0
  npm install @auto-canary/exec@9.48.4-canary.1413.17702.0
  npm install @auto-canary/first-time-contributor@9.48.4-canary.1413.17702.0
  npm install @auto-canary/gem@9.48.4-canary.1413.17702.0
  npm install @auto-canary/gh-pages@9.48.4-canary.1413.17702.0
  npm install @auto-canary/git-tag@9.48.4-canary.1413.17702.0
  npm install @auto-canary/gradle@9.48.4-canary.1413.17702.0
  npm install @auto-canary/jira@9.48.4-canary.1413.17702.0
  npm install @auto-canary/maven@9.48.4-canary.1413.17702.0
  npm install @auto-canary/npm@9.48.4-canary.1413.17702.0
  npm install @auto-canary/omit-commits@9.48.4-canary.1413.17702.0
  npm install @auto-canary/omit-release-notes@9.48.4-canary.1413.17702.0
  npm install @auto-canary/released@9.48.4-canary.1413.17702.0
  npm install @auto-canary/s3@9.48.4-canary.1413.17702.0
  npm install @auto-canary/slack@9.48.4-canary.1413.17702.0
  npm install @auto-canary/twitter@9.48.4-canary.1413.17702.0
  npm install @auto-canary/upload-assets@9.48.4-canary.1413.17702.0
  # or 
  yarn add @auto-canary/bot-list@9.48.4-canary.1413.17702.0
  yarn add @auto-canary/auto@9.48.4-canary.1413.17702.0
  yarn add @auto-canary/core@9.48.4-canary.1413.17702.0
  yarn add @auto-canary/all-contributors@9.48.4-canary.1413.17702.0
  yarn add @auto-canary/brew@9.48.4-canary.1413.17702.0
  yarn add @auto-canary/chrome@9.48.4-canary.1413.17702.0
  yarn add @auto-canary/cocoapods@9.48.4-canary.1413.17702.0
  yarn add @auto-canary/conventional-commits@9.48.4-canary.1413.17702.0
  yarn add @auto-canary/crates@9.48.4-canary.1413.17702.0
  yarn add @auto-canary/exec@9.48.4-canary.1413.17702.0
  yarn add @auto-canary/first-time-contributor@9.48.4-canary.1413.17702.0
  yarn add @auto-canary/gem@9.48.4-canary.1413.17702.0
  yarn add @auto-canary/gh-pages@9.48.4-canary.1413.17702.0
  yarn add @auto-canary/git-tag@9.48.4-canary.1413.17702.0
  yarn add @auto-canary/gradle@9.48.4-canary.1413.17702.0
  yarn add @auto-canary/jira@9.48.4-canary.1413.17702.0
  yarn add @auto-canary/maven@9.48.4-canary.1413.17702.0
  yarn add @auto-canary/npm@9.48.4-canary.1413.17702.0
  yarn add @auto-canary/omit-commits@9.48.4-canary.1413.17702.0
  yarn add @auto-canary/omit-release-notes@9.48.4-canary.1413.17702.0
  yarn add @auto-canary/released@9.48.4-canary.1413.17702.0
  yarn add @auto-canary/s3@9.48.4-canary.1413.17702.0
  yarn add @auto-canary/slack@9.48.4-canary.1413.17702.0
  yarn add @auto-canary/twitter@9.48.4-canary.1413.17702.0
  yarn add @auto-canary/upload-assets@9.48.4-canary.1413.17702.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
