### PR TITLE
Fix lerna independent "next" releases

### DIFF
--- a/packages/core/src/__tests__/auto-in-pr-ci.test.ts
+++ b/packages/core/src/__tests__/auto-in-pr-ci.test.ts
@@ -177,7 +177,7 @@ describe("next in ci", () => {
     auto.prBody = prBody;
     auto.logger = dummyLog();
     await auto.loadConfig();
-    auto.git!.publish = () => Promise.resolve({} as any);
+    auto.git!.publish = () => Promise.resolve({ data: {} } as any);
     auto.git!.getLatestTagInBranch = () => Promise.resolve("1.2.3");
     auto.git!.getLatestRelease = () => Promise.resolve("1.2.3");
     auto.release!.generateReleaseNotes = () => Promise.resolve("notes");

--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -1335,7 +1335,7 @@ describe("Auto", () => {
       auto.logger = dummyLog();
       await auto.loadConfig();
       auto.remote = "origin";
-      auto.git!.publish = () => Promise.resolve({} as any);
+      auto.git!.publish = () => Promise.resolve({ data: {} } as any);
       auto.git!.getLatestTagInBranch = () => Promise.resolve("1.2.3");
       auto.git!.getLatestRelease = () => Promise.resolve("1.2.3");
       auto.release!.generateReleaseNotes = () => Promise.resolve("notes");
@@ -1359,8 +1359,9 @@ describe("Auto", () => {
       auto.logger = dummyLog();
       await auto.loadConfig();
       auto.remote = "origin";
-      auto.git!.publish = () => Promise.resolve({} as any);
-      auto.git!.getLastTagNotInBaseBranch = () => Promise.reject(new Error("Test"));
+      auto.git!.publish = () => Promise.resolve({ data: {} } as any);
+      auto.git!.getLastTagNotInBaseBranch = () =>
+        Promise.reject(new Error("Test"));
       auto.git!.getLatestTagInBranch = () => Promise.reject(new Error("Test"));
       auto.git!.getLatestRelease = () => Promise.resolve("abcd");
       auto.release!.generateReleaseNotes = () => Promise.resolve("notes");

--- a/packages/core/src/__tests__/validate-config.test.ts
+++ b/packages/core/src/__tests__/validate-config.test.ts
@@ -262,6 +262,7 @@ describe("validateConfig", () => {
           );
         }
 
+        // eslint-disable-next-line jest/no-if
         if (options.other && typeof options.other !== "number") {
           errors.push(
             formatError({

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -115,7 +115,7 @@ const makeDetail = (summary: string, body: string) => endent`
   </details>
 `;
 
-type ShipitRelease = "latest" | "old" | "next" | "canary";
+export type ShipitRelease = "latest" | "old" | "next" | "canary";
 
 interface BeforeShipitContext {
   /** The type of release that will be made when shipit runs. */

--- a/plugins/maven/__tests__/maven.test.ts
+++ b/plugins/maven/__tests__/maven.test.ts
@@ -392,6 +392,7 @@ describe("maven", () => {
       readFile.mockImplementation((path, options, callback) => {
         if (path === "pom.xml") {
           callback(undefined, oldParentPomXml);
+          // eslint-disable-next-line jest/no-if
         } else if (path === "child/pom.xml") {
           callback(undefined, oldChildPomXml);
         }

--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -75,7 +75,7 @@ describe("getChangedPackages ", () => {
       await getChangedPackages({
         sha: "sha",
         packages: [],
-        lernaJson: {},
+        addVersion: false,
         logger: dummyLog(),
       })
     ).toStrictEqual([]);
@@ -101,7 +101,7 @@ describe("getChangedPackages ", () => {
             version: "1.0.0",
           },
         ],
-        lernaJson: {},
+        addVersion: false,
         logger: dummyLog(),
       })
     ).toStrictEqual(["foo", "bar"]);
@@ -127,7 +127,7 @@ describe("getChangedPackages ", () => {
             version: "1.0.0",
           },
         ],
-        lernaJson: {},
+        addVersion: false,
         logger: dummyLog(),
       })
     ).toStrictEqual(["@scope/foo", "@scope/bar"]);

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -693,7 +693,9 @@ export default class NPMPlugin implements IPlugin {
               packages: lernaPackages,
               // If we are making a next release it's hard to get the independent next
               // versions to put in the changelog so we just omit them
-              addVersion: this.releaseType !== "next",
+              addVersion:
+                this.releaseType !== "next" &&
+                getLernaJson().version === "independent",
               logger: auto.logger,
               version,
             });

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -1108,9 +1108,7 @@ export default class NPMPlugin implements IPlugin {
             auto.logger.log.info(`Using release notes:\n${releaseNotes}`);
 
             // 2. make a release for just that package
-            if (releaseNotes.trim()) {
-              return auto.git?.publish(releaseNotes, tag, options.isPrerelease);
-            }
+            return auto.git?.publish(releaseNotes, tag, options.isPrerelease);
           })
         );
 

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -938,7 +938,9 @@ export default class NPMPlugin implements IPlugin {
         ).split("\n");
         await Promise.all(
           // Move tags back one commit
-          tags.map((tag) => execPromise("git", ["tag", tag, "-f", "HEAD^"]))
+          tags.map((tag) =>
+            execPromise("git", ["tag", tag, "-f", "HEAD^", "-am", tag])
+          )
         );
         // Move branch back one commit
         await execPromise("git", ["reset", "--hard", "HEAD~1"]);


### PR DESCRIPTION
# Release Notes

This PR fixes a few issues around `next` releases and lerna independent monorepos:

- implement a lerna-like versioning function for independent next releases. Allows us more control of how the repo gets versioned. this function will tag+commit the next version, relying on the previously implemented "tag-juggling" so we can rely on lerna as much as possible.
- rely on `makeRelease` hook to create `next` releases. This enables changelogs in the prerelease for each package
- keep tags annotated while moving. This makes lerna's package publishing logic work better. `lerna changed` only works on annotated tags.
- remove version from "Full Changelog"s in prerelease PRs. hard to calculate correct version so it's easier to just omit it

# Why

I personally don't use independent releases much so there are a few bugs 😅 

closes #1428 

Todo:

- [ ] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.49.4-canary.1429.17818.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.49.4-canary.1429.17818.0
  npm install @auto-canary/auto@9.49.4-canary.1429.17818.0
  npm install @auto-canary/core@9.49.4-canary.1429.17818.0
  npm install @auto-canary/all-contributors@9.49.4-canary.1429.17818.0
  npm install @auto-canary/brew@9.49.4-canary.1429.17818.0
  npm install @auto-canary/chrome@9.49.4-canary.1429.17818.0
  npm install @auto-canary/cocoapods@9.49.4-canary.1429.17818.0
  npm install @auto-canary/conventional-commits@9.49.4-canary.1429.17818.0
  npm install @auto-canary/crates@9.49.4-canary.1429.17818.0
  npm install @auto-canary/exec@9.49.4-canary.1429.17818.0
  npm install @auto-canary/first-time-contributor@9.49.4-canary.1429.17818.0
  npm install @auto-canary/gem@9.49.4-canary.1429.17818.0
  npm install @auto-canary/gh-pages@9.49.4-canary.1429.17818.0
  npm install @auto-canary/git-tag@9.49.4-canary.1429.17818.0
  npm install @auto-canary/gradle@9.49.4-canary.1429.17818.0
  npm install @auto-canary/jira@9.49.4-canary.1429.17818.0
  npm install @auto-canary/maven@9.49.4-canary.1429.17818.0
  npm install @auto-canary/npm@9.49.4-canary.1429.17818.0
  npm install @auto-canary/omit-commits@9.49.4-canary.1429.17818.0
  npm install @auto-canary/omit-release-notes@9.49.4-canary.1429.17818.0
  npm install @auto-canary/released@9.49.4-canary.1429.17818.0
  npm install @auto-canary/s3@9.49.4-canary.1429.17818.0
  npm install @auto-canary/slack@9.49.4-canary.1429.17818.0
  npm install @auto-canary/twitter@9.49.4-canary.1429.17818.0
  npm install @auto-canary/upload-assets@9.49.4-canary.1429.17818.0
  # or 
  yarn add @auto-canary/bot-list@9.49.4-canary.1429.17818.0
  yarn add @auto-canary/auto@9.49.4-canary.1429.17818.0
  yarn add @auto-canary/core@9.49.4-canary.1429.17818.0
  yarn add @auto-canary/all-contributors@9.49.4-canary.1429.17818.0
  yarn add @auto-canary/brew@9.49.4-canary.1429.17818.0
  yarn add @auto-canary/chrome@9.49.4-canary.1429.17818.0
  yarn add @auto-canary/cocoapods@9.49.4-canary.1429.17818.0
  yarn add @auto-canary/conventional-commits@9.49.4-canary.1429.17818.0
  yarn add @auto-canary/crates@9.49.4-canary.1429.17818.0
  yarn add @auto-canary/exec@9.49.4-canary.1429.17818.0
  yarn add @auto-canary/first-time-contributor@9.49.4-canary.1429.17818.0
  yarn add @auto-canary/gem@9.49.4-canary.1429.17818.0
  yarn add @auto-canary/gh-pages@9.49.4-canary.1429.17818.0
  yarn add @auto-canary/git-tag@9.49.4-canary.1429.17818.0
  yarn add @auto-canary/gradle@9.49.4-canary.1429.17818.0
  yarn add @auto-canary/jira@9.49.4-canary.1429.17818.0
  yarn add @auto-canary/maven@9.49.4-canary.1429.17818.0
  yarn add @auto-canary/npm@9.49.4-canary.1429.17818.0
  yarn add @auto-canary/omit-commits@9.49.4-canary.1429.17818.0
  yarn add @auto-canary/omit-release-notes@9.49.4-canary.1429.17818.0
  yarn add @auto-canary/released@9.49.4-canary.1429.17818.0
  yarn add @auto-canary/s3@9.49.4-canary.1429.17818.0
  yarn add @auto-canary/slack@9.49.4-canary.1429.17818.0
  yarn add @auto-canary/twitter@9.49.4-canary.1429.17818.0
  yarn add @auto-canary/upload-assets@9.49.4-canary.1429.17818.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
