### PR TITLE
add extra padding to nested lists in slack message

### DIFF
--- a/plugins/slack/__tests__/__snapshots__/slack.test.ts.snap
+++ b/plugins/slack/__tests__/__snapshots__/slack.test.ts.snap
@@ -1,5 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`postToSlack should add more indents to nested lists - 2 spaces 1`] = `"{\\"text\\":\\"@channel: New release *<https://git.hub/some/project/releases/v1.0.0|v1.0.0>*\\\\n* My Notes*\\\\n• PR <google.com|some link>\\\\n   • Another note\\",\\"link_names\\":1}"`;
+
+exports[`postToSlack should add more indents to nested lists 1`] = `"{\\"text\\":\\"@channel: New release *<https://git.hub/some/project/releases/v1.0.0|v1.0.0>*\\\\n* My Notes*\\\\n• PR <google.com|some link>\\\\n   • Another note\\",\\"link_names\\":1}"`;
+
 exports[`postToSlack should call slack api 1`] = `"{\\"text\\":\\"@channel: New release *<https://git.hub/some/project/releases/v1.0.0|v1.0.0>*\\\\n* My Notes*\\\\n• PR <google.com|some link>\\",\\"link_names\\":1}"`;
 
 exports[`postToSlack should call slack api in env var 1`] = `"{\\"text\\":\\"@channel: New release *<https://git.hub/some/project/releases/v1.0.0|v1.0.0>*\\\\n* My Notes*\\\\n• PR <google.com|some link>\\",\\"link_names\\":1}"`;

--- a/plugins/slack/__tests__/slack.test.ts
+++ b/plugins/slack/__tests__/slack.test.ts
@@ -235,6 +235,46 @@ describe("postToSlack", () => {
     expect(fetchSpy.mock.calls[0][1].body).toMatchSnapshot();
   });
 
+  test("should add more indents to nested lists", async () => {
+    const plugin = new SlackPlugin("https://custom-slack-url");
+    process.env.SLACK_TOKEN = "MY_TOKEN";
+
+    await plugin.postToSlack(
+      mockAuto,
+      "1.0.0",
+      "# My Notes\n- PR [some link](google.com)\n - Another note",
+      // @ts-ignore
+      mockResponse
+    );
+
+    expect(fetchSpy).toHaveBeenCalled();
+    expect(fetchSpy.mock.calls[0][0]).toBe(
+      "https://custom-slack-url?token=MY_TOKEN"
+    );
+    expect(fetchSpy.mock.calls[0][1].agent).toBeUndefined();
+    expect(fetchSpy.mock.calls[0][1].body).toMatchSnapshot();
+  });
+
+  test("should add more indents to nested lists - 2 spaces", async () => {
+    const plugin = new SlackPlugin("https://custom-slack-url");
+    process.env.SLACK_TOKEN = "MY_TOKEN";
+
+    await plugin.postToSlack(
+      mockAuto,
+      "1.0.0",
+      "# My Notes\n- PR [some link](google.com)\n  - Another note",
+      // @ts-ignore
+      mockResponse
+    );
+
+    expect(fetchSpy).toHaveBeenCalled();
+    expect(fetchSpy.mock.calls[0][0]).toBe(
+      "https://custom-slack-url?token=MY_TOKEN"
+    );
+    expect(fetchSpy.mock.calls[0][1].agent).toBeUndefined();
+    expect(fetchSpy.mock.calls[0][1].body).toMatchSnapshot();
+  });
+
   test("should call slack api through http proxy", async () => {
     const plugin = new SlackPlugin("https://custom-slack-url");
     process.env.SLACK_TOKEN = "MY_TOKEN";

--- a/plugins/slack/src/index.ts
+++ b/plugins/slack/src/index.ts
@@ -24,6 +24,11 @@ const sanitizeMarkdown = (markdown: string) =>
         return `*${line.replace(/^[#]+/, "")}*`;
       }
 
+      // Give extra padding to nested lists
+      if (line.match(/^\s+•/)) {
+        return line.replace(/^\s+•/, "   •");
+      }
+
       // Strip markdown code block type. Slack does not render them correctly.
       if (line.match(MARKDOWN_LANGUAGE)) {
         return line.replace(MARKDOWN_LANGUAGE, "`$2`:\n\n$1");


### PR DESCRIPTION
# What Changed

add extra spacing in nested lists

## Why

It used to only have one space so it was kinda hard to read

Todo:

- [x] Add tests

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.54.3-canary.1566.19194.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.54.3-canary.1566.19194.0
  npm install @auto-canary/auto@9.54.3-canary.1566.19194.0
  npm install @auto-canary/core@9.54.3-canary.1566.19194.0
  npm install @auto-canary/all-contributors@9.54.3-canary.1566.19194.0
  npm install @auto-canary/brew@9.54.3-canary.1566.19194.0
  npm install @auto-canary/chrome@9.54.3-canary.1566.19194.0
  npm install @auto-canary/cocoapods@9.54.3-canary.1566.19194.0
  npm install @auto-canary/conventional-commits@9.54.3-canary.1566.19194.0
  npm install @auto-canary/crates@9.54.3-canary.1566.19194.0
  npm install @auto-canary/docker@9.54.3-canary.1566.19194.0
  npm install @auto-canary/exec@9.54.3-canary.1566.19194.0
  npm install @auto-canary/first-time-contributor@9.54.3-canary.1566.19194.0
  npm install @auto-canary/gem@9.54.3-canary.1566.19194.0
  npm install @auto-canary/gh-pages@9.54.3-canary.1566.19194.0
  npm install @auto-canary/git-tag@9.54.3-canary.1566.19194.0
  npm install @auto-canary/gradle@9.54.3-canary.1566.19194.0
  npm install @auto-canary/jira@9.54.3-canary.1566.19194.0
  npm install @auto-canary/maven@9.54.3-canary.1566.19194.0
  npm install @auto-canary/npm@9.54.3-canary.1566.19194.0
  npm install @auto-canary/omit-commits@9.54.3-canary.1566.19194.0
  npm install @auto-canary/omit-release-notes@9.54.3-canary.1566.19194.0
  npm install @auto-canary/pr-body-labels@9.54.3-canary.1566.19194.0
  npm install @auto-canary/released@9.54.3-canary.1566.19194.0
  npm install @auto-canary/s3@9.54.3-canary.1566.19194.0
  npm install @auto-canary/slack@9.54.3-canary.1566.19194.0
  npm install @auto-canary/twitter@9.54.3-canary.1566.19194.0
  npm install @auto-canary/upload-assets@9.54.3-canary.1566.19194.0
  # or 
  yarn add @auto-canary/bot-list@9.54.3-canary.1566.19194.0
  yarn add @auto-canary/auto@9.54.3-canary.1566.19194.0
  yarn add @auto-canary/core@9.54.3-canary.1566.19194.0
  yarn add @auto-canary/all-contributors@9.54.3-canary.1566.19194.0
  yarn add @auto-canary/brew@9.54.3-canary.1566.19194.0
  yarn add @auto-canary/chrome@9.54.3-canary.1566.19194.0
  yarn add @auto-canary/cocoapods@9.54.3-canary.1566.19194.0
  yarn add @auto-canary/conventional-commits@9.54.3-canary.1566.19194.0
  yarn add @auto-canary/crates@9.54.3-canary.1566.19194.0
  yarn add @auto-canary/docker@9.54.3-canary.1566.19194.0
  yarn add @auto-canary/exec@9.54.3-canary.1566.19194.0
  yarn add @auto-canary/first-time-contributor@9.54.3-canary.1566.19194.0
  yarn add @auto-canary/gem@9.54.3-canary.1566.19194.0
  yarn add @auto-canary/gh-pages@9.54.3-canary.1566.19194.0
  yarn add @auto-canary/git-tag@9.54.3-canary.1566.19194.0
  yarn add @auto-canary/gradle@9.54.3-canary.1566.19194.0
  yarn add @auto-canary/jira@9.54.3-canary.1566.19194.0
  yarn add @auto-canary/maven@9.54.3-canary.1566.19194.0
  yarn add @auto-canary/npm@9.54.3-canary.1566.19194.0
  yarn add @auto-canary/omit-commits@9.54.3-canary.1566.19194.0
  yarn add @auto-canary/omit-release-notes@9.54.3-canary.1566.19194.0
  yarn add @auto-canary/pr-body-labels@9.54.3-canary.1566.19194.0
  yarn add @auto-canary/released@9.54.3-canary.1566.19194.0
  yarn add @auto-canary/s3@9.54.3-canary.1566.19194.0
  yarn add @auto-canary/slack@9.54.3-canary.1566.19194.0
  yarn add @auto-canary/twitter@9.54.3-canary.1566.19194.0
  yarn add @auto-canary/upload-assets@9.54.3-canary.1566.19194.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
