### PR TITLE
fix: use GH_TOKEN if PRIVATE_TOKEN is not set

### DIFF
--- a/plugins/all-contributors/src/index.ts
+++ b/plugins/all-contributors/src/index.ts
@@ -458,6 +458,12 @@ export default class AllContributorsPlugin implements IPlugin {
             didUpdate = true;
             auto.logger.log.info(`Adding "${username}"'s contributions...`);
 
+            // If a PRIVATE_TOKEN is not set for all-contributors-cli
+            // use the GH_TOKEN
+            if (process.env.PRIVATE_TOKEN === undefined) {
+              process.env.PRIVATE_TOKEN = process.env.GH_TOKEN
+            }
+
             // Update/add contributor in RC file
             const { contributors } = await addContributor(
               config,


### PR DESCRIPTION
# What Changed
sets `PRIVATE_TOKEN` to `GH_TOKEN` when calling to `all-contributors-cli` if it isn't already set
# Why
`all-contributors-cli` uses `PRIVATE_TOKEN` for authentication, and auto uses `GH_TOKEN`, to ease use with auto, users shouldn't need to set two separate environment variables to the same value
Todo:

- [ ] Add tests
- [ ] Add docs
