### PR TITLE
feat: add option to pass additional flags to pod repo push

### DIFF
--- a/plugins/cocoapods/README.md
+++ b/plugins/cocoapods/README.md
@@ -23,7 +23,12 @@ yarn add -D @auto-it/cocoapods
         // Required, the relative path to your podspec file
         "podspecPath": "./Test.podspec",
         // Optional, the specs repo to push to
-        "specsRepo": "https://github.com/intuit/TestSpecs.git"
+        "specsRepo": "https://github.com/intuit/TestSpecs.git",
+        // Optional, flags to pass to the `pod repo push` command
+        "flags": [
+          "--sources",
+          "https://github.com/SpecRepo.git"
+        ]
       }
     ]
     // other plugins

--- a/plugins/cocoapods/src/index.ts
+++ b/plugins/cocoapods/src/index.ts
@@ -31,6 +31,9 @@ const required = t.interface({
 const optional = t.partial({
   /** The Cocoapods repo to publish to */
   specsRepo: t.string,
+
+  /** Any additional command line flags to pass to `pod repo push` */
+  flags: t.array(t.string)
 });
 
 const pluginOptions = t.intersection([required, optional]);
@@ -162,7 +165,7 @@ export default class CocoapodsPlugin implements IPlugin {
 
       if (!this.options.specsRepo) {
         auto.logger.log.info(logMessage(`Pushing to Cocoapods trunk`));
-        await execPromise("pod", ["trunk", "push", this.options.podspecPath]);
+        await execPromise("pod", ["trunk", "push", ...(this.options.flags || []), this.options.podspecPath]);
         return;
       }
 
@@ -198,6 +201,7 @@ export default class CocoapodsPlugin implements IPlugin {
         await execPromise("pod", [
           "repo",
           "push",
+          ...(this.options.flags || []),
           "autoPublishRepo",
           this.options.podspecPath,
         ]);


### PR DESCRIPTION
# What Changed
Adds a new option to add any additional flags to the `pod repo push` command
# Why
Some private pod usage requires passes a `--sources` flag for the command to pass the podspec lint
Todo:

- [x] Add tests
- [x] Add docs
