### PR TITLE
feat: run pod lib lint during dryrun

### DIFF
--- a/plugins/cocoapods/__tests__/cocoapods.test.ts
+++ b/plugins/cocoapods/__tests__/cocoapods.test.ts
@@ -189,6 +189,52 @@ describe("Cocoapods Plugin", () => {
     });
   });
 
+  describe("beforeShipit hook", () => {
+    test("should call pod lib lint with dryRun flag", async () => {
+      mockPodspec(specWithVersion("0.0.1"));
+
+      const plugin = new CocoapodsPlugin(options);
+      const hook = makeHooks();
+
+      plugin.apply({
+        hooks: hook,
+        logger: dummyLog(),
+        prefixRelease,
+      } as Auto.Auto);
+
+      await hook.beforeShipIt.promise({ releaseType: "latest", dryRun: true });
+
+      expect(exec).toBeCalledTimes(1);
+      expect(exec).lastCalledWith("pod", ["lib", "lint", "./Test.podspec"]);
+    });
+    test("should call pod lib lint with options with dryRun flag", async () => {
+      mockPodspec(specWithVersion("0.0.1"));
+
+      const plugin = new CocoapodsPlugin({
+        ...options,
+        flags: ["--flag"],
+        podCommand: "notpod",
+      });
+      const hook = makeHooks();
+
+      plugin.apply({
+        hooks: hook,
+        logger: dummyLog(),
+        prefixRelease,
+      } as Auto.Auto);
+
+      await hook.beforeShipIt.promise({ releaseType: "latest", dryRun: true });
+
+      expect(exec).toBeCalledTimes(1);
+      expect(exec).lastCalledWith("notpod", [
+        "lib",
+        "lint",
+        "--flag",
+        "./Test.podspec",
+      ]);
+    });
+  });
+
   describe("publish hook", () => {
     test("should push to trunk if no specsRepo in options", async () => {
       mockPodspec(specWithVersion("0.0.1"));

--- a/plugins/cocoapods/src/index.ts
+++ b/plugins/cocoapods/src/index.ts
@@ -157,6 +157,22 @@ export default class CocoapodsPlugin implements IPlugin {
       ]);
     });
 
+    auto.hooks.beforeShipIt.tapPromise(this.name, async ({ dryRun }) => {
+      if (dryRun) {
+        auto.logger.log.info(logMessage('dryRun - running "pod lib lint"'));
+        const [pod, ...commands] = this.options.podCommand?.split(" ") || [
+          "pod",
+        ];
+        await execPromise(pod, [
+          ...commands,
+          "lib",
+          "lint",
+          ...(this.options.flags || []),
+          this.options.podspecPath,
+        ]);
+      }
+    });
+
     auto.hooks.publish.tapPromise(this.name, async () => {
       const [pod, ...commands] = this.options.podCommand?.split(" ") || ["pod"];
 


### PR DESCRIPTION
# What Changed

Tap the `beforeShipIt` hook to run `pod lib lint` during a `dryRun` of `shipit`. 

## Why

During an actual `shipit` call, `pod repo push` is executed to push the updated podspec file to the specs repository. Internally, `pod repo push` will call `pod lib lint` to ensure the podspec file validates before pushing it.

During a dryrun, we will now run `pod lib lint` to simulate part of `pod repo push` while giving feedback to the user if shipit could have succeeded.


Todo:

- [x] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.55.1-canary.1576.19315.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.55.1-canary.1576.19315.0
  npm install @auto-canary/auto@9.55.1-canary.1576.19315.0
  npm install @auto-canary/core@9.55.1-canary.1576.19315.0
  npm install @auto-canary/all-contributors@9.55.1-canary.1576.19315.0
  npm install @auto-canary/brew@9.55.1-canary.1576.19315.0
  npm install @auto-canary/chrome@9.55.1-canary.1576.19315.0
  npm install @auto-canary/cocoapods@9.55.1-canary.1576.19315.0
  npm install @auto-canary/conventional-commits@9.55.1-canary.1576.19315.0
  npm install @auto-canary/crates@9.55.1-canary.1576.19315.0
  npm install @auto-canary/docker@9.55.1-canary.1576.19315.0
  npm install @auto-canary/exec@9.55.1-canary.1576.19315.0
  npm install @auto-canary/first-time-contributor@9.55.1-canary.1576.19315.0
  npm install @auto-canary/gem@9.55.1-canary.1576.19315.0
  npm install @auto-canary/gh-pages@9.55.1-canary.1576.19315.0
  npm install @auto-canary/git-tag@9.55.1-canary.1576.19315.0
  npm install @auto-canary/gradle@9.55.1-canary.1576.19315.0
  npm install @auto-canary/jira@9.55.1-canary.1576.19315.0
  npm install @auto-canary/maven@9.55.1-canary.1576.19315.0
  npm install @auto-canary/npm@9.55.1-canary.1576.19315.0
  npm install @auto-canary/omit-commits@9.55.1-canary.1576.19315.0
  npm install @auto-canary/omit-release-notes@9.55.1-canary.1576.19315.0
  npm install @auto-canary/pr-body-labels@9.55.1-canary.1576.19315.0
  npm install @auto-canary/released@9.55.1-canary.1576.19315.0
  npm install @auto-canary/s3@9.55.1-canary.1576.19315.0
  npm install @auto-canary/slack@9.55.1-canary.1576.19315.0
  npm install @auto-canary/twitter@9.55.1-canary.1576.19315.0
  npm install @auto-canary/upload-assets@9.55.1-canary.1576.19315.0
  # or 
  yarn add @auto-canary/bot-list@9.55.1-canary.1576.19315.0
  yarn add @auto-canary/auto@9.55.1-canary.1576.19315.0
  yarn add @auto-canary/core@9.55.1-canary.1576.19315.0
  yarn add @auto-canary/all-contributors@9.55.1-canary.1576.19315.0
  yarn add @auto-canary/brew@9.55.1-canary.1576.19315.0
  yarn add @auto-canary/chrome@9.55.1-canary.1576.19315.0
  yarn add @auto-canary/cocoapods@9.55.1-canary.1576.19315.0
  yarn add @auto-canary/conventional-commits@9.55.1-canary.1576.19315.0
  yarn add @auto-canary/crates@9.55.1-canary.1576.19315.0
  yarn add @auto-canary/docker@9.55.1-canary.1576.19315.0
  yarn add @auto-canary/exec@9.55.1-canary.1576.19315.0
  yarn add @auto-canary/first-time-contributor@9.55.1-canary.1576.19315.0
  yarn add @auto-canary/gem@9.55.1-canary.1576.19315.0
  yarn add @auto-canary/gh-pages@9.55.1-canary.1576.19315.0
  yarn add @auto-canary/git-tag@9.55.1-canary.1576.19315.0
  yarn add @auto-canary/gradle@9.55.1-canary.1576.19315.0
  yarn add @auto-canary/jira@9.55.1-canary.1576.19315.0
  yarn add @auto-canary/maven@9.55.1-canary.1576.19315.0
  yarn add @auto-canary/npm@9.55.1-canary.1576.19315.0
  yarn add @auto-canary/omit-commits@9.55.1-canary.1576.19315.0
  yarn add @auto-canary/omit-release-notes@9.55.1-canary.1576.19315.0
  yarn add @auto-canary/pr-body-labels@9.55.1-canary.1576.19315.0
  yarn add @auto-canary/released@9.55.1-canary.1576.19315.0
  yarn add @auto-canary/s3@9.55.1-canary.1576.19315.0
  yarn add @auto-canary/slack@9.55.1-canary.1576.19315.0
  yarn add @auto-canary/twitter@9.55.1-canary.1576.19315.0
  yarn add @auto-canary/upload-assets@9.55.1-canary.1576.19315.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
