### PR TITLE
Run various hooks in a --dry-run

### DIFF
--- a/docs/pages/docs/plugins/release-lifecycle-hooks.mdx
+++ b/docs/pages/docs/plugins/release-lifecycle-hooks.mdx
@@ -177,12 +177,12 @@ You can either return a string value of just the version or an object containing
 - `details` - The body of the details element
 
 ```ts
-auto.hooks.canary.tapPromise(this.name, async (version, postFix) => {
+auto.hooks.canary.tapPromise(this.name, async ({ bump, canaryIdentifier }) => {
   const lastRelease = await auto.git!.getLatestRelease();
   const current = await auto.getCurrentVersion(lastRelease);
-  const nextVersion = inc(current, version as ReleaseType);
+  const nextVersion = inc(current, bump as ReleaseType);
   const isScopedPackage = name.match(/@\S+\/\S+/);
-  const canaryVersion = `${nextVersion}-canary${postFix}`;
+  const canaryVersion = `${nextVersion}-canary${canaryIdentifier}`;
 
   await execPromise("npm", ["version", canaryVersion, "--no-git-tag-version"]);
   await execPromise("npm", ["publish", "--tag", "canary"]);

--- a/docs/pages/docs/plugins/release-lifecycle-hooks.mdx
+++ b/docs/pages/docs/plugins/release-lifecycle-hooks.mdx
@@ -116,7 +116,7 @@ This hooks is required for plugin that facilitate publishing.
 Here `npm` does it for us.
 
 ```ts
-auto.hooks.version.tapPromise("NPM", async ({ bump, dryRun }) => {
+auto.hooks.version.tapPromise("NPM", async ({ bump, dryRun, quiet }) => {
   if (dryRun) {
     const { version } = await loadPackageJson();
     console.log(inc(version, bump));
@@ -144,7 +144,7 @@ _Examples:_
 - [brew](../generated/brew) - Create a new brew formula once the package a=has been versioned
 
 ```ts
-auto.hooks.version.tapPromise("NPM", async ({ dryRun }) => {});
+auto.hooks.afterVersion.tapPromise("NPM", async ({ dryRun }) => {});
 ```
 
 ## publish
@@ -187,7 +187,7 @@ You can either return a string value of just the version or an object containing
 - `details` - The body of the details element
 
 ```ts
-auto.hooks.canary.tapPromise(this.name, async ({ bump, canaryIdentifier }) => {
+auto.hooks.canary.tapPromise(this.name, async ({ bump, canaryIdentifier, dryRun, quiet }) => {
   const lastRelease = await auto.git!.getLatestRelease();
   const current = await auto.getCurrentVersion(lastRelease);
   const nextVersion = inc(current, bump as ReleaseType);

--- a/docs/pages/docs/plugins/release-lifecycle-hooks.mdx
+++ b/docs/pages/docs/plugins/release-lifecycle-hooks.mdx
@@ -144,9 +144,7 @@ _Examples:_
 - [brew](../generated/brew) - Create a new brew formula once the package a=has been versioned
 
 ```ts
-auto.hooks.version.tapPromise("NPM", async ({ dryRun }) => {
-
-});
+auto.hooks.version.tapPromise("NPM", async ({ dryRun }) => {});
 ```
 
 ## publish
@@ -230,34 +228,37 @@ import {
   getCurrentBranch,
 } from "@auto-it/core";
 
-auto.hooks.next.tapPromise(this.name, async (preReleaseVersions, bump, { dryRun }) => {
-  const branch = getCurrentBranch() || "";
-  const lastRelease = await auto.git.getLatestRelease();
-  const current =
-    (await auto.git.getLastTagNotInBaseBranch(branch)) ||
-    (await auto.getCurrentVersion(lastRelease));
-  // Use this helper function to determine the next prerelease version
-  const prerelease = determineNextVersion(lastRelease, current, bump, "next");
+auto.hooks.next.tapPromise(
+  this.name,
+  async (preReleaseVersions, bump, { dryRun }) => {
+    const branch = getCurrentBranch() || "";
+    const lastRelease = await auto.git.getLatestRelease();
+    const current =
+      (await auto.git.getLastTagNotInBaseBranch(branch)) ||
+      (await auto.getCurrentVersion(lastRelease));
+    // Use this helper function to determine the next prerelease version
+    const prerelease = determineNextVersion(lastRelease, current, bump, "next");
 
-  // Make sure to add the version to the list
-  preReleaseVersions.push(prerelease);
+    // Make sure to add the version to the list
+    preReleaseVersions.push(prerelease);
 
-  if (dryRun) {
+    if (dryRun) {
+      return preReleaseVersions;
+    }
+
+    // Create a new tag for it
+    await execPromise("git", [
+      "tag",
+      prerelease,
+      "-m",
+      `"Tag pre-release: ${prerelease}"`,
+    ]);
+    // Push the tag
+    await execPromise("git", ["push", auto.remote, "--tags"]);
+
     return preReleaseVersions;
   }
-
-  // Create a new tag for it
-  await execPromise("git", [
-    "tag",
-    prerelease,
-    "-m",
-    `"Tag pre-release: ${prerelease}"`,
-  ]);
-  // Push the tag
-  await execPromise("git", ["push", auto.remote, "--tags"]);
-
-  return preReleaseVersions;
-});
+);
 ```
 
 `next` version should not produce any of the following:

--- a/docs/pages/docs/plugins/release-lifecycle-hooks.mdx
+++ b/docs/pages/docs/plugins/release-lifecycle-hooks.mdx
@@ -116,10 +116,16 @@ This hooks is required for plugin that facilitate publishing.
 Here `npm` does it for us.
 
 ```ts
-auto.hooks.version.tapPromise("NPM", async (version: SEMVER) => {
+auto.hooks.version.tapPromise("NPM", async ({ bump, dryRun }) => {
+  if (dryRun) {
+    const { version } = await loadPackageJson();
+    console.log(inc(version, bump));
+    return;
+  }
+
   await execPromise("npm", [
     "version",
-    version,
+    bump,
     "-m",
     "Bump version to: %s [skip ci]",
   ]);
@@ -136,6 +142,12 @@ _Examples:_
 
 - In Core: Used to exit early is new commits are detected on the remote
 - [brew](../generated/brew) - Create a new brew formula once the package a=has been versioned
+
+```ts
+auto.hooks.version.tapPromise("NPM", async ({ dryRun }) => {
+
+});
+```
 
 ## publish
 

--- a/docs/pages/docs/plugins/release-lifecycle-hooks.mdx
+++ b/docs/pages/docs/plugins/release-lifecycle-hooks.mdx
@@ -218,7 +218,7 @@ import {
   getCurrentBranch,
 } from "@auto-it/core";
 
-auto.hooks.next.tapPromise(this.name, async (preReleaseVersions, bump) => {
+auto.hooks.next.tapPromise(this.name, async (preReleaseVersions, bump, { dryRun }) => {
   const branch = getCurrentBranch() || "";
   const lastRelease = await auto.git.getLatestRelease();
   const current =
@@ -226,6 +226,13 @@ auto.hooks.next.tapPromise(this.name, async (preReleaseVersions, bump) => {
     (await auto.getCurrentVersion(lastRelease));
   // Use this helper function to determine the next prerelease version
   const prerelease = determineNextVersion(lastRelease, current, bump, "next");
+
+  // Make sure to add the version to the list
+  preReleaseVersions.push(prerelease);
+
+  if (dryRun) {
+    return preReleaseVersions;
+  }
 
   // Create a new tag for it
   await execPromise("git", [
@@ -237,8 +244,6 @@ auto.hooks.next.tapPromise(this.name, async (preReleaseVersions, bump) => {
   // Push the tag
   await execPromise("git", ["push", auto.remote, "--tags"]);
 
-  // Make sure to add the version to the list
-  preReleaseVersions.push(prerelease);
   return preReleaseVersions;
 });
 ```

--- a/docs/pages/docs/plugins/writing-publishing-plugins.mdx
+++ b/docs/pages/docs/plugins/writing-publishing-plugins.mdx
@@ -68,9 +68,14 @@ export default class GitTagPlugin implements IPlugin {
   // ...
   apply(auto: Auto) {
     // ...
-    auto.hooks.version.tapPromise(this.name, async (version) => {
+    auto.hooks.version.tapPromise(this.name, async ({ bump }) => {
       const lastTag = await getTag();
       const newTag = inc(lastTag, version as ReleaseType);
+
+      if (newTag && dryRun) {
+        console.log(newTag);
+        return;
+      }
 
       if (!newTag) {
         auto.logger.log.info("No release found, doing nothing");

--- a/packages/core/src/__tests__/auto-canary-local.test.ts
+++ b/packages/core/src/__tests__/auto-canary-local.test.ts
@@ -47,5 +47,10 @@ test("shipit should publish canary in locally when not on master", async () => {
   auto.hooks.canary.tap("test", canary);
 
   await auto.shipit();
-  expect(canary).toHaveBeenCalledWith(SEMVER.patch, "canary.abc");
+  expect(canary).toHaveBeenCalledWith(
+    expect.objectContaining({
+      bump: SEMVER.patch,
+      canaryIdentifier: "canary.abc",
+    })
+  );
 });

--- a/packages/core/src/__tests__/auto-in-pr-ci.test.ts
+++ b/packages/core/src/__tests__/auto-in-pr-ci.test.ts
@@ -61,7 +61,12 @@ describe("canary in ci", () => {
     jest.spyOn(auto.release!, "getCommits").mockImplementation();
 
     await auto.canary();
-    expect(canary).toHaveBeenCalledWith(SEMVER.patch, "canary.123.1");
+    expect(canary).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bump: SEMVER.patch,
+        canaryIdentifier: "canary.123.1",
+      })
+    );
   });
 
   test("comments on PR in CI", async () => {
@@ -117,7 +122,10 @@ describe("canary in ci", () => {
     const addToPrBody = jest.fn();
     auto.git!.addToPrBody = addToPrBody;
     jest.spyOn(auto.release!, "getCommits").mockImplementation();
-    auto.hooks.canary.tap("test", (bump, post) => `1.2.4-${post}`);
+    auto.hooks.canary.tap(
+      "test",
+      ({ canaryIdentifier }) => `1.2.4-${canaryIdentifier}`
+    );
 
     await auto.canary({ pr: 123, build: 1, message: "false" });
     expect(addToPrBody).not.toHaveBeenCalled();
@@ -135,7 +143,10 @@ describe("canary in ci", () => {
     const addToPrBody = jest.fn();
     auto.git!.addToPrBody = addToPrBody;
     jest.spyOn(auto.release!, "getCommits").mockImplementation();
-    auto.hooks.canary.tap("test", (bump, post) => `1.2.4-${post}`);
+    auto.hooks.canary.tap(
+      "test",
+      ({ canaryIdentifier }) => `1.2.4-${canaryIdentifier}`
+    );
 
     const version = await auto.canary({ pr: 456, build: 5 });
     expect(version!.newVersion).toBe("1.2.4-canary.456.5");
@@ -159,7 +170,12 @@ describe("shipit in ci", () => {
     auto.hooks.canary.tap("test", canary);
 
     await auto.shipit();
-    expect(canary).toHaveBeenCalledWith(SEMVER.patch, "canary.123.1");
+    expect(canary).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bump: SEMVER.patch,
+        canaryIdentifier: "canary.123.1",
+      })
+    );
   });
 });
 

--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -1306,29 +1306,6 @@ describe("Auto", () => {
       await expect(auto.next({})).rejects.not.toBeUndefined();
     });
 
-    test("does not call next hook in dry-run", async () => {
-      const auto = new Auto(defaults);
-
-      // @ts-ignore
-      auto.checkClean = () => Promise.resolve(true);
-      auto.logger = dummyLog();
-      await auto.loadConfig();
-      auto.remote = "origin";
-      auto.git!.getProject = () => Promise.resolve({ data: {} } as any);
-      auto.git!.getLatestRelease = () => Promise.resolve("1.2.3");
-      auto.release!.generateReleaseNotes = () => Promise.resolve("notes");
-      auto.git!.getLatestTagInBranch = () => Promise.resolve("1.2.3");
-      auto.release!.getCommitsInRelease = () =>
-        Promise.resolve([makeCommitFromMsg("Test Commit")]);
-
-      const next = jest.fn();
-      auto.hooks.next.tap("test", next);
-      jest.spyOn(auto.release!, "getCommits").mockImplementation();
-
-      await auto.next({ dryRun: true });
-      expect(next).not.toHaveBeenCalled();
-    });
-
     test("calls the next hook with the release info", async () => {
       const auto = new Auto({ ...defaults, plugins: [] });
 

--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -1151,24 +1151,6 @@ describe("Auto", () => {
       await expect(auto.canary()).rejects.not.toBeUndefined();
     });
 
-    test("does not call canary hook in dry-run", async () => {
-      const auto = new Auto(defaults);
-      // @ts-ignore
-      auto.checkClean = () => Promise.resolve(true);
-
-      auto.logger = dummyLog();
-      await auto.loadConfig();
-      auto.git!.getLatestRelease = () => Promise.resolve("1.2.3");
-      auto.release!.getCommitsInRelease = () =>
-        Promise.resolve([makeCommitFromMsg("Test Commit")]);
-      const canary = jest.fn();
-      auto.hooks.canary.tap("test", canary);
-      jest.spyOn(auto.release!, "getCommits").mockImplementation();
-
-      await auto.canary({ pr: 123, build: 1, dryRun: true });
-      expect(canary).not.toHaveBeenCalled();
-    });
-
     test("calls the canary hook with the pr info", async () => {
       const auto = new Auto({ ...defaults, plugins: [] });
       // @ts-ignore
@@ -1187,7 +1169,12 @@ describe("Auto", () => {
       jest.spyOn(auto.release!, "getCommits").mockImplementation();
 
       await auto.canary({ pr: 123, build: 1 });
-      expect(canary).toHaveBeenCalledWith(SEMVER.patch, "canary.123.1");
+      expect(canary).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bump: SEMVER.patch,
+          canaryIdentifier: "canary.123.1",
+        })
+      );
       expect(auto.git!.addToPrBody).toHaveBeenCalled();
     });
 
@@ -1207,7 +1194,12 @@ describe("Auto", () => {
       jest.spyOn(auto.release!, "getCommits").mockImplementation();
 
       await auto.canary();
-      expect(canary).toHaveBeenCalledWith(SEMVER.patch, "canary.abc");
+      expect(canary).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bump: SEMVER.patch,
+          canaryIdentifier: "canary.abc",
+        })
+      );
     });
 
     test("doesn't comment if there is an error", async () => {
@@ -1246,7 +1238,12 @@ describe("Auto", () => {
       auto.hooks.canary.tap("test", canary);
 
       await auto.canary();
-      expect(canary).toHaveBeenCalledWith(SEMVER.patch, "canary.abcd");
+      expect(canary).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bump: SEMVER.patch,
+          canaryIdentifier: "canary.abcd",
+        })
+      );
     });
 
     test('should not publish when is present "skip-release" label', async () => {
@@ -1290,7 +1287,12 @@ describe("Auto", () => {
       auto.hooks.canary.tap("test", canary);
 
       await auto.canary({ force: true });
-      expect(canary).toHaveBeenCalledWith(SEMVER.patch, "canary.abcd");
+      expect(canary).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bump: SEMVER.patch,
+          canaryIdentifier: "canary.abcd",
+        })
+      );
     });
   });
 

--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -1464,8 +1464,7 @@ describe("Auto", () => {
       jest.spyOn(auto.release!, "generateReleaseNotes").mockImplementation();
       jest.spyOn(auto.release!, "addToChangelog").mockImplementation();
       const spy = jest.fn();
-      auto.hooks.version.tap("test", spy);
-      auto.hooks.afterRelease.tap("test", spy);
+      auto.hooks.publish.tap("test", spy);
 
       await auto.shipit({ dryRun: true });
       expect(spy).not.toHaveBeenCalled();

--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -903,24 +903,6 @@ describe("Auto", () => {
       expect(exit).toHaveBeenCalled();
     });
 
-    test("doesn't try to overwrite releases", async () => {
-      const auto = new Auto({ ...defaults, plugins: [] });
-      auto.logger = dummyLog();
-      await auto.loadConfig();
-      auto.git!.getLatestRelease = () => Promise.resolve("1.2.3");
-      jest.spyOn(auto.release!, "generateReleaseNotes").mockImplementation();
-      auto.release!.getCommitsInRelease = () =>
-        Promise.resolve([makeCommitFromMsg("Test Commit")]);
-
-      auto.hooks.getPreviousVersion.tap("test", () => "1.2.3");
-      const afterRelease = jest.fn();
-      auto.hooks.afterRelease.tap("test", afterRelease);
-      jest.spyOn(auto.release!, "getCommits").mockImplementation();
-
-      await auto.runRelease();
-      expect(afterRelease).not.toHaveBeenCalled();
-    });
-
     test("should publish with default options", async () => {
       const auto = new Auto({ ...defaults, plugins: [] });
       auto.logger = dummyLog();
@@ -1395,7 +1377,10 @@ describe("Auto", () => {
       // @ts-ignore
       auto.makeChangelog = () => Promise.resolve();
       auto.git!.getLatestRelease = () => Promise.resolve("1.2.3");
-      jest.spyOn(auto.git!, "publish").mockImplementation();
+      auto.git!.publish = () =>
+        Promise.resolve({
+          data: { html_url: "https://github.com/my/repo/release" },
+        } as any);
       jest.spyOn(auto.release!, "getCommitsInRelease").mockImplementation();
       jest.spyOn(auto.release!, "generateReleaseNotes").mockImplementation();
       jest.spyOn(auto.release!, "addToChangelog").mockImplementation();
@@ -1415,7 +1400,10 @@ describe("Auto", () => {
       auto.remote = "https://github.com/intuit/auto";
 
       auto.git!.getLatestRelease = () => Promise.resolve("1.2.3");
-      jest.spyOn(auto.git!, "publish").mockImplementation();
+      auto.git!.publish = () =>
+        Promise.resolve({
+          data: { html_url: "https://github.com/my/repo/release" },
+        } as any);
       jest.spyOn(auto.release!, "getCommitsInRelease").mockImplementation();
       jest.spyOn(auto.release!, "generateReleaseNotes").mockImplementation();
       jest.spyOn(auto.release!, "addToChangelog").mockImplementation();

--- a/packages/core/src/auto-args.ts
+++ b/packages/core/src/auto-args.ts
@@ -52,7 +52,7 @@ export type IVersionOptions = ReleaseCalculationOptions & {
   from?: string;
 };
 
-interface Quiet {
+export interface QuietOption {
   /** Print **only** the result of the command */
   quiet?: boolean;
 }
@@ -62,7 +62,7 @@ interface NoVersionPrefix {
   noVersionPrefix?: boolean;
 }
 
-interface DryRun {
+export interface DryRunOption {
   /** Do not actually do anything */
   dryRun?: boolean;
 }
@@ -90,8 +90,8 @@ interface BaseBranch {
 export type IChangelogOptions = BaseBranch &
   ChangelogTitle &
   ChangelogMessage &
-  Quiet &
-  DryRun &
+  QuietOption &
+  DryRunOption &
   NoVersionPrefix &
   Partial<AuthorInformation> & {
     /** Commit to start calculating the changelog from */
@@ -104,7 +104,7 @@ export type IChangelogOptions = BaseBranch &
 
 export type IReleaseOptions = BaseBranch &
   Prerelease &
-  DryRun &
+  DryRunOption &
   NoVersionPrefix &
   Partial<AuthorInformation> &
   Partial<RepoInformation> & {
@@ -116,7 +116,7 @@ export type IReleaseOptions = BaseBranch &
     useVersion?: string;
   };
 
-export type ICommentOptions = DryRun & {
+export type ICommentOptions = DryRunOption & {
   /** The message to use when commenting */
   message?: string;
   /** THe PR to comment on */
@@ -132,13 +132,13 @@ export type ICommentOptions = DryRun & {
 export type IPRBodyOptions = Omit<ICommentOptions, "edit" | "delete">;
 
 export type ILatestOptions = BaseBranch &
-  DryRun &
+  DryRunOption &
   Partial<AuthorInformation> &
   Prerelease &
   NoVersionPrefix &
   ChangelogTitle &
   ChangelogMessage &
-  Quiet &
+  QuietOption &
   ReleaseCalculationOptions & {
     /** Skip creating the changelog */
     noChangelog?: boolean;
@@ -154,7 +154,7 @@ export type IShipItOptions = ILatestOptions & {
   onlyGraduateWithReleaseLabel?: boolean;
 };
 
-export type ICanaryOptions = Quiet & {
+export type ICanaryOptions = QuietOption & {
   /** Do not actually do anything */
   dryRun?: boolean;
   /** THe PR to attach the canary to */
@@ -167,7 +167,7 @@ export type ICanaryOptions = Quiet & {
   force?: boolean;
 };
 
-export type INextOptions = Quiet & {
+export type INextOptions = QuietOption & {
   /** Do not actually do anything */
   dryRun?: boolean;
   /** The message used when attaching the prerelease version to a PR */

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -218,10 +218,11 @@ export interface IAutoHooks {
   /** Version the package. This is a good opportunity to `git tag` the release also.  */
   version: AsyncParallelHook<
     [
-      DryRunOption & {
-        /** The semver bump to apply */
-        bump: SEMVER;
-      }
+      DryRunOption &
+        QuietOption & {
+          /** The semver bump to apply */
+          bump: SEMVER;
+        }
     ]
   >;
   /** Ran after the package has been versioned. */
@@ -231,12 +232,13 @@ export interface IAutoHooks {
   /** Used to publish a canary release. In this hook you get the semver bump and the unique canary postfix ID. */
   canary: AsyncSeriesBailHook<
     [
-      DryRunOption & {
-        /** The bump to apply to the version */
-        bump: SEMVER;
-        /** The post-version identifier to add to the version */
-        canaryIdentifier: string;
-      }
+      DryRunOption &
+        QuietOption & {
+          /** The bump to apply to the version */
+          bump: SEMVER;
+          /** The post-version identifier to add to the version */
+          canaryIdentifier: string;
+        }
     ],
     | string
     | {
@@ -1177,6 +1179,7 @@ export default class Auto {
       bump,
       canaryIdentifier,
       dryRun: args.dryRun,
+      quiet: args.quiet,
     });
 
     if (typeof result === "object" && "error" in result) {
@@ -1571,7 +1574,7 @@ export default class Auto {
     }
 
     this.logger.verbose.info("Calling version hook");
-    await this.hooks.version.promise({ bump, dryRun: options.dryRun });
+    await this.hooks.version.promise({ bump, dryRun: options.dryRun, quiet: options.quiet });
     this.logger.verbose.info("Calling after version hook");
     await this.hooks.afterVersion.promise({ dryRun: options.dryRun });
 

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1574,7 +1574,11 @@ export default class Auto {
     }
 
     this.logger.verbose.info("Calling version hook");
-    await this.hooks.version.promise({ bump, dryRun: options.dryRun, quiet: options.quiet });
+    await this.hooks.version.promise({
+      bump,
+      dryRun: options.dryRun,
+      quiet: options.quiet,
+    });
     this.logger.verbose.info("Calling after version hook");
     await this.hooks.afterVersion.promise({ dryRun: options.dryRun });
 

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -253,6 +253,8 @@ export interface IAutoHooks {
       {
         /** The complete information about the PR */
         pr: RestEndpointMethodTypes["pulls"]["get"]["response"]["data"];
+        /** Do not actually do anything */
+        dryRun?: boolean;
       }
     ]
   >;
@@ -886,7 +888,7 @@ export default class Auto {
 
     try {
       const res = await this.git.getPullRequest(prNumber);
-      await this.hooks.prCheck.promise({ pr: res.data });
+      await this.hooks.prCheck.promise({ pr: res.data, dryRun });
 
       sha = res.data.head.sha;
 

--- a/packages/core/src/utils/get-lerna-packages.ts
+++ b/packages/core/src/utils/get-lerna-packages.ts
@@ -1,6 +1,6 @@
 import execPromise from "./exec-promise";
 
-interface LernaPackage {
+export interface LernaPackage {
   /** Path to package */
   path: string;
   /** Name of package */

--- a/packages/core/src/utils/make-hooks.ts
+++ b/packages/core/src/utils/make-hooks.ts
@@ -31,7 +31,7 @@ export const makeHooks = (): IAutoHooks => ({
   getRepository: new AsyncSeriesBailHook(),
   prCheck: new AsyncSeriesBailHook(["prInformation"]),
   version: new AsyncParallelHook(["version"]),
-  afterVersion: new AsyncParallelHook(),
+  afterVersion: new AsyncParallelHook(["context"]),
   publish: new AsyncParallelHook(["version"]),
   afterPublish: new AsyncParallelHook(),
   canary: new AsyncSeriesBailHook(["canaryContext"]),

--- a/packages/core/src/utils/make-hooks.ts
+++ b/packages/core/src/utils/make-hooks.ts
@@ -34,7 +34,7 @@ export const makeHooks = (): IAutoHooks => ({
   afterVersion: new AsyncParallelHook(),
   publish: new AsyncParallelHook(["version"]),
   afterPublish: new AsyncParallelHook(),
-  canary: new AsyncSeriesBailHook(["canaryVersion", "postFix"]),
+  canary: new AsyncSeriesBailHook(["canaryContext"]),
   next: new AsyncSeriesWaterfallHook(["preReleaseVersions", "bump", "context"]),
 });
 

--- a/plugins/brew/__tests__/brew.test.ts
+++ b/plugins/brew/__tests__/brew.test.ts
@@ -50,7 +50,7 @@ describe("Brew Plugin", () => {
 
     brewPlugin.apply({ hooks: autoHooks, logger: dummyLog() } as Auto);
 
-    await autoHooks.afterVersion.promise();
+    await autoHooks.afterVersion.promise({});
 
     expect(exec).not.toHaveBeenCalled();
   });
@@ -73,7 +73,7 @@ describe("Brew Plugin", () => {
       },
     } as unknown) as Auto);
 
-    await autoHooks.afterVersion.promise();
+    await autoHooks.afterVersion.promise({});
 
     expect(exit).toHaveBeenCalled();
   });
@@ -118,7 +118,7 @@ describe("Brew Plugin", () => {
     readFileSync.mockReturnValueOnce("");
     exec.mockReturnValueOnce("1234 1234");
 
-    await autoHooks.afterVersion.promise();
+    await autoHooks.afterVersion.promise({});
 
     expect(mkdirSync).toHaveBeenCalled();
   });
@@ -137,7 +137,7 @@ describe("Brew Plugin", () => {
     readFileSync.mockReturnValueOnce("");
     exec.mockReturnValueOnce("1234 1234");
 
-    await autoHooks.afterVersion.promise();
+    await autoHooks.afterVersion.promise({});
 
     expect(mkdirSync).not.toHaveBeenCalled();
   });
@@ -155,7 +155,7 @@ describe("Brew Plugin", () => {
     readFileSync.mockReturnValueOnce("$VERSION $SHA");
     exec.mockReturnValueOnce("1234 1234");
 
-    await autoHooks.afterVersion.promise();
+    await autoHooks.afterVersion.promise({});
 
     expect(writeFileSync).toHaveBeenCalledWith(
       "./Formula/foo.rb",
@@ -179,7 +179,7 @@ describe("Brew Plugin", () => {
     readFileSync.mockReturnValue("$VERSION $SHA");
     exec.mockReturnValue("1234 1234");
 
-    await autoHooks.afterVersion.promise();
+    await autoHooks.afterVersion.promise({});
 
     expect(writeFileSync).toHaveBeenCalledWith(
       "./Formula/foo.rb",

--- a/plugins/brew/src/index.ts
+++ b/plugins/brew/src/index.ts
@@ -46,8 +46,12 @@ export default class BrewPlugin implements IPlugin {
       }
     });
 
-    auto.hooks.afterVersion.tapPromise("Update brew", async () => {
-      this.formulas.map((formula) => this.createFormula(auto, formula));
+    auto.hooks.afterVersion.tapPromise("Update brew", async ({ dryRun }) => {
+      if (!dryRun) {
+        await Promise.all(
+          this.formulas.map((formula) => this.createFormula(auto, formula))
+        );
+      }
     });
   }
 

--- a/plugins/chrome/src/index.ts
+++ b/plugins/chrome/src/index.ts
@@ -154,12 +154,18 @@ export default class ChromeWebStorePlugin implements IPlugin {
       );
     });
 
-    auto.hooks.version.tapPromise(this.name, async (bump) => {
+    auto.hooks.version.tapPromise(this.name, async ({ bump, dryRun }) => {
       const version = await getVersion();
 
       // increment version
       const manifest = await getManifest(this.options.manifest);
       manifest.version = inc(version, bump as ReleaseType);
+
+      if (dryRun) {
+        console.log(manifest.version);
+        return;
+      }
+
       await writeFile(
         this.options.manifest,
         JSON.stringify(manifest, undefined, 2)

--- a/plugins/chrome/src/index.ts
+++ b/plugins/chrome/src/index.ts
@@ -154,44 +154,52 @@ export default class ChromeWebStorePlugin implements IPlugin {
       );
     });
 
-    auto.hooks.version.tapPromise(this.name, async ({ bump, dryRun }) => {
-      const version = await getVersion();
+    auto.hooks.version.tapPromise(
+      this.name,
+      async ({ bump, dryRun, quiet }) => {
+        const version = await getVersion();
 
-      // increment version
-      const manifest = await getManifest(this.options.manifest);
-      manifest.version = inc(version, bump as ReleaseType);
+        // increment version
+        const manifest = await getManifest(this.options.manifest);
+        manifest.version = inc(version, bump as ReleaseType);
 
-      if (dryRun) {
-        console.log(manifest.version);
-        return;
+        if (dryRun) {
+          if (quiet) {
+            console.log(manifest.version);
+          } else {
+            auto.logger.log.info(`Would have published: ${manifest.version}`);
+          }
+
+          return;
+        }
+
+        await writeFile(
+          this.options.manifest,
+          JSON.stringify(manifest, undefined, 2)
+        );
+
+        await copyFile(
+          this.options.manifest,
+          path.join(this.options.build, "manifest.json")
+        );
+
+        // commit new version
+        await execPromise("git", ["add", this.options.manifest]);
+        await execPromise("git", [
+          "commit",
+          "-m",
+          `"Bump version to ${manifest.version} [skip ci]"`,
+          "--no-verify",
+        ]);
+
+        await execPromise("git", [
+          "tag",
+          manifest.version,
+          "-m",
+          `"Update version to ${manifest.version}"`,
+        ]);
       }
-
-      await writeFile(
-        this.options.manifest,
-        JSON.stringify(manifest, undefined, 2)
-      );
-
-      await copyFile(
-        this.options.manifest,
-        path.join(this.options.build, "manifest.json")
-      );
-
-      // commit new version
-      await execPromise("git", ["add", this.options.manifest]);
-      await execPromise("git", [
-        "commit",
-        "-m",
-        `"Bump version to ${manifest.version} [skip ci]"`,
-        "--no-verify",
-      ]);
-
-      await execPromise("git", [
-        "tag",
-        manifest.version,
-        "-m",
-        `"Update version to ${manifest.version}"`,
-      ]);
-    });
+    );
 
     auto.hooks.publish.tapPromise(this.name, async () => {
       // publish extension

--- a/plugins/cocoapods/__tests__/cocoapods.test.ts
+++ b/plugins/cocoapods/__tests__/cocoapods.test.ts
@@ -148,7 +148,7 @@ describe("Cocoapods Plugin", () => {
 
       const mock = jest.spyOn(utilities, "writePodspecContents");
 
-      await hooks.version.promise(Auto.SEMVER.patch);
+      await hooks.version.promise({ bump: Auto.SEMVER.patch });
 
       expect(mock).lastCalledWith(expect.any(String), specWithVersion("0.0.2"));
     });
@@ -157,7 +157,7 @@ describe("Cocoapods Plugin", () => {
 
       const mock = jest.spyOn(utilities, "writePodspecContents");
 
-      await hooks.version.promise(Auto.SEMVER.minor);
+      await hooks.version.promise({ bump: Auto.SEMVER.minor });
 
       expect(mock).lastCalledWith(expect.any(String), specWithVersion("0.1.0"));
     });
@@ -166,7 +166,7 @@ describe("Cocoapods Plugin", () => {
 
       const mock = jest.spyOn(utilities, "writePodspecContents");
 
-      await hooks.version.promise(Auto.SEMVER.major);
+      await hooks.version.promise({ bump: Auto.SEMVER.major });
 
       expect(mock).lastCalledWith(expect.any(String), specWithVersion("1.0.0"));
     });
@@ -180,7 +180,7 @@ describe("Cocoapods Plugin", () => {
         });
 
       await expect(
-        hooks.version.promise(Auto.SEMVER.major)
+        hooks.version.promise({ bump: Auto.SEMVER.major })
       ).rejects.toThrowError(
         "Error updating version in podspec: ./Test.podspec"
       );

--- a/plugins/cocoapods/src/index.ts
+++ b/plugins/cocoapods/src/index.ts
@@ -144,12 +144,17 @@ export default class CocoapodsPlugin implements IPlugin {
       auto.prefixRelease(getVersion(this.options.podspecPath))
     );
 
-    auto.hooks.version.tapPromise(this.name, async ({ bump, dryRun }) => {
+    auto.hooks.version.tapPromise(this.name, async ({ bump, dryRun, quiet }) => {
       const previousVersion = getVersion(this.options.podspecPath);
       const releaseVersion = inc(previousVersion, bump as ReleaseType);
 
       if (dryRun && releaseVersion) {
-        console.log(releaseVersion);
+        if (quiet) {
+          console.log(releaseVersion);
+        } else {
+          auto.logger.log.info(`Would have published: ${releaseVersion}`);
+        }
+
         return;
       }
 

--- a/plugins/cocoapods/src/index.ts
+++ b/plugins/cocoapods/src/index.ts
@@ -144,9 +144,14 @@ export default class CocoapodsPlugin implements IPlugin {
       auto.prefixRelease(getVersion(this.options.podspecPath))
     );
 
-    auto.hooks.version.tapPromise(this.name, async (version) => {
+    auto.hooks.version.tapPromise(this.name, async ({ bump, dryRun }) => {
       const previousVersion = getVersion(this.options.podspecPath);
-      const releaseVersion = inc(previousVersion, version as ReleaseType);
+      const releaseVersion = inc(previousVersion, bump as ReleaseType);
+
+      if (dryRun && releaseVersion) {
+        console.log(releaseVersion);
+        return;
+      }
 
       if (!releaseVersion) {
         throw new Error(

--- a/plugins/crates/__tests__/crates.test.ts
+++ b/plugins/crates/__tests__/crates.test.ts
@@ -41,8 +41,9 @@ const writeFile = jest.fn();
 const writeFileSync = jest.fn();
 const readResult = "{}";
 
-jest.mock("../../../packages/core/dist/utils/exec-promise", () => (...args: any[]) =>
-  exec(...args)
+jest.mock(
+  "../../../packages/core/dist/utils/exec-promise",
+  () => (...args: any[]) => exec(...args)
 );
 // @ts-ignore
 jest.mock("env-ci", () => () => ({ isCi: false }));
@@ -199,7 +200,7 @@ describe("CratesPlugin", () => {
 
         const hooks = makeHooks();
         plugin.apply({ hooks, logger: dummyLog() } as Auto.Auto);
-        await hooks.version.promise(Auto.SEMVER.patch);
+        await hooks.version.promise({ bump: Auto.SEMVER.patch });
         expect(exec).toHaveBeenCalledWith("cargo", ["build"]);
         expect(exec).toHaveBeenCalledWith("git", [
           "add",

--- a/plugins/crates/src/index.ts
+++ b/plugins/crates/src/index.ts
@@ -72,27 +72,35 @@ export default class CratesPlugin implements IPlugin {
       return version;
     });
 
-    auto.hooks.version.tapPromise(this.name, async ({ bump, dryRun }) => {
-      const versionNew = bumpVersion(bump);
+    auto.hooks.version.tapPromise(
+      this.name,
+      async ({ bump, dryRun, quiet }) => {
+        const versionNew = bumpVersion(bump);
 
-      if (dryRun) {
-        console.log(versionNew);
-        return;
+        if (dryRun) {
+          if (quiet) {
+            console.log(versionNew);
+          } else {
+            auto.logger.log.info(`Would have published: ${versionNew}`);
+          }
+
+          return;
+        }
+
+        auto.logger.log.info(`Bumped version to: ${versionNew}`);
+        auto.logger.log.info("Building to update Cargo.lock");
+        await execPromise("cargo", ["build"]);
+        auto.logger.verbose.info("Committing files");
+        await execPromise("git", ["add", "Cargo.toml", "Cargo.lock"]);
+        await execPromise("git", [
+          "commit",
+          "-m",
+          `'Bump version to: ${versionNew} [skip ci]'`,
+          "--no-verify",
+        ]);
+        auto.logger.log.info("Create git commit for new version");
       }
-
-      auto.logger.log.info(`Bumped version to: ${versionNew}`);
-      auto.logger.log.info("Building to update Cargo.lock");
-      await execPromise("cargo", ["build"]);
-      auto.logger.verbose.info("Committing files");
-      await execPromise("git", ["add", "Cargo.toml", "Cargo.lock"]);
-      await execPromise("git", [
-        "commit",
-        "-m",
-        `'Bump version to: ${versionNew} [skip ci]'`,
-        "--no-verify",
-      ]);
-      auto.logger.log.info("Create git commit for new version");
-    });
+    );
 
     auto.hooks.publish.tapPromise(this.name, async () => {
       auto.logger.log.info("Publishing via cargo");

--- a/plugins/crates/src/index.ts
+++ b/plugins/crates/src/index.ts
@@ -72,8 +72,14 @@ export default class CratesPlugin implements IPlugin {
       return version;
     });
 
-    auto.hooks.version.tapPromise(this.name, async (version) => {
-      const versionNew = bumpVersion(version);
+    auto.hooks.version.tapPromise(this.name, async ({ bump, dryRun }) => {
+      const versionNew = bumpVersion(bump);
+
+      if (dryRun) {
+        console.log(versionNew);
+        return;
+      }
+
       auto.logger.log.info(`Bumped version to: ${versionNew}`);
       auto.logger.log.info("Building to update Cargo.lock");
       await execPromise("cargo", ["build"]);

--- a/plugins/docker/__tests__/docker.test.ts
+++ b/plugins/docker/__tests__/docker.test.ts
@@ -106,13 +106,13 @@ describe("Docker Plugin", () => {
   describe("version", () => {
     test("should do nothing without git", async () => {
       const hooks = setup();
-      await hooks.version.promise(Auto.SEMVER.patch);
+      await hooks.version.promise({ bump: Auto.SEMVER.patch });
       expect(exec).not.toHaveBeenCalled();
     });
 
     test("should do nothing with a bad version bump", async () => {
       const hooks = setup({ getLatestTagInBranch: () => "v1.0.0" });
-      await hooks.version.promise("wrong" as Auto.SEMVER);
+      await hooks.version.promise({ bump: "wrong" as Auto.SEMVER });
       expect(exec).not.toHaveBeenCalled();
     });
 
@@ -122,7 +122,7 @@ describe("Docker Plugin", () => {
         { getLatestTagInBranch: () => "v1.0.0" },
         { registry, image: sourceImage }
       );
-      await hooks.version.promise(Auto.SEMVER.patch);
+      await hooks.version.promise({ bump: Auto.SEMVER.patch });
       expect(exec).toHaveBeenCalledWith("git", [
         "tag",
         "1.0.1",
@@ -142,7 +142,7 @@ describe("Docker Plugin", () => {
         { getLatestTagInBranch: () => "v1.0.0" },
         { registry, image: sourceImage, tagLatest: true }
       );
-      await hooks.version.promise(Auto.SEMVER.patch);
+      await hooks.version.promise({ bump: Auto.SEMVER.patch });
       expect(exec).toHaveBeenCalledWith("git", [
         "tag",
         "1.0.1",
@@ -211,6 +211,7 @@ describe("Docker Plugin", () => {
         bump: Auto.SEMVER.patch,
         canaryIdentifier: "canary.123.1",
         dryRun: true,
+        quiet: true,
       });
 
       expect(log).toHaveBeenCalledWith("1.0.1-canary.123.1");
@@ -272,7 +273,10 @@ describe("Docker Plugin", () => {
       );
 
       expect(
-        await hooks.next.promise([], Auto.SEMVER.patch, { dryRun: true } as any)
+        await hooks.next.promise([], Auto.SEMVER.patch, {
+          dryRun: true,
+          quiet: true,
+        } as any)
       ).toStrictEqual(["1.0.1-next.0"]);
       expect(exec).not.toHaveBeenCalled();
     });
@@ -289,7 +293,7 @@ describe("Docker Plugin", () => {
         },
         { registry, image: sourceImage, tagLatest: false }
       );
-      await hooks.version.promise(Auto.SEMVER.patch);
+      await hooks.version.promise({ bump: Auto.SEMVER.patch });
 
       await hooks.publish.promise(Auto.SEMVER.patch);
       expect(exec).toHaveBeenCalledWith("docker", [
@@ -308,7 +312,7 @@ describe("Docker Plugin", () => {
         },
         { registry, image: sourceImage, tagLatest: true }
       );
-      await hooks.version.promise(Auto.SEMVER.patch);
+      await hooks.version.promise({ bump: Auto.SEMVER.patch });
 
       await hooks.publish.promise(Auto.SEMVER.patch);
       expect(exec).toHaveBeenCalledWith("docker", [

--- a/plugins/docker/__tests__/docker.test.ts
+++ b/plugins/docker/__tests__/docker.test.ts
@@ -260,6 +260,22 @@ describe("Docker Plugin", () => {
         `${registry}:1.0.1-next.0`,
       ]);
     });
+
+    test("return next version in dry run", async () => {
+      const sourceImage = "app:sha-123";
+      const hooks = setup(
+        {
+          getLatestRelease: () => "v0.1.0",
+          getLastTagNotInBaseBranch: () => "v1.0.0",
+        },
+        { registry, image: sourceImage }
+      );
+
+      expect(
+        await hooks.next.promise([], Auto.SEMVER.patch, { dryRun: true } as any)
+      ).toStrictEqual(["1.0.1-next.0"]);
+      expect(exec).not.toHaveBeenCalled();
+    });
   });
 
   describe("publish", () => {

--- a/plugins/docker/src/index.ts
+++ b/plugins/docker/src/index.ts
@@ -142,42 +142,50 @@ export default class DockerPlugin implements IPlugin {
       }
     );
 
-    auto.hooks.next.tapPromise(this.name, async (preReleaseVersions, bump) => {
-      if (!auto.git) {
+    auto.hooks.next.tapPromise(
+      this.name,
+      async (preReleaseVersions, bump, { dryRun }) => {
+        if (!auto.git) {
+          return preReleaseVersions;
+        }
+
+        const prereleaseBranches =
+          auto.config?.prereleaseBranches ?? DEFAULT_PRERELEASE_BRANCHES;
+        const branch = getCurrentBranch() || "";
+        const prereleaseBranch = prereleaseBranches.includes(branch)
+          ? branch
+          : prereleaseBranches[0];
+        const lastRelease = await auto.git.getLatestRelease();
+        const current =
+          (await auto.git.getLastTagNotInBaseBranch(prereleaseBranch)) ||
+          (await auto.getCurrentVersion(lastRelease));
+        const prerelease = determineNextVersion(
+          lastRelease,
+          current,
+          bump,
+          prereleaseBranch
+        );
+        const targetImage = `${this.options.registry}:${prerelease}`;
+
+        preReleaseVersions.push(prerelease);
+
+        if (dryRun) {
+          return preReleaseVersions;
+        }
+
+        await execPromise("git", [
+          "tag",
+          prerelease,
+          "-m",
+          `"Tag pre-release: ${prerelease}"`,
+        ]);
+        await execPromise("docker", ["tag", this.options.image, targetImage]);
+        await execPromise("docker", ["push", targetImage]);
+        await execPromise("git", ["push", auto.remote, branch, "--tags"]);
+
         return preReleaseVersions;
       }
-
-      const prereleaseBranches =
-        auto.config?.prereleaseBranches ?? DEFAULT_PRERELEASE_BRANCHES;
-      const branch = getCurrentBranch() || "";
-      const prereleaseBranch = prereleaseBranches.includes(branch)
-        ? branch
-        : prereleaseBranches[0];
-      const lastRelease = await auto.git.getLatestRelease();
-      const current =
-        (await auto.git.getLastTagNotInBaseBranch(prereleaseBranch)) ||
-        (await auto.getCurrentVersion(lastRelease));
-      const prerelease = determineNextVersion(
-        lastRelease,
-        current,
-        bump,
-        prereleaseBranch
-      );
-      const targetImage = `${this.options.registry}:${prerelease}`;
-
-      await execPromise("git", [
-        "tag",
-        prerelease,
-        "-m",
-        `"Tag pre-release: ${prerelease}"`,
-      ]);
-      await execPromise("docker", ["tag", this.options.image, targetImage]);
-      await execPromise("docker", ["push", targetImage]);
-      await execPromise("git", ["push", auto.remote, branch, "--tags"]);
-
-      preReleaseVersions.push(prerelease);
-      return preReleaseVersions;
-    });
+    );
 
     auto.hooks.publish.tapPromise(this.name, async () => {
       auto.logger.log.info("Pushing new tag to GitHub");

--- a/plugins/exec/__tests__/exec.test.ts
+++ b/plugins/exec/__tests__/exec.test.ts
@@ -92,9 +92,12 @@ describe("Exec Plugin", () => {
       execSpy.mockReturnValueOnce(canaryVersion);
       plugins.apply({ hooks } as Auto);
 
-      expect(await hooks.canary.promise(SEMVER.patch, "-canary")).toBe(
-        canaryVersion
-      );
+      expect(
+        await hooks.canary.promise({
+          bump: SEMVER.patch,
+          canaryIdentifier: "-canary",
+        })
+      ).toBe(canaryVersion);
     });
 
     test("should handle object return values", async () => {
@@ -107,9 +110,12 @@ describe("Exec Plugin", () => {
       execSpy.mockReturnValueOnce(JSON.stringify(canaryVersion));
       plugins.apply({ hooks } as Auto);
 
-      expect(await hooks.canary.promise(SEMVER.patch, "-canary")).toStrictEqual(
-        canaryVersion
-      );
+      expect(
+        await hooks.canary.promise({
+          bump: SEMVER.patch,
+          canaryIdentifier: "-canary",
+        })
+      ).toStrictEqual(canaryVersion);
     });
   });
 

--- a/plugins/exec/__tests__/exec.test.ts
+++ b/plugins/exec/__tests__/exec.test.ts
@@ -46,7 +46,7 @@ describe("Exec Plugin", () => {
     const hooks = makeHooks();
 
     plugins.apply({ hooks } as Auto);
-    await hooks.version.promise(SEMVER.patch);
+    await hooks.version.promise({ bump: SEMVER.patch });
 
     expect(execSpy).toHaveBeenCalledWith("echo bar", expect.anything());
   });

--- a/plugins/gem/__tests__/gem.test.ts
+++ b/plugins/gem/__tests__/gem.test.ts
@@ -19,8 +19,9 @@ const execSpy = jest.fn();
 execSpy.mockReturnValue("");
 
 // @ts-ignore
-jest.mock("../../../packages/core/dist/utils/exec-promise", () => (...args: any[]) =>
-  execSpy(...args)
+jest.mock(
+  "../../../packages/core/dist/utils/exec-promise",
+  () => (...args: any[]) => execSpy(...args)
 );
 
 const globSpy = jest.fn();
@@ -232,7 +233,7 @@ describe("Gem Plugin", () => {
       const hooks = makeHooks();
 
       plugin.apply({ hooks, logger } as any);
-      await hooks.version.promise(SEMVER.minor);
+      await hooks.version.promise({ bump: SEMVER.minor });
 
       expect(writeFile).toHaveBeenCalledWith(
         "test.gemspec",
@@ -257,9 +258,9 @@ describe("Gem Plugin", () => {
 
       plugin.apply({ hooks, logger } as any);
 
-      await expect(hooks.version.promise(SEMVER.minor)).rejects.toBeInstanceOf(
-        Error
-      );
+      await expect(
+        hooks.version.promise({ bump: SEMVER.minor })
+      ).rejects.toBeInstanceOf(Error);
     });
   });
 

--- a/plugins/gem/src/index.ts
+++ b/plugins/gem/src/index.ts
@@ -93,9 +93,14 @@ export default class GemPlugin implements IPlugin {
       };
     });
 
-    auto.hooks.version.tapPromise(this.name, async (bump) => {
+    auto.hooks.version.tapPromise(this.name, async ({ bump, dryRun }) => {
       const [version, versionFile] = await this.getVersion(auto);
       const newTag = inc(version, bump as ReleaseType);
+
+      if (dryRun && newTag) {
+        console.log(newTag);
+        return;
+      }
 
       if (!newTag) {
         throw new Error(

--- a/plugins/git-tag/__tests__/git-tag.test.ts
+++ b/plugins/git-tag/__tests__/git-tag.test.ts
@@ -63,19 +63,19 @@ describe("Git Tag Plugin", () => {
   describe("version", () => {
     test("should do nothing without git", async () => {
       const hooks = setup();
-      await hooks.version.promise(Auto.SEMVER.patch);
+      await hooks.version.promise({ bump: Auto.SEMVER.patch });
       expect(exec).not.toHaveBeenCalled();
     });
 
     test("should do nothing with a bad version bump", async () => {
       const hooks = setup({ getLatestTagInBranch: () => "v1.0.0" });
-      await hooks.version.promise("wrong" as Auto.SEMVER);
+      await hooks.version.promise({ bump: "wrong" as Auto.SEMVER });
       expect(exec).not.toHaveBeenCalled();
     });
 
     test("should tag next version", async () => {
       const hooks = setup({ getLatestTagInBranch: () => "v1.0.0" });
-      await hooks.version.promise(Auto.SEMVER.patch);
+      await hooks.version.promise({ bump: Auto.SEMVER.patch });
       expect(exec).toHaveBeenCalledWith("git", [
         "tag",
         "v1.0.1",

--- a/plugins/git-tag/__tests__/git-tag.test.ts
+++ b/plugins/git-tag/__tests__/git-tag.test.ts
@@ -8,8 +8,9 @@ const exec = jest.fn();
 jest.mock("../../../packages/core/dist/utils/get-current-branch", () => ({
   getCurrentBranch: () => "next",
 }));
-jest.mock("../../../packages/core/dist/utils/exec-promise", () => (...args: any[]) =>
-  exec(...args)
+jest.mock(
+  "../../../packages/core/dist/utils/exec-promise",
+  () => (...args: any[]) => exec(...args)
 );
 
 const setup = (mockGit?: any) => {
@@ -111,6 +112,19 @@ describe("Git Tag Plugin", () => {
         "next",
         "--tags",
       ]);
+    });
+
+    test("return next version in dry run", async () => {
+      const hooks = setup({
+        getLatestRelease: () => "v0.1.0",
+        getLastTagNotInBaseBranch: () => "v1.0.0",
+      });
+
+      expect(
+        await hooks.next.promise([], Auto.SEMVER.patch, { dryRun: true } as any)
+      ).toStrictEqual(["v1.0.1-next.0"]);
+
+      expect(exec).not.toHaveBeenCalled();
     });
   });
 });

--- a/plugins/git-tag/src/index.ts
+++ b/plugins/git-tag/src/index.ts
@@ -34,13 +34,18 @@ export default class GitTagPlugin implements IPlugin {
       return getTag();
     });
 
-    auto.hooks.version.tapPromise(this.name, async (version) => {
+    auto.hooks.version.tapPromise(this.name, async ({ bump, dryRun }) => {
       if (!auto.git) {
         return;
       }
 
       const lastTag = await getTag();
-      const newTag = inc(lastTag, version as ReleaseType);
+      const newTag = inc(lastTag, bump as ReleaseType);
+
+      if (dryRun && newTag) {
+        console.log(newTag);
+        return;
+      }
 
       if (!newTag) {
         auto.logger.log.info("No release found, doing nothing");

--- a/plugins/gradle/__tests__/gradle.test.ts
+++ b/plugins/gradle/__tests__/gradle.test.ts
@@ -8,8 +8,9 @@ import GradleReleasePlugin, {
 
 const exec = jest.fn();
 
-jest.mock("../../../packages/core/dist/utils/exec-promise", () => (...args: any[]) =>
-  exec(...args)
+jest.mock(
+  "../../../packages/core/dist/utils/exec-promise",
+  () => (...args: any[]) => exec(...args)
 );
 
 describe("Gradle Plugin", () => {
@@ -47,7 +48,7 @@ describe("Gradle Plugin", () => {
       const spy = jest.fn();
       exec.mockReturnValueOnce(properties).mockImplementation(spy);
 
-      await hooks.version.promise(Auto.SEMVER.patch);
+      await hooks.version.promise({ bump: Auto.SEMVER.patch });
 
       expect(spy).toHaveBeenCalledWith(expect.stringMatching("gradle"), [
         "release",
@@ -67,7 +68,7 @@ describe("Gradle Plugin", () => {
       const spy = jest.fn();
       exec.mockReturnValueOnce(properties).mockImplementation(spy);
 
-      await hooks.version.promise(Auto.SEMVER.major);
+      await hooks.version.promise({ bump: Auto.SEMVER.major });
 
       expect(spy).toHaveBeenCalledWith(expect.stringMatching("gradle"), [
         "release",
@@ -88,7 +89,7 @@ describe("Gradle Plugin", () => {
       const spy = jest.fn();
       exec.mockReturnValueOnce(properties).mockImplementation(spy);
 
-      await hooks.version.promise(Auto.SEMVER.major);
+      await hooks.version.promise({ bump: Auto.SEMVER.major });
 
       expect(spy).toHaveBeenCalledWith(expect.stringMatching("gradle"), [
         "release",
@@ -108,7 +109,7 @@ describe("Gradle Plugin", () => {
       const spy = jest.fn();
       exec.mockReturnValueOnce(properties).mockImplementation(spy);
 
-      await hooks.version.promise(Auto.SEMVER.minor);
+      await hooks.version.promise({ bump: Auto.SEMVER.minor });
 
       expect(spy).toHaveBeenCalledWith(expect.stringMatching("gradle"), [
         "release",
@@ -128,7 +129,7 @@ describe("Gradle Plugin", () => {
       const spy = jest.fn();
       exec.mockReturnValueOnce(properties).mockImplementation(spy);
 
-      await hooks.version.promise(Auto.SEMVER.patch);
+      await hooks.version.promise({ bump: Auto.SEMVER.patch });
 
       expect(spy).toHaveBeenCalledWith(expect.stringMatching("gradle"), [
         "release",
@@ -152,7 +153,7 @@ describe("Gradle Plugin", () => {
       const spy = jest.fn();
       exec.mockReturnValueOnce(properties).mockImplementation(spy);
 
-      await hooks.version.promise(Auto.SEMVER.patch);
+      await hooks.version.promise({ bump: Auto.SEMVER.patch });
 
       expect(spy).toHaveBeenCalledWith(expect.stringMatching("gradle"), [
         "release",
@@ -187,7 +188,7 @@ describe("Gradle Plugin - Custom Command", () => {
       const spy = jest.fn();
       exec.mockReturnValueOnce("version: 1.0.0").mockImplementation(spy);
 
-      await hooks.version.promise(Auto.SEMVER.patch);
+      await hooks.version.promise({ bump: Auto.SEMVER.patch });
 
       expect(spy).toHaveBeenCalledWith(expect.stringMatching("gradlew"), [
         "release",

--- a/plugins/gradle/src/index.ts
+++ b/plugins/gradle/src/index.ts
@@ -170,7 +170,7 @@ export default class GradleReleasePluginPlugin implements IPlugin {
       );
     });
 
-    auto.hooks.version.tapPromise(this.name, async (version: string) => {
+    auto.hooks.version.tapPromise(this.name, async ({ bump, dryRun }) => {
       const previousVersion = await getVersion(
         this.options.gradleCommand,
         this.options.gradleOptions
@@ -180,9 +180,14 @@ export default class GradleReleasePluginPlugin implements IPlugin {
         // After release we bump the version by a patch and add -SNAPSHOT
         // Given that we do not need to increment when versioning, since
         // it has already been done
-        this.snapshotRelease && version === "patch"
+        this.snapshotRelease && bump === "patch"
           ? previousVersion
-          : inc(previousVersion, version as ReleaseType);
+          : inc(previousVersion, bump as ReleaseType);
+
+      if (dryRun && releaseVersion) {
+        console.log(releaseVersion);
+        return;
+      }
 
       if (!releaseVersion) {
         throw new Error(

--- a/plugins/gradle/src/index.ts
+++ b/plugins/gradle/src/index.ts
@@ -170,46 +170,54 @@ export default class GradleReleasePluginPlugin implements IPlugin {
       );
     });
 
-    auto.hooks.version.tapPromise(this.name, async ({ bump, dryRun }) => {
-      const previousVersion = await getVersion(
-        this.options.gradleCommand,
-        this.options.gradleOptions
-      );
-
-      const releaseVersion =
-        // After release we bump the version by a patch and add -SNAPSHOT
-        // Given that we do not need to increment when versioning, since
-        // it has already been done
-        this.snapshotRelease && bump === "patch"
-          ? previousVersion
-          : inc(previousVersion, bump as ReleaseType);
-
-      if (dryRun && releaseVersion) {
-        console.log(releaseVersion);
-        return;
-      }
-
-      if (!releaseVersion) {
-        throw new Error(
-          `Could not increment previous version: ${previousVersion}`
+    auto.hooks.version.tapPromise(
+      this.name,
+      async ({ bump, dryRun, quiet }) => {
+        const previousVersion = await getVersion(
+          this.options.gradleCommand,
+          this.options.gradleOptions
         );
+
+        const releaseVersion =
+          // After release we bump the version by a patch and add -SNAPSHOT
+          // Given that we do not need to increment when versioning, since
+          // it has already been done
+          this.snapshotRelease && bump === "patch"
+            ? previousVersion
+            : inc(previousVersion, bump as ReleaseType);
+
+        if (dryRun && releaseVersion) {
+          if (quiet) {
+            console.log(releaseVersion);
+          } else {
+            auto.logger.log.info(`Would have published: ${releaseVersion}`);
+          }
+
+          return;
+        }
+
+        if (!releaseVersion) {
+          throw new Error(
+            `Could not increment previous version: ${previousVersion}`
+          );
+        }
+
+        await this.updateGradleVersion(
+          releaseVersion,
+          `release version: ${releaseVersion} [skip ci]`
+        );
+
+        const newVersion = auto.prefixRelease(releaseVersion);
+
+        // Ensure tag is on this commit, changelog will be added automatically
+        await execPromise("git", [
+          "tag",
+          newVersion,
+          "-m",
+          `"Update version to ${newVersion}"`,
+        ]);
       }
-
-      await this.updateGradleVersion(
-        releaseVersion,
-        `release version: ${releaseVersion} [skip ci]`
-      );
-
-      const newVersion = auto.prefixRelease(releaseVersion);
-
-      // Ensure tag is on this commit, changelog will be added automatically
-      await execPromise("git", [
-        "tag",
-        newVersion,
-        "-m",
-        `"Update version to ${newVersion}"`,
-      ]);
-    });
+    );
 
     auto.hooks.publish.tapPromise(this.name, async () => {
       const { publish } = this.properties;

--- a/plugins/maven/__tests__/maven.test.ts
+++ b/plugins/maven/__tests__/maven.test.ts
@@ -46,8 +46,9 @@ const mockReadFile = (result: string) =>
 // @ts-ignore
 execSync.mockImplementation(exec);
 
-jest.mock("../../../packages/core/dist/utils/exec-promise", () => (...args: any[]) =>
-  exec(...args)
+jest.mock(
+  "../../../packages/core/dist/utils/exec-promise",
+  () => (...args: any[]) => exec(...args)
 );
 
 describe("maven", () => {
@@ -262,7 +263,7 @@ describe("maven", () => {
 
       await hooks.beforeRun.promise({} as any);
 
-      await hooks.version.promise(Auto.SEMVER.patch);
+      await hooks.version.promise({ bump: Auto.SEMVER.patch });
 
       const call = exec.mock.calls[0][1];
       expect(call).toContain("tag");
@@ -282,7 +283,7 @@ describe("maven", () => {
 
       await hooks.beforeRun.promise({} as any);
 
-      await hooks.version.promise(Auto.SEMVER.patch);
+      await hooks.version.promise({ bump: Auto.SEMVER.patch });
 
       const call = exec.mock.calls[0][1];
       expect(call).toContain("tag");
@@ -310,7 +311,7 @@ describe("maven", () => {
       mockReadFile(oldPomXml);
 
       await hooks.beforeRun.promise({} as any);
-      await hooks.version.promise(Auto.SEMVER.patch);
+      await hooks.version.promise({ bump: Auto.SEMVER.patch });
 
       expect(await readFile).toHaveBeenCalledTimes(4);
       expect(await readFile).toHaveBeenLastCalledWith(
@@ -344,7 +345,7 @@ describe("maven", () => {
                 </project>`);
 
       await hooks.beforeRun.promise({} as any);
-      await hooks.version.promise(Auto.SEMVER.patch);
+      await hooks.version.promise({ bump: Auto.SEMVER.patch });
 
       expect(await readFile).toHaveBeenCalledTimes(3);
       expect(await readFile).toHaveBeenLastCalledWith(
@@ -398,7 +399,7 @@ describe("maven", () => {
       });
 
       await hooks.beforeRun.promise({} as any);
-      await hooks.version.promise(Auto.SEMVER.patch);
+      await hooks.version.promise({ bump: Auto.SEMVER.patch });
 
       expect(await readFile).toHaveBeenCalledTimes(5);
       expect(await readFile).toHaveBeenLastCalledWith(
@@ -427,7 +428,9 @@ describe("maven", () => {
 
       await hooks.beforeRun.promise({} as any);
 
-      expect(await hooks.version.promise(Auto.SEMVER.minor)).toBeUndefined();
+      expect(
+        await hooks.version.promise({ bump: Auto.SEMVER.minor })
+      ).toBeUndefined();
     });
   });
 

--- a/plugins/maven/src/index.ts
+++ b/plugins/maven/src/index.ts
@@ -222,39 +222,47 @@ export default class MavenPlugin implements IPlugin {
       };
     });
 
-    auto.hooks.version.tapPromise(this.name, async ({ bump, dryRun }) => {
-      const previousVersion = await this.getVersion(auto);
-      const releaseVersion =
-        // After release we bump the version by a patch and add -SNAPSHOT
-        // Given that we do not need to increment when versioning, since
-        // it has already been done
-        this.snapshotRelease && bump === "patch"
-          ? previousVersion
-          : inc(previousVersion, bump as ReleaseType);
+    auto.hooks.version.tapPromise(
+      this.name,
+      async ({ bump, dryRun, quiet }) => {
+        const previousVersion = await this.getVersion(auto);
+        const releaseVersion =
+          // After release we bump the version by a patch and add -SNAPSHOT
+          // Given that we do not need to increment when versioning, since
+          // it has already been done
+          this.snapshotRelease && bump === "patch"
+            ? previousVersion
+            : inc(previousVersion, bump as ReleaseType);
 
-      if (dryRun && releaseVersion) {
-        console.log(releaseVersion);
-        return;
+        if (dryRun && releaseVersion) {
+          if (quiet) {
+            console.log(releaseVersion);
+          } else {
+            auto.logger.log.info(`Would have published: ${releaseVersion}`);
+          }
+
+          return;
+        }
+
+        if (releaseVersion) {
+          await this.updatePoms(
+            releaseVersion,
+            auto,
+            `"Release ${releaseVersion} [skip ci]"`
+          );
+
+          const newVersion = auto.prefixRelease(releaseVersion);
+
+          // Ensure tag is on this commit, changelog will be added automatically
+          await execPromise("git", [
+            "tag",
+            newVersion,
+            "-m",
+            `"Update version to ${newVersion}"`,
+          ]);
+        }
       }
-
-      if (releaseVersion) {
-        await this.updatePoms(
-          releaseVersion,
-          auto,
-          `"Release ${releaseVersion} [skip ci]"`
-        );
-
-        const newVersion = auto.prefixRelease(releaseVersion);
-
-        // Ensure tag is on this commit, changelog will be added automatically
-        await execPromise("git", [
-          "tag",
-          newVersion,
-          "-m",
-          `"Update version to ${newVersion}"`,
-        ]);
-      }
-    });
+    );
 
     auto.hooks.publish.tapPromise(this.name, async () => {
       auto.logger.verbose.warn(`Running "publish"`);

--- a/plugins/maven/src/index.ts
+++ b/plugins/maven/src/index.ts
@@ -222,15 +222,20 @@ export default class MavenPlugin implements IPlugin {
       };
     });
 
-    auto.hooks.version.tapPromise(this.name, async (version: string) => {
+    auto.hooks.version.tapPromise(this.name, async ({ bump, dryRun }) => {
       const previousVersion = await this.getVersion(auto);
       const releaseVersion =
         // After release we bump the version by a patch and add -SNAPSHOT
         // Given that we do not need to increment when versioning, since
         // it has already been done
-        this.snapshotRelease && version === "patch"
+        this.snapshotRelease && bump === "patch"
           ? previousVersion
-          : inc(previousVersion, version as ReleaseType);
+          : inc(previousVersion, bump as ReleaseType);
+
+      if (dryRun && releaseVersion) {
+        console.log(releaseVersion);
+        return;
+      }
 
       if (releaseVersion) {
         await this.updatePoms(

--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -851,9 +851,46 @@ describe("canary", () => {
       }
     `;
 
-    await hooks.canary.promise(Auto.SEMVER.patch, "canary.123.1");
+    await hooks.canary.promise({
+      bump: Auto.SEMVER.patch,
+      canaryIdentifier: "canary.123.1",
+    });
     expect(execPromise.mock.calls[1]).toContain("npm");
     expect(execPromise.mock.calls[1][1]).toContain("1.2.4-canary.123.1.0");
+  });
+
+  test("prints canary version in dry run", async () => {
+    const plugin = new NPMPlugin();
+    const hooks = makeHooks();
+
+    plugin.apply(({
+      config: { prereleaseBranches: ["next"] },
+      hooks,
+      remote: "origin",
+      baseBranch: "master",
+      logger: dummyLog(),
+      getCurrentVersion: () => "1.2.3",
+      git: {
+        getLatestRelease: () => "1.2.3",
+        getLatestTagInBranch: () => Promise.resolve("1.2.3"),
+      },
+    } as unknown) as Auto.Auto);
+
+    readResult = `
+      {
+        "name": "test"
+      }
+    `;
+
+    const log = jest.fn();
+    jest.spyOn(console, "log").mockImplementation(log);
+
+    await hooks.canary.promise({
+      bump: Auto.SEMVER.patch,
+      canaryIdentifier: "canary.123.1",
+      dryRun: true,
+    });
+    expect(log).toHaveBeenCalledWith("1.2.4-canary.123.1.0");
   });
 
   test("doesn't publish private packages", async () => {
@@ -881,7 +918,10 @@ describe("canary", () => {
     `;
 
     expect(
-      await hooks.canary.promise(Auto.SEMVER.patch, "canary.123.1")
+      await hooks.canary.promise({
+        bump: Auto.SEMVER.patch,
+        canaryIdentifier: "canary.123.1",
+      })
     ).toStrictEqual({
       error: "Package private, cannot make canary release to npm.",
     });
@@ -915,7 +955,10 @@ describe("canary", () => {
     // second doesn't
     execPromise.mockReturnValueOnce(false);
 
-    await hooks.canary.promise(Auto.SEMVER.patch, "canary.123.1");
+    await hooks.canary.promise({
+      bump: Auto.SEMVER.patch,
+      canaryIdentifier: "canary.123.1",
+    });
     expect(execPromise.mock.calls[2]).toContain("npm");
     expect(execPromise.mock.calls[2][1]).toContain("1.2.4-canary.123.1.1");
   });
@@ -944,7 +987,10 @@ describe("canary", () => {
       }
     `;
 
-    await hooks.canary.promise(Auto.SEMVER.patch, "canary.123.1");
+    await hooks.canary.promise({
+      bump: Auto.SEMVER.patch,
+      canaryIdentifier: "canary.123.1",
+    });
     expect(execPromise).toHaveBeenCalledWith("npm", [
       "publish",
       "--tag",
@@ -977,7 +1023,10 @@ describe("canary", () => {
       }
     `;
 
-    await hooks.canary.promise(Auto.SEMVER.patch, "canary.123.1");
+    await hooks.canary.promise({
+      bump: Auto.SEMVER.patch,
+      canaryIdentifier: "canary.123.1",
+    });
     expect(execPromise.mock.calls[1]).toContain("npm");
     expect(execPromise.mock.calls[1][1]).toContain("1.2.4-canary.123.1.0");
   });
@@ -1021,10 +1070,63 @@ describe("canary", () => {
     monorepoPackages.mockReturnValueOnce(packages.map((p) => ({ package: p })));
     getLernaPackages.mockImplementation(async () => Promise.resolve(packages));
 
-    const value = await hooks.canary.promise(Auto.SEMVER.patch, "");
+    const value = await hooks.canary.promise({
+      bump: Auto.SEMVER.patch,
+      canaryIdentifier: "",
+    });
     expect(execPromise.mock.calls[1][1]).toContain("lerna");
     // @ts-ignore
     expect(value.newVersion).toBe("1.2.3-canary.0");
+  });
+
+  test("prints version monorepo dry run", async () => {
+    const plugin = new NPMPlugin();
+    const hooks = makeHooks();
+
+    plugin.apply({
+      config: { prereleaseBranches: ["next"] },
+      hooks,
+      remote: "origin",
+      baseBranch: "master",
+      logger: dummyLog(),
+      git: {
+        getLatestRelease: () => Promise.resolve("1.2.3"),
+        getLatestTagInBranch: () => Promise.resolve("1.2.3"),
+      },
+    } as any);
+    existsSync.mockReturnValueOnce(true);
+
+    readResult = `
+      {
+        "name": "test"
+      }
+    `;
+
+    const packages = [
+      {
+        path: "path/to/package",
+        name: "@foobar/app",
+        version: "1.2.3-canary.0+abcd",
+      },
+      {
+        path: "path/to/package",
+        name: "@foobar/lib",
+        version: "1.2.3-canary.0+abcd",
+      },
+    ];
+
+    const log = jest.fn();
+    jest.spyOn(console, "log").mockImplementation(log);
+    monorepoPackages.mockReturnValueOnce(packages.map((p) => ({ package: p })));
+    getLernaPackages.mockImplementation(async () => Promise.resolve(packages));
+
+    await hooks.canary.promise({
+      bump: Auto.SEMVER.patch,
+      canaryIdentifier: "canary.123.1",
+      dryRun: true,
+    });
+
+    expect(log).toHaveBeenCalledWith("1.2.4-canary.123.1.0");
   });
 
   test("legacy auth works in monorepo", async () => {
@@ -1067,7 +1169,10 @@ describe("canary", () => {
     monorepoPackages.mockReturnValueOnce(packages.map((p) => ({ package: p })));
     getLernaPackages.mockImplementation(async () => Promise.resolve(packages));
 
-    await hooks.canary.promise(Auto.SEMVER.patch, "");
+    await hooks.canary.promise({
+      bump: Auto.SEMVER.patch,
+      canaryIdentifier: "",
+    });
     expect(execPromise).toHaveBeenCalledWith("npx", [
       "lerna",
       "publish",
@@ -1123,7 +1228,10 @@ describe("canary", () => {
     monorepoPackages.mockReturnValueOnce(packages.map((p) => ({ package: p })));
     getLernaPackages.mockImplementation(async () => Promise.resolve(packages));
 
-    const value = await hooks.canary.promise(Auto.SEMVER.patch, "");
+    const value = await hooks.canary.promise({
+      bump: Auto.SEMVER.patch,
+      canaryIdentifier: "",
+    });
     expect(value).toStrictEqual({
       error: "No packages were changed. No canary published.",
     });
@@ -1218,7 +1326,12 @@ describe("canary", () => {
       ])
     );
 
-    expect(await hooks.canary.promise(Auto.SEMVER.patch, "")).toMatchSnapshot();
+    expect(
+      await hooks.canary.promise({
+        bump: Auto.SEMVER.patch,
+        canaryIdentifier: "",
+      })
+    ).toMatchSnapshot();
   });
 
   test("error when no canary release found - independent", async () => {
@@ -1260,7 +1373,10 @@ describe("canary", () => {
       ])
     );
 
-    const value = await hooks.canary.promise(Auto.SEMVER.patch, "");
+    const value = await hooks.canary.promise({
+      bump: Auto.SEMVER.patch,
+      canaryIdentifier: "",
+    });
     expect(value).toStrictEqual({
       error: "No packages were changed. No canary published.",
     });

--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -483,7 +483,7 @@ describe("publish", () => {
       }
     `;
 
-    await hooks.version.promise(Auto.SEMVER.patch);
+    await hooks.version.promise({ bump: Auto.SEMVER.patch });
     expect(execPromise).toHaveBeenCalledWith("npm", [
       "version",
       Auto.SEMVER.patch,
@@ -513,7 +513,7 @@ describe("publish", () => {
       }
     `;
 
-    await hooks.version.promise(Auto.SEMVER.patch);
+    await hooks.version.promise({ bump: Auto.SEMVER.patch });
     expect(execPromise).toHaveBeenCalledWith("npm", [
       "version",
       Auto.SEMVER.patch,
@@ -544,7 +544,7 @@ describe("publish", () => {
       }
     `;
 
-    await hooks.version.promise(Auto.SEMVER.patch);
+    await hooks.version.promise({ bump: Auto.SEMVER.patch });
     expect(execPromise).toHaveBeenCalledWith("npx", [
       "lerna",
       "version",
@@ -580,7 +580,7 @@ describe("publish", () => {
       }
     `;
 
-    await hooks.version.promise(Auto.SEMVER.patch);
+    await hooks.version.promise({ bump: Auto.SEMVER.patch });
     expect(execPromise).toHaveBeenCalledWith("npx", [
       "lerna",
       "version",
@@ -616,7 +616,7 @@ describe("publish", () => {
       }
     `;
 
-    await hooks.version.promise(Auto.SEMVER.patch);
+    await hooks.version.promise({ bump: Auto.SEMVER.patch });
     expect(execPromise).toHaveBeenCalledWith("npx", [
       "lerna",
       "version",
@@ -745,7 +745,7 @@ describe("publish", () => {
       }
     `;
 
-    await hooks.version.promise(Auto.SEMVER.patch);
+    await hooks.version.promise({ bump: Auto.SEMVER.patch });
     expect(execPromise).toHaveBeenCalledWith("npm", [
       "version",
       "1.0.1",
@@ -777,7 +777,7 @@ describe("publish", () => {
       }
     `;
 
-    await hooks.version.promise(Auto.SEMVER.patch);
+    await hooks.version.promise({ bump: Auto.SEMVER.patch });
     expect(execPromise).toHaveBeenNthCalledWith(2, "npx", [
       "lerna",
       "version",
@@ -889,6 +889,7 @@ describe("canary", () => {
       bump: Auto.SEMVER.patch,
       canaryIdentifier: "canary.123.1",
       dryRun: true,
+      quiet: true,
     });
     expect(log).toHaveBeenCalledWith("1.2.4-canary.123.1.0");
   });
@@ -1124,6 +1125,7 @@ describe("canary", () => {
       bump: Auto.SEMVER.patch,
       canaryIdentifier: "canary.123.1",
       dryRun: true,
+      quiet: true,
     });
 
     expect(log).toHaveBeenCalledWith("1.2.4-canary.123.1.0");
@@ -1272,7 +1274,7 @@ describe("canary", () => {
       ])
     );
 
-    await hooks.version.promise(Auto.SEMVER.patch);
+    await hooks.version.promise({ bump: Auto.SEMVER.patch });
     expect(execPromise).toHaveBeenNthCalledWith(1, "npx", [
       "lerna",
       "version",


### PR DESCRIPTION
# What Changed

Previously a lot of the hooks would not run during a dry run and `auto` would try to guess what they would do. This lead to the output versions of some commands to be off.

Now `auto` will call to the plugins for various hooks so they can control that.

## Why

closes #1600
closes #1490
closes #1279

Todo:

- [x] Add tests
- [x] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [ ] `minor`
- [x] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.60.2-canary.1604.19722.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.60.2-canary.1604.19722.0
  npm install @auto-canary/auto@9.60.2-canary.1604.19722.0
  npm install @auto-canary/core@9.60.2-canary.1604.19722.0
  npm install @auto-canary/all-contributors@9.60.2-canary.1604.19722.0
  npm install @auto-canary/brew@9.60.2-canary.1604.19722.0
  npm install @auto-canary/chrome@9.60.2-canary.1604.19722.0
  npm install @auto-canary/cocoapods@9.60.2-canary.1604.19722.0
  npm install @auto-canary/conventional-commits@9.60.2-canary.1604.19722.0
  npm install @auto-canary/crates@9.60.2-canary.1604.19722.0
  npm install @auto-canary/docker@9.60.2-canary.1604.19722.0
  npm install @auto-canary/exec@9.60.2-canary.1604.19722.0
  npm install @auto-canary/first-time-contributor@9.60.2-canary.1604.19722.0
  npm install @auto-canary/gem@9.60.2-canary.1604.19722.0
  npm install @auto-canary/gh-pages@9.60.2-canary.1604.19722.0
  npm install @auto-canary/git-tag@9.60.2-canary.1604.19722.0
  npm install @auto-canary/gradle@9.60.2-canary.1604.19722.0
  npm install @auto-canary/jira@9.60.2-canary.1604.19722.0
  npm install @auto-canary/maven@9.60.2-canary.1604.19722.0
  npm install @auto-canary/npm@9.60.2-canary.1604.19722.0
  npm install @auto-canary/omit-commits@9.60.2-canary.1604.19722.0
  npm install @auto-canary/omit-release-notes@9.60.2-canary.1604.19722.0
  npm install @auto-canary/pr-body-labels@9.60.2-canary.1604.19722.0
  npm install @auto-canary/released@9.60.2-canary.1604.19722.0
  npm install @auto-canary/s3@9.60.2-canary.1604.19722.0
  npm install @auto-canary/slack@9.60.2-canary.1604.19722.0
  npm install @auto-canary/twitter@9.60.2-canary.1604.19722.0
  npm install @auto-canary/upload-assets@9.60.2-canary.1604.19722.0
  # or 
  yarn add @auto-canary/bot-list@9.60.2-canary.1604.19722.0
  yarn add @auto-canary/auto@9.60.2-canary.1604.19722.0
  yarn add @auto-canary/core@9.60.2-canary.1604.19722.0
  yarn add @auto-canary/all-contributors@9.60.2-canary.1604.19722.0
  yarn add @auto-canary/brew@9.60.2-canary.1604.19722.0
  yarn add @auto-canary/chrome@9.60.2-canary.1604.19722.0
  yarn add @auto-canary/cocoapods@9.60.2-canary.1604.19722.0
  yarn add @auto-canary/conventional-commits@9.60.2-canary.1604.19722.0
  yarn add @auto-canary/crates@9.60.2-canary.1604.19722.0
  yarn add @auto-canary/docker@9.60.2-canary.1604.19722.0
  yarn add @auto-canary/exec@9.60.2-canary.1604.19722.0
  yarn add @auto-canary/first-time-contributor@9.60.2-canary.1604.19722.0
  yarn add @auto-canary/gem@9.60.2-canary.1604.19722.0
  yarn add @auto-canary/gh-pages@9.60.2-canary.1604.19722.0
  yarn add @auto-canary/git-tag@9.60.2-canary.1604.19722.0
  yarn add @auto-canary/gradle@9.60.2-canary.1604.19722.0
  yarn add @auto-canary/jira@9.60.2-canary.1604.19722.0
  yarn add @auto-canary/maven@9.60.2-canary.1604.19722.0
  yarn add @auto-canary/npm@9.60.2-canary.1604.19722.0
  yarn add @auto-canary/omit-commits@9.60.2-canary.1604.19722.0
  yarn add @auto-canary/omit-release-notes@9.60.2-canary.1604.19722.0
  yarn add @auto-canary/pr-body-labels@9.60.2-canary.1604.19722.0
  yarn add @auto-canary/released@9.60.2-canary.1604.19722.0
  yarn add @auto-canary/s3@9.60.2-canary.1604.19722.0
  yarn add @auto-canary/slack@9.60.2-canary.1604.19722.0
  yarn add @auto-canary/twitter@9.60.2-canary.1604.19722.0
  yarn add @auto-canary/upload-assets@9.60.2-canary.1604.19722.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
