### PR TITLE
don't prefix tags in lerna independent mode

### DIFF
--- a/plugins/npm/__tests__/npm-next.test.ts
+++ b/plugins/npm/__tests__/npm-next.test.ts
@@ -313,7 +313,7 @@ describe("next", () => {
       remote: "origin",
       baseBranch: "master",
       logger: dummyLog(),
-      prefixRelease: (v: string) => v,
+      prefixRelease: (v: string) => `v${v}`,
       git: {
         getLatestRelease: () => "@foo/1@0.1.0",
         getLastTagNotInBaseBranch: () => "@foo/1@1.0.0-next.0",

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -211,7 +211,9 @@ function getLegacyAuthArgs(
 /** Get the args to set the registry. Only used with lerna */
 async function getRegistryArgs() {
   const registry = await getRegistry();
-  return registry === DEFAULT_REGISTRY || !registry ? [] : ["--registry", registry];
+  return registry === DEFAULT_REGISTRY || !registry
+    ? []
+    : ["--registry", registry];
 }
 
 const pluginOptions = t.partial({
@@ -945,7 +947,7 @@ export default class NPMPlugin implements IPlugin {
 
         preReleaseVersions = [
           ...preReleaseVersions,
-          ...tags.map(auto.prefixRelease),
+          ...(isIndependent ? tags : tags.map(auto.prefixRelease)),
         ];
       } else {
         auto.logger.verbose.info("Detected single npm package");


### PR DESCRIPTION
# What Changed

see title

# Why

closes #1425 

Todo:

- [x] Add tests


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.49.2-canary.1427.17789.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.49.2-canary.1427.17789.0
  npm install @auto-canary/auto@9.49.2-canary.1427.17789.0
  npm install @auto-canary/core@9.49.2-canary.1427.17789.0
  npm install @auto-canary/all-contributors@9.49.2-canary.1427.17789.0
  npm install @auto-canary/brew@9.49.2-canary.1427.17789.0
  npm install @auto-canary/chrome@9.49.2-canary.1427.17789.0
  npm install @auto-canary/cocoapods@9.49.2-canary.1427.17789.0
  npm install @auto-canary/conventional-commits@9.49.2-canary.1427.17789.0
  npm install @auto-canary/crates@9.49.2-canary.1427.17789.0
  npm install @auto-canary/exec@9.49.2-canary.1427.17789.0
  npm install @auto-canary/first-time-contributor@9.49.2-canary.1427.17789.0
  npm install @auto-canary/gem@9.49.2-canary.1427.17789.0
  npm install @auto-canary/gh-pages@9.49.2-canary.1427.17789.0
  npm install @auto-canary/git-tag@9.49.2-canary.1427.17789.0
  npm install @auto-canary/gradle@9.49.2-canary.1427.17789.0
  npm install @auto-canary/jira@9.49.2-canary.1427.17789.0
  npm install @auto-canary/maven@9.49.2-canary.1427.17789.0
  npm install @auto-canary/npm@9.49.2-canary.1427.17789.0
  npm install @auto-canary/omit-commits@9.49.2-canary.1427.17789.0
  npm install @auto-canary/omit-release-notes@9.49.2-canary.1427.17789.0
  npm install @auto-canary/released@9.49.2-canary.1427.17789.0
  npm install @auto-canary/s3@9.49.2-canary.1427.17789.0
  npm install @auto-canary/slack@9.49.2-canary.1427.17789.0
  npm install @auto-canary/twitter@9.49.2-canary.1427.17789.0
  npm install @auto-canary/upload-assets@9.49.2-canary.1427.17789.0
  # or 
  yarn add @auto-canary/bot-list@9.49.2-canary.1427.17789.0
  yarn add @auto-canary/auto@9.49.2-canary.1427.17789.0
  yarn add @auto-canary/core@9.49.2-canary.1427.17789.0
  yarn add @auto-canary/all-contributors@9.49.2-canary.1427.17789.0
  yarn add @auto-canary/brew@9.49.2-canary.1427.17789.0
  yarn add @auto-canary/chrome@9.49.2-canary.1427.17789.0
  yarn add @auto-canary/cocoapods@9.49.2-canary.1427.17789.0
  yarn add @auto-canary/conventional-commits@9.49.2-canary.1427.17789.0
  yarn add @auto-canary/crates@9.49.2-canary.1427.17789.0
  yarn add @auto-canary/exec@9.49.2-canary.1427.17789.0
  yarn add @auto-canary/first-time-contributor@9.49.2-canary.1427.17789.0
  yarn add @auto-canary/gem@9.49.2-canary.1427.17789.0
  yarn add @auto-canary/gh-pages@9.49.2-canary.1427.17789.0
  yarn add @auto-canary/git-tag@9.49.2-canary.1427.17789.0
  yarn add @auto-canary/gradle@9.49.2-canary.1427.17789.0
  yarn add @auto-canary/jira@9.49.2-canary.1427.17789.0
  yarn add @auto-canary/maven@9.49.2-canary.1427.17789.0
  yarn add @auto-canary/npm@9.49.2-canary.1427.17789.0
  yarn add @auto-canary/omit-commits@9.49.2-canary.1427.17789.0
  yarn add @auto-canary/omit-release-notes@9.49.2-canary.1427.17789.0
  yarn add @auto-canary/released@9.49.2-canary.1427.17789.0
  yarn add @auto-canary/s3@9.49.2-canary.1427.17789.0
  yarn add @auto-canary/slack@9.49.2-canary.1427.17789.0
  yarn add @auto-canary/twitter@9.49.2-canary.1427.17789.0
  yarn add @auto-canary/upload-assets@9.49.2-canary.1427.17789.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
