### PR TITLE
add docs about running lengthy builds during publish

### DIFF
--- a/docs/pages/docs/welcome/quick-merge.mdx
+++ b/docs/pages/docs/welcome/quick-merge.mdx
@@ -2,20 +2,37 @@
 title: Merging Quickly
 ---
 
-One caveat of `auto` is that you need to be mindful of merging multiple PRs at once. You **must not** merge a PR while another is publishing (ex: `lerna publish`). While this window is small, it exists and you should know about it.
+One caveat of `auto` is that you need to be mindful of merging multiple PRs at once.
+You **must not** merge a PR while another is publishing (ex: during `lerna publish`).
+While this window is small, it exists and you should know about it.
 
-`auto` works by looking at the `git` tree to calculate the version bump then makes commits for the `CHANGELOG.md` and the new version. If you merge a PR while another is publishing:
+`auto` works by looking at the `git` tree to calculate the version bump then makes commits for the `CHANGELOG.md` and the new version.
+If you merge a PR while another is publishing:
 
 - they might try to publish the same version number
 - one will try to push over the other's changes and fail
 
 > If you ensure that the last build on master has finished you shouldn't run into any problems!
 
+### Beware Long Publishes
+
+`auto` will do the following before trying to `publish` and push its commits:
+
+- Check for commits on the remote
+- Run the platform specific `publish` step
+
+If your `publish` step runs a lengthy build, then the window for conflicts is extended.
+The recommended approach is to build your code before running `auto` so the window for errors stays small.
+This may make sense on some platforms and not others.
+
+> Example: When using the `npm` plugin don't use the script `prepublishOnly` to build your code
+
 ## With `skip-release`
 
 The one exception to this rule with when merging a bunch of PRs with `skip-release` labels.
 
-You still can't merge a PR that triggers a release and then merge a PR with `skip-release`. This will result in problem 3 from above.
+You still can't merge a PR that triggers a release and then merge a PR with `skip-release`.
+This will result in problem 3 from above.
 
 ```txt
 1. Merge PR #4 "patch"

--- a/plugins/npm/README.md
+++ b/plugins/npm/README.md
@@ -1,10 +1,16 @@
 # NPM Plugin
 
-Publish to NPM. Works in both a monorepo setting and for a single package. This plugin is loaded by default when `auto` is installed through `npm`. If you configure `auto` to use any other plugin this will be lost. So you must add the `npm` plugin to your plugins array if you still want NPM functionality.
+Publish to NPM.
+Works in both a monorepo setting and for a single package.
+This plugin is loaded by default when `auto` is installed through `npm`.
+If you configure `auto` to use any other plugin this will be lost.
+So you must add the `npm` plugin to your plugins array if you still want NPM functionality.
 
 ## Prerequisites
 
 To publish to npm you will need an `NPM_TOKEN` set in your environment.
+
+> Warning! Avoid using the `prepublishOnly` script as it can lead to errors. [Read more here.](https://intuit.github.io/auto/docs/welcome/quick-merge#beware-long-publishes)
 
 ## Installation
 


### PR DESCRIPTION
# What Changed

see title

# Why

on some platforms it is easy to make publishing take longer and break releases

Todo:

- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.49.2-canary.1420.17736.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.49.2-canary.1420.17736.0
  npm install @auto-canary/auto@9.49.2-canary.1420.17736.0
  npm install @auto-canary/core@9.49.2-canary.1420.17736.0
  npm install @auto-canary/all-contributors@9.49.2-canary.1420.17736.0
  npm install @auto-canary/brew@9.49.2-canary.1420.17736.0
  npm install @auto-canary/chrome@9.49.2-canary.1420.17736.0
  npm install @auto-canary/cocoapods@9.49.2-canary.1420.17736.0
  npm install @auto-canary/conventional-commits@9.49.2-canary.1420.17736.0
  npm install @auto-canary/crates@9.49.2-canary.1420.17736.0
  npm install @auto-canary/exec@9.49.2-canary.1420.17736.0
  npm install @auto-canary/first-time-contributor@9.49.2-canary.1420.17736.0
  npm install @auto-canary/gem@9.49.2-canary.1420.17736.0
  npm install @auto-canary/gh-pages@9.49.2-canary.1420.17736.0
  npm install @auto-canary/git-tag@9.49.2-canary.1420.17736.0
  npm install @auto-canary/gradle@9.49.2-canary.1420.17736.0
  npm install @auto-canary/jira@9.49.2-canary.1420.17736.0
  npm install @auto-canary/maven@9.49.2-canary.1420.17736.0
  npm install @auto-canary/npm@9.49.2-canary.1420.17736.0
  npm install @auto-canary/omit-commits@9.49.2-canary.1420.17736.0
  npm install @auto-canary/omit-release-notes@9.49.2-canary.1420.17736.0
  npm install @auto-canary/released@9.49.2-canary.1420.17736.0
  npm install @auto-canary/s3@9.49.2-canary.1420.17736.0
  npm install @auto-canary/slack@9.49.2-canary.1420.17736.0
  npm install @auto-canary/twitter@9.49.2-canary.1420.17736.0
  npm install @auto-canary/upload-assets@9.49.2-canary.1420.17736.0
  # or 
  yarn add @auto-canary/bot-list@9.49.2-canary.1420.17736.0
  yarn add @auto-canary/auto@9.49.2-canary.1420.17736.0
  yarn add @auto-canary/core@9.49.2-canary.1420.17736.0
  yarn add @auto-canary/all-contributors@9.49.2-canary.1420.17736.0
  yarn add @auto-canary/brew@9.49.2-canary.1420.17736.0
  yarn add @auto-canary/chrome@9.49.2-canary.1420.17736.0
  yarn add @auto-canary/cocoapods@9.49.2-canary.1420.17736.0
  yarn add @auto-canary/conventional-commits@9.49.2-canary.1420.17736.0
  yarn add @auto-canary/crates@9.49.2-canary.1420.17736.0
  yarn add @auto-canary/exec@9.49.2-canary.1420.17736.0
  yarn add @auto-canary/first-time-contributor@9.49.2-canary.1420.17736.0
  yarn add @auto-canary/gem@9.49.2-canary.1420.17736.0
  yarn add @auto-canary/gh-pages@9.49.2-canary.1420.17736.0
  yarn add @auto-canary/git-tag@9.49.2-canary.1420.17736.0
  yarn add @auto-canary/gradle@9.49.2-canary.1420.17736.0
  yarn add @auto-canary/jira@9.49.2-canary.1420.17736.0
  yarn add @auto-canary/maven@9.49.2-canary.1420.17736.0
  yarn add @auto-canary/npm@9.49.2-canary.1420.17736.0
  yarn add @auto-canary/omit-commits@9.49.2-canary.1420.17736.0
  yarn add @auto-canary/omit-release-notes@9.49.2-canary.1420.17736.0
  yarn add @auto-canary/released@9.49.2-canary.1420.17736.0
  yarn add @auto-canary/s3@9.49.2-canary.1420.17736.0
  yarn add @auto-canary/slack@9.49.2-canary.1420.17736.0
  yarn add @auto-canary/twitter@9.49.2-canary.1420.17736.0
  yarn add @auto-canary/upload-assets@9.49.2-canary.1420.17736.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
