### PR TITLE
Add better verbose logging in gh-pages plugin

### DIFF
--- a/plugins/gh-pages/__tests__/gh-pages.test.ts
+++ b/plugins/gh-pages/__tests__/gh-pages.test.ts
@@ -130,6 +130,25 @@ describe("Gh-Pages Plugin", () => {
       expect(execSpy).toHaveBeenCalledWith("npx", [
         "push-dir",
         "--cleanup",
+        false,
+        "--remote=undefined",
+        "--dir=test",
+        "--branch=gh-pages",
+        '--message="Update docs [skip ci]"',
+      ]);
+    });
+
+    test("should use verbose logs", async () => {
+      const logger = dummyLog();
+      logger.logLevel = "verbose";
+      const hooks = createTest({ dir: "test" }, { logger });
+      await hooks.afterRelease.promise({
+        response: { data: { prerelease: false } },
+      } as any);
+      expect(execSpy).toHaveBeenCalledWith("npx", [
+        "push-dir",
+        "--cleanup",
+        "--verbose",
         "--remote=undefined",
         "--dir=test",
         "--branch=gh-pages",

--- a/plugins/gh-pages/src/index.ts
+++ b/plugins/gh-pages/src/index.ts
@@ -7,7 +7,7 @@ import {
 } from "@auto-it/core";
 import { execSync } from "child_process";
 import * as t from "io-ts";
-import endent from 'endent';
+import endent from "endent";
 
 const required = t.interface({
   /** The directory to push to gh-pages */
@@ -106,9 +106,14 @@ export default class GhPagesPlugin implements IPlugin {
     }
 
     try {
+      const isVerbose =
+        auto.logger.logLevel === "verbose" ||
+        auto.logger.logLevel === "veryVerbose";
+
       await execPromise("npx", [
         "push-dir",
         "--cleanup",
+        isVerbose && "--verbose",
         `--remote=${auto.remote}`,
         `--dir=${this.options.dir}`,
         `--branch=${this.options.branch}`,
@@ -119,7 +124,7 @@ export default class GhPagesPlugin implements IPlugin {
         "Oh no! It looks like there was trouble publishing to GitHub Pages 😢"
       );
 
-      if (error.message.includes('git not clean')) {
+      if (error.message.includes("git not clean")) {
         auto.logger.log.error(endent`
           Your repo currently has uncommitted files in it.
           For the gh-pages plugin to work your git state must be clean.
@@ -127,14 +132,14 @@ export default class GhPagesPlugin implements IPlugin {
 
           1. Add the files to your gitignore (ex: your built gh-pages website dist files)
           2. Commit the files (ex: Something you want to track in the repo)
-        `)
+        `);
 
         const status = await execPromise("git", ["status", "--porcelain"]);
 
         if (status) {
           auto.logger.log.error("Uncomitted Changes:\n", status);
         }
-      } 
+      }
 
       throw error;
     }


### PR DESCRIPTION
# What Changed

Pass along --verbose to push-dir

## Why

More logs are better!

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.59.1-canary.1591.19467.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.59.1-canary.1591.19467.0
  npm install @auto-canary/auto@9.59.1-canary.1591.19467.0
  npm install @auto-canary/core@9.59.1-canary.1591.19467.0
  npm install @auto-canary/all-contributors@9.59.1-canary.1591.19467.0
  npm install @auto-canary/brew@9.59.1-canary.1591.19467.0
  npm install @auto-canary/chrome@9.59.1-canary.1591.19467.0
  npm install @auto-canary/cocoapods@9.59.1-canary.1591.19467.0
  npm install @auto-canary/conventional-commits@9.59.1-canary.1591.19467.0
  npm install @auto-canary/crates@9.59.1-canary.1591.19467.0
  npm install @auto-canary/docker@9.59.1-canary.1591.19467.0
  npm install @auto-canary/exec@9.59.1-canary.1591.19467.0
  npm install @auto-canary/first-time-contributor@9.59.1-canary.1591.19467.0
  npm install @auto-canary/gem@9.59.1-canary.1591.19467.0
  npm install @auto-canary/gh-pages@9.59.1-canary.1591.19467.0
  npm install @auto-canary/git-tag@9.59.1-canary.1591.19467.0
  npm install @auto-canary/gradle@9.59.1-canary.1591.19467.0
  npm install @auto-canary/jira@9.59.1-canary.1591.19467.0
  npm install @auto-canary/maven@9.59.1-canary.1591.19467.0
  npm install @auto-canary/npm@9.59.1-canary.1591.19467.0
  npm install @auto-canary/omit-commits@9.59.1-canary.1591.19467.0
  npm install @auto-canary/omit-release-notes@9.59.1-canary.1591.19467.0
  npm install @auto-canary/pr-body-labels@9.59.1-canary.1591.19467.0
  npm install @auto-canary/released@9.59.1-canary.1591.19467.0
  npm install @auto-canary/s3@9.59.1-canary.1591.19467.0
  npm install @auto-canary/slack@9.59.1-canary.1591.19467.0
  npm install @auto-canary/twitter@9.59.1-canary.1591.19467.0
  npm install @auto-canary/upload-assets@9.59.1-canary.1591.19467.0
  # or 
  yarn add @auto-canary/bot-list@9.59.1-canary.1591.19467.0
  yarn add @auto-canary/auto@9.59.1-canary.1591.19467.0
  yarn add @auto-canary/core@9.59.1-canary.1591.19467.0
  yarn add @auto-canary/all-contributors@9.59.1-canary.1591.19467.0
  yarn add @auto-canary/brew@9.59.1-canary.1591.19467.0
  yarn add @auto-canary/chrome@9.59.1-canary.1591.19467.0
  yarn add @auto-canary/cocoapods@9.59.1-canary.1591.19467.0
  yarn add @auto-canary/conventional-commits@9.59.1-canary.1591.19467.0
  yarn add @auto-canary/crates@9.59.1-canary.1591.19467.0
  yarn add @auto-canary/docker@9.59.1-canary.1591.19467.0
  yarn add @auto-canary/exec@9.59.1-canary.1591.19467.0
  yarn add @auto-canary/first-time-contributor@9.59.1-canary.1591.19467.0
  yarn add @auto-canary/gem@9.59.1-canary.1591.19467.0
  yarn add @auto-canary/gh-pages@9.59.1-canary.1591.19467.0
  yarn add @auto-canary/git-tag@9.59.1-canary.1591.19467.0
  yarn add @auto-canary/gradle@9.59.1-canary.1591.19467.0
  yarn add @auto-canary/jira@9.59.1-canary.1591.19467.0
  yarn add @auto-canary/maven@9.59.1-canary.1591.19467.0
  yarn add @auto-canary/npm@9.59.1-canary.1591.19467.0
  yarn add @auto-canary/omit-commits@9.59.1-canary.1591.19467.0
  yarn add @auto-canary/omit-release-notes@9.59.1-canary.1591.19467.0
  yarn add @auto-canary/pr-body-labels@9.59.1-canary.1591.19467.0
  yarn add @auto-canary/released@9.59.1-canary.1591.19467.0
  yarn add @auto-canary/s3@9.59.1-canary.1591.19467.0
  yarn add @auto-canary/slack@9.59.1-canary.1591.19467.0
  yarn add @auto-canary/twitter@9.59.1-canary.1591.19467.0
  yarn add @auto-canary/upload-assets@9.59.1-canary.1591.19467.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
