### PR TITLE
correct enterprise upload assets baseUrl

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,6 @@
   },
   "dependencies": {
     "@auto-it/bot-list": "link:../../packages/bot-list",
-    "@octokit/graphql": "^4.4.0",
     "@octokit/plugin-enterprise-compatibility": "^1.2.2",
     "@octokit/plugin-retry": "^3.0.1",
     "@octokit/plugin-throttling": "^3.2.0",

--- a/plugins/upload-assets/src/index.ts
+++ b/plugins/upload-assets/src/index.ts
@@ -66,11 +66,15 @@ export default class UploadAssetsPlugin implements IPlugin {
           const stats = await stat(asset);
           const type = await FileType.fromBuffer(file);
 
-          const options = {
+          const DEFAULT_BASE_URL = "https://api.github.com"
+          const baseUrl = auto.git.options.baseUrl || DEFAULT_BASE_URL;
+          const { origin } = new URL(baseUrl)
+          const options= {
             data: (file as unknown) as string,
             name: path.basename(asset),
             owner: auto.git.options.owner,
             repo: auto.git.options.repo,
+            baseUrl: baseUrl === DEFAULT_BASE_URL ? undefined : `${origin}/api/uploads`,
             headers: {
               "content-length": stats.size,
               "content-type": type ? type.mime : "application/octet-stream",

--- a/yarn.lock
+++ b/yarn.lock
@@ -53,13 +53,12 @@
   integrity sha512-m2OzlTDbhvzK4hgswH9Lx0cdpq1AntXu53Klz5RGkFfuoDvKsnlU7tmtVfNWtUiP0zZbGtrb/BZYH7aB6TRnMA==
 
 "@auto-it/bot-list@link:packages/bot-list":
-  version "9.50.1"
+  version "9.50.3"
 
 "@auto-it/core@link:packages/core":
-  version "9.50.1"
+  version "9.50.3"
   dependencies:
     "@auto-it/bot-list" "link:packages/bot-list"
-    "@octokit/graphql" "^4.4.0"
     "@octokit/plugin-enterprise-compatibility" "^1.2.2"
     "@octokit/plugin-retry" "^3.0.1"
     "@octokit/plugin-throttling" "^3.2.0"
@@ -97,7 +96,7 @@
     url-join "^4.0.0"
 
 "@auto-it/npm@link:plugins/npm":
-  version "9.50.1"
+  version "9.50.3"
   dependencies:
     "@auto-it/core" "link:packages/core"
     await-to-js "^2.1.1"
@@ -115,7 +114,7 @@
     user-home "^2.0.0"
 
 "@auto-it/released@link:plugins/released":
-  version "9.50.1"
+  version "9.50.3"
   dependencies:
     "@auto-it/core" "link:packages/core"
     deepmerge "^4.0.0"
@@ -2725,7 +2724,7 @@
     is-plain-object "^4.0.0"
     universal-user-agent "^6.0.0"
 
-"@octokit/graphql@^4.3.1", "@octokit/graphql@^4.4.0":
+"@octokit/graphql@^4.3.1":
   version "4.5.3"
   resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-4.5.3.tgz#d5ff0d4a8a33e98614a2a7359dac98bc285e062f"
   integrity sha512-JyYvi3j2tOb5ofASEpcg1Advs07H+Ag+I+ez7buuZfNVAmh1IYcDTuxd4gnYH8S2PSGu+f5IdDGxMmkK+5zsdA==


### PR DESCRIPTION
# What Changed

On `uploadReleaseAsset` we now set the right `baseUrl`

# Why

The plugin wasn't working in enterprise

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.50.4-canary.1466.18172.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.50.4-canary.1466.18172.0
  npm install @auto-canary/auto@9.50.4-canary.1466.18172.0
  npm install @auto-canary/core@9.50.4-canary.1466.18172.0
  npm install @auto-canary/all-contributors@9.50.4-canary.1466.18172.0
  npm install @auto-canary/brew@9.50.4-canary.1466.18172.0
  npm install @auto-canary/chrome@9.50.4-canary.1466.18172.0
  npm install @auto-canary/cocoapods@9.50.4-canary.1466.18172.0
  npm install @auto-canary/conventional-commits@9.50.4-canary.1466.18172.0
  npm install @auto-canary/crates@9.50.4-canary.1466.18172.0
  npm install @auto-canary/exec@9.50.4-canary.1466.18172.0
  npm install @auto-canary/first-time-contributor@9.50.4-canary.1466.18172.0
  npm install @auto-canary/gem@9.50.4-canary.1466.18172.0
  npm install @auto-canary/gh-pages@9.50.4-canary.1466.18172.0
  npm install @auto-canary/git-tag@9.50.4-canary.1466.18172.0
  npm install @auto-canary/gradle@9.50.4-canary.1466.18172.0
  npm install @auto-canary/jira@9.50.4-canary.1466.18172.0
  npm install @auto-canary/maven@9.50.4-canary.1466.18172.0
  npm install @auto-canary/npm@9.50.4-canary.1466.18172.0
  npm install @auto-canary/omit-commits@9.50.4-canary.1466.18172.0
  npm install @auto-canary/omit-release-notes@9.50.4-canary.1466.18172.0
  npm install @auto-canary/released@9.50.4-canary.1466.18172.0
  npm install @auto-canary/s3@9.50.4-canary.1466.18172.0
  npm install @auto-canary/slack@9.50.4-canary.1466.18172.0
  npm install @auto-canary/twitter@9.50.4-canary.1466.18172.0
  npm install @auto-canary/upload-assets@9.50.4-canary.1466.18172.0
  # or 
  yarn add @auto-canary/bot-list@9.50.4-canary.1466.18172.0
  yarn add @auto-canary/auto@9.50.4-canary.1466.18172.0
  yarn add @auto-canary/core@9.50.4-canary.1466.18172.0
  yarn add @auto-canary/all-contributors@9.50.4-canary.1466.18172.0
  yarn add @auto-canary/brew@9.50.4-canary.1466.18172.0
  yarn add @auto-canary/chrome@9.50.4-canary.1466.18172.0
  yarn add @auto-canary/cocoapods@9.50.4-canary.1466.18172.0
  yarn add @auto-canary/conventional-commits@9.50.4-canary.1466.18172.0
  yarn add @auto-canary/crates@9.50.4-canary.1466.18172.0
  yarn add @auto-canary/exec@9.50.4-canary.1466.18172.0
  yarn add @auto-canary/first-time-contributor@9.50.4-canary.1466.18172.0
  yarn add @auto-canary/gem@9.50.4-canary.1466.18172.0
  yarn add @auto-canary/gh-pages@9.50.4-canary.1466.18172.0
  yarn add @auto-canary/git-tag@9.50.4-canary.1466.18172.0
  yarn add @auto-canary/gradle@9.50.4-canary.1466.18172.0
  yarn add @auto-canary/jira@9.50.4-canary.1466.18172.0
  yarn add @auto-canary/maven@9.50.4-canary.1466.18172.0
  yarn add @auto-canary/npm@9.50.4-canary.1466.18172.0
  yarn add @auto-canary/omit-commits@9.50.4-canary.1466.18172.0
  yarn add @auto-canary/omit-release-notes@9.50.4-canary.1466.18172.0
  yarn add @auto-canary/released@9.50.4-canary.1466.18172.0
  yarn add @auto-canary/s3@9.50.4-canary.1466.18172.0
  yarn add @auto-canary/slack@9.50.4-canary.1466.18172.0
  yarn add @auto-canary/twitter@9.50.4-canary.1466.18172.0
  yarn add @auto-canary/upload-assets@9.50.4-canary.1466.18172.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
