### PR TITLE
chore: updated docs:watch script

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ yarn test
 ### Run the docs
 
 ```bash
-yarn docs:watch
+yarn docs
 ```
 
 ### Create a new plugin

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "docs": "yarn docs:generate && ignite dev",
     "docs:generate": "./docs/generate-command-docs.js",
     "docs:build": "yarn docs:generate && ignite build",
-    "docs:watch": "ignite dev",
     "create:plugin": "./scripts/create-plugin.js",
     "install-mac": "yarn lerna run bundle --scope=auto && gunzip -c ./packages/cli/binary/auto-macos.gz > /usr/local/bin/auto"
   },

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "docs": "yarn docs:generate && ignite dev",
     "docs:generate": "./docs/generate-command-docs.js",
     "docs:build": "yarn docs:generate && ignite build",
+    "docs:watch": "ignite dev",
     "create:plugin": "./scripts/create-plugin.js",
     "install-mac": "yarn lerna run bundle --scope=auto && gunzip -c ./packages/cli/binary/auto-macos.gz > /usr/local/bin/auto"
   },


### PR DESCRIPTION
# What Changed
The docs:watch command was added to package.json

## Why
The README contains a script to build and [run the docs](https://github.com/intuit/auto#run-the-docs) but the command was missing from package.json

Todo:

- [x] Add tests
- [x] Add docs

## Change Type

Indicate the type of change your pull request is:

- [x] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
