### PR TITLE
feat: adding cocoapod verbose logging

### DIFF
--- a/plugins/cocoapods/README.md
+++ b/plugins/cocoapods/README.md
@@ -28,9 +28,7 @@ yarn add -D @auto-it/cocoapods
         // Optional, the specs repo to push to
         "specsRepo": "https://github.com/intuit/TestSpecs.git",
         // Optional, flags to pass to the `pod repo push` command
-        "flags": [
-          "--sources=https://github.com/SpecRepo.git"
-        ],
+        "flags": ["--sources=https://github.com/SpecRepo.git"],
         // Optional, specify a different executable for `pod`
         "podCommand": "bundle exec pod"
       }
@@ -47,6 +45,7 @@ yarn add -D @auto-it/cocoapods
 - The machine running this plugin must have the [CocoaPods](https://cocoapods.org/) `pod` CLI installed already, or `podCommand` specified in your plugin configuration.
 - Your `podspec` file must pass `pod lib lint` in order for publishing to a Specs repository to work.
   - All warnings and errors must be addressed before attempting to push to a Specs repository.
+- Using the logging flags with Auto (`auto -v`, `auto -vv`, `auto -q`) will also add the verbose or silent flags to the CocoaPod commands.
 
 ### Pushing to the CocoaPods Trunk
 

--- a/plugins/cocoapods/__tests__/cocoapods.test.ts
+++ b/plugins/cocoapods/__tests__/cocoapods.test.ts
@@ -257,6 +257,9 @@ describe("Cocoapods Plugin", () => {
     test("should push to trunk if no specsRepo in options with flags", async () => {
       mockPodspec(specWithVersion("0.0.1"));
 
+      const logger = dummyLog();
+      logger.logLevel = "verbose";
+
       const plugin = new CocoapodsPlugin({
         ...options,
         flags: ["--sources", "someOtherSpecsRepo"],
@@ -264,7 +267,7 @@ describe("Cocoapods Plugin", () => {
       const hook = makeHooks();
       plugin.apply({
         hooks: hook,
-        logger: dummyLog(),
+        logger,
         prefixRelease,
       } as Auto.Auto);
 
@@ -277,11 +280,15 @@ describe("Cocoapods Plugin", () => {
         "--sources",
         "someOtherSpecsRepo",
         "./Test.podspec",
+        "--verbose",
       ]);
     });
 
     test("should push to specs repo if specsRepo in options", async () => {
       mockPodspec(specWithVersion("0.0.1"));
+
+      const logger = dummyLog();
+      logger.logLevel = "quiet";
 
       const plugin = new CocoapodsPlugin({
         ...options,
@@ -290,7 +297,7 @@ describe("Cocoapods Plugin", () => {
       const hook = makeHooks();
       plugin.apply({
         hooks: hook,
-        logger: dummyLog(),
+        logger,
         prefixRelease,
       } as Auto.Auto);
 
@@ -303,22 +310,28 @@ describe("Cocoapods Plugin", () => {
         "add",
         "autoPublishRepo",
         "someSpecsRepo",
+        "--silent",
       ]);
       expect(exec).toHaveBeenNthCalledWith(4, "pod", [
         "repo",
         "push",
         "autoPublishRepo",
         "./Test.podspec",
+        "--silent",
       ]);
       expect(exec).toHaveBeenNthCalledWith(5, "pod", [
         "repo",
         "remove",
         "autoPublishRepo",
+        "--silent",
       ]);
     });
 
     test("should push to specs repo if specsRepo in options with flags", async () => {
       mockPodspec(specWithVersion("0.0.1"));
+
+      const logger = dummyLog();
+      logger.logLevel = "veryVerbose";
 
       const plugin = new CocoapodsPlugin({
         ...options,
@@ -328,7 +341,7 @@ describe("Cocoapods Plugin", () => {
       const hook = makeHooks();
       plugin.apply({
         hooks: hook,
-        logger: dummyLog(),
+        logger,
         prefixRelease,
       } as Auto.Auto);
 
@@ -341,6 +354,7 @@ describe("Cocoapods Plugin", () => {
         "add",
         "autoPublishRepo",
         "someSpecsRepo",
+        "--verbose",
       ]);
       expect(exec).toHaveBeenNthCalledWith(4, "pod", [
         "repo",
@@ -349,13 +363,16 @@ describe("Cocoapods Plugin", () => {
         "someOtherSpecsRepo",
         "autoPublishRepo",
         "./Test.podspec",
+        "--verbose",
       ]);
       expect(exec).toHaveBeenNthCalledWith(5, "pod", [
         "repo",
         "remove",
         "autoPublishRepo",
+        "--verbose",
       ]);
     });
+
     test("should delete autoPublishRepo if it exists and push to specs repo if specsRepo in options", async () => {
       mockPodspec(specWithVersion("0.0.1"));
 

--- a/plugins/cocoapods/src/index.ts
+++ b/plugins/cocoapods/src/index.ts
@@ -123,6 +123,12 @@ export default class CocoapodsPlugin implements IPlugin {
 
   /** Tap into auto plugin points. */
   apply(auto: Auto) {
+    const isQuiet = auto.logger.logLevel === "quiet";
+    const isVerbose =
+      auto.logger.logLevel === "verbose" ||
+      auto.logger.logLevel === "veryVerbose";
+    const podLogLevel = isQuiet ? ["--silent"] : isVerbose ? ["--verbose"] : [];
+
     auto.hooks.validateConfig.tapPromise(this.name, async (name, options) => {
       if (name === this.name || name === `@auto-it/${this.name}`) {
         return validatePluginConfiguration(this.name, pluginOptions, options);
@@ -176,6 +182,7 @@ export default class CocoapodsPlugin implements IPlugin {
           "push",
           ...(this.options.flags || []),
           this.options.podspecPath,
+          ...podLogLevel,
         ]);
         return;
       }
@@ -193,6 +200,7 @@ export default class CocoapodsPlugin implements IPlugin {
             "repo",
             "remove",
             "autoPublishRepo",
+            ...podLogLevel,
           ]);
         }
       } catch (error) {
@@ -208,6 +216,7 @@ export default class CocoapodsPlugin implements IPlugin {
           "add",
           "autoPublishRepo",
           this.options.specsRepo,
+          ...podLogLevel,
         ]);
 
         auto.logger.log.info(
@@ -221,6 +230,7 @@ export default class CocoapodsPlugin implements IPlugin {
           ...(this.options.flags || []),
           "autoPublishRepo",
           this.options.podspecPath,
+          ...podLogLevel,
         ]);
       } catch (error) {
         auto.logger.log.error(
@@ -235,6 +245,7 @@ export default class CocoapodsPlugin implements IPlugin {
           "repo",
           "remove",
           "autoPublishRepo",
+          ...podLogLevel,
         ]);
       }
     });


### PR DESCRIPTION
# What Changed
> Updated CocoaPod plugin to check logging level of `Auto` and perform the appropriate logging based off of that.

## Why
> To give greater control to those using the CocoaPod plugin. Solves #1553 

Todo:

- [X] Add tests
- [X] Add docs

## Change Type

Indicate the type of change your pull request is:

- [X] `documentation`
- [ ] `patch`
- [X] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.57.1-canary.1580.19378.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.57.1-canary.1580.19378.0
  npm install @auto-canary/auto@9.57.1-canary.1580.19378.0
  npm install @auto-canary/core@9.57.1-canary.1580.19378.0
  npm install @auto-canary/all-contributors@9.57.1-canary.1580.19378.0
  npm install @auto-canary/brew@9.57.1-canary.1580.19378.0
  npm install @auto-canary/chrome@9.57.1-canary.1580.19378.0
  npm install @auto-canary/cocoapods@9.57.1-canary.1580.19378.0
  npm install @auto-canary/conventional-commits@9.57.1-canary.1580.19378.0
  npm install @auto-canary/crates@9.57.1-canary.1580.19378.0
  npm install @auto-canary/docker@9.57.1-canary.1580.19378.0
  npm install @auto-canary/exec@9.57.1-canary.1580.19378.0
  npm install @auto-canary/first-time-contributor@9.57.1-canary.1580.19378.0
  npm install @auto-canary/gem@9.57.1-canary.1580.19378.0
  npm install @auto-canary/gh-pages@9.57.1-canary.1580.19378.0
  npm install @auto-canary/git-tag@9.57.1-canary.1580.19378.0
  npm install @auto-canary/gradle@9.57.1-canary.1580.19378.0
  npm install @auto-canary/jira@9.57.1-canary.1580.19378.0
  npm install @auto-canary/maven@9.57.1-canary.1580.19378.0
  npm install @auto-canary/npm@9.57.1-canary.1580.19378.0
  npm install @auto-canary/omit-commits@9.57.1-canary.1580.19378.0
  npm install @auto-canary/omit-release-notes@9.57.1-canary.1580.19378.0
  npm install @auto-canary/pr-body-labels@9.57.1-canary.1580.19378.0
  npm install @auto-canary/released@9.57.1-canary.1580.19378.0
  npm install @auto-canary/s3@9.57.1-canary.1580.19378.0
  npm install @auto-canary/slack@9.57.1-canary.1580.19378.0
  npm install @auto-canary/twitter@9.57.1-canary.1580.19378.0
  npm install @auto-canary/upload-assets@9.57.1-canary.1580.19378.0
  # or 
  yarn add @auto-canary/bot-list@9.57.1-canary.1580.19378.0
  yarn add @auto-canary/auto@9.57.1-canary.1580.19378.0
  yarn add @auto-canary/core@9.57.1-canary.1580.19378.0
  yarn add @auto-canary/all-contributors@9.57.1-canary.1580.19378.0
  yarn add @auto-canary/brew@9.57.1-canary.1580.19378.0
  yarn add @auto-canary/chrome@9.57.1-canary.1580.19378.0
  yarn add @auto-canary/cocoapods@9.57.1-canary.1580.19378.0
  yarn add @auto-canary/conventional-commits@9.57.1-canary.1580.19378.0
  yarn add @auto-canary/crates@9.57.1-canary.1580.19378.0
  yarn add @auto-canary/docker@9.57.1-canary.1580.19378.0
  yarn add @auto-canary/exec@9.57.1-canary.1580.19378.0
  yarn add @auto-canary/first-time-contributor@9.57.1-canary.1580.19378.0
  yarn add @auto-canary/gem@9.57.1-canary.1580.19378.0
  yarn add @auto-canary/gh-pages@9.57.1-canary.1580.19378.0
  yarn add @auto-canary/git-tag@9.57.1-canary.1580.19378.0
  yarn add @auto-canary/gradle@9.57.1-canary.1580.19378.0
  yarn add @auto-canary/jira@9.57.1-canary.1580.19378.0
  yarn add @auto-canary/maven@9.57.1-canary.1580.19378.0
  yarn add @auto-canary/npm@9.57.1-canary.1580.19378.0
  yarn add @auto-canary/omit-commits@9.57.1-canary.1580.19378.0
  yarn add @auto-canary/omit-release-notes@9.57.1-canary.1580.19378.0
  yarn add @auto-canary/pr-body-labels@9.57.1-canary.1580.19378.0
  yarn add @auto-canary/released@9.57.1-canary.1580.19378.0
  yarn add @auto-canary/s3@9.57.1-canary.1580.19378.0
  yarn add @auto-canary/slack@9.57.1-canary.1580.19378.0
  yarn add @auto-canary/twitter@9.57.1-canary.1580.19378.0
  yarn add @auto-canary/upload-assets@9.57.1-canary.1580.19378.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
