### PR TITLE
correct renderChangelogLine hook usage

### DIFF
--- a/docs/pages/docs/plugins/changelog-hooks.mdx
+++ b/docs/pages/docs/plugins/changelog-hooks.mdx
@@ -31,7 +31,7 @@ The following adds a random GIF from [giphy](https://giphy.com) to each new chan
 
 ```ts
 auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
-  changelog.hooks.renderChangelogLine.tapPromise(
+  changelog.hooks.addToBody.tapPromise(
     'Giphy',
     async (notes, commits) => {
       const response = await fetch(`https://api.giphy.com/v1/gifs/random?api_key=${process.env.GIPHY_KEY}`);
@@ -60,8 +60,7 @@ The following plugin would change all the bullet points in the changelog to star
 auto.hooks.onCreateChangelog.tapPromise('Stars', changelog =>
   changelog.hooks.renderChangelogLine.tapPromise(
     'Stars',
-    async (commit, line) =>
-      [commit, `${line.replace('-', ':star:')}\n`]
+    async (line, commit) => `${line.replace('-', ':star:')}\n`
   );
 );
 ```

--- a/packages/core/src/changelog.ts
+++ b/packages/core/src/changelog.ts
@@ -31,7 +31,7 @@ interface ICommitSplit {
 
 export interface IChangelogHooks {
   /** Change how the changelog renders lines. */
-  renderChangelogLine: AsyncSeriesWaterfallHook<[[IExtendedCommit, string]]>;
+  renderChangelogLine: AsyncSeriesWaterfallHook<[string, IExtendedCommit]>;
   /** Sort the lines in a changelog section. */
   sortChangelogLines: AsyncSeriesWaterfallHook<[string[]]>;
   /** Change how the changelog renders titles */
@@ -119,10 +119,7 @@ export default class Changelog {
         author.name && user ? `${author.name} (${user})` : user;
       return authorString ? `- ${authorString}` : undefined;
     });
-    this.hooks.renderChangelogLine.tap("Default", ([commit, line]) => [
-      commit,
-      line,
-    ]);
+    this.hooks.renderChangelogLine.tap("Default", (line) => line);
     this.hooks.renderChangelogTitle.tap(
       "Default",
       (label, changelogTitles) => `#### ${changelogTitles[label]}\n`
@@ -394,10 +391,10 @@ export default class Changelog {
               return true;
             }
 
-            const [, line] = await this.hooks.renderChangelogLine.promise([
-              commit,
+            const line = await this.hooks.renderChangelogLine.promise(
               await this.generateCommitNote(commit),
-            ]);
+              commit
+            );
 
             lines.add(line);
           })

--- a/packages/core/src/utils/make-hooks.ts
+++ b/packages/core/src/utils/make-hooks.ts
@@ -64,7 +64,7 @@ export const makeInteractiveInitHooks = (): InteractiveInitHooks => ({
 export const makeChangelogHooks = (): IChangelogHooks => ({
   addToBody: new AsyncSeriesWaterfallHook(["notes", "commits"]),
   sortChangelogLines: new AsyncSeriesWaterfallHook(["lines"]),
-  renderChangelogLine: new AsyncSeriesWaterfallHook(["lineData"]),
+  renderChangelogLine: new AsyncSeriesWaterfallHook(["line", "commit"]),
   renderChangelogTitle: new AsyncSeriesBailHook(["commits", "lineRender"]),
   renderChangelogAuthor: new AsyncSeriesBailHook([
     "author",

--- a/plugins/jira/__tests__/jira.test.ts
+++ b/plugins/jira/__tests__/jira.test.ts
@@ -81,7 +81,7 @@ describe("render jira", () => {
     );
 
     expect(
-      (await changelogHooks.renderChangelogLine.promise([commit, "Add log"]))[1]
+      await changelogHooks.renderChangelogLine.promise("Add log", commit)
     ).toBe("Add log");
   });
 
@@ -96,10 +96,10 @@ describe("render jira", () => {
       SEMVER.patch
     );
 
-    const [, line] = await changelogHooks.renderChangelogLine.promise([
-      makeCommitFromMsg("[PLAYA-5052] Add log"),
+    const line = await changelogHooks.renderChangelogLine.promise(
       "[PLAYA-5052] Add log [author](link/to/author)",
-    ]);
+      makeCommitFromMsg("[PLAYA-5052] Add log")
+    );
 
     expect(line).toBe(
       "[PLAYA-5052](jira.com/PLAYA-5052): Add log [author](link/to/author)"

--- a/plugins/jira/src/index.ts
+++ b/plugins/jira/src/index.ts
@@ -110,7 +110,7 @@ export default class JiraPlugin implements IPlugin {
     auto.hooks.onCreateChangelog.tap(this.name, (changelog) => {
       changelog.hooks.renderChangelogLine.tap(
         this.name,
-        ([commit, currentRender]) => {
+        (currentRender, commit) => {
           let line = currentRender;
           const jiraCommit = parseJira(commit);
 
@@ -124,7 +124,7 @@ export default class JiraPlugin implements IPlugin {
             );
           }
 
-          return [commit, line];
+          return line;
         }
       );
     });

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -706,9 +706,9 @@ export default class NPMPlugin implements IPlugin {
       (changelog, version = SEMVER.patch) => {
         changelog.hooks.renderChangelogLine.tapPromise(
           "NPM - Monorepo",
-          async ([commit, line]) => {
+          async (line, commit) => {
             if (!isMonorepo() || !this.monorepoChangelog) {
-              return [commit, line];
+              return line;
             }
 
             const lernaPackages = await this.getLernaPackages();
@@ -729,10 +729,10 @@ export default class NPMPlugin implements IPlugin {
               : "monorepo";
 
             if (section === "monorepo") {
-              return [commit, line];
+              return line;
             }
 
-            return [commit, [`- ${section}`, `  ${line}`].join("\n")];
+            return [`- ${section}`, `  ${line}`].join("\n");
           }
         );
 


### PR DESCRIPTION
# Release notes

We were implementing the `renderChangelogLine` in a way that was more complex than needed

Previously the hook took a tuple and had to return a tuple

```ts
auto.hooks.onCreateChangelog.tapPromise('Stars', changelog =>
  changelog.hooks.renderChangelogLine.tapPromise(
    'Stars',
    async ([commit, line]) =>
      [commit, `${line.replace('-', ':star:')}\n`]
  );
);
```

Now it can just return the rendered changelog line

```ts
auto.hooks.onCreateChangelog.tapPromise('Stars', changelog =>
  changelog.hooks.renderChangelogLine.tapPromise(
    'Stars',
    async (line, commit) => `${line.replace('-', ':star:')}\n`
  );
);
```

## Why

Simplifies hook usage

Todo:

- [x] Add tests
- [x] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [ ] `minor`
- [x] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.60.2-canary.1607.19710.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.60.2-canary.1607.19710.0
  npm install @auto-canary/auto@9.60.2-canary.1607.19710.0
  npm install @auto-canary/core@9.60.2-canary.1607.19710.0
  npm install @auto-canary/all-contributors@9.60.2-canary.1607.19710.0
  npm install @auto-canary/brew@9.60.2-canary.1607.19710.0
  npm install @auto-canary/chrome@9.60.2-canary.1607.19710.0
  npm install @auto-canary/cocoapods@9.60.2-canary.1607.19710.0
  npm install @auto-canary/conventional-commits@9.60.2-canary.1607.19710.0
  npm install @auto-canary/crates@9.60.2-canary.1607.19710.0
  npm install @auto-canary/docker@9.60.2-canary.1607.19710.0
  npm install @auto-canary/exec@9.60.2-canary.1607.19710.0
  npm install @auto-canary/first-time-contributor@9.60.2-canary.1607.19710.0
  npm install @auto-canary/gem@9.60.2-canary.1607.19710.0
  npm install @auto-canary/gh-pages@9.60.2-canary.1607.19710.0
  npm install @auto-canary/git-tag@9.60.2-canary.1607.19710.0
  npm install @auto-canary/gradle@9.60.2-canary.1607.19710.0
  npm install @auto-canary/jira@9.60.2-canary.1607.19710.0
  npm install @auto-canary/maven@9.60.2-canary.1607.19710.0
  npm install @auto-canary/npm@9.60.2-canary.1607.19710.0
  npm install @auto-canary/omit-commits@9.60.2-canary.1607.19710.0
  npm install @auto-canary/omit-release-notes@9.60.2-canary.1607.19710.0
  npm install @auto-canary/pr-body-labels@9.60.2-canary.1607.19710.0
  npm install @auto-canary/released@9.60.2-canary.1607.19710.0
  npm install @auto-canary/s3@9.60.2-canary.1607.19710.0
  npm install @auto-canary/slack@9.60.2-canary.1607.19710.0
  npm install @auto-canary/twitter@9.60.2-canary.1607.19710.0
  npm install @auto-canary/upload-assets@9.60.2-canary.1607.19710.0
  # or 
  yarn add @auto-canary/bot-list@9.60.2-canary.1607.19710.0
  yarn add @auto-canary/auto@9.60.2-canary.1607.19710.0
  yarn add @auto-canary/core@9.60.2-canary.1607.19710.0
  yarn add @auto-canary/all-contributors@9.60.2-canary.1607.19710.0
  yarn add @auto-canary/brew@9.60.2-canary.1607.19710.0
  yarn add @auto-canary/chrome@9.60.2-canary.1607.19710.0
  yarn add @auto-canary/cocoapods@9.60.2-canary.1607.19710.0
  yarn add @auto-canary/conventional-commits@9.60.2-canary.1607.19710.0
  yarn add @auto-canary/crates@9.60.2-canary.1607.19710.0
  yarn add @auto-canary/docker@9.60.2-canary.1607.19710.0
  yarn add @auto-canary/exec@9.60.2-canary.1607.19710.0
  yarn add @auto-canary/first-time-contributor@9.60.2-canary.1607.19710.0
  yarn add @auto-canary/gem@9.60.2-canary.1607.19710.0
  yarn add @auto-canary/gh-pages@9.60.2-canary.1607.19710.0
  yarn add @auto-canary/git-tag@9.60.2-canary.1607.19710.0
  yarn add @auto-canary/gradle@9.60.2-canary.1607.19710.0
  yarn add @auto-canary/jira@9.60.2-canary.1607.19710.0
  yarn add @auto-canary/maven@9.60.2-canary.1607.19710.0
  yarn add @auto-canary/npm@9.60.2-canary.1607.19710.0
  yarn add @auto-canary/omit-commits@9.60.2-canary.1607.19710.0
  yarn add @auto-canary/omit-release-notes@9.60.2-canary.1607.19710.0
  yarn add @auto-canary/pr-body-labels@9.60.2-canary.1607.19710.0
  yarn add @auto-canary/released@9.60.2-canary.1607.19710.0
  yarn add @auto-canary/s3@9.60.2-canary.1607.19710.0
  yarn add @auto-canary/slack@9.60.2-canary.1607.19710.0
  yarn add @auto-canary/twitter@9.60.2-canary.1607.19710.0
  yarn add @auto-canary/upload-assets@9.60.2-canary.1607.19710.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
