### PR TITLE
rename afterAddToChangelog hook to afterChangelog

### DIFF
--- a/docs/pages/docs/plugins/release-lifecycle-hooks.mdx
+++ b/docs/pages/docs/plugins/release-lifecycle-hooks.mdx
@@ -8,7 +8,7 @@ These hooks is where the publishing of your package actually happens.
 - [prCheck](#prCheck)
 - [beforeShipIt](#beforeshipit)
 - [beforeCommitChangelog](#beforecommitchangelog)
-- [afterAddToChangelog](#afteraddtochangelog)
+- [afterChangelog](#afterchangelog)
 - [version](#version)
 - [afterVersion](#afterversion)
 - [publish](#publish)

--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -1442,12 +1442,12 @@ describe("Auto", () => {
       jest.spyOn(auto.release!, "addToChangelog").mockImplementation();
       const beforeCommitChangelog = jest.fn();
       auto.hooks.beforeCommitChangelog.tap("test", beforeCommitChangelog);
-      const afterAddToChangelog = jest.fn();
-      auto.hooks.afterAddToChangelog.tap("test", afterAddToChangelog);
+      const afterChangelog = jest.fn();
+      auto.hooks.afterChangelog.tap("test", afterChangelog);
 
       await auto.shipit({ noChangelog: true });
       expect(beforeCommitChangelog).not.toHaveBeenCalled();
-      expect(afterAddToChangelog).toHaveBeenCalled();
+      expect(afterChangelog).toHaveBeenCalled();
     });
 
     test("should not publish when behind remote", async () => {

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -147,7 +147,7 @@ export interface IAutoHooks {
   /** Ran before the `changelog` command commits the new release notes to `CHANGELOG.md`. */
   beforeCommitChangelog: AsyncSeriesHook<[ChangelogLifecycle]>;
   /** Ran after the `changelog` command adds the new release notes to `CHANGELOG.md`. */
-  afterAddToChangelog: AsyncSeriesHook<[ChangelogLifecycle]>;
+  afterChangelog: AsyncSeriesHook<[ChangelogLifecycle]>;
   /** Ran after the `shipit` command has run. */
   afterShipIt: AsyncParallelHook<
     [
@@ -1763,7 +1763,7 @@ export default class Auto {
       this.logger.verbose.info("Committed new changelog.");
     }
 
-    await this.hooks.afterAddToChangelog.promise(context);
+    await this.hooks.afterChangelog.promise(context);
   }
 
   /** Make a release over a range of commits */

--- a/packages/core/src/utils/make-hooks.ts
+++ b/packages/core/src/utils/make-hooks.ts
@@ -18,7 +18,7 @@ export const makeHooks = (): IAutoHooks => ({
   modifyConfig: new SyncWaterfallHook(["config"]),
   validateConfig: new AsyncSeriesBailHook(["name", "options"]),
   beforeShipIt: new AsyncSeriesHook(["context"]),
-  afterAddToChangelog: new AsyncSeriesHook(["context"]),
+  afterChangelog: new AsyncSeriesHook(["context"]),
   beforeCommitChangelog: new AsyncSeriesHook(["context"]),
   afterShipIt: new AsyncParallelHook(["version", "commits", "context"]),
   makeRelease: new AsyncSeriesBailHook(["releaseInfo"]),

--- a/plugins/all-contributors/__tests__/all-contributors.test.ts
+++ b/plugins/all-contributors/__tests__/all-contributors.test.ts
@@ -28,7 +28,7 @@ jest.mock("child_process");
 jest.mock("all-contributors-cli/dist/contributors");
 jest.mock("all-contributors-cli/dist/generate");
 
-// @ts-ignore 
+// @ts-ignore
 generateReadme.mockImplementation(generateMock);
 // @ts-ignore
 addContributor.mockImplementation(addContributorMock);
@@ -38,7 +38,10 @@ env.mockImplementation(envMock);
 jest.mock("../../../packages/core/dist/utils/exec-promise", () => (...args) =>
   gitShow(...args)
 );
-jest.mock("../../../packages/core/dist/utils/get-lerna-packages", () => (...args: any[]) => getLernaPackages(...args));
+jest.mock(
+  "../../../packages/core/dist/utils/get-lerna-packages",
+  () => (...args: any[]) => getLernaPackages(...args)
+);
 jest.spyOn(process, "chdir").mockReturnValue();
 
 const mockRead = (result: string) =>
@@ -264,7 +267,7 @@ describe("All Contributors Plugin", () => {
 
     releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto.Auto);
 
-    await autoHooks.afterAddToChangelog.promise({
+    await autoHooks.afterChangelog.promise({
       bump: Auto.SEMVER.patch,
       currentVersion: "0.0.0",
       lastRelease: "0.0.0",
@@ -296,7 +299,7 @@ describe("All Contributors Plugin", () => {
 
     releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto.Auto);
 
-    await autoHooks.afterAddToChangelog.promise({
+    await autoHooks.afterChangelog.promise({
       bump: Auto.SEMVER.patch,
       currentVersion: "0.0.0",
       lastRelease: "0.0.0",
@@ -325,7 +328,7 @@ describe("All Contributors Plugin", () => {
 
     releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto.Auto);
 
-    await autoHooks.afterAddToChangelog.promise({
+    await autoHooks.afterChangelog.promise({
       bump: Auto.SEMVER.patch,
       currentVersion: "0.0.0",
       lastRelease: "0.0.0",
@@ -353,7 +356,7 @@ describe("All Contributors Plugin", () => {
 
     releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto.Auto);
 
-    await autoHooks.afterAddToChangelog.promise({
+    await autoHooks.afterChangelog.promise({
       bump: Auto.SEMVER.patch,
       currentVersion: "0.0.0",
       lastRelease: "0.0.0",
@@ -380,7 +383,7 @@ describe("All Contributors Plugin", () => {
 
     releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto.Auto);
 
-    await autoHooks.afterAddToChangelog.promise({
+    await autoHooks.afterChangelog.promise({
       bump: Auto.SEMVER.patch,
       currentVersion: "0.0.0",
       lastRelease: "0.0.0",
@@ -429,7 +432,7 @@ describe("All Contributors Plugin", () => {
 
     releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto.Auto);
 
-    await autoHooks.afterAddToChangelog.promise({
+    await autoHooks.afterChangelog.promise({
       bump: Auto.SEMVER.patch,
       currentVersion: "0.0.0",
       lastRelease: "0.0.0",
@@ -472,7 +475,7 @@ describe("All Contributors Plugin", () => {
 
     releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto.Auto);
 
-    await autoHooks.afterAddToChangelog.promise({
+    await autoHooks.afterChangelog.promise({
       bump: Auto.SEMVER.patch,
       currentVersion: "0.0.0",
       lastRelease: "0.0.0",
@@ -501,7 +504,7 @@ describe("All Contributors Plugin", () => {
 
     releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto.Auto);
 
-    await autoHooks.afterAddToChangelog.promise({
+    await autoHooks.afterChangelog.promise({
       bump: Auto.SEMVER.patch,
       currentVersion: "0.0.0",
       lastRelease: "0.0.0",
@@ -535,7 +538,7 @@ describe("All Contributors Plugin", () => {
 
     releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto.Auto);
 
-    await autoHooks.afterAddToChangelog.promise({
+    await autoHooks.afterChangelog.promise({
       bump: Auto.SEMVER.patch,
       currentVersion: "0.0.0",
       lastRelease: "0.0.0",
@@ -564,7 +567,7 @@ describe("All Contributors Plugin", () => {
 
     releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto.Auto);
 
-    await autoHooks.afterAddToChangelog.promise({
+    await autoHooks.afterChangelog.promise({
       bump: Auto.SEMVER.patch,
       currentVersion: "0.0.0",
       lastRelease: "0.0.0",


### PR DESCRIPTION
# What Changed

see title

## Why

This hook is called even when not adding to the changelog

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [ ] `minor`
- [x] `major`
