### PR TITLE
Fix Independent `next` versioning

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -697,7 +697,7 @@ export default class Auto {
       "git"  version: v${gitVersion.replace('git version ', '')}
       "node" version: ${process.version.trim()}${
         access['x-github-enterprise-version'] 
-          ? `GHE version:    v${access['x-github-enterprise-version']}\n`
+          ? `\nGHE version:    v${access['x-github-enterprise-version']}\n`
           : '\n'}
       ${chalk.underline.white('Project Information:')}
 

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -219,7 +219,7 @@ export default class Git {
 
   /** Get the first commit for the repo */
   async getFirstCommit(): Promise<string> {
-    const list = await execPromise("git", ["rev-list", "HEAD"]);
+    const list = await execPromise("git", ["rev-list", "--max-parents=0", "HEAD"]);
     return list.split("\n").pop() as string;
   }
 

--- a/plugins/npm/__tests__/npm-next.test.ts
+++ b/plugins/npm/__tests__/npm-next.test.ts
@@ -307,21 +307,21 @@ describe("next", () => {
     readFileSync.mockReturnValue('{ "version": "independent" }');
     getLernaPackages.mockResolvedValueOnce([
       {
-        name: "@foo/1",
+        name: "@foo/foo",
         path: "/path/to/1",
       },
       {
-        name: "@foo/2",
+        name: "@foo/foo-bar",
         path: "/path/to/2",
       },
     ]);
     execPromise.mockImplementation((command, args) => {
       if (command === "git" && args[0] === "tag") {
-        return Promise.resolve("@foo/1@1.0.0-next.0\n@foo/2@2.0.0-next.0");
+        return Promise.resolve("@foo/foo@1.0.0-next.0\n@foo/foo-bar@2.0.0-next.0");
       }
 
-      if (command === "yarn" && args[0] === "lerna" && args[0] === "changed") {
-        return Promise.resolve("@foo/1\n@foo/2");
+      if (command === "yarn" && args[0] === "lerna" && args[1] === "changed") {
+        return Promise.resolve("@foo/foo\n@foo/foo-bar");
       }
 
       return Promise.resolve("");
@@ -335,14 +335,14 @@ describe("next", () => {
       logger: dummyLog(),
       prefixRelease: (v: string) => `v${v}`,
       git: {
-        getLatestRelease: () => "@foo/1@0.1.0",
-        getLastTagNotInBaseBranch: () => "@foo/1@1.0.0-next.0",
+        getLatestRelease: () => "@foo/foo@0.1.0",
+        getLastTagNotInBaseBranch: () => "@foo/foo@1.0.0-next.0",
       },
     } as unknown) as Auto.Auto);
 
     expect(
       await hooks.next.promise([], Auto.SEMVER.patch, {} as any)
-    ).toStrictEqual(["@foo/1@1.0.0-next.0", "@foo/2@2.0.0-next.0"]);
+    ).toStrictEqual(["@foo/foo@1.0.0-next.0", "@foo/foo-bar@2.0.0-next.0"]);
 
     expect(execPromise).toHaveBeenCalledWith(
       "npx",

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -394,9 +394,10 @@ const tagIndependentNextReleases = async (
       }
 
       const currentVersion = lernaPackage?.version || "0.0.0";
+      const name = `${p}@`;
       const lastTag =
-        allTags.find((tag) => tag.startsWith(p)) || currentVersion;
-      const lastVersion = lastTag.replace(`${p}@`, "");
+        allTags.find((tag) => tag.startsWith(name)) || currentVersion;
+      const lastVersion = lastTag.replace(name, "");
 
       return {
         ...lernaPackage,
@@ -572,7 +573,8 @@ export default class NPMPlugin implements IPlugin {
       : isVerbose
       ? ["--loglevel", "silly"]
       : [];
-    const prereleaseBranches = auto.config?.prereleaseBranches || DEFAULT_PRERELEASE_BRANCHES;
+    const prereleaseBranches =
+      auto.config?.prereleaseBranches || DEFAULT_PRERELEASE_BRANCHES;
     const branch = getCurrentBranch();
     // if ran from master we publish the prerelease to the first
     // configured prerelease branch


### PR DESCRIPTION
# What Changed

The `npm` plugin was matching the name of the package. If one package name was the substring of another then the wrong tag would get found, and the name replacement would fail. Now we correctly match the full name up to the `@`.

# Why

closes #1443 

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.49.6-canary.1445.17967.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.49.6-canary.1445.17967.0
  npm install @auto-canary/auto@9.49.6-canary.1445.17967.0
  npm install @auto-canary/core@9.49.6-canary.1445.17967.0
  npm install @auto-canary/all-contributors@9.49.6-canary.1445.17967.0
  npm install @auto-canary/brew@9.49.6-canary.1445.17967.0
  npm install @auto-canary/chrome@9.49.6-canary.1445.17967.0
  npm install @auto-canary/cocoapods@9.49.6-canary.1445.17967.0
  npm install @auto-canary/conventional-commits@9.49.6-canary.1445.17967.0
  npm install @auto-canary/crates@9.49.6-canary.1445.17967.0
  npm install @auto-canary/exec@9.49.6-canary.1445.17967.0
  npm install @auto-canary/first-time-contributor@9.49.6-canary.1445.17967.0
  npm install @auto-canary/gem@9.49.6-canary.1445.17967.0
  npm install @auto-canary/gh-pages@9.49.6-canary.1445.17967.0
  npm install @auto-canary/git-tag@9.49.6-canary.1445.17967.0
  npm install @auto-canary/gradle@9.49.6-canary.1445.17967.0
  npm install @auto-canary/jira@9.49.6-canary.1445.17967.0
  npm install @auto-canary/maven@9.49.6-canary.1445.17967.0
  npm install @auto-canary/npm@9.49.6-canary.1445.17967.0
  npm install @auto-canary/omit-commits@9.49.6-canary.1445.17967.0
  npm install @auto-canary/omit-release-notes@9.49.6-canary.1445.17967.0
  npm install @auto-canary/released@9.49.6-canary.1445.17967.0
  npm install @auto-canary/s3@9.49.6-canary.1445.17967.0
  npm install @auto-canary/slack@9.49.6-canary.1445.17967.0
  npm install @auto-canary/twitter@9.49.6-canary.1445.17967.0
  npm install @auto-canary/upload-assets@9.49.6-canary.1445.17967.0
  # or 
  yarn add @auto-canary/bot-list@9.49.6-canary.1445.17967.0
  yarn add @auto-canary/auto@9.49.6-canary.1445.17967.0
  yarn add @auto-canary/core@9.49.6-canary.1445.17967.0
  yarn add @auto-canary/all-contributors@9.49.6-canary.1445.17967.0
  yarn add @auto-canary/brew@9.49.6-canary.1445.17967.0
  yarn add @auto-canary/chrome@9.49.6-canary.1445.17967.0
  yarn add @auto-canary/cocoapods@9.49.6-canary.1445.17967.0
  yarn add @auto-canary/conventional-commits@9.49.6-canary.1445.17967.0
  yarn add @auto-canary/crates@9.49.6-canary.1445.17967.0
  yarn add @auto-canary/exec@9.49.6-canary.1445.17967.0
  yarn add @auto-canary/first-time-contributor@9.49.6-canary.1445.17967.0
  yarn add @auto-canary/gem@9.49.6-canary.1445.17967.0
  yarn add @auto-canary/gh-pages@9.49.6-canary.1445.17967.0
  yarn add @auto-canary/git-tag@9.49.6-canary.1445.17967.0
  yarn add @auto-canary/gradle@9.49.6-canary.1445.17967.0
  yarn add @auto-canary/jira@9.49.6-canary.1445.17967.0
  yarn add @auto-canary/maven@9.49.6-canary.1445.17967.0
  yarn add @auto-canary/npm@9.49.6-canary.1445.17967.0
  yarn add @auto-canary/omit-commits@9.49.6-canary.1445.17967.0
  yarn add @auto-canary/omit-release-notes@9.49.6-canary.1445.17967.0
  yarn add @auto-canary/released@9.49.6-canary.1445.17967.0
  yarn add @auto-canary/s3@9.49.6-canary.1445.17967.0
  yarn add @auto-canary/slack@9.49.6-canary.1445.17967.0
  yarn add @auto-canary/twitter@9.49.6-canary.1445.17967.0
  yarn add @auto-canary/upload-assets@9.49.6-canary.1445.17967.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
