### PR TITLE
doc: breaking change should bump major not minor

### DIFF
--- a/plugins/conventional-commits/README.md
+++ b/plugins/conventional-commits/README.md
@@ -6,7 +6,7 @@ The default behavior extends the [conventional commits spec](https://www.convent
 
 - Type `fix:` => `patch`
 - Type `feat:` => `minor`
-- Type `BREAKING:` => `minor`
+- Type `BREAKING:` => `major`
 - A `!` in the type indicated a breaking change
 - `BREAKING CHANGE` in the footer indicates a breaking change
 - All other types are considered `skip-release`


### PR DESCRIPTION
# What Changed
Change documentation for conventional-commits

## Why

Breaking change indicating wrong behaviour.

## Change Type

Indicate the type of change your pull request is:

- [x] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
