### PR TITLE
auto generate contributors if a contributors list exists but none are…

### DIFF
--- a/plugins/all-contributors/__tests__/all-contributors.test.ts
+++ b/plugins/all-contributors/__tests__/all-contributors.test.ts
@@ -145,4 +145,32 @@ describe('All Contributors Plugin', () => {
 
     expect(exec).not.toHaveBeenCalled();
   });
+
+  test('should initialize contributors if not already initialized', async () => {
+    const releasedLabel = new AllContributors();
+    const autoHooks = makeHooks();
+    mockRead(
+      '{ "contributors": [ { "login": "Jeff", "contributions": ["code"] } ], "files": ["README.md"]}'
+    );
+
+    mockRead(
+      '<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section --><!-- prettier-ignore-start -->\n<!-- markdownlint-disable -->\n<!-- markdownlint-restore -->\n<!-- prettier-ignore-end -->\n<!-- ALL-CONTRIBUTORS-LIST:END -->'
+    );
+
+    releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto);
+
+    await autoHooks.afterAddToChangelog.promise({
+      currentVersion: '0.0.0',
+      lastRelease: '0.0.0',
+      releaseNotes: '',
+      commits: [
+        makeCommitFromMsg('Do the thing', {
+          files: ['src/index.ts'],
+          username: 'Jeff'
+        })
+      ]
+    });
+
+    expect(exec.mock.calls[0][0]).toBe('npx all-contributors generate');
+  });
 });

--- a/plugins/all-contributors/src/index.ts
+++ b/plugins/all-contributors/src/index.ts
@@ -53,6 +53,8 @@ interface Contributor {
 interface AllContributorsRc {
   /** All of the current contributors */
   contributors: Contributor[];
+  /** The list of files to add all-contributors to */
+  files: string[];
 }
 
 const defaultOptions: IAllContributorsPluginOptions = {
@@ -144,6 +146,23 @@ export default class AllContributorsPlugin implements IPlugin {
               ].join(',')}`,
               { stdio: 'inherit' }
             );
+          }
+
+          // if the all-contributors has not been generated ... generate it
+          if (config.contributors.length && config.files) {
+            try {
+              // test if the first file in the list of files has been init
+              const file = path.join(process.cwd(), config.files[0]);
+              const displayFile = fs.readFileSync(file, 'utf8');
+
+              const notInitalized = displayFile.indexOf(
+                '<!-- markdownlint-disable -->\n<!-- markdownlint-restore -->'
+              );
+
+              if (notInitalized) {
+                execSync(`npx all-contributors generate`, { stdio: 'inherit' });
+              }
+            } catch {}
           }
         }
       );


### PR DESCRIPTION
When i first add auto all contributors to a project I have to back track and add the all contributors list to my repo
 that is fine but if a list exists in my rc can auto check if it is initialized in my readme and if it isnt can it add it?

-- I might be able to clean this up and streamline it a bit 🤔 but was wondering about the concept

 
