### PR TITLE
Group monorepo changelog lines if possivle

### DIFF
--- a/docs/pages/docs/plugins/changelog-hooks.mdx
+++ b/docs/pages/docs/plugins/changelog-hooks.mdx
@@ -9,6 +9,7 @@ The hooks it provides allow you to customize everything about how the changelog 
 - [onCreateChangelog](#oncreatechangelog)
 - [addToBody](#addtobody)
 - [renderChangelogLine](#renderchangelogline)
+- [sortChangelogLines](#sortchangeloglines)
 - [renderChangelogTitle](#renderchangelogtitle)
 - [renderChangelogAuthor](#renderchangelogauthor)
 - [renderChangelogAuthorLine](#renderchangelogauthorline)
@@ -61,6 +62,22 @@ auto.hooks.onCreateChangelog.tapPromise('Stars', changelog =>
     'Stars',
     async (commit, line) =>
       [commit, `${line.replace('-', ':star:')}\n`]
+  );
+);
+```
+
+## sortChangelogLines
+
+Change how the changelog lines are sorted
+You must return the lines from this hook.
+
+```ts
+auto.hooks.onCreateChangelog.tapPromise('Stars', changelog =>
+  changelog.hooks.sortChangelogLines.tapPromise(
+    'Stars',
+    async (lines) => {
+      // sorting logic
+    }
   );
 );
 ```

--- a/packages/core/src/changelog.ts
+++ b/packages/core/src/changelog.ts
@@ -32,6 +32,8 @@ interface ICommitSplit {
 export interface IChangelogHooks {
   /** Change how the changelog renders lines. */
   renderChangelogLine: AsyncSeriesWaterfallHook<[[IExtendedCommit, string]]>;
+  /** Sort the lines in a changelog section. */
+  sortChangelogLines: AsyncSeriesWaterfallHook<[string[]]>;
   /** Change how the changelog renders titles */
   renderChangelogTitle: AsyncSeriesBailHook<
     [string, { [label: string]: string }],
@@ -401,12 +403,11 @@ export default class Changelog {
           })
         );
 
-        return [
-          title as string,
-          [...lines].sort(
-            (a, b) => a.split("\n").length - b.split("\n").length
-          ),
-        ] as [string, string[]];
+        const sortedLines = await this.hooks.sortChangelogLines.promise(
+          [...lines].sort((a, b) => a.split("\n").length - b.split("\n").length)
+        );
+
+        return [title || "", sortedLines] as const;
       })
     );
 

--- a/packages/core/src/utils/make-hooks.ts
+++ b/packages/core/src/utils/make-hooks.ts
@@ -29,7 +29,7 @@ export const makeHooks = (): IAutoHooks => ({
   getAuthor: new AsyncSeriesBailHook(),
   getPreviousVersion: new AsyncSeriesBailHook(),
   getRepository: new AsyncSeriesBailHook(),
-  prCheck: new AsyncSeriesBailHook(['prInformation']),
+  prCheck: new AsyncSeriesBailHook(["prInformation"]),
   version: new AsyncParallelHook(["version"]),
   afterVersion: new AsyncParallelHook(),
   publish: new AsyncParallelHook(["version"]),
@@ -63,6 +63,7 @@ export const makeInteractiveInitHooks = (): InteractiveInitHooks => ({
 /** Make the hooks for "Changelog" */
 export const makeChangelogHooks = (): IChangelogHooks => ({
   addToBody: new AsyncSeriesWaterfallHook(["notes", "commits"]),
+  sortChangelogLines: new AsyncSeriesWaterfallHook(["lines"]),
   renderChangelogLine: new AsyncSeriesWaterfallHook(["lineData"]),
   renderChangelogTitle: new AsyncSeriesBailHook(["commits", "lineRender"]),
   renderChangelogAuthor: new AsyncSeriesBailHook([

--- a/plugins/npm/__tests__/__snapshots__/monorepo-log.test.ts.snap
+++ b/plugins/npm/__tests__/__snapshots__/monorepo-log.test.ts.snap
@@ -6,7 +6,6 @@ exports[`should add versions for independent packages 1`] = `
 - woot [#12343](https://github.custom.com/pull/12343) (adam@dierkens.com)
 - \`@foobar/release@1.0.1\`, \`@foobar/party@1.0.3\`
   - [PLAYA-5052] - Some Feature [#12345](https://github.custom.com/pull/12345) (adam@dierkens.com)
-- \`@foobar/release@1.0.1\`, \`@foobar/party@1.0.3\`
   - [PLAYA-5052] - Some Feature - Revert [#12345](https://github.custom.com/pull/12345) (adam@dierkens.com)
 
 #### 🏠 Internal
@@ -39,9 +38,27 @@ exports[`should create sections for packages 1`] = `
 "#### 💥 Breaking Change
 
 - woot [#12343](https://github.custom.com/pull/12343) (adam@dierkens.com)
+- \`@foobar/party\`
+  - [PLAYA-5052] - Some Feature [#12345](https://github.custom.com/pull/12345) (adam@dierkens.com)
+- \`@foobar/release\`
+  - [PLAYA-5052] - Some Feature - Revert [#12345](https://github.custom.com/pull/12345) (adam@dierkens.com)
+
+#### 🏠 Internal
+
+- \`@foobar/release\`
+  - Another Feature [#1234](https://github.custom.com/pull/1234) (adam@dierkens.com)
+
+#### Authors: 1
+
+- Adam Dierkens (adam@dierkens.com)"
+`;
+
+exports[`should group sections for packages 1`] = `
+"#### 💥 Breaking Change
+
+- woot [#12343](https://github.custom.com/pull/12343) (adam@dierkens.com)
 - \`@foobar/release\`, \`@foobar/party\`
   - [PLAYA-5052] - Some Feature [#12345](https://github.custom.com/pull/12345) (adam@dierkens.com)
-- \`@foobar/release\`, \`@foobar/party\`
   - [PLAYA-5052] - Some Feature - Revert [#12345](https://github.custom.com/pull/12345) (adam@dierkens.com)
 
 #### 🏠 Internal


### PR DESCRIPTION
# What Changed

Add a hook to sort changelog lines and use it in npm plugin

## Why

closes #1586

Todo:

- [x] Add tests

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.58.1-canary.1589.19427.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.58.1-canary.1589.19427.0
  npm install @auto-canary/auto@9.58.1-canary.1589.19427.0
  npm install @auto-canary/core@9.58.1-canary.1589.19427.0
  npm install @auto-canary/all-contributors@9.58.1-canary.1589.19427.0
  npm install @auto-canary/brew@9.58.1-canary.1589.19427.0
  npm install @auto-canary/chrome@9.58.1-canary.1589.19427.0
  npm install @auto-canary/cocoapods@9.58.1-canary.1589.19427.0
  npm install @auto-canary/conventional-commits@9.58.1-canary.1589.19427.0
  npm install @auto-canary/crates@9.58.1-canary.1589.19427.0
  npm install @auto-canary/docker@9.58.1-canary.1589.19427.0
  npm install @auto-canary/exec@9.58.1-canary.1589.19427.0
  npm install @auto-canary/first-time-contributor@9.58.1-canary.1589.19427.0
  npm install @auto-canary/gem@9.58.1-canary.1589.19427.0
  npm install @auto-canary/gh-pages@9.58.1-canary.1589.19427.0
  npm install @auto-canary/git-tag@9.58.1-canary.1589.19427.0
  npm install @auto-canary/gradle@9.58.1-canary.1589.19427.0
  npm install @auto-canary/jira@9.58.1-canary.1589.19427.0
  npm install @auto-canary/maven@9.58.1-canary.1589.19427.0
  npm install @auto-canary/npm@9.58.1-canary.1589.19427.0
  npm install @auto-canary/omit-commits@9.58.1-canary.1589.19427.0
  npm install @auto-canary/omit-release-notes@9.58.1-canary.1589.19427.0
  npm install @auto-canary/pr-body-labels@9.58.1-canary.1589.19427.0
  npm install @auto-canary/released@9.58.1-canary.1589.19427.0
  npm install @auto-canary/s3@9.58.1-canary.1589.19427.0
  npm install @auto-canary/slack@9.58.1-canary.1589.19427.0
  npm install @auto-canary/twitter@9.58.1-canary.1589.19427.0
  npm install @auto-canary/upload-assets@9.58.1-canary.1589.19427.0
  # or 
  yarn add @auto-canary/bot-list@9.58.1-canary.1589.19427.0
  yarn add @auto-canary/auto@9.58.1-canary.1589.19427.0
  yarn add @auto-canary/core@9.58.1-canary.1589.19427.0
  yarn add @auto-canary/all-contributors@9.58.1-canary.1589.19427.0
  yarn add @auto-canary/brew@9.58.1-canary.1589.19427.0
  yarn add @auto-canary/chrome@9.58.1-canary.1589.19427.0
  yarn add @auto-canary/cocoapods@9.58.1-canary.1589.19427.0
  yarn add @auto-canary/conventional-commits@9.58.1-canary.1589.19427.0
  yarn add @auto-canary/crates@9.58.1-canary.1589.19427.0
  yarn add @auto-canary/docker@9.58.1-canary.1589.19427.0
  yarn add @auto-canary/exec@9.58.1-canary.1589.19427.0
  yarn add @auto-canary/first-time-contributor@9.58.1-canary.1589.19427.0
  yarn add @auto-canary/gem@9.58.1-canary.1589.19427.0
  yarn add @auto-canary/gh-pages@9.58.1-canary.1589.19427.0
  yarn add @auto-canary/git-tag@9.58.1-canary.1589.19427.0
  yarn add @auto-canary/gradle@9.58.1-canary.1589.19427.0
  yarn add @auto-canary/jira@9.58.1-canary.1589.19427.0
  yarn add @auto-canary/maven@9.58.1-canary.1589.19427.0
  yarn add @auto-canary/npm@9.58.1-canary.1589.19427.0
  yarn add @auto-canary/omit-commits@9.58.1-canary.1589.19427.0
  yarn add @auto-canary/omit-release-notes@9.58.1-canary.1589.19427.0
  yarn add @auto-canary/pr-body-labels@9.58.1-canary.1589.19427.0
  yarn add @auto-canary/released@9.58.1-canary.1589.19427.0
  yarn add @auto-canary/s3@9.58.1-canary.1589.19427.0
  yarn add @auto-canary/slack@9.58.1-canary.1589.19427.0
  yarn add @auto-canary/twitter@9.58.1-canary.1589.19427.0
  yarn add @auto-canary/upload-assets@9.58.1-canary.1589.19427.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
