### PR TITLE
Add Docker Publish Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Auto has an extensive plugin system and wide variety of official plugins. Make a
 - [chrome](./plugins/chrome) - Publish code to Chrome Web Store
 - [crates](./plugins/crates) - Publish Rust crates
 - [cocoapods](./plugins/cocoapods) - Version your [Cocoapod](https://cocoapods.org/), and push to your specs repository!
+- [docker](./plugins/docker) - Publish images with Docker
 - [gem](./plugins/gem) - Publish ruby gems
 - [git-tag](./plugins/git-tag) - Manage your projects version through just a git tag (`default` when used with binary)
 - [gradle](./plugins/gradle) - Publish code with gradle
@@ -239,6 +240,7 @@ Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/kentcdodds/all-contributors) specification. Contributions of any kind welcome!

--- a/docs/pages/docs/_sidebar.mdx
+++ b/docs/pages/docs/_sidebar.mdx
@@ -49,6 +49,7 @@ Package Manager Plugins
 - [Chrome Web Store](./generated/chrome)
 - [Cocoapod](./generated/cocoapods)
 - [Crates](./generated/crates)
+- [Docker](./generated/docker)
 - [Gem](./generated/gem)
 - [Git Tag](./generated/git-tag)
 - [Gradle](./generated/gradle)

--- a/plugins/docker/README.md
+++ b/plugins/docker/README.md
@@ -1,0 +1,50 @@
+# Docker Plugin
+
+This plugin automates tagging and publishing images to a docker registry.
+
+## Prerequisites
+
+To publish to a docker registry, you'll first need to authenticate with the target registry. For example, the [Docker Login Action](https://github.com/docker/login-action) for GitHub, or [the `withRegistry` helper](https://www.jenkins.io/doc/book/pipeline/docker/#custom-registry) in Jenkins.
+
+## Installation
+
+This plugin is not included with the `auto` CLI installed via NPM. To install:
+
+```bash
+npm i --save-dev @auto-it/docker
+# or
+yarn add -D @auto-it/docker
+```
+
+## Usage
+
+You must first must build the desired image to publish.
+
+These environment variables tell `auto` what to publish.
+
+- IMAGE - The image ID, digest, or tag of the locally available image to tag and publish. This is required unless you want to statically tag the local image, in which case you can provide it as an option.
+
+```json
+{
+  "plugins": [
+    ["docker", { "registry": "ghcr.io/my/app" }]
+    // other plugins
+  ]
+}
+```
+
+If you'd like to tag releases with `latest` too, you can specify the `tagLatest` option:
+
+```json
+{
+  "plugins": [["docker", { "registry": "ghcr.io/my/app", "tagLatest": true }]]
+}
+```
+
+If you're tagging the locally built image in a static manner, you can also pass `image` instead of `IMAGE` as an environment variable.
+
+```json
+{
+  "plugins": [["docker", { "registry": "ghcr.io/my/app", "image": "myapp" }]]
+}
+```

--- a/plugins/docker/__tests__/docker.test.ts
+++ b/plugins/docker/__tests__/docker.test.ts
@@ -16,7 +16,7 @@ jest.mock("../../../packages/core/dist/utils/exec-promise", () => ({
 const registry = "registry.io/app";
 
 const setup = (mockGit?: any, options?: IDockerPluginOptions) => {
-  const plugin = new DockerPlugin(options);
+  const plugin = new DockerPlugin(options || { registry });
   const hooks = makeHooks();
 
   plugin.apply(({
@@ -32,7 +32,7 @@ const setup = (mockGit?: any, options?: IDockerPluginOptions) => {
   return hooks;
 };
 
-describe("Git Tag Plugin", () => {
+describe("Docker Plugin", () => {
   beforeEach(() => {
     exec.mockClear();
   });
@@ -49,7 +49,7 @@ describe("Git Tag Plugin", () => {
       const hooks = setup();
       await expect(
         hooks.validateConfig.promise("docker", { registry: registry })
-      ).resolves.toHaveLength(1);
+      ).resolves.toHaveLength(0);
     });
   });
 

--- a/plugins/docker/__tests__/docker.test.ts
+++ b/plugins/docker/__tests__/docker.test.ts
@@ -1,0 +1,157 @@
+import * as Auto from "@auto-it/core";
+import { makeHooks } from "@auto-it/core/dist/utils/make-hooks";
+import { dummyLog } from "@auto-it/core/dist/utils/logger";
+
+import DockerPlugin, { IDockerPluginOptions } from "../src";
+
+const exec = jest.fn();
+jest.mock("../../../packages/core/dist/utils/get-current-branch", () => ({
+  getCurrentBranch: () => "next",
+}));
+jest.mock("../../../packages/core/dist/utils/exec-promise", () => ({
+  // @ts-ignore
+  default: (...args) => exec(...args),
+}));
+
+const registry = "registry.io/app";
+
+const setup = (mockGit?: any, options?: IDockerPluginOptions) => {
+  const plugin = new DockerPlugin(options);
+  const hooks = makeHooks();
+
+  plugin.apply(({
+    hooks,
+    git: mockGit,
+    remote: "origin",
+    logger: dummyLog(),
+    prefixRelease: (r: string) => r,
+    config: { prereleaseBranches: ["next"] },
+    getCurrentVersion: () => "v1.0.0",
+  } as unknown) as Auto.Auto);
+
+  return hooks;
+};
+
+describe("Git Tag Plugin", () => {
+  beforeEach(() => {
+    exec.mockClear();
+  });
+
+  describe("validateConfig", () => {
+    test("should error without options", async () => {
+      const hooks = setup();
+      await expect(
+        hooks.validateConfig.promise("docker", null)
+      ).resolves.toHaveLength(1);
+    });
+
+    test("should pass with valid options", async () => {
+      const hooks = setup();
+      await expect(
+        hooks.validateConfig.promise("docker", { registry: registry })
+      ).resolves.toHaveLength(1);
+    });
+  });
+
+  describe("getPreviousVersion", () => {
+    test("should error without git", async () => {
+      const hooks = setup();
+      await expect(hooks.getPreviousVersion.promise()).rejects.toBeInstanceOf(
+        Error
+      );
+    });
+
+    test("should get previous version", async () => {
+      const hooks = setup({ getLatestTagInBranch: () => "v1.0.0" });
+      const previousVersion = await hooks.getPreviousVersion.promise();
+      expect(previousVersion).toBe("v1.0.0");
+    });
+
+    test("should default to 0.0.0 when no previous version", async () => {
+      const hooks = setup({
+        getLatestTagInBranch: () => {
+          throw new Error();
+        },
+      });
+      const previousVersion = await hooks.getPreviousVersion.promise();
+      expect(previousVersion).toBe("0.0.0");
+    });
+  });
+
+  describe("version", () => {
+    test("should do nothing without git", async () => {
+      const hooks = setup();
+      await hooks.version.promise(Auto.SEMVER.patch);
+      expect(exec).not.toHaveBeenCalled();
+    });
+
+    test("should do nothing with a bad version bump", async () => {
+      const hooks = setup({ getLatestTagInBranch: () => "v1.0.0" });
+      await hooks.version.promise("wrong" as Auto.SEMVER);
+      expect(exec).not.toHaveBeenCalled();
+    });
+
+    test("should tag next version", async () => {
+      const sourceImage = "app:sha-123";
+      const hooks = setup(
+        { getLatestTagInBranch: () => "v1.0.0" },
+        { registry, image: sourceImage }
+      );
+      await hooks.version.promise(Auto.SEMVER.patch);
+      expect(exec).toHaveBeenCalledWith("git", [
+        "tag",
+        "1.0.1",
+        "-m",
+        '"Update version to 1.0.1"',
+      ]);
+      expect(exec).toHaveBeenCalledWith("docker", [
+        "tag",
+        sourceImage,
+        `${registry}:1.0.1`,
+      ]);
+    });
+  });
+
+  describe("next", () => {
+    test("should do nothing without git", async () => {
+      const hooks = setup();
+      await hooks.next.promise([], Auto.SEMVER.patch, {} as any);
+      expect(exec).not.toHaveBeenCalled();
+    });
+
+    test("should tag next version", async () => {
+      const sourceImage = "app:sha-123";
+      const hooks = setup(
+        {
+          getLatestRelease: () => "v0.1.0",
+          getLastTagNotInBaseBranch: () => "v1.0.0",
+        },
+        { registry, image: sourceImage }
+      );
+
+      await hooks.next.promise([], Auto.SEMVER.patch, {} as any);
+
+      expect(exec).toHaveBeenCalledWith("git", [
+        "tag",
+        "1.0.1-next.0",
+        "-m",
+        '"Tag pre-release: 1.0.1-next.0"',
+      ]);
+      expect(exec).toHaveBeenCalledWith("git", [
+        "push",
+        "origin",
+        "next",
+        "--tags",
+      ]);
+      expect(exec).toHaveBeenCalledWith("docker", [
+        "tag",
+        sourceImage,
+        `${registry}:1.0.1-next.0`,
+      ]);
+      expect(exec).toHaveBeenCalledWith("docker", [
+        "push",
+        `${registry}:1.0.1-next.0`,
+      ]);
+    });
+  });
+});

--- a/plugins/docker/package.json
+++ b/plugins/docker/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@auto-it/docker",
+  "version": "9.52.0",
+  "main": "dist/index.js",
+  "description": "Facilitates publishing built images to a Docker Registry.",
+  "license": "MIT",
+  "author": {
+    "name": "Andrew Lisowski",
+    "email": "lisowski54@gmail.com"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/intuit/auto"
+  },
+  "files": [
+    "dist"
+  ],
+  "keywords": [
+    "automation",
+    "semantic",
+    "release",
+    "github",
+    "labels",
+    "automated",
+    "continuos integration",
+    "changelog",
+    "docker"
+  ],
+  "scripts": {
+    "build": "tsc -b",
+    "start": "npm run build -- -w",
+    "lint": "eslint src --ext .ts",
+    "test": "jest --maxWorkers=2 --config ../../package.json"
+  },
+  "dependencies": {
+    "@auto-it/core": "link:../../packages/core",
+    "fp-ts": "^2.5.3",
+    "io-ts": "^2.1.2",
+    "semver": "^7.0.0",
+    "tslib": "1.10.0"
+  }
+}

--- a/plugins/docker/src/index.ts
+++ b/plugins/docker/src/index.ts
@@ -174,7 +174,9 @@ export default class DockerPlugin implements IPlugin {
       auto.logger.log.info("Pushing new tag to GitHub");
 
       await Promise.all(
-        this.calculatedTags!.map((tag) => execPromise("docker", ["push", tag]))
+        this.calculatedTags!.map((tag) =>
+          execPromise("docker", ["push", `${this.options.registry}:${tag}`])
+        )
       );
 
       await execPromise("git", [

--- a/plugins/docker/src/index.ts
+++ b/plugins/docker/src/index.ts
@@ -116,7 +116,11 @@ export default class DockerPlugin implements IPlugin {
     });
 
     auto.hooks.canary.tapPromise(this.name, async (version, postFix) => {
-      const lastRelease = await auto.git!.getLatestRelease();
+      if (!auto.git) {
+        return;
+      }
+
+      const lastRelease = await auto.git.getLatestRelease();
       const current = await auto.getCurrentVersion(lastRelease);
       const nextVersion = inc(current, version as ReleaseType);
       const canaryVersion = `${nextVersion}-canary${postFix}`;

--- a/plugins/docker/src/index.ts
+++ b/plugins/docker/src/index.ts
@@ -1,0 +1,195 @@
+import {
+  Auto,
+  determineNextVersion,
+  execPromise,
+  IPlugin,
+  getCurrentBranch,
+  DEFAULT_PRERELEASE_BRANCHES,
+  validatePluginConfiguration,
+} from "@auto-it/core";
+import * as t from "io-ts";
+import { inc, ReleaseType } from "semver";
+
+const pluginOptions = t.intersection([
+  t.interface({
+    /** The target registry to push too */
+    registry: t.string,
+  }),
+  t.partial({
+    /** Whether to tag non-prerelease images with latest */
+    tagLatest: t.boolean,
+    /** The source image, if a static name and/or tag */
+    image: t.string,
+  }),
+]);
+
+export type IDockerPluginOptions = t.TypeOf<typeof pluginOptions>;
+
+/** Manages tagging and publishing to docker registries. */
+export default class DockerPlugin implements IPlugin {
+  /** The name of the plugin */
+  name = "docker";
+
+  /** The calculated docker tags for publish */
+  private calculatedTags?: string[];
+
+  /** Initialize the plugin with it's options */
+  constructor(private readonly options: IDockerPluginOptions) {
+    this.options.image = options.image || process.env.IMAGE;
+  }
+
+  /** Tap into auto plugin points. */
+  apply(auto: Auto) {
+    /** Gets the latest tag for a given branch */
+    async function getTag() {
+      try {
+        return await auto.git!.getLatestTagInBranch();
+      } catch (error) {
+        return auto.prefixRelease("0.0.0");
+      }
+    }
+
+    auto.hooks.validateConfig.tapPromise(this.name, async (name, options) => {
+      if (name === this.name || name === `@auto-it/${this.name}`) {
+        if (Array.isArray(options)) {
+          const errors = await Promise.all(
+            options.map((o) =>
+              validatePluginConfiguration(this.name, pluginOptions, o)
+            )
+          );
+
+          return errors.reduce((acc, item) => [...acc, ...item], []);
+        }
+
+        return validatePluginConfiguration(this.name, pluginOptions, options);
+      }
+    });
+
+    auto.hooks.beforeRun.tap(this.name, (rc) => {
+      const dockerPlugin = rc.plugins!.find(
+        (plugin) =>
+          plugin[0] === this.name || plugin[0] === `@auto-it/${this.name}`
+      ) as [string, IDockerPluginOptions];
+      if (!dockerPlugin?.[1]?.image) {
+        auto.checkEnv(this.name, "IMAGE");
+      }
+    });
+
+    auto.hooks.getPreviousVersion.tapPromise(this.name, async () => {
+      if (!auto.git) {
+        throw new Error(
+          "Can't calculate previous version without Git initialized!"
+        );
+      }
+
+      return getTag();
+    });
+
+    auto.hooks.version.tapPromise(this.name, async (version) => {
+      if (!auto.git) {
+        return;
+      }
+
+      const lastTag = await getTag();
+      const newTag = inc(lastTag, version as ReleaseType);
+
+      if (!newTag) {
+        auto.logger.log.info("No release found, doing nothing");
+        return;
+      }
+
+      const prefixedTag = auto.prefixRelease(newTag);
+
+      auto.logger.log.info(`Tagging new tag: ${lastTag} => ${prefixedTag}`);
+      await execPromise("git", [
+        "tag",
+        prefixedTag,
+        "-m",
+        `"Update version to ${prefixedTag}"`,
+      ]);
+
+      await execPromise("docker", [
+        "tag",
+        process.env.IMAGE,
+        `${this.options.registry}:${newTag}`,
+      ]);
+      this.calculatedTags = [newTag];
+
+      if (this.options.tagLatest === true && !version.startsWith("pre")) {
+        await execPromise("docker", [
+          "tag",
+          process.env.IMAGE,
+          `${this.options.registry}:latest`,
+        ]);
+        this.calculatedTags.push("latest");
+      }
+    });
+
+    auto.hooks.canary.tapPromise(this.name, async (version, postFix) => {
+      const lastRelease = await auto.git!.getLatestRelease();
+      const current = await auto.getCurrentVersion(lastRelease);
+      const nextVersion = inc(current, version as ReleaseType);
+      const canaryVersion = `${nextVersion}-canary${postFix}`;
+      const targetImage = `${this.options.registry}:${canaryVersion}`;
+
+      await execPromise("docker", ["tag", process.env.IMAGE, targetImage]);
+      await execPromise("docker", ["push", targetImage]);
+
+      auto.logger.verbose.info("Successfully published canary version");
+      return canaryVersion;
+    });
+
+    auto.hooks.next.tapPromise(this.name, async (preReleaseVersions, bump) => {
+      if (!auto.git) {
+        return preReleaseVersions;
+      }
+
+      const prereleaseBranches =
+        auto.config?.prereleaseBranches ?? DEFAULT_PRERELEASE_BRANCHES;
+      const branch = getCurrentBranch() || "";
+      const prereleaseBranch = prereleaseBranches.includes(branch)
+        ? branch
+        : prereleaseBranches[0];
+      const lastRelease = await auto.git.getLatestRelease();
+      const current =
+        (await auto.git.getLastTagNotInBaseBranch(prereleaseBranch)) ||
+        (await auto.getCurrentVersion(lastRelease));
+      const prerelease = determineNextVersion(
+        lastRelease,
+        current,
+        bump,
+        prereleaseBranch
+      );
+      const targetImage = `${this.options.registry}:${prerelease}`;
+
+      await execPromise("git", [
+        "tag",
+        prerelease,
+        "-m",
+        `"Tag pre-release: ${prerelease}"`,
+      ]);
+      await execPromise("docker", ["tag", process.env.IMAGE, targetImage]);
+      await execPromise("docker", ["push", targetImage]);
+      await execPromise("git", ["push", auto.remote, branch, "--tags"]);
+
+      preReleaseVersions.push(prerelease);
+      return preReleaseVersions;
+    });
+
+    auto.hooks.publish.tapPromise(this.name, async () => {
+      auto.logger.log.info("Pushing new tag to GitHub");
+
+      await Promise.all(
+        this.calculatedTags!.map((tag) => execPromise("docker", ["push", tag]))
+      );
+
+      await execPromise("git", [
+        "push",
+        "--follow-tags",
+        "--set-upstream",
+        auto.remote,
+        getCurrentBranch() || auto.baseBranch,
+      ]);
+    });
+  }
+}

--- a/plugins/docker/tsconfig.json
+++ b/plugins/docker/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*", "../../typings/**/*"],
+
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+
+  "references": [
+    {
+      "path": "../../packages/core"
+    }
+  ]
+}

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -67,6 +67,9 @@
     },
     {
       "path": "plugins/gem"
+    },
+    {
+      "path": "plugins/docker"
     }
   ]
 }


### PR DESCRIPTION
# What Changed

Adds a Docker publish plugin.

# Why

Simplifies publishing docker images with semver tags.

TODO:
I _think_ most everything is done, possibly tests could be improved.
