### PR TITLE
fix default bump type

### DIFF
--- a/packages/core/src/__tests__/semver.test.ts
+++ b/packages/core/src/__tests__/semver.test.ts
@@ -12,9 +12,9 @@ const semverMap = getVersionMap([
 ]);
 
 test("ranks releases right", () => {
-  expect(getHigherSemverTag(SEMVER.major, "minor")).toBe("major");
-  expect(getHigherSemverTag(SEMVER.noVersion, "bar")).toBe("patch");
-  expect(getHigherSemverTag(SEMVER.minor, "patch")).toBe("minor");
+  expect(getHigherSemverTag(SEMVER.major, SEMVER.minor)).toBe("major");
+  expect(getHigherSemverTag(SEMVER.noVersion, SEMVER.patch)).toBe("patch");
+  expect(getHigherSemverTag(SEMVER.minor, SEMVER.patch)).toBe("minor");
 });
 
 describe("calculateSemVerBump", () => {
@@ -54,6 +54,14 @@ describe("calculateSemVerBump", () => {
         labels: [{ default: true, name: "minor", releaseType: SEMVER.minor }],
       })
     ).toBe(SEMVER.minor);
+  });
+
+  test("should be able to configure default no-version clean", () => {
+    expect(
+      calculateSemVerBump([[], []], semverMap, {
+        labels: [{ default: true, name: "docs", releaseType: "none" }],
+      })
+    ).toBe(SEMVER.noVersion);
   });
 
   test("should not skip things before none", () => {


### PR DESCRIPTION
# What Changed

When the default bump was set to a `none` release `version` was still returning `patch`.

# Why

closes #1469


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.50.7-canary.1470.18220.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.50.7-canary.1470.18220.0
  npm install @auto-canary/auto@9.50.7-canary.1470.18220.0
  npm install @auto-canary/core@9.50.7-canary.1470.18220.0
  npm install @auto-canary/all-contributors@9.50.7-canary.1470.18220.0
  npm install @auto-canary/brew@9.50.7-canary.1470.18220.0
  npm install @auto-canary/chrome@9.50.7-canary.1470.18220.0
  npm install @auto-canary/cocoapods@9.50.7-canary.1470.18220.0
  npm install @auto-canary/conventional-commits@9.50.7-canary.1470.18220.0
  npm install @auto-canary/crates@9.50.7-canary.1470.18220.0
  npm install @auto-canary/exec@9.50.7-canary.1470.18220.0
  npm install @auto-canary/first-time-contributor@9.50.7-canary.1470.18220.0
  npm install @auto-canary/gem@9.50.7-canary.1470.18220.0
  npm install @auto-canary/gh-pages@9.50.7-canary.1470.18220.0
  npm install @auto-canary/git-tag@9.50.7-canary.1470.18220.0
  npm install @auto-canary/gradle@9.50.7-canary.1470.18220.0
  npm install @auto-canary/jira@9.50.7-canary.1470.18220.0
  npm install @auto-canary/maven@9.50.7-canary.1470.18220.0
  npm install @auto-canary/npm@9.50.7-canary.1470.18220.0
  npm install @auto-canary/omit-commits@9.50.7-canary.1470.18220.0
  npm install @auto-canary/omit-release-notes@9.50.7-canary.1470.18220.0
  npm install @auto-canary/released@9.50.7-canary.1470.18220.0
  npm install @auto-canary/s3@9.50.7-canary.1470.18220.0
  npm install @auto-canary/slack@9.50.7-canary.1470.18220.0
  npm install @auto-canary/twitter@9.50.7-canary.1470.18220.0
  npm install @auto-canary/upload-assets@9.50.7-canary.1470.18220.0
  # or 
  yarn add @auto-canary/bot-list@9.50.7-canary.1470.18220.0
  yarn add @auto-canary/auto@9.50.7-canary.1470.18220.0
  yarn add @auto-canary/core@9.50.7-canary.1470.18220.0
  yarn add @auto-canary/all-contributors@9.50.7-canary.1470.18220.0
  yarn add @auto-canary/brew@9.50.7-canary.1470.18220.0
  yarn add @auto-canary/chrome@9.50.7-canary.1470.18220.0
  yarn add @auto-canary/cocoapods@9.50.7-canary.1470.18220.0
  yarn add @auto-canary/conventional-commits@9.50.7-canary.1470.18220.0
  yarn add @auto-canary/crates@9.50.7-canary.1470.18220.0
  yarn add @auto-canary/exec@9.50.7-canary.1470.18220.0
  yarn add @auto-canary/first-time-contributor@9.50.7-canary.1470.18220.0
  yarn add @auto-canary/gem@9.50.7-canary.1470.18220.0
  yarn add @auto-canary/gh-pages@9.50.7-canary.1470.18220.0
  yarn add @auto-canary/git-tag@9.50.7-canary.1470.18220.0
  yarn add @auto-canary/gradle@9.50.7-canary.1470.18220.0
  yarn add @auto-canary/jira@9.50.7-canary.1470.18220.0
  yarn add @auto-canary/maven@9.50.7-canary.1470.18220.0
  yarn add @auto-canary/npm@9.50.7-canary.1470.18220.0
  yarn add @auto-canary/omit-commits@9.50.7-canary.1470.18220.0
  yarn add @auto-canary/omit-release-notes@9.50.7-canary.1470.18220.0
  yarn add @auto-canary/released@9.50.7-canary.1470.18220.0
  yarn add @auto-canary/s3@9.50.7-canary.1470.18220.0
  yarn add @auto-canary/slack@9.50.7-canary.1470.18220.0
  yarn add @auto-canary/twitter@9.50.7-canary.1470.18220.0
  yarn add @auto-canary/upload-assets@9.50.7-canary.1470.18220.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
