### PR TITLE
fix diff limit warning in all-contributors plugin

### DIFF
--- a/plugins/all-contributors/src/index.ts
+++ b/plugins/all-contributors/src/index.ts
@@ -381,6 +381,7 @@ export default class AllContributorsPlugin implements IPlugin {
           "--first-parent",
           "-m",
           commit.hash,
+          "-l0",
         ]);
 
         commit.files = [...new Set([...commit.files, ...extra.split("\n")])];


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.54.2-canary.1562.19155.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.54.2-canary.1562.19155.0
  npm install @auto-canary/auto@9.54.2-canary.1562.19155.0
  npm install @auto-canary/core@9.54.2-canary.1562.19155.0
  npm install @auto-canary/all-contributors@9.54.2-canary.1562.19155.0
  npm install @auto-canary/brew@9.54.2-canary.1562.19155.0
  npm install @auto-canary/chrome@9.54.2-canary.1562.19155.0
  npm install @auto-canary/cocoapods@9.54.2-canary.1562.19155.0
  npm install @auto-canary/conventional-commits@9.54.2-canary.1562.19155.0
  npm install @auto-canary/crates@9.54.2-canary.1562.19155.0
  npm install @auto-canary/docker@9.54.2-canary.1562.19155.0
  npm install @auto-canary/exec@9.54.2-canary.1562.19155.0
  npm install @auto-canary/first-time-contributor@9.54.2-canary.1562.19155.0
  npm install @auto-canary/gem@9.54.2-canary.1562.19155.0
  npm install @auto-canary/gh-pages@9.54.2-canary.1562.19155.0
  npm install @auto-canary/git-tag@9.54.2-canary.1562.19155.0
  npm install @auto-canary/gradle@9.54.2-canary.1562.19155.0
  npm install @auto-canary/jira@9.54.2-canary.1562.19155.0
  npm install @auto-canary/maven@9.54.2-canary.1562.19155.0
  npm install @auto-canary/npm@9.54.2-canary.1562.19155.0
  npm install @auto-canary/omit-commits@9.54.2-canary.1562.19155.0
  npm install @auto-canary/omit-release-notes@9.54.2-canary.1562.19155.0
  npm install @auto-canary/pr-body-labels@9.54.2-canary.1562.19155.0
  npm install @auto-canary/released@9.54.2-canary.1562.19155.0
  npm install @auto-canary/s3@9.54.2-canary.1562.19155.0
  npm install @auto-canary/slack@9.54.2-canary.1562.19155.0
  npm install @auto-canary/twitter@9.54.2-canary.1562.19155.0
  npm install @auto-canary/upload-assets@9.54.2-canary.1562.19155.0
  # or 
  yarn add @auto-canary/bot-list@9.54.2-canary.1562.19155.0
  yarn add @auto-canary/auto@9.54.2-canary.1562.19155.0
  yarn add @auto-canary/core@9.54.2-canary.1562.19155.0
  yarn add @auto-canary/all-contributors@9.54.2-canary.1562.19155.0
  yarn add @auto-canary/brew@9.54.2-canary.1562.19155.0
  yarn add @auto-canary/chrome@9.54.2-canary.1562.19155.0
  yarn add @auto-canary/cocoapods@9.54.2-canary.1562.19155.0
  yarn add @auto-canary/conventional-commits@9.54.2-canary.1562.19155.0
  yarn add @auto-canary/crates@9.54.2-canary.1562.19155.0
  yarn add @auto-canary/docker@9.54.2-canary.1562.19155.0
  yarn add @auto-canary/exec@9.54.2-canary.1562.19155.0
  yarn add @auto-canary/first-time-contributor@9.54.2-canary.1562.19155.0
  yarn add @auto-canary/gem@9.54.2-canary.1562.19155.0
  yarn add @auto-canary/gh-pages@9.54.2-canary.1562.19155.0
  yarn add @auto-canary/git-tag@9.54.2-canary.1562.19155.0
  yarn add @auto-canary/gradle@9.54.2-canary.1562.19155.0
  yarn add @auto-canary/jira@9.54.2-canary.1562.19155.0
  yarn add @auto-canary/maven@9.54.2-canary.1562.19155.0
  yarn add @auto-canary/npm@9.54.2-canary.1562.19155.0
  yarn add @auto-canary/omit-commits@9.54.2-canary.1562.19155.0
  yarn add @auto-canary/omit-release-notes@9.54.2-canary.1562.19155.0
  yarn add @auto-canary/pr-body-labels@9.54.2-canary.1562.19155.0
  yarn add @auto-canary/released@9.54.2-canary.1562.19155.0
  yarn add @auto-canary/s3@9.54.2-canary.1562.19155.0
  yarn add @auto-canary/slack@9.54.2-canary.1562.19155.0
  yarn add @auto-canary/twitter@9.54.2-canary.1562.19155.0
  yarn add @auto-canary/upload-assets@9.54.2-canary.1562.19155.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
