### PR TITLE
correct behavior for lerna project with private packages

### DIFF
--- a/packages/core/src/utils/get-lerna-packages.ts
+++ b/packages/core/src/utils/get-lerna-packages.ts
@@ -11,7 +11,7 @@ interface LernaPackage {
 
 /** Get all of the packages in the lerna monorepo */
 export default async function getLernaPackages(): Promise<LernaPackage[]> {
-  return execPromise("npx", ["lerna", "ls", "-pl"]).then((res) =>
+  return execPromise("npx", ["lerna", "ls", "-pla"]).then((res) =>
     res.split("\n").map((packageInfo) => {
       const [packagePath, name, version] = packageInfo.split(":");
       return { path: packagePath, name, version };

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -375,10 +375,11 @@ const tagIndependentNextReleases = async (
 ) => {
   const packages = await getLernaPackages();
   const [, changedPackagesResult = ""] = await on(
-    execPromise("yarn", ["lerna", "changed"])
+    execPromise("yarn", ["lerna", "changed", "-a"])
   );
   const changedPackages = changedPackagesResult
     .split("\n")
+    .map((changedPackage) => changedPackage.replace(" (PRIVATE)", ""))
     .filter((changedPackage) =>
       packages.some((p) => p.name === changedPackage)
     );
@@ -638,7 +639,7 @@ export default class NPMPlugin implements IPlugin {
       // made, so no release will be made.
       if (isIndependent) {
         try {
-          await execPromise("yarn", ["lerna", "updated"]);
+          await execPromise("yarn", ["lerna", "updated", "-a"]);
         } catch (error) {
           auto.logger.log.warn(
             "Lerna detected no changes in project. Aborting release since nothing would be published."


### PR DESCRIPTION
# What Changed

Previously that `npm` plugin would exit early if `lerna changed` returned no changes. This didn't take into account private packages. Now we use the `-a` flag to get those package changes too.

**Behavior:**

- `canary`: No canaries will be published for private packages. This wouldn't make much sense
- `next`: A next version will be tagged and released for a private package
- `latest`: private package will be versioned and tagged but not published.

# Why

There was a hole in the previous implementation where if the only package that changed was a private one a release would not happen.

closes #1463

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.50.8-canary.1472.18237.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.50.8-canary.1472.18237.0
  npm install @auto-canary/auto@9.50.8-canary.1472.18237.0
  npm install @auto-canary/core@9.50.8-canary.1472.18237.0
  npm install @auto-canary/all-contributors@9.50.8-canary.1472.18237.0
  npm install @auto-canary/brew@9.50.8-canary.1472.18237.0
  npm install @auto-canary/chrome@9.50.8-canary.1472.18237.0
  npm install @auto-canary/cocoapods@9.50.8-canary.1472.18237.0
  npm install @auto-canary/conventional-commits@9.50.8-canary.1472.18237.0
  npm install @auto-canary/crates@9.50.8-canary.1472.18237.0
  npm install @auto-canary/exec@9.50.8-canary.1472.18237.0
  npm install @auto-canary/first-time-contributor@9.50.8-canary.1472.18237.0
  npm install @auto-canary/gem@9.50.8-canary.1472.18237.0
  npm install @auto-canary/gh-pages@9.50.8-canary.1472.18237.0
  npm install @auto-canary/git-tag@9.50.8-canary.1472.18237.0
  npm install @auto-canary/gradle@9.50.8-canary.1472.18237.0
  npm install @auto-canary/jira@9.50.8-canary.1472.18237.0
  npm install @auto-canary/maven@9.50.8-canary.1472.18237.0
  npm install @auto-canary/npm@9.50.8-canary.1472.18237.0
  npm install @auto-canary/omit-commits@9.50.8-canary.1472.18237.0
  npm install @auto-canary/omit-release-notes@9.50.8-canary.1472.18237.0
  npm install @auto-canary/released@9.50.8-canary.1472.18237.0
  npm install @auto-canary/s3@9.50.8-canary.1472.18237.0
  npm install @auto-canary/slack@9.50.8-canary.1472.18237.0
  npm install @auto-canary/twitter@9.50.8-canary.1472.18237.0
  npm install @auto-canary/upload-assets@9.50.8-canary.1472.18237.0
  # or 
  yarn add @auto-canary/bot-list@9.50.8-canary.1472.18237.0
  yarn add @auto-canary/auto@9.50.8-canary.1472.18237.0
  yarn add @auto-canary/core@9.50.8-canary.1472.18237.0
  yarn add @auto-canary/all-contributors@9.50.8-canary.1472.18237.0
  yarn add @auto-canary/brew@9.50.8-canary.1472.18237.0
  yarn add @auto-canary/chrome@9.50.8-canary.1472.18237.0
  yarn add @auto-canary/cocoapods@9.50.8-canary.1472.18237.0
  yarn add @auto-canary/conventional-commits@9.50.8-canary.1472.18237.0
  yarn add @auto-canary/crates@9.50.8-canary.1472.18237.0
  yarn add @auto-canary/exec@9.50.8-canary.1472.18237.0
  yarn add @auto-canary/first-time-contributor@9.50.8-canary.1472.18237.0
  yarn add @auto-canary/gem@9.50.8-canary.1472.18237.0
  yarn add @auto-canary/gh-pages@9.50.8-canary.1472.18237.0
  yarn add @auto-canary/git-tag@9.50.8-canary.1472.18237.0
  yarn add @auto-canary/gradle@9.50.8-canary.1472.18237.0
  yarn add @auto-canary/jira@9.50.8-canary.1472.18237.0
  yarn add @auto-canary/maven@9.50.8-canary.1472.18237.0
  yarn add @auto-canary/npm@9.50.8-canary.1472.18237.0
  yarn add @auto-canary/omit-commits@9.50.8-canary.1472.18237.0
  yarn add @auto-canary/omit-release-notes@9.50.8-canary.1472.18237.0
  yarn add @auto-canary/released@9.50.8-canary.1472.18237.0
  yarn add @auto-canary/s3@9.50.8-canary.1472.18237.0
  yarn add @auto-canary/slack@9.50.8-canary.1472.18237.0
  yarn add @auto-canary/twitter@9.50.8-canary.1472.18237.0
  yarn add @auto-canary/upload-assets@9.50.8-canary.1472.18237.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
