### PR TITLE
fix parsing PR body when it's empty

### DIFF
--- a/plugins/released/src/index.ts
+++ b/plugins/released/src/index.ts
@@ -136,7 +136,7 @@ export default class ReleasedLabelPlugin implements IPlugin {
         releases,
       });
 
-      pr.data.body.split("\n").map((line) => messages.push(line));
+      pr.data.body?.split("\n").map((line) => messages.push(line));
 
       const commitsInPr = await auto.git!.getCommitsForPR(
         commit.pullRequest.number


### PR DESCRIPTION
# What Changed

see title

## Why

closes #1602

Todo:

- [x] Add tests

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.60.1-canary.1603.19672.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.60.1-canary.1603.19672.0
  npm install @auto-canary/auto@9.60.1-canary.1603.19672.0
  npm install @auto-canary/core@9.60.1-canary.1603.19672.0
  npm install @auto-canary/all-contributors@9.60.1-canary.1603.19672.0
  npm install @auto-canary/brew@9.60.1-canary.1603.19672.0
  npm install @auto-canary/chrome@9.60.1-canary.1603.19672.0
  npm install @auto-canary/cocoapods@9.60.1-canary.1603.19672.0
  npm install @auto-canary/conventional-commits@9.60.1-canary.1603.19672.0
  npm install @auto-canary/crates@9.60.1-canary.1603.19672.0
  npm install @auto-canary/docker@9.60.1-canary.1603.19672.0
  npm install @auto-canary/exec@9.60.1-canary.1603.19672.0
  npm install @auto-canary/first-time-contributor@9.60.1-canary.1603.19672.0
  npm install @auto-canary/gem@9.60.1-canary.1603.19672.0
  npm install @auto-canary/gh-pages@9.60.1-canary.1603.19672.0
  npm install @auto-canary/git-tag@9.60.1-canary.1603.19672.0
  npm install @auto-canary/gradle@9.60.1-canary.1603.19672.0
  npm install @auto-canary/jira@9.60.1-canary.1603.19672.0
  npm install @auto-canary/maven@9.60.1-canary.1603.19672.0
  npm install @auto-canary/npm@9.60.1-canary.1603.19672.0
  npm install @auto-canary/omit-commits@9.60.1-canary.1603.19672.0
  npm install @auto-canary/omit-release-notes@9.60.1-canary.1603.19672.0
  npm install @auto-canary/pr-body-labels@9.60.1-canary.1603.19672.0
  npm install @auto-canary/released@9.60.1-canary.1603.19672.0
  npm install @auto-canary/s3@9.60.1-canary.1603.19672.0
  npm install @auto-canary/slack@9.60.1-canary.1603.19672.0
  npm install @auto-canary/twitter@9.60.1-canary.1603.19672.0
  npm install @auto-canary/upload-assets@9.60.1-canary.1603.19672.0
  # or 
  yarn add @auto-canary/bot-list@9.60.1-canary.1603.19672.0
  yarn add @auto-canary/auto@9.60.1-canary.1603.19672.0
  yarn add @auto-canary/core@9.60.1-canary.1603.19672.0
  yarn add @auto-canary/all-contributors@9.60.1-canary.1603.19672.0
  yarn add @auto-canary/brew@9.60.1-canary.1603.19672.0
  yarn add @auto-canary/chrome@9.60.1-canary.1603.19672.0
  yarn add @auto-canary/cocoapods@9.60.1-canary.1603.19672.0
  yarn add @auto-canary/conventional-commits@9.60.1-canary.1603.19672.0
  yarn add @auto-canary/crates@9.60.1-canary.1603.19672.0
  yarn add @auto-canary/docker@9.60.1-canary.1603.19672.0
  yarn add @auto-canary/exec@9.60.1-canary.1603.19672.0
  yarn add @auto-canary/first-time-contributor@9.60.1-canary.1603.19672.0
  yarn add @auto-canary/gem@9.60.1-canary.1603.19672.0
  yarn add @auto-canary/gh-pages@9.60.1-canary.1603.19672.0
  yarn add @auto-canary/git-tag@9.60.1-canary.1603.19672.0
  yarn add @auto-canary/gradle@9.60.1-canary.1603.19672.0
  yarn add @auto-canary/jira@9.60.1-canary.1603.19672.0
  yarn add @auto-canary/maven@9.60.1-canary.1603.19672.0
  yarn add @auto-canary/npm@9.60.1-canary.1603.19672.0
  yarn add @auto-canary/omit-commits@9.60.1-canary.1603.19672.0
  yarn add @auto-canary/omit-release-notes@9.60.1-canary.1603.19672.0
  yarn add @auto-canary/pr-body-labels@9.60.1-canary.1603.19672.0
  yarn add @auto-canary/released@9.60.1-canary.1603.19672.0
  yarn add @auto-canary/s3@9.60.1-canary.1603.19672.0
  yarn add @auto-canary/slack@9.60.1-canary.1603.19672.0
  yarn add @auto-canary/twitter@9.60.1-canary.1603.19672.0
  yarn add @auto-canary/upload-assets@9.60.1-canary.1603.19672.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
