### PR TITLE
docs: fix typo

### DIFF
--- a/docs/pages/docs/welcome/getting-started.mdx
+++ b/docs/pages/docs/welcome/getting-started.mdx
@@ -19,7 +19,7 @@ To get detailed help for any command use the `--help` flag.
 ```bash
 auto --help
 # or command help
-auto comment --help
+auto command --help
 ```
 
 ### Make "Latest Release"


### PR DESCRIPTION
# What Changed

I think this meant to say "command" rather than "comment"

# Why
I think fixing typos are important

Todo:

- [ ] Add tests
- [ ] Add docs
