### PR TITLE
🤖 don't thank any of the bots in bot-list

### DIFF
--- a/plugins/first-time-contributor/package.json
+++ b/plugins/first-time-contributor/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@auto-it/core": "link:../../packages/core",
+    "@auto-it/bot-list": "link:../../packages/bot-list",
     "array.prototype.flatmap": "^1.2.2",
     "endent": "^2.0.1",
     "tslib": "2.0.1",

--- a/plugins/first-time-contributor/src/index.ts
+++ b/plugins/first-time-contributor/src/index.ts
@@ -1,5 +1,6 @@
 import { Auto, IPlugin } from "@auto-it/core";
 import { ICommitAuthor } from "@auto-it/core/dist/log-parse";
+import botList from "@auto-it/bot-list";
 import flatMap from "array.prototype.flatmap";
 import endent from "endent";
 import urlJoin from "url-join";
@@ -34,7 +35,12 @@ export default class FirstTimeContributorPlugin implements IPlugin {
           const newContributors: ICommitAuthor[] = [];
 
           for (const author of flatMap(commits, (c) => c.authors)) {
-            if (!author.username || author.type === "Bot") {
+            if (
+              !author.username ||
+              author.type === "Bot" ||
+              botList.includes(author.username) ||
+              (author.name && botList.includes(author.name))
+            ) {
               continue;
             }
 


### PR DESCRIPTION
# What Changed

also check botlist along with bot type

# Why

We don't have to thank our 🤖 overlords

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.50.5-canary.1467.18188.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.50.5-canary.1467.18188.0
  npm install @auto-canary/auto@9.50.5-canary.1467.18188.0
  npm install @auto-canary/core@9.50.5-canary.1467.18188.0
  npm install @auto-canary/all-contributors@9.50.5-canary.1467.18188.0
  npm install @auto-canary/brew@9.50.5-canary.1467.18188.0
  npm install @auto-canary/chrome@9.50.5-canary.1467.18188.0
  npm install @auto-canary/cocoapods@9.50.5-canary.1467.18188.0
  npm install @auto-canary/conventional-commits@9.50.5-canary.1467.18188.0
  npm install @auto-canary/crates@9.50.5-canary.1467.18188.0
  npm install @auto-canary/exec@9.50.5-canary.1467.18188.0
  npm install @auto-canary/first-time-contributor@9.50.5-canary.1467.18188.0
  npm install @auto-canary/gem@9.50.5-canary.1467.18188.0
  npm install @auto-canary/gh-pages@9.50.5-canary.1467.18188.0
  npm install @auto-canary/git-tag@9.50.5-canary.1467.18188.0
  npm install @auto-canary/gradle@9.50.5-canary.1467.18188.0
  npm install @auto-canary/jira@9.50.5-canary.1467.18188.0
  npm install @auto-canary/maven@9.50.5-canary.1467.18188.0
  npm install @auto-canary/npm@9.50.5-canary.1467.18188.0
  npm install @auto-canary/omit-commits@9.50.5-canary.1467.18188.0
  npm install @auto-canary/omit-release-notes@9.50.5-canary.1467.18188.0
  npm install @auto-canary/released@9.50.5-canary.1467.18188.0
  npm install @auto-canary/s3@9.50.5-canary.1467.18188.0
  npm install @auto-canary/slack@9.50.5-canary.1467.18188.0
  npm install @auto-canary/twitter@9.50.5-canary.1467.18188.0
  npm install @auto-canary/upload-assets@9.50.5-canary.1467.18188.0
  # or 
  yarn add @auto-canary/bot-list@9.50.5-canary.1467.18188.0
  yarn add @auto-canary/auto@9.50.5-canary.1467.18188.0
  yarn add @auto-canary/core@9.50.5-canary.1467.18188.0
  yarn add @auto-canary/all-contributors@9.50.5-canary.1467.18188.0
  yarn add @auto-canary/brew@9.50.5-canary.1467.18188.0
  yarn add @auto-canary/chrome@9.50.5-canary.1467.18188.0
  yarn add @auto-canary/cocoapods@9.50.5-canary.1467.18188.0
  yarn add @auto-canary/conventional-commits@9.50.5-canary.1467.18188.0
  yarn add @auto-canary/crates@9.50.5-canary.1467.18188.0
  yarn add @auto-canary/exec@9.50.5-canary.1467.18188.0
  yarn add @auto-canary/first-time-contributor@9.50.5-canary.1467.18188.0
  yarn add @auto-canary/gem@9.50.5-canary.1467.18188.0
  yarn add @auto-canary/gh-pages@9.50.5-canary.1467.18188.0
  yarn add @auto-canary/git-tag@9.50.5-canary.1467.18188.0
  yarn add @auto-canary/gradle@9.50.5-canary.1467.18188.0
  yarn add @auto-canary/jira@9.50.5-canary.1467.18188.0
  yarn add @auto-canary/maven@9.50.5-canary.1467.18188.0
  yarn add @auto-canary/npm@9.50.5-canary.1467.18188.0
  yarn add @auto-canary/omit-commits@9.50.5-canary.1467.18188.0
  yarn add @auto-canary/omit-release-notes@9.50.5-canary.1467.18188.0
  yarn add @auto-canary/released@9.50.5-canary.1467.18188.0
  yarn add @auto-canary/s3@9.50.5-canary.1467.18188.0
  yarn add @auto-canary/slack@9.50.5-canary.1467.18188.0
  yarn add @auto-canary/twitter@9.50.5-canary.1467.18188.0
  yarn add @auto-canary/upload-assets@9.50.5-canary.1467.18188.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
