### PR TITLE
Add pr-body-labels plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,23 @@ jobs:
       - attach_workspace:
           at: ~/auto
       - run: *lint
+      - run:
+          name: Release
+          command: yarn auto pr-check --url $CIRCLE_PULL_REQUEST
+
+  pr-check:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/auto
+      - run:
+          name: Check for SemVer Label
+          command: | 
+            if [ ! -z "$CIRCLE_PR_NUMBER" ]; then
+              yarn auto pr-check --url $CIRCLE_PULL_REQUEST
+            else
+              echo "No pull request, not checking for semver label"
+            fi
 
   test:
     <<: *defaults
@@ -99,6 +116,10 @@ workflows:
       - build:
           requires:
             - install
+
+      - pr-check:
+          requires:
+            - build
 
       - lint:
           requires:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,17 @@
 # What Changed
 
-# Why
+## Why
 
 Todo:
 
 - [ ] Add tests
 - [ ] Add docs
+
+## Change Type
+
+Indicate the type of change your pull request is:
+
+- [ ] `documentation`
+- [ ] `patch`
+- [ ] `minor`
+- [ ] `major`

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Auto has an extensive plugin system and wide variety of official plugins. Make a
 - [jira](./plugins/jira) - Include Jira story links in the changelog
 - [omit-commits](./plugins/omit-commits) - Ignore commits base on name, email, subject, labels, and username
 - [omit-release-notes](./plugins/omit-release-notes) - Ignore release notes in PRs made by certain accounts
+- [pr-body-labels](./plugins/pr-body-labels) - Allow outside contributors to indicate what semver label should be applied to the Pull Request
 - [released](./plugins/released) - Add a `released` label to published PRs, comment with the version it's included in and comment on the issues the PR closes
 - [s3](./plugins/s3) - Post your built artifacts to amazon s3
 - [slack](./plugins/slack) - Post release notes to slack

--- a/docs/pages/docs/_sidebar.mdx
+++ b/docs/pages/docs/_sidebar.mdx
@@ -67,6 +67,7 @@ Functionality Plugins
 - [Jira](./generated/jira)
 - [Omit Commits](./generated/omit-commits)
 - [Omit Release Notes](./generated/omit-release-notes)
+- [PR Body Labels](./generated/pr-body-labels)
 - [Released](./generated/released)
 - [Slack](./generated/slack)
 - [Twitter](./generated/twitter)

--- a/docs/pages/docs/plugins/release-lifecycle-hooks.mdx
+++ b/docs/pages/docs/plugins/release-lifecycle-hooks.mdx
@@ -5,6 +5,7 @@ title: Release Lifecycle Hooks
 The following hooks are all called during various release commands (ex: `latest`, `next`, `canary`, `shipit`).
 These hooks is where the publishing of your package actually happens.
 
+- [prCheck](#prCheck)
 - [beforeShipIt](#beforeshipit)
 - [beforeCommitChangelog](#beforecommitchangelog)
 - [afterAddToChangelog](#afteraddtochangelog)
@@ -17,6 +18,20 @@ These hooks is where the publishing of your package actually happens.
 - [makeRelease](#makerelease)
 - [afterRelease](#afterrelease)
 - [afterShipIt](#aftershipit)
+
+## prCheck
+
+Called before `auto pr-check` is ran/
+
+Context Object:
+
+- `pr` - All github information related to the PR
+
+```ts
+auto.hooks.prCheck.tapPromise("NPM", async ({ pr }) => {
+  // Do stuff
+});
+```
 
 ## beforeShipIt
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   ],
   "scripts": {
     "clean": "lerna clean --yes && rimraf node_modules '+(packages|plugins)/**/+(dist|tsconfig.tsbuildinfo)'",
-    "semver:check": "./scripts/post-install.sh",
     "build": "tsc -b tsconfig.dev.json",
     "start": "npm run build -- --watch",
     "lint": "eslint packages plugins --ext .ts --cache",

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
       ],
       "released",
       "first-time-contributor",
+      "pr-body-labels",
       "./scripts/auto-update-curl-version.js",
       [
         "all-contributors",

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -245,6 +245,15 @@ export interface IAutoHooks {
   next: AsyncSeriesWaterfallHook<[string[], SEMVER, NextContext]>;
   /** Ran after the package has been published. */
   afterPublish: AsyncParallelHook<[]>;
+  /** Ran after the package has been published. */
+  prCheck: AsyncSeriesHook<
+    [
+      {
+        /** The complete information about the PR */
+        pr: RestEndpointMethodTypes["pulls"]["get"]["response"]["data"];
+      }
+    ]
+  >;
 }
 
 /** Load the .env file into process.env. Useful for local usage. */
@@ -875,6 +884,8 @@ export default class Auto {
 
     try {
       const res = await this.git.getPullRequest(prNumber);
+      await this.hooks.prCheck.promise({ pr: res.data });
+
       sha = res.data.head.sha;
 
       const labels = await this.git.getLabels(prNumber);

--- a/packages/core/src/utils/make-hooks.ts
+++ b/packages/core/src/utils/make-hooks.ts
@@ -29,6 +29,7 @@ export const makeHooks = (): IAutoHooks => ({
   getAuthor: new AsyncSeriesBailHook(),
   getPreviousVersion: new AsyncSeriesBailHook(),
   getRepository: new AsyncSeriesBailHook(),
+  prCheck: new AsyncSeriesBailHook(['prInformation']),
   version: new AsyncParallelHook(["version"]),
   afterVersion: new AsyncParallelHook(),
   publish: new AsyncParallelHook(["version"]),

--- a/plugins/pr-body-labels/README.md
+++ b/plugins/pr-body-labels/README.md
@@ -1,0 +1,39 @@
+# Pr-Body-Labels Plugin
+
+Allow outside contributors to indicate what semver label should be applied to the Pull Request.
+
+## Installation
+
+This plugin is not included with the `auto` CLI installed via NPM. To install:
+
+```bash
+npm i --save-dev @auto-it/pr-body-labels
+# or
+yarn add -D @auto-it/pr-body-labels
+```
+
+## Usage
+
+```json
+{
+  "plugins": [
+    ["pr-body-labels"]
+    // other plugins
+  ]
+}
+```
+
+Then something like the following to your `.github/PULL_REQUEST_TEMPLATE.md`.
+The only part of this that really matters is a markdown checkbox + one of your labels.
+You control what labels an outside contributor can apply through the PR body.
+This example only exposes the semantic versioning labels but you can include any label in your project.
+
+```md
+## Change Type
+
+Indicate the type of change your pull request is:
+
+- [ ] `patch`
+- [ ] `minor`
+- [ ] `major`
+```

--- a/plugins/pr-body-labels/README.md
+++ b/plugins/pr-body-labels/README.md
@@ -37,3 +37,15 @@ Indicate the type of change your pull request is:
 - [ ] `minor`
 - [ ] `major`
 ```
+
+## Options
+
+### `disabledLabels`
+
+Labels the user cannot apply through the PR.
+
+```json
+{
+  "plugins": [["pr-body-labels", { "disabledLabels": ["release"] }]]
+}
+```

--- a/plugins/pr-body-labels/__tests__/pr-body-labels.test.ts
+++ b/plugins/pr-body-labels/__tests__/pr-body-labels.test.ts
@@ -10,10 +10,13 @@ describe("Pr-Body-Labels Plugin", () => {
 
     plugin.apply({
       hooks,
-      git: { getProjectLabels: () => Promise.resolve([]), addLabelToPr },
+      labels: [],
+      git: { addLabelToPr },
     } as any);
 
-    await hooks.prCheck.promise({ pr: { body: "- [x] `unknown-label`" } } as any);
+    await hooks.prCheck.promise({
+      pr: { body: "- [x] `unknown-label`" },
+    } as any);
     expect(addLabelToPr).not.toHaveBeenCalled();
   });
 
@@ -24,10 +27,13 @@ describe("Pr-Body-Labels Plugin", () => {
 
     plugin.apply({
       hooks,
-      git: { getProjectLabels: () => Promise.resolve(["patch"]), addLabelToPr },
+      labels: [{ name: "patch" }],
+      git: { addLabelToPr },
     } as any);
 
-    await hooks.prCheck.promise({ pr: { body: "- [x] `patch`", number: 1 } } as any);
+    await hooks.prCheck.promise({
+      pr: { body: "- [x] `patch`", number: 1 },
+    } as any);
     expect(addLabelToPr).toHaveBeenCalledWith(1, "patch");
   });
 });

--- a/plugins/pr-body-labels/__tests__/pr-body-labels.test.ts
+++ b/plugins/pr-body-labels/__tests__/pr-body-labels.test.ts
@@ -1,0 +1,33 @@
+import { makeHooks } from "@auto-it/core/dist/utils/make-hooks";
+
+import PrBodyLabels from "../src";
+
+describe("Pr-Body-Labels Plugin", () => {
+  test("not add labels not present in project", async () => {
+    const plugin = new PrBodyLabels();
+    const hooks = makeHooks();
+    const addLabelToPr = jest.fn();
+
+    plugin.apply({
+      hooks,
+      git: { getProjectLabels: () => Promise.resolve([]), addLabelToPr },
+    } as any);
+
+    await hooks.prCheck.promise({ pr: { body: "- [x] `unknown-label`" } } as any);
+    expect(addLabelToPr).not.toHaveBeenCalled();
+  });
+
+  test("add labels present in project", async () => {
+    const plugin = new PrBodyLabels();
+    const hooks = makeHooks();
+    const addLabelToPr = jest.fn();
+
+    plugin.apply({
+      hooks,
+      git: { getProjectLabels: () => Promise.resolve(["patch"]), addLabelToPr },
+    } as any);
+
+    await hooks.prCheck.promise({ pr: { body: "- [x] `patch`", number: 1 } } as any);
+    expect(addLabelToPr).toHaveBeenCalledWith(1, "patch");
+  });
+});

--- a/plugins/pr-body-labels/__tests__/pr-body-labels.test.ts
+++ b/plugins/pr-body-labels/__tests__/pr-body-labels.test.ts
@@ -36,4 +36,21 @@ describe("Pr-Body-Labels Plugin", () => {
     } as any);
     expect(addLabelToPr).toHaveBeenCalledWith(1, "patch");
   });
+
+  test("not add labels in disabledLabels list", async () => {
+    const plugin = new PrBodyLabels({ disabledLabels: ["patch"] });
+    const hooks = makeHooks();
+    const addLabelToPr = jest.fn();
+
+    plugin.apply({
+      hooks,
+      labels: [{ name: "patch" }],
+      git: { addLabelToPr },
+    } as any);
+
+    await hooks.prCheck.promise({
+      pr: { body: "- [x] `patch`", number: 1 },
+    } as any);
+    expect(addLabelToPr).not.toHaveBeenCalled();
+  });
 });

--- a/plugins/pr-body-labels/package.json
+++ b/plugins/pr-body-labels/package.json
@@ -37,6 +37,8 @@
   },
   "dependencies": {
     "@auto-it/core": "link:../../packages/core",
+    "fp-ts": "^2.5.3",
+    "io-ts": "^2.1.2",
     "tslib": "1.10.0"
   }
 }

--- a/plugins/pr-body-labels/package.json
+++ b/plugins/pr-body-labels/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@auto-it/pr-body-labels",
+  "version": "9.53.1",
+  "main": "dist/index.js",
+  "description": "Allow outside contributors to indicate what semver label should be applied to the Pull Request",
+  "license": "MIT",
+  "author": {
+    "name": "Andrew Lisowski",
+    "email": "lisowski54@gmail.com"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/intuit/auto"
+  },
+  "files": [
+    "dist"
+  ],
+  "keywords": [
+    "automation",
+    "semantic",
+    "release",
+    "github",
+    "labels",
+    "automated",
+    "continuos integration",
+    "changelog"
+  ],
+  "scripts": {
+    "build": "tsc -b",
+    "start": "npm run build -- -w",
+    "lint": "eslint src --ext .ts",
+    "test": "jest --maxWorkers=2 --config ../../package.json"
+  },
+  "dependencies": {
+    "@auto-it/core": "link:../../packages/core",
+    "tslib": "1.10.0"
+  }
+}

--- a/plugins/pr-body-labels/src/index.ts
+++ b/plugins/pr-body-labels/src/index.ts
@@ -1,9 +1,27 @@
 import { Auto, IPlugin } from "@auto-it/core";
+import * as t from "io-ts";
+
+const pluginOptions = t.partial({
+  /** Labels the user cannot apply through the PR */
+  disabledLabels: t.array(t.string),
+});
+
+export type IPrBodyLabelsPluginOptions = t.TypeOf<typeof pluginOptions>;
 
 /** Allow outside contributors to indicate what semver label should be applied to the Pull Request */
 export default class PrBodyLabelsPlugin implements IPlugin {
   /** The name of the plugin */
   name = "pr-body-labels";
+
+  /** The options of the plugin */
+  private readonly options: Required<IPrBodyLabelsPluginOptions>;
+
+  /** Initialize the plugin with it's options */
+  constructor(options: IPrBodyLabelsPluginOptions = {}) {
+    this.options = {
+      disabledLabels: options.disabledLabels || [],
+    };
+  }
 
   /** Tap into auto plugin points. */
   apply(auto: Auto) {
@@ -14,7 +32,10 @@ export default class PrBodyLabelsPlugin implements IPlugin {
 
       await Promise.all(
         auto.labels.map(async (label) => {
-          if (pr.body.includes(`- [x] \`${label.name}\``)) {
+          if (
+            pr.body.includes(`- [x] \`${label.name}\``) &&
+            !this.options.disabledLabels.includes(label.name)
+          ) {
             await auto.git?.addLabelToPr(pr.number, label.name);
           }
         })

--- a/plugins/pr-body-labels/src/index.ts
+++ b/plugins/pr-body-labels/src/index.ts
@@ -1,0 +1,26 @@
+import { Auto, IPlugin } from "@auto-it/core";
+
+/** Allow outside contributors to indicate what semver label should be applied to the Pull Request */
+export default class PrBodyLabelsPlugin implements IPlugin {
+  /** The name of the plugin */
+  name = "pr-body-labels";
+
+  /** Tap into auto plugin points. */
+  apply(auto: Auto) {
+    auto.hooks.prCheck.tapPromise(this.name, async ({ pr }) => {
+      if (!auto.git) {
+        return;
+      }
+
+      const projectLabels = await auto.git.getProjectLabels();
+
+      await Promise.all(
+        projectLabels.map(async (label) => {
+          if (pr.body.includes(`- [x] \`${label}\``)) {
+            await auto.git?.addLabelToPr(pr.number, label);
+          }
+        })
+      );
+    });
+  }
+}

--- a/plugins/pr-body-labels/src/index.ts
+++ b/plugins/pr-body-labels/src/index.ts
@@ -8,16 +8,14 @@ export default class PrBodyLabelsPlugin implements IPlugin {
   /** Tap into auto plugin points. */
   apply(auto: Auto) {
     auto.hooks.prCheck.tapPromise(this.name, async ({ pr }) => {
-      if (!auto.git) {
+      if (!auto.git || !auto.labels) {
         return;
       }
 
-      const projectLabels = await auto.git.getProjectLabels();
-
       await Promise.all(
-        projectLabels.map(async (label) => {
-          if (pr.body.includes(`- [x] \`${label}\``)) {
-            await auto.git?.addLabelToPr(pr.number, label);
+        auto.labels.map(async (label) => {
+          if (pr.body.includes(`- [x] \`${label.name}\``)) {
+            await auto.git?.addLabelToPr(pr.number, label.name);
           }
         })
       );

--- a/plugins/pr-body-labels/tsconfig.json
+++ b/plugins/pr-body-labels/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*", "../../typings/**/*"],
+
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+
+  "references": [
+    {
+      "path": "../../packages/core"
+    }
+  ]
+}

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -1,5 +1,0 @@
-chmod +x ./dist/bin/auto.js
-
-if [ ! -z "$CIRCLE_PR_NUMBER" ]; then
-  ./dist/bin/auto.js pr-check --pr $CIRCLE_PR_NUMBER --url $CIRCLE_PULL_REQUEST
-fi

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -70,6 +70,9 @@
     },
     {
       "path": "plugins/docker"
+    },
+    {
+      "path": "plugins/pr-body-labels"
     }
   ]
 }


### PR DESCRIPTION
# What Changed

Add a plugin that detect GitHub labels in a PR body and adds them to the PR.

## Why

Outside contributors can't add these labels

Todo:

- [x] Add tests
- [x] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.53.2-canary.1554.19032.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.53.2-canary.1554.19032.0
  npm install @auto-canary/auto@9.53.2-canary.1554.19032.0
  npm install @auto-canary/core@9.53.2-canary.1554.19032.0
  npm install @auto-canary/all-contributors@9.53.2-canary.1554.19032.0
  npm install @auto-canary/brew@9.53.2-canary.1554.19032.0
  npm install @auto-canary/chrome@9.53.2-canary.1554.19032.0
  npm install @auto-canary/cocoapods@9.53.2-canary.1554.19032.0
  npm install @auto-canary/conventional-commits@9.53.2-canary.1554.19032.0
  npm install @auto-canary/crates@9.53.2-canary.1554.19032.0
  npm install @auto-canary/docker@9.53.2-canary.1554.19032.0
  npm install @auto-canary/exec@9.53.2-canary.1554.19032.0
  npm install @auto-canary/first-time-contributor@9.53.2-canary.1554.19032.0
  npm install @auto-canary/gem@9.53.2-canary.1554.19032.0
  npm install @auto-canary/gh-pages@9.53.2-canary.1554.19032.0
  npm install @auto-canary/git-tag@9.53.2-canary.1554.19032.0
  npm install @auto-canary/gradle@9.53.2-canary.1554.19032.0
  npm install @auto-canary/jira@9.53.2-canary.1554.19032.0
  npm install @auto-canary/maven@9.53.2-canary.1554.19032.0
  npm install @auto-canary/npm@9.53.2-canary.1554.19032.0
  npm install @auto-canary/omit-commits@9.53.2-canary.1554.19032.0
  npm install @auto-canary/omit-release-notes@9.53.2-canary.1554.19032.0
  npm install @auto-canary/pr-body-labels@9.53.2-canary.1554.19032.0
  npm install @auto-canary/released@9.53.2-canary.1554.19032.0
  npm install @auto-canary/s3@9.53.2-canary.1554.19032.0
  npm install @auto-canary/slack@9.53.2-canary.1554.19032.0
  npm install @auto-canary/twitter@9.53.2-canary.1554.19032.0
  npm install @auto-canary/upload-assets@9.53.2-canary.1554.19032.0
  # or 
  yarn add @auto-canary/bot-list@9.53.2-canary.1554.19032.0
  yarn add @auto-canary/auto@9.53.2-canary.1554.19032.0
  yarn add @auto-canary/core@9.53.2-canary.1554.19032.0
  yarn add @auto-canary/all-contributors@9.53.2-canary.1554.19032.0
  yarn add @auto-canary/brew@9.53.2-canary.1554.19032.0
  yarn add @auto-canary/chrome@9.53.2-canary.1554.19032.0
  yarn add @auto-canary/cocoapods@9.53.2-canary.1554.19032.0
  yarn add @auto-canary/conventional-commits@9.53.2-canary.1554.19032.0
  yarn add @auto-canary/crates@9.53.2-canary.1554.19032.0
  yarn add @auto-canary/docker@9.53.2-canary.1554.19032.0
  yarn add @auto-canary/exec@9.53.2-canary.1554.19032.0
  yarn add @auto-canary/first-time-contributor@9.53.2-canary.1554.19032.0
  yarn add @auto-canary/gem@9.53.2-canary.1554.19032.0
  yarn add @auto-canary/gh-pages@9.53.2-canary.1554.19032.0
  yarn add @auto-canary/git-tag@9.53.2-canary.1554.19032.0
  yarn add @auto-canary/gradle@9.53.2-canary.1554.19032.0
  yarn add @auto-canary/jira@9.53.2-canary.1554.19032.0
  yarn add @auto-canary/maven@9.53.2-canary.1554.19032.0
  yarn add @auto-canary/npm@9.53.2-canary.1554.19032.0
  yarn add @auto-canary/omit-commits@9.53.2-canary.1554.19032.0
  yarn add @auto-canary/omit-release-notes@9.53.2-canary.1554.19032.0
  yarn add @auto-canary/pr-body-labels@9.53.2-canary.1554.19032.0
  yarn add @auto-canary/released@9.53.2-canary.1554.19032.0
  yarn add @auto-canary/s3@9.53.2-canary.1554.19032.0
  yarn add @auto-canary/slack@9.53.2-canary.1554.19032.0
  yarn add @auto-canary/twitter@9.53.2-canary.1554.19032.0
  yarn add @auto-canary/upload-assets@9.53.2-canary.1554.19032.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
