### PR TITLE
don't leak GH_TOKEN in exec promise output

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -569,7 +569,7 @@ export default class Auto {
     this.logger.verbose.info(
       `Using remote: ${this.remote.replace(
         token,
-        `****${token.substring(0, 4)}`
+        `****${token.slice(-4)}`
       )}`
     );
     this.hooks.onCreateRelease.call(this.release);

--- a/packages/core/src/utils/__tests__/exec-promise.test.ts
+++ b/packages/core/src/utils/__tests__/exec-promise.test.ts
@@ -29,6 +29,14 @@ test("fails correctly", async () => {
   );
 });
 
+test("fails correctly with GH_TOKEN", async () => {
+  process.env.GH_TOKEN = '1234567890'
+  expect.assertions(1);
+  return expect(exec("false", [process.env.GH_TOKEN])).rejects.toMatchInlineSnapshot(
+    `[Error: Running command 'false' with args [****7890] failed]`
+  );
+});
+
 test("appends stdout and stderr", async () => {
   expect.assertions(1);
   return expect(

--- a/packages/core/src/utils/exec-promise.ts
+++ b/packages/core/src/utils/exec-promise.ts
@@ -66,11 +66,15 @@ export default async function execPromise(
         let appendedStdErr = "";
         appendedStdErr += allStdout.length ? `\n\n${allStdout}` : "";
         appendedStdErr += allStderr.length ? `\n\n${allStderr}` : "";
+        const argList = filteredArgs
+          .join(", ")
+          .replace(
+            new RegExp(`${process.env.GH_TOKEN}`, "g"),
+            `****${(process.env.GH_TOKEN || "").slice(-4)}`
+          );
 
         const error = new Error(
-          `Running command '${cmd}' with args [${args.join(
-            ", "
-          )}] failed${appendedStdErr}`
+          `Running command '${cmd}' with args [${argList}] failed${appendedStdErr}`
         );
         error.stack = (error.stack || "") + callSite;
         reject(error);


### PR DESCRIPTION
# What Changed

sanitize the execPromise error output of the GH_TOKEN

# Why

tokens in logs are bad!

Todo:

- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.49.1-canary.1419.17719.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.49.1-canary.1419.17719.0
  npm install @auto-canary/auto@9.49.1-canary.1419.17719.0
  npm install @auto-canary/core@9.49.1-canary.1419.17719.0
  npm install @auto-canary/all-contributors@9.49.1-canary.1419.17719.0
  npm install @auto-canary/brew@9.49.1-canary.1419.17719.0
  npm install @auto-canary/chrome@9.49.1-canary.1419.17719.0
  npm install @auto-canary/cocoapods@9.49.1-canary.1419.17719.0
  npm install @auto-canary/conventional-commits@9.49.1-canary.1419.17719.0
  npm install @auto-canary/crates@9.49.1-canary.1419.17719.0
  npm install @auto-canary/exec@9.49.1-canary.1419.17719.0
  npm install @auto-canary/first-time-contributor@9.49.1-canary.1419.17719.0
  npm install @auto-canary/gem@9.49.1-canary.1419.17719.0
  npm install @auto-canary/gh-pages@9.49.1-canary.1419.17719.0
  npm install @auto-canary/git-tag@9.49.1-canary.1419.17719.0
  npm install @auto-canary/gradle@9.49.1-canary.1419.17719.0
  npm install @auto-canary/jira@9.49.1-canary.1419.17719.0
  npm install @auto-canary/maven@9.49.1-canary.1419.17719.0
  npm install @auto-canary/npm@9.49.1-canary.1419.17719.0
  npm install @auto-canary/omit-commits@9.49.1-canary.1419.17719.0
  npm install @auto-canary/omit-release-notes@9.49.1-canary.1419.17719.0
  npm install @auto-canary/released@9.49.1-canary.1419.17719.0
  npm install @auto-canary/s3@9.49.1-canary.1419.17719.0
  npm install @auto-canary/slack@9.49.1-canary.1419.17719.0
  npm install @auto-canary/twitter@9.49.1-canary.1419.17719.0
  npm install @auto-canary/upload-assets@9.49.1-canary.1419.17719.0
  # or 
  yarn add @auto-canary/bot-list@9.49.1-canary.1419.17719.0
  yarn add @auto-canary/auto@9.49.1-canary.1419.17719.0
  yarn add @auto-canary/core@9.49.1-canary.1419.17719.0
  yarn add @auto-canary/all-contributors@9.49.1-canary.1419.17719.0
  yarn add @auto-canary/brew@9.49.1-canary.1419.17719.0
  yarn add @auto-canary/chrome@9.49.1-canary.1419.17719.0
  yarn add @auto-canary/cocoapods@9.49.1-canary.1419.17719.0
  yarn add @auto-canary/conventional-commits@9.49.1-canary.1419.17719.0
  yarn add @auto-canary/crates@9.49.1-canary.1419.17719.0
  yarn add @auto-canary/exec@9.49.1-canary.1419.17719.0
  yarn add @auto-canary/first-time-contributor@9.49.1-canary.1419.17719.0
  yarn add @auto-canary/gem@9.49.1-canary.1419.17719.0
  yarn add @auto-canary/gh-pages@9.49.1-canary.1419.17719.0
  yarn add @auto-canary/git-tag@9.49.1-canary.1419.17719.0
  yarn add @auto-canary/gradle@9.49.1-canary.1419.17719.0
  yarn add @auto-canary/jira@9.49.1-canary.1419.17719.0
  yarn add @auto-canary/maven@9.49.1-canary.1419.17719.0
  yarn add @auto-canary/npm@9.49.1-canary.1419.17719.0
  yarn add @auto-canary/omit-commits@9.49.1-canary.1419.17719.0
  yarn add @auto-canary/omit-release-notes@9.49.1-canary.1419.17719.0
  yarn add @auto-canary/released@9.49.1-canary.1419.17719.0
  yarn add @auto-canary/s3@9.49.1-canary.1419.17719.0
  yarn add @auto-canary/slack@9.49.1-canary.1419.17719.0
  yarn add @auto-canary/twitter@9.49.1-canary.1419.17719.0
  yarn add @auto-canary/upload-assets@9.49.1-canary.1419.17719.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
