### PR TITLE
add dryRun to BeforeShipItContext

### DIFF
--- a/docs/pages/docs/plugins/release-lifecycle-hooks.mdx
+++ b/docs/pages/docs/plugins/release-lifecycle-hooks.mdx
@@ -41,6 +41,7 @@ This is a great way to throw an error if a token or key is not present.
 Context Object:
 
 - `releaseType` (`latest` | `old` | `next` | `canary`) - The type of release `shipit` will attempt to make.
+- `dryRun` - Whether the run is a dry run
 
 ```ts
 auto.hooks.beforeShipIt.tapPromise("NPM", async (context) => {

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -120,6 +120,8 @@ export type ShipitRelease = "latest" | "old" | "next" | "canary";
 interface BeforeShipitContext {
   /** The type of release that will be made when shipit runs. */
   releaseType: ShipitRelease;
+  /** Whether the run is a dry run */
+  dryRun?: boolean;
 }
 
 interface NextContext {
@@ -1485,7 +1487,7 @@ export default class Auto {
       releaseType = "next";
     }
 
-    await this.hooks.beforeShipIt.promise({ releaseType });
+    await this.hooks.beforeShipIt.promise({ releaseType, dryRun: options.dryRun });
 
     if (releaseType === "latest") {
       publishInfo = await this.latest(options);

--- a/plugins/all-contributors/src/index.ts
+++ b/plugins/all-contributors/src/index.ts
@@ -80,6 +80,7 @@ function getRcFile(auto: Auto) {
       `Encountered errors loading all-contributors configuration at ${rcFile}`,
       error
     );
+    process.exit(1)
   }
 }
 


### PR DESCRIPTION
# What Changed

see title

## Why

You might want to automate some check only in a dryRun before shipit runs.

Todo:

- [x] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.54.7-canary.1572.19271.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.54.7-canary.1572.19271.0
  npm install @auto-canary/auto@9.54.7-canary.1572.19271.0
  npm install @auto-canary/core@9.54.7-canary.1572.19271.0
  npm install @auto-canary/all-contributors@9.54.7-canary.1572.19271.0
  npm install @auto-canary/brew@9.54.7-canary.1572.19271.0
  npm install @auto-canary/chrome@9.54.7-canary.1572.19271.0
  npm install @auto-canary/cocoapods@9.54.7-canary.1572.19271.0
  npm install @auto-canary/conventional-commits@9.54.7-canary.1572.19271.0
  npm install @auto-canary/crates@9.54.7-canary.1572.19271.0
  npm install @auto-canary/docker@9.54.7-canary.1572.19271.0
  npm install @auto-canary/exec@9.54.7-canary.1572.19271.0
  npm install @auto-canary/first-time-contributor@9.54.7-canary.1572.19271.0
  npm install @auto-canary/gem@9.54.7-canary.1572.19271.0
  npm install @auto-canary/gh-pages@9.54.7-canary.1572.19271.0
  npm install @auto-canary/git-tag@9.54.7-canary.1572.19271.0
  npm install @auto-canary/gradle@9.54.7-canary.1572.19271.0
  npm install @auto-canary/jira@9.54.7-canary.1572.19271.0
  npm install @auto-canary/maven@9.54.7-canary.1572.19271.0
  npm install @auto-canary/npm@9.54.7-canary.1572.19271.0
  npm install @auto-canary/omit-commits@9.54.7-canary.1572.19271.0
  npm install @auto-canary/omit-release-notes@9.54.7-canary.1572.19271.0
  npm install @auto-canary/pr-body-labels@9.54.7-canary.1572.19271.0
  npm install @auto-canary/released@9.54.7-canary.1572.19271.0
  npm install @auto-canary/s3@9.54.7-canary.1572.19271.0
  npm install @auto-canary/slack@9.54.7-canary.1572.19271.0
  npm install @auto-canary/twitter@9.54.7-canary.1572.19271.0
  npm install @auto-canary/upload-assets@9.54.7-canary.1572.19271.0
  # or 
  yarn add @auto-canary/bot-list@9.54.7-canary.1572.19271.0
  yarn add @auto-canary/auto@9.54.7-canary.1572.19271.0
  yarn add @auto-canary/core@9.54.7-canary.1572.19271.0
  yarn add @auto-canary/all-contributors@9.54.7-canary.1572.19271.0
  yarn add @auto-canary/brew@9.54.7-canary.1572.19271.0
  yarn add @auto-canary/chrome@9.54.7-canary.1572.19271.0
  yarn add @auto-canary/cocoapods@9.54.7-canary.1572.19271.0
  yarn add @auto-canary/conventional-commits@9.54.7-canary.1572.19271.0
  yarn add @auto-canary/crates@9.54.7-canary.1572.19271.0
  yarn add @auto-canary/docker@9.54.7-canary.1572.19271.0
  yarn add @auto-canary/exec@9.54.7-canary.1572.19271.0
  yarn add @auto-canary/first-time-contributor@9.54.7-canary.1572.19271.0
  yarn add @auto-canary/gem@9.54.7-canary.1572.19271.0
  yarn add @auto-canary/gh-pages@9.54.7-canary.1572.19271.0
  yarn add @auto-canary/git-tag@9.54.7-canary.1572.19271.0
  yarn add @auto-canary/gradle@9.54.7-canary.1572.19271.0
  yarn add @auto-canary/jira@9.54.7-canary.1572.19271.0
  yarn add @auto-canary/maven@9.54.7-canary.1572.19271.0
  yarn add @auto-canary/npm@9.54.7-canary.1572.19271.0
  yarn add @auto-canary/omit-commits@9.54.7-canary.1572.19271.0
  yarn add @auto-canary/omit-release-notes@9.54.7-canary.1572.19271.0
  yarn add @auto-canary/pr-body-labels@9.54.7-canary.1572.19271.0
  yarn add @auto-canary/released@9.54.7-canary.1572.19271.0
  yarn add @auto-canary/s3@9.54.7-canary.1572.19271.0
  yarn add @auto-canary/slack@9.54.7-canary.1572.19271.0
  yarn add @auto-canary/twitter@9.54.7-canary.1572.19271.0
  yarn add @auto-canary/upload-assets@9.54.7-canary.1572.19271.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
