### PR TITLE
Improve package manager plugin docs

### DIFF
--- a/docs/pages/docs/_sidebar.mdx
+++ b/docs/pages/docs/_sidebar.mdx
@@ -47,8 +47,8 @@ Package Manager Plugins
 
 - [Homebrew](./generated/brew)
 - [Chrome Web Store](./generated/chrome)
-- [Crates](./generated/crates)
 - [Cocoapod](./generated/cocoapods)
+- [Crates](./generated/crates)
 - [Gem](./generated/gem)
 - [Git Tag](./generated/git-tag)
 - [Gradle](./generated/gradle)

--- a/docs/pages/docs/configuration/plugins.mdx
+++ b/docs/pages/docs/configuration/plugins.mdx
@@ -17,6 +17,9 @@ If you don't configure plugins in your `.autorc` configuration file `auto` will 
 - Installed through `npm` => uses [`npm`](../generated/npm)
 - Installed through executable => uses [`git-tag`](../generated/git-tag)
 
+For the majority of "package manager" plugins you should only use one at a time.
+Using multiple _will_ lead to undesired results.
+
 ### No Plugins
 
 If you don't want to include the default plugins, you can supply an empty array in the `.autorc` configuration file like the following:

--- a/plugins/chrome/README.md
+++ b/plugins/chrome/README.md
@@ -22,6 +22,9 @@ npm i --save-dev @auto-it/chrome
 yarn add -D @auto-it/chrome
 ```
 
+> WARNING: You can only use one "package manager" at a time!
+> Mixing them will lead to undesired results.
+
 ## Usage
 
 You must first pack/zip your plugin before running `auto`.

--- a/plugins/cocoapods/README.md
+++ b/plugins/cocoapods/README.md
@@ -12,6 +12,9 @@ npm i --save-dev @auto-it/cocoapods
 yarn add -D @auto-it/cocoapods
 ```
 
+> WARNING: You can only use one "package manager" at a time!
+> Mixing them will lead to undesired results.
+
 ## Usage
 
 ```json

--- a/plugins/crates/README.md
+++ b/plugins/crates/README.md
@@ -12,6 +12,9 @@ npm i --save-dev @auto-it/crates
 yarn add -D @auto-it/crates
 ```
 
+> WARNING: You can only use one "package manager" at a time!
+> Mixing them will lead to undesired results.
+
 ## Usage
 
 ```json

--- a/plugins/gem/README.md
+++ b/plugins/gem/README.md
@@ -20,6 +20,9 @@ npm i --save-dev @auto-it/gem
 yarn add -D @auto-it/gem
 ```
 
+> WARNING: You can only use one "package manager" at a time!
+> Mixing them will lead to undesired results.
+
 ## Usage
 
 ```json

--- a/plugins/git-tag/README.md
+++ b/plugins/git-tag/README.md
@@ -27,6 +27,9 @@ npm i --save-dev @auto-it/git-tag
 yarn add -D @auto-it/git-tag
 ```
 
+> WARNING: You can only use one "package manager" at a time!
+> Mixing them will lead to undesired results.
+
 ## Usage
 
 Simply add the plugins to your auto configuration.

--- a/plugins/git-tag/README.md
+++ b/plugins/git-tag/README.md
@@ -1,6 +1,7 @@
 # Git Tag Plugin
 
-Manage your projects version through just a git tag. This plugin is loaded by default when `auto` is installed through the binaries released on GitHub.
+Manage your projects version through just a git tag.
+This plugin is loaded by default when `auto` is installed through the binaries released on GitHub.
 
 If you're using this plugin you aren't releasing your code to any platform (npm, maven, etc). Instead you version calculations is done entirely though git tags.
 
@@ -10,6 +11,11 @@ This plugin only:
 2. bump it to new version
 3. create new tags
 4. push to github
+
+It will not:
+
+1. Publish to a specific platform
+2. Use any platform specific project information (ex: `author` or `repo` from a `package.json`)
 
 ## Installation
 

--- a/plugins/gradle/README.md
+++ b/plugins/gradle/README.md
@@ -14,6 +14,9 @@ npm i --save-dev @auto-it/gradle
 yarn add -D @auto-it/gradle
 ```
 
+> WARNING: You can only use one "package manager" at a time!
+> Mixing them will lead to undesired results.
+
 ## Usage
 
 ```json

--- a/plugins/maven/README.md
+++ b/plugins/maven/README.md
@@ -6,11 +6,14 @@ Release a Java project to a [maven][maven] repository.
 
 This plugin is not included with the `auto` CLI installed via NPM. To install:
 
-```bashell script
+```bash
 npm i --save-dev @auto-it/maven
 # or
 yarn add -D @auto-it/maven
 ```
+
+> WARNING: You can only use one "package manager" at a time!
+> Mixing them will lead to undesired results.
 
 ## Usage
 

--- a/plugins/npm/README.md
+++ b/plugins/npm/README.md
@@ -43,7 +43,12 @@ yarn add -D @auto-it/npm
 
 ## Monorepo Usage
 
-The `npm` plugin works out of the box with `lerna` in both [`independent`](https://github.com/lerna/lerna#independent-mode) and [`fixed`](https://github.com/lerna/lerna#fixedlocked-mode-default) mode. `auto` works on a repo basis and should be run from the root of the repo, not on each sub-package. No additional setup is required.
+The `npm` plugin works out of the box with `lerna` in both [`independent`](https://github.com/lerna/lerna#independent-mode) and [`fixed`](https://github.com/lerna/lerna#fixedlocked-mode-default) mode. 
+`auto` works on a repo basis and should be run from the root of the repo, not on each sub-package.
+No additional setup is required.
+
+> Do you have a package in your monorepo you don't want to publish but still want versioned?
+> Just set that `"private": true` you that package's `package.json`!
 
 ## Options
 

--- a/plugins/npm/README.md
+++ b/plugins/npm/README.md
@@ -22,6 +22,9 @@ npm i --save-dev @auto-it/npm
 yarn add -D @auto-it/npm
 ```
 
+> WARNING: You can only use one "package manager" at a time!
+> Mixing them will lead to undesired results.
+
 ## Usage
 
 ```json


### PR DESCRIPTION
# What Changed

Detail what the git-tag plugin will not do

# Why

Try to address the confusion in #1462, #1463 

Todo:

- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.50.4-canary.1465.18155.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.50.4-canary.1465.18155.0
  npm install @auto-canary/auto@9.50.4-canary.1465.18155.0
  npm install @auto-canary/core@9.50.4-canary.1465.18155.0
  npm install @auto-canary/all-contributors@9.50.4-canary.1465.18155.0
  npm install @auto-canary/brew@9.50.4-canary.1465.18155.0
  npm install @auto-canary/chrome@9.50.4-canary.1465.18155.0
  npm install @auto-canary/cocoapods@9.50.4-canary.1465.18155.0
  npm install @auto-canary/conventional-commits@9.50.4-canary.1465.18155.0
  npm install @auto-canary/crates@9.50.4-canary.1465.18155.0
  npm install @auto-canary/exec@9.50.4-canary.1465.18155.0
  npm install @auto-canary/first-time-contributor@9.50.4-canary.1465.18155.0
  npm install @auto-canary/gem@9.50.4-canary.1465.18155.0
  npm install @auto-canary/gh-pages@9.50.4-canary.1465.18155.0
  npm install @auto-canary/git-tag@9.50.4-canary.1465.18155.0
  npm install @auto-canary/gradle@9.50.4-canary.1465.18155.0
  npm install @auto-canary/jira@9.50.4-canary.1465.18155.0
  npm install @auto-canary/maven@9.50.4-canary.1465.18155.0
  npm install @auto-canary/npm@9.50.4-canary.1465.18155.0
  npm install @auto-canary/omit-commits@9.50.4-canary.1465.18155.0
  npm install @auto-canary/omit-release-notes@9.50.4-canary.1465.18155.0
  npm install @auto-canary/released@9.50.4-canary.1465.18155.0
  npm install @auto-canary/s3@9.50.4-canary.1465.18155.0
  npm install @auto-canary/slack@9.50.4-canary.1465.18155.0
  npm install @auto-canary/twitter@9.50.4-canary.1465.18155.0
  npm install @auto-canary/upload-assets@9.50.4-canary.1465.18155.0
  # or 
  yarn add @auto-canary/bot-list@9.50.4-canary.1465.18155.0
  yarn add @auto-canary/auto@9.50.4-canary.1465.18155.0
  yarn add @auto-canary/core@9.50.4-canary.1465.18155.0
  yarn add @auto-canary/all-contributors@9.50.4-canary.1465.18155.0
  yarn add @auto-canary/brew@9.50.4-canary.1465.18155.0
  yarn add @auto-canary/chrome@9.50.4-canary.1465.18155.0
  yarn add @auto-canary/cocoapods@9.50.4-canary.1465.18155.0
  yarn add @auto-canary/conventional-commits@9.50.4-canary.1465.18155.0
  yarn add @auto-canary/crates@9.50.4-canary.1465.18155.0
  yarn add @auto-canary/exec@9.50.4-canary.1465.18155.0
  yarn add @auto-canary/first-time-contributor@9.50.4-canary.1465.18155.0
  yarn add @auto-canary/gem@9.50.4-canary.1465.18155.0
  yarn add @auto-canary/gh-pages@9.50.4-canary.1465.18155.0
  yarn add @auto-canary/git-tag@9.50.4-canary.1465.18155.0
  yarn add @auto-canary/gradle@9.50.4-canary.1465.18155.0
  yarn add @auto-canary/jira@9.50.4-canary.1465.18155.0
  yarn add @auto-canary/maven@9.50.4-canary.1465.18155.0
  yarn add @auto-canary/npm@9.50.4-canary.1465.18155.0
  yarn add @auto-canary/omit-commits@9.50.4-canary.1465.18155.0
  yarn add @auto-canary/omit-release-notes@9.50.4-canary.1465.18155.0
  yarn add @auto-canary/released@9.50.4-canary.1465.18155.0
  yarn add @auto-canary/s3@9.50.4-canary.1465.18155.0
  yarn add @auto-canary/slack@9.50.4-canary.1465.18155.0
  yarn add @auto-canary/twitter@9.50.4-canary.1465.18155.0
  yarn add @auto-canary/upload-assets@9.50.4-canary.1465.18155.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
