### PR TITLE
add Github Package Registry docs

### DIFF
--- a/docs/pages/docs/build-platforms/github-actions.mdx
+++ b/docs/pages/docs/build-platforms/github-actions.mdx
@@ -49,6 +49,25 @@ jobs:
           npx auto shipit
 ```
 
+### NPM: Github Package Registry
+
+If you are publishing to the Github Package Registry you will need to change the `NPM_TOKEN` token secret to match the following:
+
+```yml
+- name: Create Release
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  run: |
+    yarn install --frozen-lockfile
+    yarn build
+    npx auto shipit
+```
+
+This will use your `GITHUB_TOKEN` to publish to the Github Package Registry.
+The `NODE_AUTH_TOKEN` variable is required the `.npmrc` that `actions/setup-node@v1` sets up.
+If you aren't using `actions/setup-node@v1` replace the variable name `NODE_AUTH_TOKEN` with `NPM_TOKEN` and the `.npmrc` `auto` will handle authentication instead.
+
 ## Troubleshooting
 
 If you are having problems make sure you have done the following:

--- a/plugins/conventional-commits/src/index.ts
+++ b/plugins/conventional-commits/src/index.ts
@@ -23,7 +23,7 @@ export default class ConventionalCommitsPlugin implements IPlugin {
             mappers.increment,
             parse(commit.subject)
           );
-          // conventional commits will return a falsy value when no incrememnt is detected (e.g., chore/perf/refactor commits)
+          // conventional commits will return a falsy value when no increment is detected (e.g., chore/perf/refactor commits)
           const commitIncrement =
             (conventionalCommit.increment as VersionLabel) || "skip";
           const incrementLabel = auto.semVerLabels.get(commitIncrement);


### PR DESCRIPTION
# What Changed

Add docs to help with GPR setup

# Why

It is not very obvious. Many pits of despair

Todo:

- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.48.3-canary.1414.17676.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.48.3-canary.1414.17676.0
  npm install @auto-canary/auto@9.48.3-canary.1414.17676.0
  npm install @auto-canary/core@9.48.3-canary.1414.17676.0
  npm install @auto-canary/all-contributors@9.48.3-canary.1414.17676.0
  npm install @auto-canary/brew@9.48.3-canary.1414.17676.0
  npm install @auto-canary/chrome@9.48.3-canary.1414.17676.0
  npm install @auto-canary/cocoapods@9.48.3-canary.1414.17676.0
  npm install @auto-canary/conventional-commits@9.48.3-canary.1414.17676.0
  npm install @auto-canary/crates@9.48.3-canary.1414.17676.0
  npm install @auto-canary/exec@9.48.3-canary.1414.17676.0
  npm install @auto-canary/first-time-contributor@9.48.3-canary.1414.17676.0
  npm install @auto-canary/gem@9.48.3-canary.1414.17676.0
  npm install @auto-canary/gh-pages@9.48.3-canary.1414.17676.0
  npm install @auto-canary/git-tag@9.48.3-canary.1414.17676.0
  npm install @auto-canary/gradle@9.48.3-canary.1414.17676.0
  npm install @auto-canary/jira@9.48.3-canary.1414.17676.0
  npm install @auto-canary/maven@9.48.3-canary.1414.17676.0
  npm install @auto-canary/npm@9.48.3-canary.1414.17676.0
  npm install @auto-canary/omit-commits@9.48.3-canary.1414.17676.0
  npm install @auto-canary/omit-release-notes@9.48.3-canary.1414.17676.0
  npm install @auto-canary/released@9.48.3-canary.1414.17676.0
  npm install @auto-canary/s3@9.48.3-canary.1414.17676.0
  npm install @auto-canary/slack@9.48.3-canary.1414.17676.0
  npm install @auto-canary/twitter@9.48.3-canary.1414.17676.0
  npm install @auto-canary/upload-assets@9.48.3-canary.1414.17676.0
  # or 
  yarn add @auto-canary/bot-list@9.48.3-canary.1414.17676.0
  yarn add @auto-canary/auto@9.48.3-canary.1414.17676.0
  yarn add @auto-canary/core@9.48.3-canary.1414.17676.0
  yarn add @auto-canary/all-contributors@9.48.3-canary.1414.17676.0
  yarn add @auto-canary/brew@9.48.3-canary.1414.17676.0
  yarn add @auto-canary/chrome@9.48.3-canary.1414.17676.0
  yarn add @auto-canary/cocoapods@9.48.3-canary.1414.17676.0
  yarn add @auto-canary/conventional-commits@9.48.3-canary.1414.17676.0
  yarn add @auto-canary/crates@9.48.3-canary.1414.17676.0
  yarn add @auto-canary/exec@9.48.3-canary.1414.17676.0
  yarn add @auto-canary/first-time-contributor@9.48.3-canary.1414.17676.0
  yarn add @auto-canary/gem@9.48.3-canary.1414.17676.0
  yarn add @auto-canary/gh-pages@9.48.3-canary.1414.17676.0
  yarn add @auto-canary/git-tag@9.48.3-canary.1414.17676.0
  yarn add @auto-canary/gradle@9.48.3-canary.1414.17676.0
  yarn add @auto-canary/jira@9.48.3-canary.1414.17676.0
  yarn add @auto-canary/maven@9.48.3-canary.1414.17676.0
  yarn add @auto-canary/npm@9.48.3-canary.1414.17676.0
  yarn add @auto-canary/omit-commits@9.48.3-canary.1414.17676.0
  yarn add @auto-canary/omit-release-notes@9.48.3-canary.1414.17676.0
  yarn add @auto-canary/released@9.48.3-canary.1414.17676.0
  yarn add @auto-canary/s3@9.48.3-canary.1414.17676.0
  yarn add @auto-canary/slack@9.48.3-canary.1414.17676.0
  yarn add @auto-canary/twitter@9.48.3-canary.1414.17676.0
  yarn add @auto-canary/upload-assets@9.48.3-canary.1414.17676.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
