### PR TITLE
feat: option to specify a different command to use for pod

### DIFF
--- a/plugins/cocoapods/README.md
+++ b/plugins/cocoapods/README.md
@@ -29,9 +29,10 @@ yarn add -D @auto-it/cocoapods
         "specsRepo": "https://github.com/intuit/TestSpecs.git",
         // Optional, flags to pass to the `pod repo push` command
         "flags": [
-          "--sources",
-          "https://github.com/SpecRepo.git"
-        ]
+          "--sources=https://github.com/SpecRepo.git"
+        ],
+        // Optional, specify a different executable for `pod`
+        "podCommand": "bundle exec pod"
       }
     ]
     // other plugins

--- a/plugins/cocoapods/README.md
+++ b/plugins/cocoapods/README.md
@@ -44,7 +44,7 @@ yarn add -D @auto-it/cocoapods
 
 ### General
 
-- The machine running this plugin must have the [CocoaPods](https://cocoapods.org/) `pod` CLI installed already.
+- The machine running this plugin must have the [CocoaPods](https://cocoapods.org/) `pod` CLI installed already, or `podCommand` specified in your plugin configuration.
 - Your `podspec` file must pass `pod lib lint` in order for publishing to a Specs repository to work.
   - All warnings and errors must be addressed before attempting to push to a Specs repository.
 

--- a/plugins/cocoapods/__tests__/cocoapods.test.ts
+++ b/plugins/cocoapods/__tests__/cocoapods.test.ts
@@ -207,6 +207,40 @@ describe("Cocoapods Plugin", () => {
       expect(exec).lastCalledWith("pod", ["trunk", "push", "./Test.podspec"]);
     });
 
+    test("should push with different pod command if in options", async () => {
+      mockPodspec(specWithVersion("0.0.1"));
+
+      const plugin = new CocoapodsPlugin({...options, podCommand: 'notpod'});
+      const hook = makeHooks();
+      plugin.apply({
+        hooks: hook,
+        logger: dummyLog(),
+        prefixRelease,
+      } as Auto.Auto);
+
+      await hook.publish.promise(Auto.SEMVER.patch);
+
+      expect(exec).toBeCalledTimes(2);
+      expect(exec).lastCalledWith("notpod", ["trunk", "push", "./Test.podspec"]);
+    });
+
+    test("should push with different pod command with spaces if in options", async () => {
+      mockPodspec(specWithVersion("0.0.1"));
+
+      const plugin = new CocoapodsPlugin({...options, podCommand: 'bundle exec pod'});
+      const hook = makeHooks();
+      plugin.apply({
+        hooks: hook,
+        logger: dummyLog(),
+        prefixRelease,
+      } as Auto.Auto);
+
+      await hook.publish.promise(Auto.SEMVER.patch);
+
+      expect(exec).toBeCalledTimes(2);
+      expect(exec).lastCalledWith("bundle", ["exec", "pod", "trunk", "push", "./Test.podspec"]);
+    });
+
     test("should push to trunk if no specsRepo in options with flags", async () => {
       mockPodspec(specWithVersion("0.0.1"));
 

--- a/plugins/cocoapods/src/index.ts
+++ b/plugins/cocoapods/src/index.ts
@@ -36,7 +36,7 @@ const optional = t.partial({
   flags: t.array(t.string),
 
   /** The command to use for `pod` if it needs to be separate like `bundle exec pod` */
-  podCommand: t.string
+  podCommand: t.string,
 });
 
 const pluginOptions = t.intersection([required, optional]);
@@ -158,7 +158,8 @@ export default class CocoapodsPlugin implements IPlugin {
     });
 
     auto.hooks.publish.tapPromise(this.name, async () => {
-      const [pod, ...commands] = this.options.podCommand?.split(' ') || ["pod"]
+      const [pod, ...commands] = this.options.podCommand?.split(" ") || ["pod"];
+
       await execPromise("git", [
         "push",
         "--follow-tags",
@@ -169,46 +170,58 @@ export default class CocoapodsPlugin implements IPlugin {
 
       if (!this.options.specsRepo) {
         auto.logger.log.info(logMessage(`Pushing to Cocoapods trunk`));
-        await execPromise(pod, commands.concat(["trunk", "push", ...(this.options.flags || []), this.options.podspecPath]));
+        await execPromise(pod, [
+          ...commands,
+          "trunk",
+          "push",
+          ...(this.options.flags || []),
+          this.options.podspecPath,
+        ]);
         return;
       }
 
       try {
-        const existingRepos = await execPromise(pod, commands.concat([
+        const existingRepos = await execPromise(pod, [
+          ...commands,
           "repo",
-          "list"
-        ]));
-        if (existingRepos.indexOf('autoPublishRepo') !== -1) {
-          auto.logger.log.info('Removing existing autoPublishRepo')
-          await execPromise(pod, commands.concat([
+          "list",
+        ]);
+        if (existingRepos.indexOf("autoPublishRepo") !== -1) {
+          auto.logger.log.info("Removing existing autoPublishRepo");
+          await execPromise(pod, [
+            ...commands,
             "repo",
             "remove",
-            "autoPublishRepo"
-          ]))
+            "autoPublishRepo",
+          ]);
         }
       } catch (error) {
-        auto.logger.log.warn(`Error Checking for existing Specs repositories: ${error}`)
+        auto.logger.log.warn(
+          `Error Checking for existing Specs repositories: ${error}`
+        );
       }
 
       try {
-        await execPromise(pod, commands.concat([
+        await execPromise(pod, [
+          ...commands,
           "repo",
           "add",
           "autoPublishRepo",
           this.options.specsRepo,
-        ]));
+        ]);
 
         auto.logger.log.info(
           logMessage(`Pushing to specs repo: ${this.options.specsRepo}`)
         );
 
-        await execPromise(pod, commands.concat([
+        await execPromise(pod, [
+          ...commands,
           "repo",
           "push",
           ...(this.options.flags || []),
           "autoPublishRepo",
           this.options.podspecPath,
-        ]));
+        ]);
       } catch (error) {
         auto.logger.log.error(
           logMessage(
@@ -217,7 +230,12 @@ export default class CocoapodsPlugin implements IPlugin {
         );
         process.exit(1);
       } finally {
-        await execPromise(pod, commands.concat(["repo", "remove", "autoPublishRepo"]));
+        await execPromise(pod, [
+          ...commands,
+          "repo",
+          "remove",
+          "autoPublishRepo",
+        ]);
       }
     });
   }

--- a/plugins/cocoapods/src/index.ts
+++ b/plugins/cocoapods/src/index.ts
@@ -33,7 +33,10 @@ const optional = t.partial({
   specsRepo: t.string,
 
   /** Any additional command line flags to pass to `pod repo push` */
-  flags: t.array(t.string)
+  flags: t.array(t.string),
+
+  /** The command to use for `pod` if it needs to be separate like `bundle exec pod` */
+  podCommand: t.string
 });
 
 const pluginOptions = t.intersection([required, optional]);
@@ -155,6 +158,7 @@ export default class CocoapodsPlugin implements IPlugin {
     });
 
     auto.hooks.publish.tapPromise(this.name, async () => {
+      const [pod, ...commands] = this.options.podCommand?.split(' ') || ["pod"]
       await execPromise("git", [
         "push",
         "--follow-tags",
@@ -165,46 +169,46 @@ export default class CocoapodsPlugin implements IPlugin {
 
       if (!this.options.specsRepo) {
         auto.logger.log.info(logMessage(`Pushing to Cocoapods trunk`));
-        await execPromise("pod", ["trunk", "push", ...(this.options.flags || []), this.options.podspecPath]);
+        await execPromise(pod, commands.concat(["trunk", "push", ...(this.options.flags || []), this.options.podspecPath]));
         return;
       }
 
       try {
-        const existingRepos = await execPromise("pod", [
+        const existingRepos = await execPromise(pod, commands.concat([
           "repo",
           "list"
-        ]);
+        ]));
         if (existingRepos.indexOf('autoPublishRepo') !== -1) {
           auto.logger.log.info('Removing existing autoPublishRepo')
-          await execPromise("pod", [
+          await execPromise(pod, commands.concat([
             "repo",
             "remove",
             "autoPublishRepo"
-          ])
+          ]))
         }
       } catch (error) {
         auto.logger.log.warn(`Error Checking for existing Specs repositories: ${error}`)
       }
 
       try {
-        await execPromise("pod", [
+        await execPromise(pod, commands.concat([
           "repo",
           "add",
           "autoPublishRepo",
           this.options.specsRepo,
-        ]);
+        ]));
 
         auto.logger.log.info(
           logMessage(`Pushing to specs repo: ${this.options.specsRepo}`)
         );
 
-        await execPromise("pod", [
+        await execPromise(pod, commands.concat([
           "repo",
           "push",
           ...(this.options.flags || []),
           "autoPublishRepo",
           this.options.podspecPath,
-        ]);
+        ]));
       } catch (error) {
         auto.logger.log.error(
           logMessage(
@@ -213,7 +217,7 @@ export default class CocoapodsPlugin implements IPlugin {
         );
         process.exit(1);
       } finally {
-        await execPromise("pod", ["repo", "remove", "autoPublishRepo"]);
+        await execPromise(pod, commands.concat(["repo", "remove", "autoPublishRepo"]));
       }
     });
   }


### PR DESCRIPTION
# What Changed
Adds a new option `podCommand` to allow users to specify a different executable to use for `pod`
# Why
Not all environments can have `pod` preinstalled, or may not want to use a preinstalled `pod` cli, this allows users to specify a command to use in place of `pod`
Todo:

- [x] Add tests
- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.50.12-canary.1487.18395.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.50.12-canary.1487.18395.0
  npm install @auto-canary/auto@9.50.12-canary.1487.18395.0
  npm install @auto-canary/core@9.50.12-canary.1487.18395.0
  npm install @auto-canary/all-contributors@9.50.12-canary.1487.18395.0
  npm install @auto-canary/brew@9.50.12-canary.1487.18395.0
  npm install @auto-canary/chrome@9.50.12-canary.1487.18395.0
  npm install @auto-canary/cocoapods@9.50.12-canary.1487.18395.0
  npm install @auto-canary/conventional-commits@9.50.12-canary.1487.18395.0
  npm install @auto-canary/crates@9.50.12-canary.1487.18395.0
  npm install @auto-canary/exec@9.50.12-canary.1487.18395.0
  npm install @auto-canary/first-time-contributor@9.50.12-canary.1487.18395.0
  npm install @auto-canary/gem@9.50.12-canary.1487.18395.0
  npm install @auto-canary/gh-pages@9.50.12-canary.1487.18395.0
  npm install @auto-canary/git-tag@9.50.12-canary.1487.18395.0
  npm install @auto-canary/gradle@9.50.12-canary.1487.18395.0
  npm install @auto-canary/jira@9.50.12-canary.1487.18395.0
  npm install @auto-canary/maven@9.50.12-canary.1487.18395.0
  npm install @auto-canary/npm@9.50.12-canary.1487.18395.0
  npm install @auto-canary/omit-commits@9.50.12-canary.1487.18395.0
  npm install @auto-canary/omit-release-notes@9.50.12-canary.1487.18395.0
  npm install @auto-canary/released@9.50.12-canary.1487.18395.0
  npm install @auto-canary/s3@9.50.12-canary.1487.18395.0
  npm install @auto-canary/slack@9.50.12-canary.1487.18395.0
  npm install @auto-canary/twitter@9.50.12-canary.1487.18395.0
  npm install @auto-canary/upload-assets@9.50.12-canary.1487.18395.0
  # or 
  yarn add @auto-canary/bot-list@9.50.12-canary.1487.18395.0
  yarn add @auto-canary/auto@9.50.12-canary.1487.18395.0
  yarn add @auto-canary/core@9.50.12-canary.1487.18395.0
  yarn add @auto-canary/all-contributors@9.50.12-canary.1487.18395.0
  yarn add @auto-canary/brew@9.50.12-canary.1487.18395.0
  yarn add @auto-canary/chrome@9.50.12-canary.1487.18395.0
  yarn add @auto-canary/cocoapods@9.50.12-canary.1487.18395.0
  yarn add @auto-canary/conventional-commits@9.50.12-canary.1487.18395.0
  yarn add @auto-canary/crates@9.50.12-canary.1487.18395.0
  yarn add @auto-canary/exec@9.50.12-canary.1487.18395.0
  yarn add @auto-canary/first-time-contributor@9.50.12-canary.1487.18395.0
  yarn add @auto-canary/gem@9.50.12-canary.1487.18395.0
  yarn add @auto-canary/gh-pages@9.50.12-canary.1487.18395.0
  yarn add @auto-canary/git-tag@9.50.12-canary.1487.18395.0
  yarn add @auto-canary/gradle@9.50.12-canary.1487.18395.0
  yarn add @auto-canary/jira@9.50.12-canary.1487.18395.0
  yarn add @auto-canary/maven@9.50.12-canary.1487.18395.0
  yarn add @auto-canary/npm@9.50.12-canary.1487.18395.0
  yarn add @auto-canary/omit-commits@9.50.12-canary.1487.18395.0
  yarn add @auto-canary/omit-release-notes@9.50.12-canary.1487.18395.0
  yarn add @auto-canary/released@9.50.12-canary.1487.18395.0
  yarn add @auto-canary/s3@9.50.12-canary.1487.18395.0
  yarn add @auto-canary/slack@9.50.12-canary.1487.18395.0
  yarn add @auto-canary/twitter@9.50.12-canary.1487.18395.0
  yarn add @auto-canary/upload-assets@9.50.12-canary.1487.18395.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
