### PR TITLE
v10

### DIFF
--- a/docs/pages/docs/plugins/changelog-hooks.mdx
+++ b/docs/pages/docs/plugins/changelog-hooks.mdx
@@ -31,7 +31,7 @@ The following adds a random GIF from [giphy](https://giphy.com) to each new chan
 
 ```ts
 auto.hooks.onCreateChangelog.tapPromise('Giphy', changelog =>
-  changelog.hooks.renderChangelogLine.tapPromise(
+  changelog.hooks.addToBody.tapPromise(
     'Giphy',
     async (notes, commits) => {
       const response = await fetch(`https://api.giphy.com/v1/gifs/random?api_key=${process.env.GIPHY_KEY}`);
@@ -60,8 +60,7 @@ The following plugin would change all the bullet points in the changelog to star
 auto.hooks.onCreateChangelog.tapPromise('Stars', changelog =>
   changelog.hooks.renderChangelogLine.tapPromise(
     'Stars',
-    async (commit, line) =>
-      [commit, `${line.replace('-', ':star:')}\n`]
+    async (line, commit) => `${line.replace('-', ':star:')}\n`
   );
 );
 ```

--- a/docs/pages/docs/plugins/changelog-hooks.mdx
+++ b/docs/pages/docs/plugins/changelog-hooks.mdx
@@ -21,6 +21,10 @@ The hooks it provides allow you to customize everything about how the changelog 
 This is where you hook into the changelog's hooks.
 See examples below.
 
+```ts
+auto.hooks.onCreateChangelog.tapPromise('Giphy', (changelog, { bump }) => {});
+```
+
 ## addToBody
 
 Add extra content to your changelogs.

--- a/docs/pages/docs/plugins/release-lifecycle-hooks.mdx
+++ b/docs/pages/docs/plugins/release-lifecycle-hooks.mdx
@@ -8,7 +8,7 @@ These hooks is where the publishing of your package actually happens.
 - [prCheck](#prCheck)
 - [beforeShipIt](#beforeshipit)
 - [beforeCommitChangelog](#beforecommitchangelog)
-- [afterAddToChangelog](#afteraddtochangelog)
+- [afterChangelog](#afterchangelog)
 - [version](#version)
 - [afterVersion](#afterversion)
 - [publish](#publish)

--- a/docs/pages/docs/plugins/release-lifecycle-hooks.mdx
+++ b/docs/pages/docs/plugins/release-lifecycle-hooks.mdx
@@ -154,10 +154,10 @@ You must push the tags to github!
 This hooks is required for plugin that facilitate publishing.
 
 ```ts
-auto.hooks.publish.tapPromise("NPM", async (version: SEMVER) => {
+auto.hooks.publish.tapPromise("NPM", async ({ bump }) => {
   await execPromise("npm", [
     "version",
-    version,
+    bump,
     "-m",
     "Bump version to: %s [skip ci]",
   ]);
@@ -187,19 +187,26 @@ You can either return a string value of just the version or an object containing
 - `details` - The body of the details element
 
 ```ts
-auto.hooks.canary.tapPromise(this.name, async ({ bump, canaryIdentifier, dryRun, quiet }) => {
-  const lastRelease = await auto.git!.getLatestRelease();
-  const current = await auto.getCurrentVersion(lastRelease);
-  const nextVersion = inc(current, bump as ReleaseType);
-  const isScopedPackage = name.match(/@\S+\/\S+/);
-  const canaryVersion = `${nextVersion}-canary${canaryIdentifier}`;
+auto.hooks.canary.tapPromise(
+  this.name,
+  async ({ bump, canaryIdentifier, dryRun, quiet }) => {
+    const lastRelease = await auto.git!.getLatestRelease();
+    const current = await auto.getCurrentVersion(lastRelease);
+    const nextVersion = inc(current, bump as ReleaseType);
+    const isScopedPackage = name.match(/@\S+\/\S+/);
+    const canaryVersion = `${nextVersion}-canary${canaryIdentifier}`;
 
-  await execPromise("npm", ["version", canaryVersion, "--no-git-tag-version"]);
-  await execPromise("npm", ["publish", "--tag", "canary"]);
+    await execPromise("npm", [
+      "version",
+      canaryVersion,
+      "--no-git-tag-version",
+    ]);
+    await execPromise("npm", ["publish", "--tag", "canary"]);
 
-  auto.logger.verbose.info("Successfully published canary version");
-  return canaryVersion;
-});
+    auto.logger.verbose.info("Successfully published canary version");
+    return canaryVersion;
+  }
+);
 ```
 
 `canary` version should not produce any of the following:
@@ -230,7 +237,7 @@ import {
 
 auto.hooks.next.tapPromise(
   this.name,
-  async (preReleaseVersions, bump, { dryRun }) => {
+  async (preReleaseVersions, { bump, dryRun }) => {
     const branch = getCurrentBranch() || "";
     const lastRelease = await auto.git.getLatestRelease();
     const current =
@@ -328,18 +335,15 @@ _Other examples:_
 
 Ran after the `shipit` command has run.
 
-- `newVersion` - The new version that was release
-- `commits` - the commits in the release
 - `data`
+  - `newVersion` - The new version that was release
+  - `commits` - the commits in the release
   - `context` - The type of release that was created (`latest`, `next`, `canary`, or `old`)
 
 ```ts
-auto.hooks.afterShipIt.tap(
-  "MyPlugin",
-  async (newVersion, commits, { context }) => {
-    // do something
-  }
-);
+auto.hooks.afterShipIt.tap("MyPlugin", async ({ context }) => {
+  // do something
+});
 ```
 
 _Other examples:_

--- a/docs/pages/docs/plugins/release-lifecycle-hooks.mdx
+++ b/docs/pages/docs/plugins/release-lifecycle-hooks.mdx
@@ -116,10 +116,16 @@ This hooks is required for plugin that facilitate publishing.
 Here `npm` does it for us.
 
 ```ts
-auto.hooks.version.tapPromise("NPM", async (version: SEMVER) => {
+auto.hooks.version.tapPromise("NPM", async ({ bump, dryRun, quiet }) => {
+  if (dryRun) {
+    const { version } = await loadPackageJson();
+    console.log(inc(version, bump));
+    return;
+  }
+
   await execPromise("npm", [
     "version",
-    version,
+    bump,
     "-m",
     "Bump version to: %s [skip ci]",
   ]);
@@ -136,6 +142,10 @@ _Examples:_
 
 - In Core: Used to exit early is new commits are detected on the remote
 - [brew](../generated/brew) - Create a new brew formula once the package a=has been versioned
+
+```ts
+auto.hooks.afterVersion.tapPromise("NPM", async ({ dryRun }) => {});
+```
 
 ## publish
 
@@ -177,12 +187,12 @@ You can either return a string value of just the version or an object containing
 - `details` - The body of the details element
 
 ```ts
-auto.hooks.canary.tapPromise(this.name, async (version, postFix) => {
+auto.hooks.canary.tapPromise(this.name, async ({ bump, canaryIdentifier, dryRun, quiet }) => {
   const lastRelease = await auto.git!.getLatestRelease();
   const current = await auto.getCurrentVersion(lastRelease);
-  const nextVersion = inc(current, version as ReleaseType);
+  const nextVersion = inc(current, bump as ReleaseType);
   const isScopedPackage = name.match(/@\S+\/\S+/);
-  const canaryVersion = `${nextVersion}-canary${postFix}`;
+  const canaryVersion = `${nextVersion}-canary${canaryIdentifier}`;
 
   await execPromise("npm", ["version", canaryVersion, "--no-git-tag-version"]);
   await execPromise("npm", ["publish", "--tag", "canary"]);
@@ -218,29 +228,37 @@ import {
   getCurrentBranch,
 } from "@auto-it/core";
 
-auto.hooks.next.tapPromise(this.name, async (preReleaseVersions, bump) => {
-  const branch = getCurrentBranch() || "";
-  const lastRelease = await auto.git.getLatestRelease();
-  const current =
-    (await auto.git.getLastTagNotInBaseBranch(branch)) ||
-    (await auto.getCurrentVersion(lastRelease));
-  // Use this helper function to determine the next prerelease version
-  const prerelease = determineNextVersion(lastRelease, current, bump, "next");
+auto.hooks.next.tapPromise(
+  this.name,
+  async (preReleaseVersions, bump, { dryRun }) => {
+    const branch = getCurrentBranch() || "";
+    const lastRelease = await auto.git.getLatestRelease();
+    const current =
+      (await auto.git.getLastTagNotInBaseBranch(branch)) ||
+      (await auto.getCurrentVersion(lastRelease));
+    // Use this helper function to determine the next prerelease version
+    const prerelease = determineNextVersion(lastRelease, current, bump, "next");
 
-  // Create a new tag for it
-  await execPromise("git", [
-    "tag",
-    prerelease,
-    "-m",
-    `"Tag pre-release: ${prerelease}"`,
-  ]);
-  // Push the tag
-  await execPromise("git", ["push", auto.remote, "--tags"]);
+    // Make sure to add the version to the list
+    preReleaseVersions.push(prerelease);
 
-  // Make sure to add the version to the list
-  preReleaseVersions.push(prerelease);
-  return preReleaseVersions;
-});
+    if (dryRun) {
+      return preReleaseVersions;
+    }
+
+    // Create a new tag for it
+    await execPromise("git", [
+      "tag",
+      prerelease,
+      "-m",
+      `"Tag pre-release: ${prerelease}"`,
+    ]);
+    // Push the tag
+    await execPromise("git", ["push", auto.remote, "--tags"]);
+
+    return preReleaseVersions;
+  }
+);
 ```
 
 `next` version should not produce any of the following:

--- a/docs/pages/docs/plugins/writing-publishing-plugins.mdx
+++ b/docs/pages/docs/plugins/writing-publishing-plugins.mdx
@@ -68,9 +68,14 @@ export default class GitTagPlugin implements IPlugin {
   // ...
   apply(auto: Auto) {
     // ...
-    auto.hooks.version.tapPromise(this.name, async (version) => {
+    auto.hooks.version.tapPromise(this.name, async ({ bump }) => {
       const lastTag = await getTag();
       const newTag = inc(lastTag, version as ReleaseType);
+
+      if (newTag && dryRun) {
+        console.log(newTag);
+        return;
+      }
 
       if (!newTag) {
         auto.logger.log.info("No release found, doing nothing");

--- a/packages/core/src/__tests__/auto-canary-local.test.ts
+++ b/packages/core/src/__tests__/auto-canary-local.test.ts
@@ -47,5 +47,10 @@ test("shipit should publish canary in locally when not on master", async () => {
   auto.hooks.canary.tap("test", canary);
 
   await auto.shipit();
-  expect(canary).toHaveBeenCalledWith(SEMVER.patch, "canary.abc");
+  expect(canary).toHaveBeenCalledWith(
+    expect.objectContaining({
+      bump: SEMVER.patch,
+      canaryIdentifier: "canary.abc",
+    })
+  );
 });

--- a/packages/core/src/__tests__/auto-in-pr-ci.test.ts
+++ b/packages/core/src/__tests__/auto-in-pr-ci.test.ts
@@ -61,7 +61,12 @@ describe("canary in ci", () => {
     jest.spyOn(auto.release!, "getCommits").mockImplementation();
 
     await auto.canary();
-    expect(canary).toHaveBeenCalledWith(SEMVER.patch, "canary.123.1");
+    expect(canary).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bump: SEMVER.patch,
+        canaryIdentifier: "canary.123.1",
+      })
+    );
   });
 
   test("comments on PR in CI", async () => {
@@ -117,7 +122,10 @@ describe("canary in ci", () => {
     const addToPrBody = jest.fn();
     auto.git!.addToPrBody = addToPrBody;
     jest.spyOn(auto.release!, "getCommits").mockImplementation();
-    auto.hooks.canary.tap("test", (bump, post) => `1.2.4-${post}`);
+    auto.hooks.canary.tap(
+      "test",
+      ({ canaryIdentifier }) => `1.2.4-${canaryIdentifier}`
+    );
 
     await auto.canary({ pr: 123, build: 1, message: "false" });
     expect(addToPrBody).not.toHaveBeenCalled();
@@ -135,7 +143,10 @@ describe("canary in ci", () => {
     const addToPrBody = jest.fn();
     auto.git!.addToPrBody = addToPrBody;
     jest.spyOn(auto.release!, "getCommits").mockImplementation();
-    auto.hooks.canary.tap("test", (bump, post) => `1.2.4-${post}`);
+    auto.hooks.canary.tap(
+      "test",
+      ({ canaryIdentifier }) => `1.2.4-${canaryIdentifier}`
+    );
 
     const version = await auto.canary({ pr: 456, build: 5 });
     expect(version!.newVersion).toBe("1.2.4-canary.456.5");
@@ -159,7 +170,12 @@ describe("shipit in ci", () => {
     auto.hooks.canary.tap("test", canary);
 
     await auto.shipit();
-    expect(canary).toHaveBeenCalledWith(SEMVER.patch, "canary.123.1");
+    expect(canary).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bump: SEMVER.patch,
+        canaryIdentifier: "canary.123.1",
+      })
+    );
   });
 });
 

--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -1442,12 +1442,12 @@ describe("Auto", () => {
       jest.spyOn(auto.release!, "addToChangelog").mockImplementation();
       const beforeCommitChangelog = jest.fn();
       auto.hooks.beforeCommitChangelog.tap("test", beforeCommitChangelog);
-      const afterAddToChangelog = jest.fn();
-      auto.hooks.afterAddToChangelog.tap("test", afterAddToChangelog);
+      const afterChangelog = jest.fn();
+      auto.hooks.afterChangelog.tap("test", afterChangelog);
 
       await auto.shipit({ noChangelog: true });
       expect(beforeCommitChangelog).not.toHaveBeenCalled();
-      expect(afterAddToChangelog).toHaveBeenCalled();
+      expect(afterChangelog).toHaveBeenCalled();
     });
 
     test("should not publish when behind remote", async () => {

--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -903,24 +903,6 @@ describe("Auto", () => {
       expect(exit).toHaveBeenCalled();
     });
 
-    test("doesn't try to overwrite releases", async () => {
-      const auto = new Auto({ ...defaults, plugins: [] });
-      auto.logger = dummyLog();
-      await auto.loadConfig();
-      auto.git!.getLatestRelease = () => Promise.resolve("1.2.3");
-      jest.spyOn(auto.release!, "generateReleaseNotes").mockImplementation();
-      auto.release!.getCommitsInRelease = () =>
-        Promise.resolve([makeCommitFromMsg("Test Commit")]);
-
-      auto.hooks.getPreviousVersion.tap("test", () => "1.2.3");
-      const afterRelease = jest.fn();
-      auto.hooks.afterRelease.tap("test", afterRelease);
-      jest.spyOn(auto.release!, "getCommits").mockImplementation();
-
-      await auto.runRelease();
-      expect(afterRelease).not.toHaveBeenCalled();
-    });
-
     test("should publish with default options", async () => {
       const auto = new Auto({ ...defaults, plugins: [] });
       auto.logger = dummyLog();
@@ -1151,24 +1133,6 @@ describe("Auto", () => {
       await expect(auto.canary()).rejects.not.toBeUndefined();
     });
 
-    test("does not call canary hook in dry-run", async () => {
-      const auto = new Auto(defaults);
-      // @ts-ignore
-      auto.checkClean = () => Promise.resolve(true);
-
-      auto.logger = dummyLog();
-      await auto.loadConfig();
-      auto.git!.getLatestRelease = () => Promise.resolve("1.2.3");
-      auto.release!.getCommitsInRelease = () =>
-        Promise.resolve([makeCommitFromMsg("Test Commit")]);
-      const canary = jest.fn();
-      auto.hooks.canary.tap("test", canary);
-      jest.spyOn(auto.release!, "getCommits").mockImplementation();
-
-      await auto.canary({ pr: 123, build: 1, dryRun: true });
-      expect(canary).not.toHaveBeenCalled();
-    });
-
     test("calls the canary hook with the pr info", async () => {
       const auto = new Auto({ ...defaults, plugins: [] });
       // @ts-ignore
@@ -1187,7 +1151,12 @@ describe("Auto", () => {
       jest.spyOn(auto.release!, "getCommits").mockImplementation();
 
       await auto.canary({ pr: 123, build: 1 });
-      expect(canary).toHaveBeenCalledWith(SEMVER.patch, "canary.123.1");
+      expect(canary).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bump: SEMVER.patch,
+          canaryIdentifier: "canary.123.1",
+        })
+      );
       expect(auto.git!.addToPrBody).toHaveBeenCalled();
     });
 
@@ -1207,7 +1176,12 @@ describe("Auto", () => {
       jest.spyOn(auto.release!, "getCommits").mockImplementation();
 
       await auto.canary();
-      expect(canary).toHaveBeenCalledWith(SEMVER.patch, "canary.abc");
+      expect(canary).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bump: SEMVER.patch,
+          canaryIdentifier: "canary.abc",
+        })
+      );
     });
 
     test("doesn't comment if there is an error", async () => {
@@ -1246,7 +1220,12 @@ describe("Auto", () => {
       auto.hooks.canary.tap("test", canary);
 
       await auto.canary();
-      expect(canary).toHaveBeenCalledWith(SEMVER.patch, "canary.abcd");
+      expect(canary).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bump: SEMVER.patch,
+          canaryIdentifier: "canary.abcd",
+        })
+      );
     });
 
     test('should not publish when is present "skip-release" label', async () => {
@@ -1290,7 +1269,12 @@ describe("Auto", () => {
       auto.hooks.canary.tap("test", canary);
 
       await auto.canary({ force: true });
-      expect(canary).toHaveBeenCalledWith(SEMVER.patch, "canary.abcd");
+      expect(canary).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bump: SEMVER.patch,
+          canaryIdentifier: "canary.abcd",
+        })
+      );
     });
   });
 
@@ -1302,29 +1286,6 @@ describe("Auto", () => {
       auto.logger = dummyLog();
 
       await expect(auto.next({})).rejects.not.toBeUndefined();
-    });
-
-    test("does not call next hook in dry-run", async () => {
-      const auto = new Auto(defaults);
-
-      // @ts-ignore
-      auto.checkClean = () => Promise.resolve(true);
-      auto.logger = dummyLog();
-      await auto.loadConfig();
-      auto.remote = "origin";
-      auto.git!.getProject = () => Promise.resolve({ data: {} } as any);
-      auto.git!.getLatestRelease = () => Promise.resolve("1.2.3");
-      auto.release!.generateReleaseNotes = () => Promise.resolve("notes");
-      auto.git!.getLatestTagInBranch = () => Promise.resolve("1.2.3");
-      auto.release!.getCommitsInRelease = () =>
-        Promise.resolve([makeCommitFromMsg("Test Commit")]);
-
-      const next = jest.fn();
-      auto.hooks.next.tap("test", next);
-      jest.spyOn(auto.release!, "getCommits").mockImplementation();
-
-      await auto.next({ dryRun: true });
-      expect(next).not.toHaveBeenCalled();
     });
 
     test("calls the next hook with the release info", async () => {
@@ -1416,7 +1377,10 @@ describe("Auto", () => {
       // @ts-ignore
       auto.makeChangelog = () => Promise.resolve();
       auto.git!.getLatestRelease = () => Promise.resolve("1.2.3");
-      jest.spyOn(auto.git!, "publish").mockImplementation();
+      auto.git!.publish = () =>
+        Promise.resolve({
+          data: { html_url: "https://github.com/my/repo/release" },
+        } as any);
       jest.spyOn(auto.release!, "getCommitsInRelease").mockImplementation();
       jest.spyOn(auto.release!, "generateReleaseNotes").mockImplementation();
       jest.spyOn(auto.release!, "addToChangelog").mockImplementation();
@@ -1436,7 +1400,10 @@ describe("Auto", () => {
       auto.remote = "https://github.com/intuit/auto";
 
       auto.git!.getLatestRelease = () => Promise.resolve("1.2.3");
-      jest.spyOn(auto.git!, "publish").mockImplementation();
+      auto.git!.publish = () =>
+        Promise.resolve({
+          data: { html_url: "https://github.com/my/repo/release" },
+        } as any);
       jest.spyOn(auto.release!, "getCommitsInRelease").mockImplementation();
       jest.spyOn(auto.release!, "generateReleaseNotes").mockImplementation();
       jest.spyOn(auto.release!, "addToChangelog").mockImplementation();
@@ -1497,8 +1464,7 @@ describe("Auto", () => {
       jest.spyOn(auto.release!, "generateReleaseNotes").mockImplementation();
       jest.spyOn(auto.release!, "addToChangelog").mockImplementation();
       const spy = jest.fn();
-      auto.hooks.version.tap("test", spy);
-      auto.hooks.afterRelease.tap("test", spy);
+      auto.hooks.publish.tap("test", spy);
 
       await auto.shipit({ dryRun: true });
       expect(spy).not.toHaveBeenCalled();

--- a/packages/core/src/auto-args.ts
+++ b/packages/core/src/auto-args.ts
@@ -52,7 +52,7 @@ export type IVersionOptions = ReleaseCalculationOptions & {
   from?: string;
 };
 
-interface Quiet {
+export interface QuietOption {
   /** Print **only** the result of the command */
   quiet?: boolean;
 }
@@ -62,7 +62,7 @@ interface NoVersionPrefix {
   noVersionPrefix?: boolean;
 }
 
-interface DryRun {
+export interface DryRunOption {
   /** Do not actually do anything */
   dryRun?: boolean;
 }
@@ -90,8 +90,8 @@ interface BaseBranch {
 export type IChangelogOptions = BaseBranch &
   ChangelogTitle &
   ChangelogMessage &
-  Quiet &
-  DryRun &
+  QuietOption &
+  DryRunOption &
   NoVersionPrefix &
   Partial<AuthorInformation> & {
     /** Commit to start calculating the changelog from */
@@ -104,7 +104,7 @@ export type IChangelogOptions = BaseBranch &
 
 export type IReleaseOptions = BaseBranch &
   Prerelease &
-  DryRun &
+  DryRunOption &
   NoVersionPrefix &
   Partial<AuthorInformation> &
   Partial<RepoInformation> & {
@@ -116,7 +116,7 @@ export type IReleaseOptions = BaseBranch &
     useVersion?: string;
   };
 
-export type ICommentOptions = DryRun & {
+export type ICommentOptions = DryRunOption & {
   /** The message to use when commenting */
   message?: string;
   /** THe PR to comment on */
@@ -132,13 +132,13 @@ export type ICommentOptions = DryRun & {
 export type IPRBodyOptions = Omit<ICommentOptions, "edit" | "delete">;
 
 export type ILatestOptions = BaseBranch &
-  DryRun &
+  DryRunOption &
   Partial<AuthorInformation> &
   Prerelease &
   NoVersionPrefix &
   ChangelogTitle &
   ChangelogMessage &
-  Quiet &
+  QuietOption &
   ReleaseCalculationOptions & {
     /** Skip creating the changelog */
     noChangelog?: boolean;
@@ -154,7 +154,7 @@ export type IShipItOptions = ILatestOptions & {
   onlyGraduateWithReleaseLabel?: boolean;
 };
 
-export type ICanaryOptions = Quiet & {
+export type ICanaryOptions = QuietOption & {
   /** Do not actually do anything */
   dryRun?: boolean;
   /** THe PR to attach the canary to */
@@ -167,7 +167,7 @@ export type ICanaryOptions = Quiet & {
   force?: boolean;
 };
 
-export type INextOptions = Quiet & {
+export type INextOptions = QuietOption & {
   /** Do not actually do anything */
   dryRun?: boolean;
   /** The message used when attaching the prerelease version to a PR */

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1150,9 +1150,7 @@ export default class Auto {
       process.exit(0);
     }
 
-    if (!args.dryRun) {
-      await this.checkClean();
-    }
+    await this.checkClean();
 
     let { pr, build } = await this.getPrEnvInfo();
     pr = options.pr ? String(options.pr) : pr;
@@ -1268,10 +1266,7 @@ export default class Auto {
       process.exit(0);
     }
 
-    if (!args.dryRun) {
-      await this.checkClean();
-    }
-
+    await this.checkClean();
     await this.setGitUser();
 
     this.hooks.onCreateLogParse.tap("Omit merges from master", (logParse) => {
@@ -1591,9 +1586,7 @@ export default class Auto {
       noCommit: options.noChangelog,
     });
 
-    if (!options.dryRun) {
-      await this.checkClean();
-    }
+    await this.checkClean();
 
     this.logger.verbose.info("Calling version hook");
     await this.hooks.version.promise({

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -147,7 +147,7 @@ export interface IAutoHooks {
   /** Ran before the `changelog` command commits the new release notes to `CHANGELOG.md`. */
   beforeCommitChangelog: AsyncSeriesHook<[ChangelogLifecycle]>;
   /** Ran after the `changelog` command adds the new release notes to `CHANGELOG.md`. */
-  afterAddToChangelog: AsyncSeriesHook<[ChangelogLifecycle]>;
+  afterChangelog: AsyncSeriesHook<[ChangelogLifecycle]>;
   /** Ran after the `shipit` command has run. */
   afterShipIt: AsyncParallelHook<
     [
@@ -1763,7 +1763,7 @@ export default class Auto {
       this.logger.verbose.info("Committed new changelog.");
     }
 
-    await this.hooks.afterAddToChangelog.promise(context);
+    await this.hooks.afterChangelog.promise(context);
   }
 
   /** Make a release over a range of commits */

--- a/packages/core/src/changelog.ts
+++ b/packages/core/src/changelog.ts
@@ -31,7 +31,7 @@ interface ICommitSplit {
 
 export interface IChangelogHooks {
   /** Change how the changelog renders lines. */
-  renderChangelogLine: AsyncSeriesWaterfallHook<[[IExtendedCommit, string]]>;
+  renderChangelogLine: AsyncSeriesWaterfallHook<[string, IExtendedCommit]>;
   /** Sort the lines in a changelog section. */
   sortChangelogLines: AsyncSeriesWaterfallHook<[string[]]>;
   /** Change how the changelog renders titles */
@@ -119,10 +119,7 @@ export default class Changelog {
         author.name && user ? `${author.name} (${user})` : user;
       return authorString ? `- ${authorString}` : undefined;
     });
-    this.hooks.renderChangelogLine.tap("Default", ([commit, line]) => [
-      commit,
-      line,
-    ]);
+    this.hooks.renderChangelogLine.tap("Default", (line) => line);
     this.hooks.renderChangelogTitle.tap(
       "Default",
       (label, changelogTitles) => `#### ${changelogTitles[label]}\n`
@@ -394,10 +391,10 @@ export default class Changelog {
               return true;
             }
 
-            const [, line] = await this.hooks.renderChangelogLine.promise([
-              commit,
+            const line = await this.hooks.renderChangelogLine.promise(
               await this.generateCommitNote(commit),
-            ]);
+              commit
+            );
 
             lines.add(line);
           })

--- a/packages/core/src/utils/get-lerna-packages.ts
+++ b/packages/core/src/utils/get-lerna-packages.ts
@@ -1,6 +1,6 @@
 import execPromise from "./exec-promise";
 
-interface LernaPackage {
+export interface LernaPackage {
   /** Path to package */
   path: string;
   /** Name of package */

--- a/packages/core/src/utils/make-hooks.ts
+++ b/packages/core/src/utils/make-hooks.ts
@@ -31,10 +31,10 @@ export const makeHooks = (): IAutoHooks => ({
   getRepository: new AsyncSeriesBailHook(),
   prCheck: new AsyncSeriesBailHook(["prInformation"]),
   version: new AsyncParallelHook(["version"]),
-  afterVersion: new AsyncParallelHook(),
+  afterVersion: new AsyncParallelHook(["context"]),
   publish: new AsyncParallelHook(["version"]),
   afterPublish: new AsyncParallelHook(),
-  canary: new AsyncSeriesBailHook(["canaryVersion", "postFix"]),
+  canary: new AsyncSeriesBailHook(["canaryContext"]),
   next: new AsyncSeriesWaterfallHook(["preReleaseVersions", "bump", "context"]),
 });
 

--- a/packages/core/src/utils/make-hooks.ts
+++ b/packages/core/src/utils/make-hooks.ts
@@ -20,7 +20,7 @@ export const makeHooks = (): IAutoHooks => ({
   beforeShipIt: new AsyncSeriesHook(["context"]),
   afterChangelog: new AsyncSeriesHook(["context"]),
   beforeCommitChangelog: new AsyncSeriesHook(["context"]),
-  afterShipIt: new AsyncParallelHook(["version", "commits", "context"]),
+  afterShipIt: new AsyncParallelHook(["context"]),
   makeRelease: new AsyncSeriesBailHook(["releaseInfo"]),
   afterRelease: new AsyncParallelHook(["releaseInfo"]),
   onCreateRelease: new SyncHook(["options"]),
@@ -35,7 +35,7 @@ export const makeHooks = (): IAutoHooks => ({
   publish: new AsyncParallelHook(["version"]),
   afterPublish: new AsyncParallelHook(),
   canary: new AsyncSeriesBailHook(["canaryContext"]),
-  next: new AsyncSeriesWaterfallHook(["preReleaseVersions", "bump", "context"]),
+  next: new AsyncSeriesWaterfallHook(["preReleaseVersions", "context"]),
 });
 
 /** Make the hooks for "Release" */

--- a/packages/core/src/utils/make-hooks.ts
+++ b/packages/core/src/utils/make-hooks.ts
@@ -64,7 +64,7 @@ export const makeInteractiveInitHooks = (): InteractiveInitHooks => ({
 export const makeChangelogHooks = (): IChangelogHooks => ({
   addToBody: new AsyncSeriesWaterfallHook(["notes", "commits"]),
   sortChangelogLines: new AsyncSeriesWaterfallHook(["lines"]),
-  renderChangelogLine: new AsyncSeriesWaterfallHook(["lineData"]),
+  renderChangelogLine: new AsyncSeriesWaterfallHook(["line", "commit"]),
   renderChangelogTitle: new AsyncSeriesBailHook(["commits", "lineRender"]),
   renderChangelogAuthor: new AsyncSeriesBailHook([
     "author",

--- a/packages/core/src/utils/make-hooks.ts
+++ b/packages/core/src/utils/make-hooks.ts
@@ -18,7 +18,7 @@ export const makeHooks = (): IAutoHooks => ({
   modifyConfig: new SyncWaterfallHook(["config"]),
   validateConfig: new AsyncSeriesBailHook(["name", "options"]),
   beforeShipIt: new AsyncSeriesHook(["context"]),
-  afterAddToChangelog: new AsyncSeriesHook(["context"]),
+  afterChangelog: new AsyncSeriesHook(["context"]),
   beforeCommitChangelog: new AsyncSeriesHook(["context"]),
   afterShipIt: new AsyncParallelHook(["version", "commits", "context"]),
   makeRelease: new AsyncSeriesBailHook(["releaseInfo"]),

--- a/plugins/all-contributors/__tests__/all-contributors.test.ts
+++ b/plugins/all-contributors/__tests__/all-contributors.test.ts
@@ -28,7 +28,7 @@ jest.mock("child_process");
 jest.mock("all-contributors-cli/dist/contributors");
 jest.mock("all-contributors-cli/dist/generate");
 
-// @ts-ignore 
+// @ts-ignore
 generateReadme.mockImplementation(generateMock);
 // @ts-ignore
 addContributor.mockImplementation(addContributorMock);
@@ -38,7 +38,10 @@ env.mockImplementation(envMock);
 jest.mock("../../../packages/core/dist/utils/exec-promise", () => (...args) =>
   gitShow(...args)
 );
-jest.mock("../../../packages/core/dist/utils/get-lerna-packages", () => (...args: any[]) => getLernaPackages(...args));
+jest.mock(
+  "../../../packages/core/dist/utils/get-lerna-packages",
+  () => (...args: any[]) => getLernaPackages(...args)
+);
 jest.spyOn(process, "chdir").mockReturnValue();
 
 const mockRead = (result: string) =>
@@ -264,7 +267,7 @@ describe("All Contributors Plugin", () => {
 
     releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto.Auto);
 
-    await autoHooks.afterAddToChangelog.promise({
+    await autoHooks.afterChangelog.promise({
       bump: Auto.SEMVER.patch,
       currentVersion: "0.0.0",
       lastRelease: "0.0.0",
@@ -296,7 +299,7 @@ describe("All Contributors Plugin", () => {
 
     releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto.Auto);
 
-    await autoHooks.afterAddToChangelog.promise({
+    await autoHooks.afterChangelog.promise({
       bump: Auto.SEMVER.patch,
       currentVersion: "0.0.0",
       lastRelease: "0.0.0",
@@ -325,7 +328,7 @@ describe("All Contributors Plugin", () => {
 
     releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto.Auto);
 
-    await autoHooks.afterAddToChangelog.promise({
+    await autoHooks.afterChangelog.promise({
       bump: Auto.SEMVER.patch,
       currentVersion: "0.0.0",
       lastRelease: "0.0.0",
@@ -353,7 +356,7 @@ describe("All Contributors Plugin", () => {
 
     releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto.Auto);
 
-    await autoHooks.afterAddToChangelog.promise({
+    await autoHooks.afterChangelog.promise({
       bump: Auto.SEMVER.patch,
       currentVersion: "0.0.0",
       lastRelease: "0.0.0",
@@ -380,7 +383,7 @@ describe("All Contributors Plugin", () => {
 
     releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto.Auto);
 
-    await autoHooks.afterAddToChangelog.promise({
+    await autoHooks.afterChangelog.promise({
       bump: Auto.SEMVER.patch,
       currentVersion: "0.0.0",
       lastRelease: "0.0.0",
@@ -429,7 +432,7 @@ describe("All Contributors Plugin", () => {
 
     releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto.Auto);
 
-    await autoHooks.afterAddToChangelog.promise({
+    await autoHooks.afterChangelog.promise({
       bump: Auto.SEMVER.patch,
       currentVersion: "0.0.0",
       lastRelease: "0.0.0",
@@ -472,7 +475,7 @@ describe("All Contributors Plugin", () => {
 
     releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto.Auto);
 
-    await autoHooks.afterAddToChangelog.promise({
+    await autoHooks.afterChangelog.promise({
       bump: Auto.SEMVER.patch,
       currentVersion: "0.0.0",
       lastRelease: "0.0.0",
@@ -501,7 +504,7 @@ describe("All Contributors Plugin", () => {
 
     releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto.Auto);
 
-    await autoHooks.afterAddToChangelog.promise({
+    await autoHooks.afterChangelog.promise({
       bump: Auto.SEMVER.patch,
       currentVersion: "0.0.0",
       lastRelease: "0.0.0",
@@ -535,7 +538,7 @@ describe("All Contributors Plugin", () => {
 
     releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto.Auto);
 
-    await autoHooks.afterAddToChangelog.promise({
+    await autoHooks.afterChangelog.promise({
       bump: Auto.SEMVER.patch,
       currentVersion: "0.0.0",
       lastRelease: "0.0.0",
@@ -564,7 +567,7 @@ describe("All Contributors Plugin", () => {
 
     releasedLabel.apply({ hooks: autoHooks, logger: dummyLog() } as Auto.Auto);
 
-    await autoHooks.afterAddToChangelog.promise({
+    await autoHooks.afterChangelog.promise({
       bump: Auto.SEMVER.patch,
       currentVersion: "0.0.0",
       lastRelease: "0.0.0",

--- a/plugins/brew/__tests__/brew.test.ts
+++ b/plugins/brew/__tests__/brew.test.ts
@@ -50,7 +50,7 @@ describe("Brew Plugin", () => {
 
     brewPlugin.apply({ hooks: autoHooks, logger: dummyLog() } as Auto);
 
-    await autoHooks.afterVersion.promise();
+    await autoHooks.afterVersion.promise({});
 
     expect(exec).not.toHaveBeenCalled();
   });
@@ -73,7 +73,7 @@ describe("Brew Plugin", () => {
       },
     } as unknown) as Auto);
 
-    await autoHooks.afterVersion.promise();
+    await autoHooks.afterVersion.promise({});
 
     expect(exit).toHaveBeenCalled();
   });
@@ -118,7 +118,7 @@ describe("Brew Plugin", () => {
     readFileSync.mockReturnValueOnce("");
     exec.mockReturnValueOnce("1234 1234");
 
-    await autoHooks.afterVersion.promise();
+    await autoHooks.afterVersion.promise({});
 
     expect(mkdirSync).toHaveBeenCalled();
   });
@@ -137,7 +137,7 @@ describe("Brew Plugin", () => {
     readFileSync.mockReturnValueOnce("");
     exec.mockReturnValueOnce("1234 1234");
 
-    await autoHooks.afterVersion.promise();
+    await autoHooks.afterVersion.promise({});
 
     expect(mkdirSync).not.toHaveBeenCalled();
   });
@@ -155,7 +155,7 @@ describe("Brew Plugin", () => {
     readFileSync.mockReturnValueOnce("$VERSION $SHA");
     exec.mockReturnValueOnce("1234 1234");
 
-    await autoHooks.afterVersion.promise();
+    await autoHooks.afterVersion.promise({});
 
     expect(writeFileSync).toHaveBeenCalledWith(
       "./Formula/foo.rb",
@@ -179,7 +179,7 @@ describe("Brew Plugin", () => {
     readFileSync.mockReturnValue("$VERSION $SHA");
     exec.mockReturnValue("1234 1234");
 
-    await autoHooks.afterVersion.promise();
+    await autoHooks.afterVersion.promise({});
 
     expect(writeFileSync).toHaveBeenCalledWith(
       "./Formula/foo.rb",

--- a/plugins/brew/src/index.ts
+++ b/plugins/brew/src/index.ts
@@ -46,8 +46,12 @@ export default class BrewPlugin implements IPlugin {
       }
     });
 
-    auto.hooks.afterVersion.tapPromise("Update brew", async () => {
-      this.formulas.map((formula) => this.createFormula(auto, formula));
+    auto.hooks.afterVersion.tapPromise("Update brew", async ({ dryRun }) => {
+      if (!dryRun) {
+        await Promise.all(
+          this.formulas.map((formula) => this.createFormula(auto, formula))
+        );
+      }
     });
   }
 

--- a/plugins/cocoapods/__tests__/cocoapods.test.ts
+++ b/plugins/cocoapods/__tests__/cocoapods.test.ts
@@ -148,7 +148,7 @@ describe("Cocoapods Plugin", () => {
 
       const mock = jest.spyOn(utilities, "writePodspecContents");
 
-      await hooks.version.promise(Auto.SEMVER.patch);
+      await hooks.version.promise({ bump: Auto.SEMVER.patch });
 
       expect(mock).lastCalledWith(expect.any(String), specWithVersion("0.0.2"));
     });
@@ -157,7 +157,7 @@ describe("Cocoapods Plugin", () => {
 
       const mock = jest.spyOn(utilities, "writePodspecContents");
 
-      await hooks.version.promise(Auto.SEMVER.minor);
+      await hooks.version.promise({ bump: Auto.SEMVER.minor });
 
       expect(mock).lastCalledWith(expect.any(String), specWithVersion("0.1.0"));
     });
@@ -166,7 +166,7 @@ describe("Cocoapods Plugin", () => {
 
       const mock = jest.spyOn(utilities, "writePodspecContents");
 
-      await hooks.version.promise(Auto.SEMVER.major);
+      await hooks.version.promise({ bump: Auto.SEMVER.major });
 
       expect(mock).lastCalledWith(expect.any(String), specWithVersion("1.0.0"));
     });
@@ -180,7 +180,7 @@ describe("Cocoapods Plugin", () => {
         });
 
       await expect(
-        hooks.version.promise(Auto.SEMVER.major)
+        hooks.version.promise({ bump: Auto.SEMVER.major })
       ).rejects.toThrowError(
         "Error updating version in podspec: ./Test.podspec"
       );

--- a/plugins/cocoapods/__tests__/cocoapods.test.ts
+++ b/plugins/cocoapods/__tests__/cocoapods.test.ts
@@ -247,7 +247,7 @@ describe("Cocoapods Plugin", () => {
         prefixRelease,
       } as Auto.Auto);
 
-      await hook.publish.promise(Auto.SEMVER.patch);
+      await hook.publish.promise({ bump: Auto.SEMVER.patch });
 
       expect(exec).toBeCalledTimes(2);
       expect(exec).lastCalledWith("pod", ["trunk", "push", "./Test.podspec"]);
@@ -264,7 +264,7 @@ describe("Cocoapods Plugin", () => {
         prefixRelease,
       } as Auto.Auto);
 
-      await hook.publish.promise(Auto.SEMVER.patch);
+      await hook.publish.promise({ bump: Auto.SEMVER.patch });
 
       expect(exec).toBeCalledTimes(2);
       expect(exec).lastCalledWith("notpod", [
@@ -288,7 +288,7 @@ describe("Cocoapods Plugin", () => {
         prefixRelease,
       } as Auto.Auto);
 
-      await hook.publish.promise(Auto.SEMVER.patch);
+      await hook.publish.promise({ bump: Auto.SEMVER.patch });
 
       expect(exec).toBeCalledTimes(2);
       expect(exec).lastCalledWith("bundle", [
@@ -317,7 +317,7 @@ describe("Cocoapods Plugin", () => {
         prefixRelease,
       } as Auto.Auto);
 
-      await hook.publish.promise(Auto.SEMVER.patch);
+      await hook.publish.promise({ bump: Auto.SEMVER.patch });
 
       expect(exec).toBeCalledTimes(2);
       expect(exec).lastCalledWith("pod", [
@@ -347,7 +347,7 @@ describe("Cocoapods Plugin", () => {
         prefixRelease,
       } as Auto.Auto);
 
-      await hook.publish.promise(Auto.SEMVER.patch);
+      await hook.publish.promise({ bump: Auto.SEMVER.patch });
 
       expect(exec).toBeCalledTimes(5);
       expect(exec).toHaveBeenNthCalledWith(2, "pod", ["repo", "list"]);
@@ -391,7 +391,7 @@ describe("Cocoapods Plugin", () => {
         prefixRelease,
       } as Auto.Auto);
 
-      await hook.publish.promise(Auto.SEMVER.patch);
+      await hook.publish.promise({ bump: Auto.SEMVER.patch });
 
       expect(exec).toBeCalledTimes(5);
       expect(exec).toHaveBeenNthCalledWith(2, "pod", ["repo", "list"]);
@@ -454,7 +454,7 @@ trunk
         prefixRelease,
       } as Auto.Auto);
 
-      await hook.publish.promise(Auto.SEMVER.patch);
+      await hook.publish.promise({ bump: Auto.SEMVER.patch });
 
       expect(exec).toBeCalledTimes(6);
       expect(exec).toHaveBeenNthCalledWith(2, "pod", ["repo", "list"]);

--- a/plugins/cocoapods/src/index.ts
+++ b/plugins/cocoapods/src/index.ts
@@ -144,9 +144,19 @@ export default class CocoapodsPlugin implements IPlugin {
       auto.prefixRelease(getVersion(this.options.podspecPath))
     );
 
-    auto.hooks.version.tapPromise(this.name, async (version) => {
+    auto.hooks.version.tapPromise(this.name, async ({ bump, dryRun, quiet }) => {
       const previousVersion = getVersion(this.options.podspecPath);
-      const releaseVersion = inc(previousVersion, version as ReleaseType);
+      const releaseVersion = inc(previousVersion, bump as ReleaseType);
+
+      if (dryRun && releaseVersion) {
+        if (quiet) {
+          console.log(releaseVersion);
+        } else {
+          auto.logger.log.info(`Would have published: ${releaseVersion}`);
+        }
+
+        return;
+      }
 
       if (!releaseVersion) {
         throw new Error(

--- a/plugins/crates/__tests__/crates.test.ts
+++ b/plugins/crates/__tests__/crates.test.ts
@@ -41,8 +41,9 @@ const writeFile = jest.fn();
 const writeFileSync = jest.fn();
 const readResult = "{}";
 
-jest.mock("../../../packages/core/dist/utils/exec-promise", () => (...args: any[]) =>
-  exec(...args)
+jest.mock(
+  "../../../packages/core/dist/utils/exec-promise",
+  () => (...args: any[]) => exec(...args)
 );
 // @ts-ignore
 jest.mock("env-ci", () => () => ({ isCi: false }));
@@ -199,7 +200,7 @@ describe("CratesPlugin", () => {
 
         const hooks = makeHooks();
         plugin.apply({ hooks, logger: dummyLog() } as Auto.Auto);
-        await hooks.version.promise(Auto.SEMVER.patch);
+        await hooks.version.promise({ bump: Auto.SEMVER.patch });
         expect(exec).toHaveBeenCalledWith("cargo", ["build"]);
         expect(exec).toHaveBeenCalledWith("git", [
           "add",

--- a/plugins/crates/__tests__/crates.test.ts
+++ b/plugins/crates/__tests__/crates.test.ts
@@ -226,7 +226,7 @@ describe("CratesPlugin", () => {
           remote: "origin",
           baseBranch: "master",
         } as Auto.Auto);
-        await hooks.publish.promise(Auto.SEMVER.patch);
+        await hooks.publish.promise({ bump: Auto.SEMVER.patch });
         expect(exec).toHaveBeenCalledWith("cargo", ["publish"]);
         expect(exec).toHaveBeenCalledWith("git", [
           "push",

--- a/plugins/docker/__tests__/docker.test.ts
+++ b/plugins/docker/__tests__/docker.test.ts
@@ -165,7 +165,7 @@ describe("Docker Plugin", () => {
   describe("canary", () => {
     test("should do nothing without git", async () => {
       const hooks = setup();
-      await hooks.next.promise([], Auto.SEMVER.patch, {} as any);
+      await hooks.next.promise([], { bump: Auto.SEMVER.patch } as any);
       expect(exec).not.toHaveBeenCalled();
     });
 
@@ -223,7 +223,7 @@ describe("Docker Plugin", () => {
   describe("next", () => {
     test("should do nothing without git", async () => {
       const hooks = setup();
-      await hooks.next.promise([], Auto.SEMVER.patch, {} as any);
+      await hooks.next.promise([], { bump: Auto.SEMVER.patch } as any);
       expect(exec).not.toHaveBeenCalled();
     });
 
@@ -237,7 +237,7 @@ describe("Docker Plugin", () => {
         { registry, image: sourceImage }
       );
 
-      await hooks.next.promise([], Auto.SEMVER.patch, {} as any);
+      await hooks.next.promise([], { bump: Auto.SEMVER.patch } as any);
 
       expect(exec).toHaveBeenCalledWith("git", [
         "tag",
@@ -273,7 +273,8 @@ describe("Docker Plugin", () => {
       );
 
       expect(
-        await hooks.next.promise([], Auto.SEMVER.patch, {
+        await hooks.next.promise([], {
+          bump: Auto.SEMVER.patch,
           dryRun: true,
           quiet: true,
         } as any)
@@ -295,7 +296,7 @@ describe("Docker Plugin", () => {
       );
       await hooks.version.promise({ bump: Auto.SEMVER.patch });
 
-      await hooks.publish.promise(Auto.SEMVER.patch);
+      await hooks.publish.promise({ bump: Auto.SEMVER.patch });
       expect(exec).toHaveBeenCalledWith("docker", [
         "push",
         `${registry}:1.0.1`,
@@ -314,7 +315,7 @@ describe("Docker Plugin", () => {
       );
       await hooks.version.promise({ bump: Auto.SEMVER.patch });
 
-      await hooks.publish.promise(Auto.SEMVER.patch);
+      await hooks.publish.promise({ bump: Auto.SEMVER.patch });
       expect(exec).toHaveBeenCalledWith("docker", [
         "push",
         `${registry}:1.0.1`,

--- a/plugins/docker/__tests__/docker.test.ts
+++ b/plugins/docker/__tests__/docker.test.ts
@@ -8,8 +8,9 @@ const exec = jest.fn();
 jest.mock("../../../packages/core/dist/utils/get-current-branch", () => ({
   getCurrentBranch: () => "next",
 }));
-jest.mock("../../../packages/core/dist/utils/exec-promise", () => (...args: any[]) =>
-  exec(...args)
+jest.mock(
+  "../../../packages/core/dist/utils/exec-promise",
+  () => (...args: any[]) => exec(...args)
 );
 
 const registry = "registry.io/app";
@@ -105,13 +106,13 @@ describe("Docker Plugin", () => {
   describe("version", () => {
     test("should do nothing without git", async () => {
       const hooks = setup();
-      await hooks.version.promise(Auto.SEMVER.patch);
+      await hooks.version.promise({ bump: Auto.SEMVER.patch });
       expect(exec).not.toHaveBeenCalled();
     });
 
     test("should do nothing with a bad version bump", async () => {
       const hooks = setup({ getLatestTagInBranch: () => "v1.0.0" });
-      await hooks.version.promise("wrong" as Auto.SEMVER);
+      await hooks.version.promise({ bump: "wrong" as Auto.SEMVER });
       expect(exec).not.toHaveBeenCalled();
     });
 
@@ -121,7 +122,7 @@ describe("Docker Plugin", () => {
         { getLatestTagInBranch: () => "v1.0.0" },
         { registry, image: sourceImage }
       );
-      await hooks.version.promise(Auto.SEMVER.patch);
+      await hooks.version.promise({ bump: Auto.SEMVER.patch });
       expect(exec).toHaveBeenCalledWith("git", [
         "tag",
         "1.0.1",
@@ -141,7 +142,7 @@ describe("Docker Plugin", () => {
         { getLatestTagInBranch: () => "v1.0.0" },
         { registry, image: sourceImage, tagLatest: true }
       );
-      await hooks.version.promise(Auto.SEMVER.patch);
+      await hooks.version.promise({ bump: Auto.SEMVER.patch });
       expect(exec).toHaveBeenCalledWith("git", [
         "tag",
         "1.0.1",
@@ -178,7 +179,10 @@ describe("Docker Plugin", () => {
         { registry, image: sourceImage }
       );
 
-      await hooks.canary.promise(Auto.SEMVER.patch, ".123.1");
+      await hooks.canary.promise({
+        bump: Auto.SEMVER.patch,
+        canaryIdentifier: "canary.123.1",
+      });
       expect(exec).toHaveBeenCalledWith("docker", [
         "tag",
         sourceImage,
@@ -188,6 +192,31 @@ describe("Docker Plugin", () => {
         "push",
         `${registry}:1.0.1-canary.123.1`,
       ]);
+    });
+
+    test("should print canary version in dry run", async () => {
+      const sourceImage = "app:sha-123";
+      const hooks = setup(
+        {
+          getLatestRelease: () => "v1.0.0",
+          getCurrentVersion: () => "",
+        },
+        { registry, image: sourceImage }
+      );
+
+      const log = jest.fn();
+      jest.spyOn(console, "log").mockImplementation(log);
+
+      await hooks.canary.promise({
+        bump: Auto.SEMVER.patch,
+        canaryIdentifier: "canary.123.1",
+        dryRun: true,
+        quiet: true,
+      });
+
+      expect(log).toHaveBeenCalledWith("1.0.1-canary.123.1");
+
+      expect(exec).not.toHaveBeenCalled();
     });
   });
 
@@ -232,6 +261,25 @@ describe("Docker Plugin", () => {
         `${registry}:1.0.1-next.0`,
       ]);
     });
+
+    test("return next version in dry run", async () => {
+      const sourceImage = "app:sha-123";
+      const hooks = setup(
+        {
+          getLatestRelease: () => "v0.1.0",
+          getLastTagNotInBaseBranch: () => "v1.0.0",
+        },
+        { registry, image: sourceImage }
+      );
+
+      expect(
+        await hooks.next.promise([], Auto.SEMVER.patch, {
+          dryRun: true,
+          quiet: true,
+        } as any)
+      ).toStrictEqual(["1.0.1-next.0"]);
+      expect(exec).not.toHaveBeenCalled();
+    });
   });
 
   describe("publish", () => {
@@ -245,7 +293,7 @@ describe("Docker Plugin", () => {
         },
         { registry, image: sourceImage, tagLatest: false }
       );
-      await hooks.version.promise(Auto.SEMVER.patch);
+      await hooks.version.promise({ bump: Auto.SEMVER.patch });
 
       await hooks.publish.promise(Auto.SEMVER.patch);
       expect(exec).toHaveBeenCalledWith("docker", [
@@ -264,7 +312,7 @@ describe("Docker Plugin", () => {
         },
         { registry, image: sourceImage, tagLatest: true }
       );
-      await hooks.version.promise(Auto.SEMVER.patch);
+      await hooks.version.promise({ bump: Auto.SEMVER.patch });
 
       await hooks.publish.promise(Auto.SEMVER.patch);
       expect(exec).toHaveBeenCalledWith("docker", [

--- a/plugins/docker/src/index.ts
+++ b/plugins/docker/src/index.ts
@@ -162,7 +162,7 @@ export default class DockerPlugin implements IPlugin {
 
     auto.hooks.next.tapPromise(
       this.name,
-      async (preReleaseVersions, bump, { dryRun }) => {
+      async (preReleaseVersions, { bump, dryRun }) => {
         if (!auto.git) {
           return preReleaseVersions;
         }

--- a/plugins/docker/src/index.ts
+++ b/plugins/docker/src/index.ts
@@ -75,100 +75,135 @@ export default class DockerPlugin implements IPlugin {
       return getTag();
     });
 
-    auto.hooks.version.tapPromise(this.name, async (version) => {
-      if (!auto.git) {
-        return;
-      }
+    auto.hooks.version.tapPromise(
+      this.name,
+      async ({ bump, dryRun, quiet }) => {
+        if (!auto.git) {
+          return;
+        }
 
-      const lastTag = await getTag();
-      const newTag = inc(lastTag, version as ReleaseType);
+        const lastTag = await getTag();
+        const newTag = inc(lastTag, bump as ReleaseType);
 
-      if (!newTag) {
-        auto.logger.log.info("No release found, doing nothing");
-        return;
-      }
+        if (dryRun && newTag) {
+          if (quiet) {
+            console.log(newTag);
+          } else {
+            auto.logger.log.info(`Would have published: ${newTag}`);
+          }
 
-      const prefixedTag = auto.prefixRelease(newTag);
+          return;
+        }
 
-      auto.logger.log.info(`Tagging new tag: ${lastTag} => ${prefixedTag}`);
-      await execPromise("git", [
-        "tag",
-        prefixedTag,
-        "-m",
-        `"Update version to ${prefixedTag}"`,
-      ]);
+        if (!newTag) {
+          auto.logger.log.info("No release found, doing nothing");
+          return;
+        }
 
-      await execPromise("docker", [
-        "tag",
-        this.options.image,
-        `${this.options.registry}:${newTag}`,
-      ]);
-      this.calculatedTags = [newTag];
+        const prefixedTag = auto.prefixRelease(newTag);
 
-      if (this.options.tagLatest === true && !version.startsWith("pre")) {
+        auto.logger.log.info(`Tagging new tag: ${lastTag} => ${prefixedTag}`);
+        await execPromise("git", [
+          "tag",
+          prefixedTag,
+          "-m",
+          `"Update version to ${prefixedTag}"`,
+        ]);
+
         await execPromise("docker", [
           "tag",
           this.options.image,
-          `${this.options.registry}:latest`,
+          `${this.options.registry}:${newTag}`,
         ]);
-        this.calculatedTags.push("latest");
+        this.calculatedTags = [newTag];
+
+        if (this.options.tagLatest === true && !bump.startsWith("pre")) {
+          await execPromise("docker", [
+            "tag",
+            this.options.image,
+            `${this.options.registry}:latest`,
+          ]);
+          this.calculatedTags.push("latest");
+        }
       }
-    });
+    );
 
-    auto.hooks.canary.tapPromise(this.name, async (version, postFix) => {
-      if (!auto.git) {
-        return;
+    auto.hooks.canary.tapPromise(
+      this.name,
+      async ({ bump, canaryIdentifier, dryRun, quiet }) => {
+        if (!auto.git) {
+          return;
+        }
+
+        const lastRelease = await auto.git.getLatestRelease();
+        const current = await auto.getCurrentVersion(lastRelease);
+        const nextVersion = inc(current, bump as ReleaseType);
+        const canaryVersion = `${nextVersion}-${canaryIdentifier}`;
+
+        if (dryRun) {
+          if (quiet) {
+            console.log(canaryVersion);
+          } else {
+            auto.logger.log.info(`Would have published: ${canaryVersion}`);
+          }
+
+          return;
+        }
+
+        const targetImage = `${this.options.registry}:${canaryVersion}`;
+
+        await execPromise("docker", ["tag", this.options.image, targetImage]);
+        await execPromise("docker", ["push", targetImage]);
+
+        auto.logger.verbose.info("Successfully published canary version");
+        return canaryVersion;
       }
+    );
 
-      const lastRelease = await auto.git.getLatestRelease();
-      const current = await auto.getCurrentVersion(lastRelease);
-      const nextVersion = inc(current, version as ReleaseType);
-      const canaryVersion = `${nextVersion}-canary${postFix}`;
-      const targetImage = `${this.options.registry}:${canaryVersion}`;
+    auto.hooks.next.tapPromise(
+      this.name,
+      async (preReleaseVersions, bump, { dryRun }) => {
+        if (!auto.git) {
+          return preReleaseVersions;
+        }
 
-      await execPromise("docker", ["tag", this.options.image, targetImage]);
-      await execPromise("docker", ["push", targetImage]);
+        const prereleaseBranches =
+          auto.config?.prereleaseBranches ?? DEFAULT_PRERELEASE_BRANCHES;
+        const branch = getCurrentBranch() || "";
+        const prereleaseBranch = prereleaseBranches.includes(branch)
+          ? branch
+          : prereleaseBranches[0];
+        const lastRelease = await auto.git.getLatestRelease();
+        const current =
+          (await auto.git.getLastTagNotInBaseBranch(prereleaseBranch)) ||
+          (await auto.getCurrentVersion(lastRelease));
+        const prerelease = determineNextVersion(
+          lastRelease,
+          current,
+          bump,
+          prereleaseBranch
+        );
+        const targetImage = `${this.options.registry}:${prerelease}`;
 
-      auto.logger.verbose.info("Successfully published canary version");
-      return canaryVersion;
-    });
+        preReleaseVersions.push(prerelease);
 
-    auto.hooks.next.tapPromise(this.name, async (preReleaseVersions, bump) => {
-      if (!auto.git) {
+        if (dryRun) {
+          return preReleaseVersions;
+        }
+
+        await execPromise("git", [
+          "tag",
+          prerelease,
+          "-m",
+          `"Tag pre-release: ${prerelease}"`,
+        ]);
+        await execPromise("docker", ["tag", this.options.image, targetImage]);
+        await execPromise("docker", ["push", targetImage]);
+        await execPromise("git", ["push", auto.remote, branch, "--tags"]);
+
         return preReleaseVersions;
       }
-
-      const prereleaseBranches =
-        auto.config?.prereleaseBranches ?? DEFAULT_PRERELEASE_BRANCHES;
-      const branch = getCurrentBranch() || "";
-      const prereleaseBranch = prereleaseBranches.includes(branch)
-        ? branch
-        : prereleaseBranches[0];
-      const lastRelease = await auto.git.getLatestRelease();
-      const current =
-        (await auto.git.getLastTagNotInBaseBranch(prereleaseBranch)) ||
-        (await auto.getCurrentVersion(lastRelease));
-      const prerelease = determineNextVersion(
-        lastRelease,
-        current,
-        bump,
-        prereleaseBranch
-      );
-      const targetImage = `${this.options.registry}:${prerelease}`;
-
-      await execPromise("git", [
-        "tag",
-        prerelease,
-        "-m",
-        `"Tag pre-release: ${prerelease}"`,
-      ]);
-      await execPromise("docker", ["tag", this.options.image, targetImage]);
-      await execPromise("docker", ["push", targetImage]);
-      await execPromise("git", ["push", auto.remote, branch, "--tags"]);
-
-      preReleaseVersions.push(prerelease);
-      return preReleaseVersions;
-    });
+    );
 
     auto.hooks.publish.tapPromise(this.name, async () => {
       auto.logger.log.info("Pushing new tag to GitHub");

--- a/plugins/exec/__tests__/exec.test.ts
+++ b/plugins/exec/__tests__/exec.test.ts
@@ -46,7 +46,7 @@ describe("Exec Plugin", () => {
     const hooks = makeHooks();
 
     plugins.apply({ hooks } as Auto);
-    await hooks.version.promise(SEMVER.patch);
+    await hooks.version.promise({ bump: SEMVER.patch });
 
     expect(execSpy).toHaveBeenCalledWith("echo bar", expect.anything());
   });
@@ -92,9 +92,12 @@ describe("Exec Plugin", () => {
       execSpy.mockReturnValueOnce(canaryVersion);
       plugins.apply({ hooks } as Auto);
 
-      expect(await hooks.canary.promise(SEMVER.patch, "-canary")).toBe(
-        canaryVersion
-      );
+      expect(
+        await hooks.canary.promise({
+          bump: SEMVER.patch,
+          canaryIdentifier: "-canary",
+        })
+      ).toBe(canaryVersion);
     });
 
     test("should handle object return values", async () => {
@@ -107,9 +110,12 @@ describe("Exec Plugin", () => {
       execSpy.mockReturnValueOnce(JSON.stringify(canaryVersion));
       plugins.apply({ hooks } as Auto);
 
-      expect(await hooks.canary.promise(SEMVER.patch, "-canary")).toStrictEqual(
-        canaryVersion
-      );
+      expect(
+        await hooks.canary.promise({
+          bump: SEMVER.patch,
+          canaryIdentifier: "-canary",
+        })
+      ).toStrictEqual(canaryVersion);
     });
   });
 

--- a/plugins/exec/__tests__/exec.test.ts
+++ b/plugins/exec/__tests__/exec.test.ts
@@ -192,7 +192,7 @@ describe("Exec Plugin", () => {
       plugins.apply({ hooks } as Auto);
       hooks.onCreateChangelog.call(
         { hooks: changelogHooks } as any,
-        SEMVER.patch
+        { bump: SEMVER.patch }
       );
 
       expect(

--- a/plugins/first-time-contributor/__tests__/first-time-contributor.test.ts
+++ b/plugins/first-time-contributor/__tests__/first-time-contributor.test.ts
@@ -13,8 +13,9 @@ const graphql = jest.fn();
 const exec = jest.fn();
 exec.mockReturnValue("");
 // @ts-ignore
-jest.mock("../../../packages/core/dist/utils/exec-promise", () => (...args: any[]) =>
-  exec(...args)
+jest.mock(
+  "../../../packages/core/dist/utils/exec-promise",
+  () => (...args: any[]) => exec(...args)
 );
 
 const setup = (
@@ -45,7 +46,7 @@ const setup = (
       hooks: changelogHooks,
       options: { baseUrl: "https://github.com" },
     } as Changelog,
-    Auto.SEMVER.patch
+    { bump: Auto.SEMVER.patch }
   );
 
   return changelogHooks;

--- a/plugins/gem/__tests__/gem.test.ts
+++ b/plugins/gem/__tests__/gem.test.ts
@@ -277,7 +277,7 @@ describe("Gem Plugin", () => {
       const hooks = makeHooks();
 
       plugin.apply({ hooks, logger } as any);
-      await hooks.publish.promise(SEMVER.minor);
+      await hooks.publish.promise({ bump: SEMVER.minor });
 
       expect(execSpy).toHaveBeenCalledWith("bundle", ["exec", "rake", "build"]);
     });
@@ -296,7 +296,7 @@ describe("Gem Plugin", () => {
       const hooks = makeHooks();
 
       plugin.apply({ hooks, logger } as any);
-      await hooks.publish.promise(SEMVER.minor);
+      await hooks.publish.promise({ bump: SEMVER.minor });
 
       expect(execSyncSpy).toHaveBeenCalledWith("gem release --tag --push", {
         stdio: "inherit",

--- a/plugins/gem/__tests__/gem.test.ts
+++ b/plugins/gem/__tests__/gem.test.ts
@@ -19,8 +19,9 @@ const execSpy = jest.fn();
 execSpy.mockReturnValue("");
 
 // @ts-ignore
-jest.mock("../../../packages/core/dist/utils/exec-promise", () => (...args: any[]) =>
-  execSpy(...args)
+jest.mock(
+  "../../../packages/core/dist/utils/exec-promise",
+  () => (...args: any[]) => execSpy(...args)
 );
 
 const globSpy = jest.fn();
@@ -232,7 +233,7 @@ describe("Gem Plugin", () => {
       const hooks = makeHooks();
 
       plugin.apply({ hooks, logger } as any);
-      await hooks.version.promise(SEMVER.minor);
+      await hooks.version.promise({ bump: SEMVER.minor });
 
       expect(writeFile).toHaveBeenCalledWith(
         "test.gemspec",
@@ -257,9 +258,9 @@ describe("Gem Plugin", () => {
 
       plugin.apply({ hooks, logger } as any);
 
-      await expect(hooks.version.promise(SEMVER.minor)).rejects.toBeInstanceOf(
-        Error
-      );
+      await expect(
+        hooks.version.promise({ bump: SEMVER.minor })
+      ).rejects.toBeInstanceOf(Error);
     });
   });
 

--- a/plugins/gem/src/index.ts
+++ b/plugins/gem/src/index.ts
@@ -93,19 +93,32 @@ export default class GemPlugin implements IPlugin {
       };
     });
 
-    auto.hooks.version.tapPromise(this.name, async (bump) => {
-      const [version, versionFile] = await this.getVersion(auto);
-      const newTag = inc(version, bump as ReleaseType);
+    auto.hooks.version.tapPromise(
+      this.name,
+      async ({ bump, dryRun, quiet }) => {
+        const [version, versionFile] = await this.getVersion(auto);
+        const newTag = inc(version, bump as ReleaseType);
 
-      if (!newTag) {
-        throw new Error(
-          `The version "${version}" parsed from your version file "${versionFile}" was invalid and could not be incremented. Please fix this!`
-        );
+        if (dryRun && newTag) {
+          if (quiet) {
+            console.log(newTag);
+          } else {
+            auto.logger.log.info(`Would have published: ${newTag}`);
+          }
+
+          return;
+        }
+
+        if (!newTag) {
+          throw new Error(
+            `The version "${version}" parsed from your version file "${versionFile}" was invalid and could not be incremented. Please fix this!`
+          );
+        }
+
+        const content = await readFile(versionFile, { encoding: "utf8" });
+        await writeFile(versionFile, content.replace(version, newTag));
       }
-
-      const content = await readFile(versionFile, { encoding: "utf8" });
-      await writeFile(versionFile, content.replace(version, newTag));
-    });
+    );
 
     auto.hooks.publish.tapPromise(this.name, async () => {
       if (

--- a/plugins/git-tag/__tests__/git-tag.test.ts
+++ b/plugins/git-tag/__tests__/git-tag.test.ts
@@ -88,7 +88,7 @@ describe("Git Tag Plugin", () => {
   describe("next", () => {
     test("should do nothing without git", async () => {
       const hooks = setup();
-      await hooks.next.promise([], Auto.SEMVER.patch, {} as any);
+      await hooks.next.promise([], { bump: Auto.SEMVER.patch } as any);
       expect(exec).not.toHaveBeenCalled();
     });
 
@@ -98,7 +98,7 @@ describe("Git Tag Plugin", () => {
         getLastTagNotInBaseBranch: () => "v1.0.0",
       });
 
-      await hooks.next.promise([], Auto.SEMVER.patch, {} as any);
+      await hooks.next.promise([], { bump: Auto.SEMVER.patch } as any);
 
       expect(exec).toHaveBeenCalledWith("git", [
         "tag",
@@ -121,7 +121,10 @@ describe("Git Tag Plugin", () => {
       });
 
       expect(
-        await hooks.next.promise([], Auto.SEMVER.patch, { dryRun: true } as any)
+        await hooks.next.promise([], {
+          bump: Auto.SEMVER.patch,
+          dryRun: true,
+        } as any)
       ).toStrictEqual(["v1.0.1-next.0"]);
 
       expect(exec).not.toHaveBeenCalled();

--- a/plugins/git-tag/src/index.ts
+++ b/plugins/git-tag/src/index.ts
@@ -73,7 +73,7 @@ export default class GitTagPlugin implements IPlugin {
 
     auto.hooks.next.tapPromise(
       this.name,
-      async (preReleaseVersions, bump, { dryRun }) => {
+      async (preReleaseVersions, { bump, dryRun }) => {
         if (!auto.git) {
           return preReleaseVersions;
         }

--- a/plugins/gradle/__tests__/gradle.test.ts
+++ b/plugins/gradle/__tests__/gradle.test.ts
@@ -8,8 +8,9 @@ import GradleReleasePlugin, {
 
 const exec = jest.fn();
 
-jest.mock("../../../packages/core/dist/utils/exec-promise", () => (...args: any[]) =>
-  exec(...args)
+jest.mock(
+  "../../../packages/core/dist/utils/exec-promise",
+  () => (...args: any[]) => exec(...args)
 );
 
 describe("Gradle Plugin", () => {
@@ -47,7 +48,7 @@ describe("Gradle Plugin", () => {
       const spy = jest.fn();
       exec.mockReturnValueOnce(properties).mockImplementation(spy);
 
-      await hooks.version.promise(Auto.SEMVER.patch);
+      await hooks.version.promise({ bump: Auto.SEMVER.patch });
 
       expect(spy).toHaveBeenCalledWith(expect.stringMatching("gradle"), [
         "release",
@@ -67,7 +68,7 @@ describe("Gradle Plugin", () => {
       const spy = jest.fn();
       exec.mockReturnValueOnce(properties).mockImplementation(spy);
 
-      await hooks.version.promise(Auto.SEMVER.major);
+      await hooks.version.promise({ bump: Auto.SEMVER.major });
 
       expect(spy).toHaveBeenCalledWith(expect.stringMatching("gradle"), [
         "release",
@@ -88,7 +89,7 @@ describe("Gradle Plugin", () => {
       const spy = jest.fn();
       exec.mockReturnValueOnce(properties).mockImplementation(spy);
 
-      await hooks.version.promise(Auto.SEMVER.major);
+      await hooks.version.promise({ bump: Auto.SEMVER.major });
 
       expect(spy).toHaveBeenCalledWith(expect.stringMatching("gradle"), [
         "release",
@@ -108,7 +109,7 @@ describe("Gradle Plugin", () => {
       const spy = jest.fn();
       exec.mockReturnValueOnce(properties).mockImplementation(spy);
 
-      await hooks.version.promise(Auto.SEMVER.minor);
+      await hooks.version.promise({ bump: Auto.SEMVER.minor });
 
       expect(spy).toHaveBeenCalledWith(expect.stringMatching("gradle"), [
         "release",
@@ -128,7 +129,7 @@ describe("Gradle Plugin", () => {
       const spy = jest.fn();
       exec.mockReturnValueOnce(properties).mockImplementation(spy);
 
-      await hooks.version.promise(Auto.SEMVER.patch);
+      await hooks.version.promise({ bump: Auto.SEMVER.patch });
 
       expect(spy).toHaveBeenCalledWith(expect.stringMatching("gradle"), [
         "release",
@@ -152,7 +153,7 @@ describe("Gradle Plugin", () => {
       const spy = jest.fn();
       exec.mockReturnValueOnce(properties).mockImplementation(spy);
 
-      await hooks.version.promise(Auto.SEMVER.patch);
+      await hooks.version.promise({ bump: Auto.SEMVER.patch });
 
       expect(spy).toHaveBeenCalledWith(expect.stringMatching("gradle"), [
         "release",
@@ -187,7 +188,7 @@ describe("Gradle Plugin - Custom Command", () => {
       const spy = jest.fn();
       exec.mockReturnValueOnce("version: 1.0.0").mockImplementation(spy);
 
-      await hooks.version.promise(Auto.SEMVER.patch);
+      await hooks.version.promise({ bump: Auto.SEMVER.patch });
 
       expect(spy).toHaveBeenCalledWith(expect.stringMatching("gradlew"), [
         "release",

--- a/plugins/jira/__tests__/jira.test.ts
+++ b/plugins/jira/__tests__/jira.test.ts
@@ -81,7 +81,7 @@ describe("render jira", () => {
     );
 
     expect(
-      (await changelogHooks.renderChangelogLine.promise([commit, "Add log"]))[1]
+      await changelogHooks.renderChangelogLine.promise("Add log", commit)
     ).toBe("Add log");
   });
 
@@ -96,10 +96,10 @@ describe("render jira", () => {
       SEMVER.patch
     );
 
-    const [, line] = await changelogHooks.renderChangelogLine.promise([
-      makeCommitFromMsg("[PLAYA-5052] Add log"),
+    const line = await changelogHooks.renderChangelogLine.promise(
       "[PLAYA-5052] Add log [author](link/to/author)",
-    ]);
+      makeCommitFromMsg("[PLAYA-5052] Add log")
+    );
 
     expect(line).toBe(
       "[PLAYA-5052](jira.com/PLAYA-5052): Add log [author](link/to/author)"

--- a/plugins/jira/__tests__/jira.test.ts
+++ b/plugins/jira/__tests__/jira.test.ts
@@ -77,7 +77,7 @@ describe("render jira", () => {
     plugin.apply({ hooks, logger: dummyLog() } as Auto);
     await hooks.onCreateChangelog.promise(
       { hooks: changelogHooks } as Changelog,
-      SEMVER.patch
+      { bump: SEMVER.patch }
     );
 
     expect(
@@ -93,7 +93,7 @@ describe("render jira", () => {
     plugin.apply({ hooks, logger: dummyLog() } as Auto);
     await hooks.onCreateChangelog.promise(
       { hooks: changelogHooks } as Changelog,
-      SEMVER.patch
+      { bump: SEMVER.patch }
     );
 
     const line = await changelogHooks.renderChangelogLine.promise(
@@ -123,7 +123,7 @@ test("should create note for jira commits without PR title", async () => {
   const autoHooks = makeHooks();
 
   plugin.apply({ hooks: autoHooks } as Auto);
-  await autoHooks.onCreateChangelog.promise(changelog, SEMVER.patch);
+  await autoHooks.onCreateChangelog.promise(changelog, { bump: SEMVER.patch });
   changelog.loadDefaultHooks();
 
   const normalized = await logParse.normalizeCommits([
@@ -139,7 +139,7 @@ test("should create note for JIRA commits", async () => {
   const autoHooks = makeHooks();
 
   plugin.apply({ hooks: autoHooks } as Auto);
-  await autoHooks.onCreateChangelog.promise(changelog, SEMVER.patch);
+  await autoHooks.onCreateChangelog.promise(changelog, { bump: SEMVER.patch });
   changelog.loadDefaultHooks();
 
   const normalized = await logParse.normalizeCommits([

--- a/plugins/jira/src/index.ts
+++ b/plugins/jira/src/index.ts
@@ -110,7 +110,7 @@ export default class JiraPlugin implements IPlugin {
     auto.hooks.onCreateChangelog.tap(this.name, (changelog) => {
       changelog.hooks.renderChangelogLine.tap(
         this.name,
-        ([commit, currentRender]) => {
+        (currentRender, commit) => {
           let line = currentRender;
           const jiraCommit = parseJira(commit);
 
@@ -124,7 +124,7 @@ export default class JiraPlugin implements IPlugin {
             );
           }
 
-          return [commit, line];
+          return line;
         }
       );
     });

--- a/plugins/maven/__tests__/maven.test.ts
+++ b/plugins/maven/__tests__/maven.test.ts
@@ -46,8 +46,9 @@ const mockReadFile = (result: string) =>
 // @ts-ignore
 execSync.mockImplementation(exec);
 
-jest.mock("../../../packages/core/dist/utils/exec-promise", () => (...args: any[]) =>
-  exec(...args)
+jest.mock(
+  "../../../packages/core/dist/utils/exec-promise",
+  () => (...args: any[]) => exec(...args)
 );
 
 describe("maven", () => {
@@ -262,7 +263,7 @@ describe("maven", () => {
 
       await hooks.beforeRun.promise({} as any);
 
-      await hooks.version.promise(Auto.SEMVER.patch);
+      await hooks.version.promise({ bump: Auto.SEMVER.patch });
 
       const call = exec.mock.calls[0][1];
       expect(call).toContain("tag");
@@ -282,7 +283,7 @@ describe("maven", () => {
 
       await hooks.beforeRun.promise({} as any);
 
-      await hooks.version.promise(Auto.SEMVER.patch);
+      await hooks.version.promise({ bump: Auto.SEMVER.patch });
 
       const call = exec.mock.calls[0][1];
       expect(call).toContain("tag");
@@ -310,7 +311,7 @@ describe("maven", () => {
       mockReadFile(oldPomXml);
 
       await hooks.beforeRun.promise({} as any);
-      await hooks.version.promise(Auto.SEMVER.patch);
+      await hooks.version.promise({ bump: Auto.SEMVER.patch });
 
       expect(await readFile).toHaveBeenCalledTimes(4);
       expect(await readFile).toHaveBeenLastCalledWith(
@@ -344,7 +345,7 @@ describe("maven", () => {
                 </project>`);
 
       await hooks.beforeRun.promise({} as any);
-      await hooks.version.promise(Auto.SEMVER.patch);
+      await hooks.version.promise({ bump: Auto.SEMVER.patch });
 
       expect(await readFile).toHaveBeenCalledTimes(3);
       expect(await readFile).toHaveBeenLastCalledWith(
@@ -398,7 +399,7 @@ describe("maven", () => {
       });
 
       await hooks.beforeRun.promise({} as any);
-      await hooks.version.promise(Auto.SEMVER.patch);
+      await hooks.version.promise({ bump: Auto.SEMVER.patch });
 
       expect(await readFile).toHaveBeenCalledTimes(5);
       expect(await readFile).toHaveBeenLastCalledWith(
@@ -427,7 +428,9 @@ describe("maven", () => {
 
       await hooks.beforeRun.promise({} as any);
 
-      expect(await hooks.version.promise(Auto.SEMVER.minor)).toBeUndefined();
+      expect(
+        await hooks.version.promise({ bump: Auto.SEMVER.minor })
+      ).toBeUndefined();
     });
   });
 

--- a/plugins/maven/__tests__/maven.test.ts
+++ b/plugins/maven/__tests__/maven.test.ts
@@ -462,7 +462,7 @@ describe("maven", () => {
 
       await hooks.beforeRun.promise({} as any);
 
-      await hooks.publish.promise(Auto.SEMVER.patch);
+      await hooks.publish.promise({ bump: Auto.SEMVER.patch });
 
       expect(exec.mock.calls[0][1]).toContain("deploy");
     });

--- a/plugins/maven/src/index.ts
+++ b/plugins/maven/src/index.ts
@@ -222,34 +222,47 @@ export default class MavenPlugin implements IPlugin {
       };
     });
 
-    auto.hooks.version.tapPromise(this.name, async (version: string) => {
-      const previousVersion = await this.getVersion(auto);
-      const releaseVersion =
-        // After release we bump the version by a patch and add -SNAPSHOT
-        // Given that we do not need to increment when versioning, since
-        // it has already been done
-        this.snapshotRelease && version === "patch"
-          ? previousVersion
-          : inc(previousVersion, version as ReleaseType);
+    auto.hooks.version.tapPromise(
+      this.name,
+      async ({ bump, dryRun, quiet }) => {
+        const previousVersion = await this.getVersion(auto);
+        const releaseVersion =
+          // After release we bump the version by a patch and add -SNAPSHOT
+          // Given that we do not need to increment when versioning, since
+          // it has already been done
+          this.snapshotRelease && bump === "patch"
+            ? previousVersion
+            : inc(previousVersion, bump as ReleaseType);
 
-      if (releaseVersion) {
-        await this.updatePoms(
-          releaseVersion,
-          auto,
-          `"Release ${releaseVersion} [skip ci]"`
-        );
+        if (dryRun && releaseVersion) {
+          if (quiet) {
+            console.log(releaseVersion);
+          } else {
+            auto.logger.log.info(`Would have published: ${releaseVersion}`);
+          }
 
-        const newVersion = auto.prefixRelease(releaseVersion);
+          return;
+        }
 
-        // Ensure tag is on this commit, changelog will be added automatically
-        await execPromise("git", [
-          "tag",
-          newVersion,
-          "-m",
-          `"Update version to ${newVersion}"`,
-        ]);
+        if (releaseVersion) {
+          await this.updatePoms(
+            releaseVersion,
+            auto,
+            `"Release ${releaseVersion} [skip ci]"`
+          );
+
+          const newVersion = auto.prefixRelease(releaseVersion);
+
+          // Ensure tag is on this commit, changelog will be added automatically
+          await execPromise("git", [
+            "tag",
+            newVersion,
+            "-m",
+            `"Update version to ${newVersion}"`,
+          ]);
+        }
       }
-    });
+    );
 
     auto.hooks.publish.tapPromise(this.name, async () => {
       auto.logger.verbose.warn(`Running "publish"`);

--- a/plugins/npm/__tests__/monorepo-log.test.ts
+++ b/plugins/npm/__tests__/monorepo-log.test.ts
@@ -112,7 +112,7 @@ test("should group sections for packages", async () => {
     hooks,
     logger: dummyLog(),
   } as Auto.Auto);
-  hooks.onCreateChangelog.call(changelog, Auto.SEMVER.patch);
+  hooks.onCreateChangelog.call(changelog, { bump: Auto.SEMVER.patch });
   changelog.loadDefaultHooks();
 
   const commits = await commitsPromise;
@@ -176,7 +176,7 @@ test("should create sections for packages", async () => {
     hooks,
     logger: dummyLog(),
   } as Auto.Auto);
-  hooks.onCreateChangelog.call(changelog, Auto.SEMVER.patch);
+  hooks.onCreateChangelog.call(changelog, { bump: Auto.SEMVER.patch });
   changelog.loadDefaultHooks();
 
   const commits = await commitsPromise;
@@ -236,7 +236,7 @@ test("should be able to disable sections for packages", async () => {
     hooks,
     logger: dummyLog(),
   } as Auto.Auto);
-  hooks.onCreateChangelog.call(changelog, Auto.SEMVER.patch);
+  hooks.onCreateChangelog.call(changelog, { bump: Auto.SEMVER.patch });
   changelog.loadDefaultHooks();
 
   const commits = await commitsPromise;
@@ -296,7 +296,7 @@ test("should add versions for independent packages", async () => {
     hooks,
     logger: dummyLog(),
   } as Auto.Auto);
-  hooks.onCreateChangelog.call(changelog, Auto.SEMVER.patch);
+  hooks.onCreateChangelog.call(changelog, { bump: Auto.SEMVER.patch });
   changelog.loadDefaultHooks();
 
   const commits = await commitsPromise;

--- a/plugins/npm/__tests__/npm-next.test.ts
+++ b/plugins/npm/__tests__/npm-next.test.ts
@@ -85,7 +85,7 @@ describe("next", () => {
     `;
 
     expect(
-      await hooks.next.promise([], Auto.SEMVER.patch, {} as any)
+      await hooks.next.promise([], { bump: Auto.SEMVER.patch } as any)
     ).toStrictEqual(["1.2.4-next.0"]);
 
     expect(execPromise).toHaveBeenCalledWith("npm", [
@@ -138,7 +138,10 @@ describe("next", () => {
     `;
 
     expect(
-      await hooks.next.promise([], Auto.SEMVER.patch, { dryRun: true } as any)
+      await hooks.next.promise([], {
+        bump: Auto.SEMVER.patch,
+        dryRun: true,
+      } as any)
     ).toStrictEqual(["1.2.4-next.0"]);
     expect(execPromise).not.toHaveBeenCalledWith("npm");
   });
@@ -170,7 +173,7 @@ describe("next", () => {
     `;
 
     expect(
-      await hooks.next.promise([], Auto.SEMVER.patch, {} as any)
+      await hooks.next.promise([], { bump: Auto.SEMVER.patch } as any)
     ).toStrictEqual(["1.2.4-next.0"]);
 
     expect(execPromise).toHaveBeenCalledWith("git", [
@@ -213,7 +216,7 @@ describe("next", () => {
     `;
 
     expect(
-      await hooks.next.promise([], Auto.SEMVER.patch, {} as any)
+      await hooks.next.promise([], { bump: Auto.SEMVER.patch } as any)
     ).toStrictEqual(["1.2.4-next.0"]);
 
     expect(execPromise).toHaveBeenCalledWith("npm", [
@@ -267,7 +270,7 @@ describe("next", () => {
     } as unknown) as Auto.Auto);
 
     expect(
-      await hooks.next.promise([], Auto.SEMVER.patch, {} as any)
+      await hooks.next.promise([], { bump: Auto.SEMVER.patch } as any)
     ).toStrictEqual(["1.2.4-next.0"]);
 
     expect(execPromise).toHaveBeenCalledWith(
@@ -307,7 +310,10 @@ describe("next", () => {
     } as unknown) as Auto.Auto);
 
     expect(
-      await hooks.next.promise([], Auto.SEMVER.patch, { dryRun: true } as any)
+      await hooks.next.promise([], {
+        bump: Auto.SEMVER.patch,
+        dryRun: true,
+      } as any)
     ).toStrictEqual(["1.2.4-next.0"]);
 
     expect(execPromise).not.toHaveBeenCalledWith(
@@ -348,7 +354,7 @@ describe("next", () => {
     } as unknown) as Auto.Auto);
 
     expect(
-      await hooks.next.promise([], Auto.SEMVER.patch, {} as any)
+      await hooks.next.promise([], { bump: Auto.SEMVER.patch } as any)
     ).toStrictEqual(["1.2.4-next.0"]);
 
     expect(execPromise).toHaveBeenCalledWith(
@@ -414,7 +420,7 @@ describe("next", () => {
     } as unknown) as Auto.Auto);
 
     expect(
-      await hooks.next.promise([], Auto.SEMVER.patch, {} as any)
+      await hooks.next.promise([], { bump: Auto.SEMVER.patch } as any)
     ).toStrictEqual(["@foo/foo@1.0.0-next.0", "@foo/foo-bar@2.0.0-next.0"]);
 
     expect(execPromise).toHaveBeenCalledWith(
@@ -474,7 +480,10 @@ describe("next", () => {
     } as unknown) as Auto.Auto);
 
     expect(
-      await hooks.next.promise([], Auto.SEMVER.patch, { dryRun: true } as any)
+      await hooks.next.promise([], {
+        bump: Auto.SEMVER.patch,
+        dryRun: true,
+      } as any)
     ).toStrictEqual(["@foo/foo@1.0.0-next.1", "@foo/foo-bar@2.0.0-next.1"]);
 
     expect(execPromise).not.toHaveBeenCalledWith(
@@ -528,7 +537,7 @@ describe("next", () => {
     } as unknown) as Auto.Auto);
 
     expect(
-      await hooks.next.promise([], Auto.SEMVER.patch, {} as any)
+      await hooks.next.promise([], { bump: Auto.SEMVER.patch } as any)
     ).toStrictEqual(["@foo/foo@1.0.0-next.0"]);
   });
 });

--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -483,7 +483,7 @@ describe("publish", () => {
       }
     `;
 
-    await hooks.version.promise(Auto.SEMVER.patch);
+    await hooks.version.promise({ bump: Auto.SEMVER.patch });
     expect(execPromise).toHaveBeenCalledWith("npm", [
       "version",
       Auto.SEMVER.patch,
@@ -513,7 +513,7 @@ describe("publish", () => {
       }
     `;
 
-    await hooks.version.promise(Auto.SEMVER.patch);
+    await hooks.version.promise({ bump: Auto.SEMVER.patch });
     expect(execPromise).toHaveBeenCalledWith("npm", [
       "version",
       Auto.SEMVER.patch,
@@ -544,7 +544,7 @@ describe("publish", () => {
       }
     `;
 
-    await hooks.version.promise(Auto.SEMVER.patch);
+    await hooks.version.promise({ bump: Auto.SEMVER.patch });
     expect(execPromise).toHaveBeenCalledWith("npx", [
       "lerna",
       "version",
@@ -580,7 +580,7 @@ describe("publish", () => {
       }
     `;
 
-    await hooks.version.promise(Auto.SEMVER.patch);
+    await hooks.version.promise({ bump: Auto.SEMVER.patch });
     expect(execPromise).toHaveBeenCalledWith("npx", [
       "lerna",
       "version",
@@ -616,7 +616,7 @@ describe("publish", () => {
       }
     `;
 
-    await hooks.version.promise(Auto.SEMVER.patch);
+    await hooks.version.promise({ bump: Auto.SEMVER.patch });
     expect(execPromise).toHaveBeenCalledWith("npx", [
       "lerna",
       "version",
@@ -745,7 +745,7 @@ describe("publish", () => {
       }
     `;
 
-    await hooks.version.promise(Auto.SEMVER.patch);
+    await hooks.version.promise({ bump: Auto.SEMVER.patch });
     expect(execPromise).toHaveBeenCalledWith("npm", [
       "version",
       "1.0.1",
@@ -777,7 +777,7 @@ describe("publish", () => {
       }
     `;
 
-    await hooks.version.promise(Auto.SEMVER.patch);
+    await hooks.version.promise({ bump: Auto.SEMVER.patch });
     expect(execPromise).toHaveBeenNthCalledWith(2, "npx", [
       "lerna",
       "version",
@@ -851,9 +851,47 @@ describe("canary", () => {
       }
     `;
 
-    await hooks.canary.promise(Auto.SEMVER.patch, "canary.123.1");
+    await hooks.canary.promise({
+      bump: Auto.SEMVER.patch,
+      canaryIdentifier: "canary.123.1",
+    });
     expect(execPromise.mock.calls[1]).toContain("npm");
     expect(execPromise.mock.calls[1][1]).toContain("1.2.4-canary.123.1.0");
+  });
+
+  test("prints canary version in dry run", async () => {
+    const plugin = new NPMPlugin();
+    const hooks = makeHooks();
+
+    plugin.apply(({
+      config: { prereleaseBranches: ["next"] },
+      hooks,
+      remote: "origin",
+      baseBranch: "master",
+      logger: dummyLog(),
+      getCurrentVersion: () => "1.2.3",
+      git: {
+        getLatestRelease: () => "1.2.3",
+        getLatestTagInBranch: () => Promise.resolve("1.2.3"),
+      },
+    } as unknown) as Auto.Auto);
+
+    readResult = `
+      {
+        "name": "test"
+      }
+    `;
+
+    const log = jest.fn();
+    jest.spyOn(console, "log").mockImplementation(log);
+
+    await hooks.canary.promise({
+      bump: Auto.SEMVER.patch,
+      canaryIdentifier: "canary.123.1",
+      dryRun: true,
+      quiet: true,
+    });
+    expect(log).toHaveBeenCalledWith("1.2.4-canary.123.1.0");
   });
 
   test("doesn't publish private packages", async () => {
@@ -881,7 +919,10 @@ describe("canary", () => {
     `;
 
     expect(
-      await hooks.canary.promise(Auto.SEMVER.patch, "canary.123.1")
+      await hooks.canary.promise({
+        bump: Auto.SEMVER.patch,
+        canaryIdentifier: "canary.123.1",
+      })
     ).toStrictEqual({
       error: "Package private, cannot make canary release to npm.",
     });
@@ -915,7 +956,10 @@ describe("canary", () => {
     // second doesn't
     execPromise.mockReturnValueOnce(false);
 
-    await hooks.canary.promise(Auto.SEMVER.patch, "canary.123.1");
+    await hooks.canary.promise({
+      bump: Auto.SEMVER.patch,
+      canaryIdentifier: "canary.123.1",
+    });
     expect(execPromise.mock.calls[2]).toContain("npm");
     expect(execPromise.mock.calls[2][1]).toContain("1.2.4-canary.123.1.1");
   });
@@ -944,7 +988,10 @@ describe("canary", () => {
       }
     `;
 
-    await hooks.canary.promise(Auto.SEMVER.patch, "canary.123.1");
+    await hooks.canary.promise({
+      bump: Auto.SEMVER.patch,
+      canaryIdentifier: "canary.123.1",
+    });
     expect(execPromise).toHaveBeenCalledWith("npm", [
       "publish",
       "--tag",
@@ -977,7 +1024,10 @@ describe("canary", () => {
       }
     `;
 
-    await hooks.canary.promise(Auto.SEMVER.patch, "canary.123.1");
+    await hooks.canary.promise({
+      bump: Auto.SEMVER.patch,
+      canaryIdentifier: "canary.123.1",
+    });
     expect(execPromise.mock.calls[1]).toContain("npm");
     expect(execPromise.mock.calls[1][1]).toContain("1.2.4-canary.123.1.0");
   });
@@ -1021,10 +1071,64 @@ describe("canary", () => {
     monorepoPackages.mockReturnValueOnce(packages.map((p) => ({ package: p })));
     getLernaPackages.mockImplementation(async () => Promise.resolve(packages));
 
-    const value = await hooks.canary.promise(Auto.SEMVER.patch, "");
+    const value = await hooks.canary.promise({
+      bump: Auto.SEMVER.patch,
+      canaryIdentifier: "",
+    });
     expect(execPromise.mock.calls[1][1]).toContain("lerna");
     // @ts-ignore
     expect(value.newVersion).toBe("1.2.3-canary.0");
+  });
+
+  test("prints version monorepo dry run", async () => {
+    const plugin = new NPMPlugin();
+    const hooks = makeHooks();
+
+    plugin.apply({
+      config: { prereleaseBranches: ["next"] },
+      hooks,
+      remote: "origin",
+      baseBranch: "master",
+      logger: dummyLog(),
+      git: {
+        getLatestRelease: () => Promise.resolve("1.2.3"),
+        getLatestTagInBranch: () => Promise.resolve("1.2.3"),
+      },
+    } as any);
+    existsSync.mockReturnValueOnce(true);
+
+    readResult = `
+      {
+        "name": "test"
+      }
+    `;
+
+    const packages = [
+      {
+        path: "path/to/package",
+        name: "@foobar/app",
+        version: "1.2.3-canary.0+abcd",
+      },
+      {
+        path: "path/to/package",
+        name: "@foobar/lib",
+        version: "1.2.3-canary.0+abcd",
+      },
+    ];
+
+    const log = jest.fn();
+    jest.spyOn(console, "log").mockImplementation(log);
+    monorepoPackages.mockReturnValueOnce(packages.map((p) => ({ package: p })));
+    getLernaPackages.mockImplementation(async () => Promise.resolve(packages));
+
+    await hooks.canary.promise({
+      bump: Auto.SEMVER.patch,
+      canaryIdentifier: "canary.123.1",
+      dryRun: true,
+      quiet: true,
+    });
+
+    expect(log).toHaveBeenCalledWith("1.2.4-canary.123.1.0");
   });
 
   test("legacy auth works in monorepo", async () => {
@@ -1067,7 +1171,10 @@ describe("canary", () => {
     monorepoPackages.mockReturnValueOnce(packages.map((p) => ({ package: p })));
     getLernaPackages.mockImplementation(async () => Promise.resolve(packages));
 
-    await hooks.canary.promise(Auto.SEMVER.patch, "");
+    await hooks.canary.promise({
+      bump: Auto.SEMVER.patch,
+      canaryIdentifier: "",
+    });
     expect(execPromise).toHaveBeenCalledWith("npx", [
       "lerna",
       "publish",
@@ -1123,7 +1230,10 @@ describe("canary", () => {
     monorepoPackages.mockReturnValueOnce(packages.map((p) => ({ package: p })));
     getLernaPackages.mockImplementation(async () => Promise.resolve(packages));
 
-    const value = await hooks.canary.promise(Auto.SEMVER.patch, "");
+    const value = await hooks.canary.promise({
+      bump: Auto.SEMVER.patch,
+      canaryIdentifier: "",
+    });
     expect(value).toStrictEqual({
       error: "No packages were changed. No canary published.",
     });
@@ -1164,7 +1274,7 @@ describe("canary", () => {
       ])
     );
 
-    await hooks.version.promise(Auto.SEMVER.patch);
+    await hooks.version.promise({ bump: Auto.SEMVER.patch });
     expect(execPromise).toHaveBeenNthCalledWith(1, "npx", [
       "lerna",
       "version",
@@ -1218,7 +1328,12 @@ describe("canary", () => {
       ])
     );
 
-    expect(await hooks.canary.promise(Auto.SEMVER.patch, "")).toMatchSnapshot();
+    expect(
+      await hooks.canary.promise({
+        bump: Auto.SEMVER.patch,
+        canaryIdentifier: "",
+      })
+    ).toMatchSnapshot();
   });
 
   test("error when no canary release found - independent", async () => {
@@ -1260,7 +1375,10 @@ describe("canary", () => {
       ])
     );
 
-    const value = await hooks.canary.promise(Auto.SEMVER.patch, "");
+    const value = await hooks.canary.promise({
+      bump: Auto.SEMVER.patch,
+      canaryIdentifier: "",
+    });
     expect(value).toStrictEqual({
       error: "No packages were changed. No canary published.",
     });

--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -633,7 +633,7 @@ describe("publish", () => {
     execPromise.mockClear();
     existsSync.mockReturnValueOnce(true);
 
-    await hooks.publish.promise(Auto.SEMVER.patch);
+    await hooks.publish.promise({ bump: Auto.SEMVER.patch });
     expect(execPromise).toHaveBeenCalledWith("npx", [
       "lerna",
       "publish",
@@ -657,7 +657,7 @@ describe("publish", () => {
 
     existsSync.mockReturnValueOnce(true);
 
-    await hooks.publish.promise(Auto.SEMVER.patch);
+    await hooks.publish.promise({ bump: Auto.SEMVER.patch });
     expect(execPromise).toHaveBeenCalledWith("npx", [
       "lerna",
       "publish",
@@ -682,7 +682,7 @@ describe("publish", () => {
 
     existsSync.mockReturnValueOnce(true);
 
-    await hooks.publish.promise(Auto.SEMVER.patch);
+    await hooks.publish.promise({ bump: Auto.SEMVER.patch });
     expect(execPromise).toHaveBeenCalledWith("npx", [
       "lerna",
       "publish",
@@ -716,7 +716,7 @@ describe("publish", () => {
       }
     `;
 
-    await hooks.publish.promise(Auto.SEMVER.patch);
+    await hooks.publish.promise({ bump: Auto.SEMVER.patch });
     expect(execPromise).toHaveBeenCalledWith("npm", [
       "publish",
       "--_auth",
@@ -811,7 +811,7 @@ describe("publish", () => {
       }
     `;
 
-    await hooks.publish.promise(Auto.SEMVER.patch);
+    await hooks.publish.promise({ bump: Auto.SEMVER.patch });
     expect(execPromise).not.toHaveBeenCalledWith("npm", ["publish"]);
     expect(execPromise).toHaveBeenCalledWith("git", [
       "push",

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -706,9 +706,9 @@ export default class NPMPlugin implements IPlugin {
       (changelog, version = SEMVER.patch) => {
         changelog.hooks.renderChangelogLine.tapPromise(
           "NPM - Monorepo",
-          async ([commit, line]) => {
+          async (line, commit) => {
             if (!isMonorepo() || !this.monorepoChangelog) {
-              return [commit, line];
+              return line;
             }
 
             const lernaPackages = await this.getLernaPackages();
@@ -729,10 +729,10 @@ export default class NPMPlugin implements IPlugin {
               : "monorepo";
 
             if (section === "monorepo") {
-              return [commit, line];
+              return line;
             }
 
-            return [commit, [`- ${section}`, `  ${line}`].join("\n")];
+            return [`- ${section}`, `  ${line}`].join("\n");
           }
         );
 

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -13,6 +13,7 @@ import {
   determineNextVersion,
   getCurrentBranch,
   getLernaPackages,
+  LernaPackage,
   inFolder,
   execPromise,
   ILogger,
@@ -367,8 +368,13 @@ const makeMonorepoInstallList = (packageList: string[]) =>
     "```",
   ].join("\n");
 
-/** Find changed packages and create a tag for the current next release. */
-const tagIndependentNextReleases = async (
+interface IndependentPackageUpdate extends LernaPackage {
+  /** The packages new version */
+  newVersion: string;
+}
+
+/** Get an array of independent next version package updates */
+const getIndependentNextReleases = async (
   bump: SEMVER,
   prereleaseBranch: string
 ) => {
@@ -416,6 +422,21 @@ const tagIndependentNextReleases = async (
       };
     })
   );
+
+  return updates.filter((p): p is IndependentPackageUpdate => Boolean(p));
+};
+
+/** Find changed packages and create a tag for the current next release. */
+const tagIndependentNextReleases = async (
+  bump: SEMVER,
+  prereleaseBranch: string
+) => {
+  // Get all version updates
+  const updates = await getIndependentNextReleases(bump, prereleaseBranch);
+
+  if (!updates || !updates.length) {
+    return;
+  }
 
   // Update package.json
   await Promise.all(
@@ -836,319 +857,457 @@ export default class NPMPlugin implements IPlugin {
       }
     );
 
-    auto.hooks.version.tapPromise(this.name, async (version) => {
-      const isBaseBranch = branch === auto.baseBranch;
+    auto.hooks.version.tapPromise(
+      this.name,
+      async ({ bump, dryRun, quiet }) => {
+        const isBaseBranch = branch === auto.baseBranch;
 
-      if (isMonorepo()) {
-        auto.logger.verbose.info("Detected monorepo, using lerna");
-        const isIndependent = getLernaJson().version === "independent";
-        const monorepoBump =
-          isIndependent || !isBaseBranch
-            ? undefined
-            : await bumpLatest(getMonorepoPackage(), version);
+        /** Log the version */
+        const logVersion = (version: string) => {
+          if (quiet) {
+            console.log(version);
+          } else {
+            auto.logger.log.info(`Would have published: ${version}`);
+          }
+        };
 
-        await execPromise("npx", [
-          "lerna",
-          "version",
-          monorepoBump || version,
-          !isIndependent && this.forcePublish && "--force-publish",
-          "--no-commit-hooks",
-          "--yes",
-          "--no-push",
-          "-m",
-          isIndependent
-            ? '"Bump independent versions [skip ci]"'
-            : VERSION_COMMIT_MESSAGE,
-          this.exact && "--exact",
-          ...verboseArgs,
-        ]);
-        auto.logger.verbose.info("Successfully versioned repo");
-        return;
-      }
+        if (isMonorepo()) {
+          auto.logger.verbose.info("Detected monorepo, using lerna");
+          const monorepoVersion = getLernaJson().version;
+          const isIndependent = monorepoVersion === "independent";
 
-      const latestBump = isBaseBranch
-        ? await bumpLatest(await loadPackageJson(), version)
-        : version;
+          if (dryRun) {
+            if (isIndependent) {
+              await execPromise("npx", [
+                "lerna",
+                "version",
+                bump,
+                ...(await getRegistryArgs()),
+                ...getLegacyAuthArgs(this.legacyAuth, { isMonorepo: true }),
+                "--yes",
+                "--no-push",
+                "--no-git-tag-version",
+                "--no-commit-hooks",
+                "--exact",
+                "--ignore-scripts",
+                ...verboseArgs,
+              ]);
 
-      await execPromise("npm", [
-        "version",
-        latestBump || version,
-        "--no-commit-hooks",
-        "-m",
-        VERSION_COMMIT_MESSAGE,
-        ...verboseArgs,
-      ]);
-      auto.logger.verbose.info("Successfully versioned repo");
-    });
+              const canaryPackageList = await getPackageList();
+              // Reset after we read the packages from the system!
+              await gitReset();
 
-    auto.hooks.canary.tapPromise(this.name, async (bump, preid) => {
-      if (this.setRcToken) {
-        await setTokenOnCI(auto.logger);
-        auto.logger.verbose.info("Set CI NPM_TOKEN");
-      }
+              logVersion(canaryPackageList.join("\n"));
+            } else {
+              logVersion(inc(monorepoVersion, bump as ReleaseType) || bump);
+            }
 
-      const lastRelease = await auto.git!.getLatestRelease();
-      const [, latestTag = lastRelease] = await on(
-        auto.git!.getLatestTagInBranch()
-      );
-      const inPrerelease = prereleaseBranches.some((b) =>
-        latestTag.includes(`-${b}.`)
-      );
-
-      if (isMonorepo()) {
-        const isIndependent = getLernaJson().version === "independent";
-        auto.logger.verbose.info("Detected monorepo, using lerna");
-
-        const packagesBefore = await getLernaPackages();
-        let canaryVersion =
-          (isIndependent && `pre${bump}`) ||
-          determineNextVersion(
-            lastRelease,
-            inPrerelease ? latestTag : packagesBefore[0].version,
-            bump,
-            preid
-          );
-
-        if (this.canaryScope) {
-          await setCanaryScope(
-            this.canaryScope,
-            packagesBefore.map((p) => p.path)
-          );
-        }
-
-        if (!isIndependent) {
-          const { name } = getMonorepoPackage();
-          canaryVersion = await findAvailableCanaryVersion(
-            auto,
-            name,
-            canaryVersion
-          );
-        }
-
-        await execPromise("npx", [
-          "lerna",
-          "publish",
-          canaryVersion,
-          "--dist-tag",
-          "canary",
-          ...(await getRegistryArgs()),
-          !isIndependent && "--force-publish",
-          ...getLegacyAuthArgs(this.legacyAuth, { isMonorepo: true }),
-          "--yes", // skip prompts,
-          "--no-git-reset", // so we can get the version that just published
-          "--no-git-tag-version", // no need to tag and commit,
-          "--exact", // do not add ^ to canary versions, this can result in `npm i` resolving the wrong canary version
-          ...(isIndependent ? ["--preid", preid] : []),
-          ...verboseArgs,
-        ]);
-
-        auto.logger.verbose.info("Successfully published canary version");
-        const packages = await getLernaPackages();
-        const packageList = await getPackageList();
-        // Reset after we read the packages from the system!
-        await gitReset();
-
-        if (isIndependent) {
-          if (!packageList.some((p) => p.includes("canary"))) {
-            return { error: "No packages were changed. No canary published." };
+            return;
           }
 
-          return {
-            newVersion: "Canary Versions",
-            details: makeMonorepoInstallList(
-              packageList.filter((p) => p.includes("canary"))
-            ),
-          };
+          const monorepoBump =
+            isIndependent || !isBaseBranch
+              ? bump
+              : (await bumpLatest(getMonorepoPackage(), bump)) || bump;
+
+          await execPromise("npx", [
+            "lerna",
+            "version",
+            monorepoBump,
+            !isIndependent && this.forcePublish && "--force-publish",
+            "--no-commit-hooks",
+            "--yes",
+            "--no-push",
+            "-m",
+            isIndependent
+              ? '"Bump independent versions [skip ci]"'
+              : VERSION_COMMIT_MESSAGE,
+            this.exact && "--exact",
+            ...verboseArgs,
+          ]);
+          auto.logger.verbose.info("Successfully versioned repo");
+          return;
         }
 
-        const versioned = packages.find((p) => p.version.includes("canary"));
+        const latestBump = isBaseBranch
+          ? (await bumpLatest(await loadPackageJson(), bump)) || bump
+          : bump;
 
-        if (!versioned) {
-          return { error: "No packages were changed. No canary published." };
+        if (dryRun) {
+          logVersion(latestBump);
+          return;
         }
-
-        const version = versioned.version.split("+")[0];
-
-        return {
-          newVersion: this.canaryScope
-            ? `under canary scope @${sanitizeScope(
-                this.canaryScope
-              )}@${version}`
-            : version,
-          details: makeMonorepoInstallList(packageList),
-        };
-      }
-
-      auto.logger.verbose.info("Detected single npm package");
-      const current = await auto.getCurrentVersion(lastRelease);
-      const { name, private: isPrivate } = await loadPackageJson();
-
-      if (isPrivate) {
-        return {
-          error: "Package private, cannot make canary release to npm.",
-        };
-      }
-
-      const canaryVersion = await findAvailableCanaryVersion(
-        auto,
-        name,
-        determineNextVersion(lastRelease, current, bump, preid)
-      );
-
-      if (this.canaryScope) {
-        await setCanaryScope(this.canaryScope, ["./"]);
-      }
-
-      await execPromise("npm", [
-        "version",
-        canaryVersion,
-        "--no-git-tag-version",
-        "--no-commit-hooks",
-        ...verboseArgs,
-      ]);
-
-      const publishArgs = ["--tag", "canary"];
-      await execPromise("npm", [
-        "publish",
-        ...publishArgs,
-        ...verboseArgs,
-        ...getLegacyAuthArgs(this.legacyAuth),
-      ]);
-
-      if (this.canaryScope) {
-        await gitReset();
-      }
-
-      auto.logger.verbose.info("Successfully published canary version");
-
-      return {
-        newVersion: canaryVersion,
-        details: makeMonorepoInstallList([`${name}@${canaryVersion}`]),
-      };
-    });
-
-    auto.hooks.next.tapPromise(this.name, async (preReleaseVersions, bump) => {
-      if (this.setRcToken) {
-        await setTokenOnCI(auto.logger);
-        auto.logger.verbose.info("Set CI NPM_TOKEN");
-      }
-
-      const lastRelease = await auto.git!.getLatestRelease();
-      const latestTag =
-        (await auto.git?.getLastTagNotInBaseBranch(prereleaseBranch)) ||
-        (await getPreviousVersion(auto, prereleaseBranch));
-
-      if (isMonorepo()) {
-        auto.logger.verbose.info("Detected monorepo, using lerna");
-        const isIndependent = getLernaJson().version === "independent";
-        // It's hard to accurately predict how we should bump independent versions.
-        // So we manually make all the tags. (independent only)
-        const next = isIndependent
-          ? "from-git"
-          : determineNextVersion(
-              lastRelease,
-              latestTag,
-              bump,
-              prereleaseBranch
-            );
-
-        auto.logger.verbose.info({
-          lastRelease,
-          latestTag,
-          bump,
-          prereleaseBranch,
-          next,
-        });
-
-        if (isIndependent) {
-          await tagIndependentNextReleases(bump, prereleaseBranch);
-        }
-
-        await execPromise("npx", [
-          "lerna",
-          "publish",
-          next,
-          "--dist-tag",
-          prereleaseBranch,
-          "--preid",
-          prereleaseBranch,
-          "--no-push",
-          // you always want a next version to publish
-          !isIndependent && "--force-publish",
-          ...(await getRegistryArgs()),
-          ...getLegacyAuthArgs(this.legacyAuth, { isMonorepo: true }),
-          // skip prompts
-          "--yes",
-          // do not add ^ to next versions, this can result in `npm i` resolving the wrong next version
-          "--exact",
-          "--no-commit-hooks",
-          ...verboseArgs,
-        ]);
-
-        // we do not want to commit the next version. this causes
-        // merge conflicts when merged into master. We also do not want
-        // to re-implement the magic lerna does. So instead we let lerna
-        // commit+tag the new version and roll back all the tags to the
-        // previous commit.
-        const tags = (
-          await execPromise("git", ["tag", "--points-at", "HEAD"])
-        ).split("\n");
-        await Promise.all(
-          // Move tags back one commit
-          tags.map((tag) =>
-            execPromise("git", ["tag", tag, "-f", "HEAD^", "-am", tag])
-          )
-        );
-        // Move branch back one commit
-        await execPromise("git", ["reset", "--hard", "HEAD~1"]);
-
-        auto.logger.verbose.info("Successfully published next version");
-
-        preReleaseVersions = [
-          ...preReleaseVersions,
-          ...(isIndependent ? tags : tags.map(auto.prefixRelease)),
-        ];
-      } else {
-        auto.logger.verbose.info("Detected single npm package");
 
         await execPromise("npm", [
           "version",
-          determineNextVersion(lastRelease, latestTag, bump, prereleaseBranch),
-          // we do not want to commit the next version. this causes
-          // merge conflicts when merged into master
+          latestBump,
+          "--no-commit-hooks",
+          "-m",
+          VERSION_COMMIT_MESSAGE,
+          ...verboseArgs,
+        ]);
+        auto.logger.verbose.info("Successfully versioned repo");
+      }
+    );
+
+    auto.hooks.canary.tapPromise(
+      this.name,
+      async ({ bump, canaryIdentifier, dryRun, quiet }) => {
+        if (this.setRcToken) {
+          await setTokenOnCI(auto.logger);
+          auto.logger.verbose.info("Set CI NPM_TOKEN");
+        }
+
+        const lastRelease = await auto.git!.getLatestRelease();
+        const [, latestTag = lastRelease] = await on(
+          auto.git!.getLatestTagInBranch()
+        );
+        const inPrerelease = prereleaseBranches.some((b) =>
+          latestTag.includes(`-${b}.`)
+        );
+
+        /** Log the version */
+        const logVersion = (version: string) => {
+          if (quiet) {
+            console.log(version);
+          } else {
+            auto.logger.log.info(`Would have published: ${version}`);
+          }
+        };
+
+        if (isMonorepo()) {
+          const isIndependent = getLernaJson().version === "independent";
+          auto.logger.verbose.info("Detected monorepo, using lerna");
+
+          const packagesBefore = await getLernaPackages();
+          let canaryVersion =
+            (isIndependent && `pre${bump}`) ||
+            determineNextVersion(
+              lastRelease,
+              inPrerelease ? latestTag : packagesBefore[0].version,
+              bump,
+              canaryIdentifier
+            );
+
+          if (this.canaryScope && !dryRun) {
+            await setCanaryScope(
+              this.canaryScope,
+              packagesBefore.map((p) => p.path)
+            );
+          }
+
+          if (!isIndependent) {
+            const { name } = getMonorepoPackage();
+
+            canaryVersion = await findAvailableCanaryVersion(
+              auto,
+              name,
+              canaryVersion
+            );
+
+            if (dryRun) {
+              logVersion(canaryVersion);
+              return;
+            }
+            // Is independent and a dry run
+          } else if (dryRun) {
+            await execPromise("npx", [
+              "lerna",
+              "version",
+              canaryVersion,
+              ...(await getRegistryArgs()),
+              ...getLegacyAuthArgs(this.legacyAuth, { isMonorepo: true }),
+              "--yes",
+              "--no-push",
+              "--no-git-tag-version",
+              "--no-commit-hooks",
+              "--exact",
+              "--ignore-scripts",
+              "--preid",
+              canaryIdentifier,
+              ...verboseArgs,
+            ]);
+
+            const canaryPackageList = await getPackageList();
+            // Reset after we read the packages from the system!
+            await gitReset();
+
+            logVersion(canaryPackageList.join("\n"));
+            return;
+          }
+
+          await execPromise("npx", [
+            "lerna",
+            "publish",
+            canaryVersion,
+            "--dist-tag",
+            "canary",
+            ...(await getRegistryArgs()),
+            !isIndependent && "--force-publish",
+            ...getLegacyAuthArgs(this.legacyAuth, { isMonorepo: true }),
+            "--yes", // skip prompts,
+            "--no-git-reset", // so we can get the version that just published
+            "--no-git-tag-version", // no need to tag and commit,
+            "--exact", // do not add ^ to canary versions, this can result in `npm i` resolving the wrong canary version
+            ...(isIndependent ? ["--preid", canaryIdentifier] : []),
+            ...verboseArgs,
+          ]);
+
+          auto.logger.verbose.info("Successfully published canary version");
+          const packages = await getLernaPackages();
+          const packageList = await getPackageList();
+          // Reset after we read the packages from the system!
+          await gitReset();
+
+          if (isIndependent) {
+            if (!packageList.some((p) => p.includes("canary"))) {
+              return {
+                error: "No packages were changed. No canary published.",
+              };
+            }
+
+            return {
+              newVersion: "Canary Versions",
+              details: makeMonorepoInstallList(
+                packageList.filter((p) => p.includes("canary"))
+              ),
+            };
+          }
+
+          const versioned = packages.find((p) => p.version.includes("canary"));
+
+          if (!versioned) {
+            return { error: "No packages were changed. No canary published." };
+          }
+
+          const version = versioned.version.split("+")[0];
+
+          return {
+            newVersion: this.canaryScope
+              ? `under canary scope @${sanitizeScope(
+                  this.canaryScope
+                )}@${version}`
+              : version,
+            details: makeMonorepoInstallList(packageList),
+          };
+        }
+
+        auto.logger.verbose.info("Detected single npm package");
+        const current = await auto.getCurrentVersion(lastRelease);
+        const { name, private: isPrivate } = await loadPackageJson();
+
+        if (isPrivate) {
+          return {
+            error: "Package private, cannot make canary release to npm.",
+          };
+        }
+
+        const canaryVersion = await findAvailableCanaryVersion(
+          auto,
+          name,
+          determineNextVersion(lastRelease, current, bump, canaryIdentifier)
+        );
+
+        if (dryRun) {
+          logVersion(canaryVersion);
+          return;
+        }
+
+        if (this.canaryScope) {
+          await setCanaryScope(this.canaryScope, ["./"]);
+        }
+
+        await execPromise("npm", [
+          "version",
+          canaryVersion,
           "--no-git-tag-version",
+          "--no-commit-hooks",
           ...verboseArgs,
         ]);
 
-        const { version, private: isPrivate } = await loadPackageJson();
-        await execPromise("git", [
-          "tag",
-          auto.prefixRelease(version!),
-          "-m",
-          `"Update version to ${version}"`,
+        const publishArgs = ["--tag", "canary"];
+        await execPromise("npm", [
+          "publish",
+          ...publishArgs,
+          ...verboseArgs,
+          ...getLegacyAuthArgs(this.legacyAuth),
         ]);
 
-        if (isPrivate) {
-          auto.logger.log.info(
-            `Package private, skipping prerelease publish to npm.`
-          );
-        } else {
-          await execPromise("npm", [
-            "publish",
-            "--tag",
-            prereleaseBranch,
-            ...verboseArgs,
-            ...getLegacyAuthArgs(this.legacyAuth),
-          ]);
+        if (this.canaryScope) {
+          await gitReset();
         }
 
-        auto.logger.verbose.info("Successfully published next version");
-        preReleaseVersions.push(auto.prefixRelease(version!));
-      }
+        auto.logger.verbose.info("Successfully published canary version");
 
-      await execPromise("git", ["push", auto.remote, branch, "--tags"]);
-      return preReleaseVersions;
-    });
+        return {
+          newVersion: canaryVersion,
+          details: makeMonorepoInstallList([`${name}@${canaryVersion}`]),
+        };
+      }
+    );
+
+    auto.hooks.next.tapPromise(
+      this.name,
+      async (preReleaseVersions, bump, { dryRun }) => {
+        if (this.setRcToken) {
+          await setTokenOnCI(auto.logger);
+          auto.logger.verbose.info("Set CI NPM_TOKEN");
+        }
+
+        const lastRelease = await auto.git!.getLatestRelease();
+        const latestTag =
+          (await auto.git?.getLastTagNotInBaseBranch(prereleaseBranch)) ||
+          (await getPreviousVersion(auto, prereleaseBranch));
+
+        if (isMonorepo()) {
+          auto.logger.verbose.info("Detected monorepo, using lerna");
+          const isIndependent = getLernaJson().version === "independent";
+          // It's hard to accurately predict how we should bump independent versions.
+          // So we manually make all the tags. (independent only)
+          const next = isIndependent
+            ? "from-git"
+            : determineNextVersion(
+                lastRelease,
+                latestTag,
+                bump,
+                prereleaseBranch
+              );
+
+          auto.logger.verbose.info({
+            lastRelease,
+            latestTag,
+            bump,
+            prereleaseBranch,
+            next,
+          });
+
+          if (dryRun) {
+            if (isIndependent) {
+              const packageUpdates = await getIndependentNextReleases(
+                bump,
+                prereleaseBranch
+              );
+
+              if (!packageUpdates || !packageUpdates.length) {
+                auto.logger.log.warn(
+                  "No independent package version updates found. No canary releases would be made"
+                );
+              } else {
+                packageUpdates.forEach((p) =>
+                  preReleaseVersions.push(`${p.name}@${p.newVersion}`)
+                );
+              }
+            } else {
+              preReleaseVersions.push(next);
+            }
+
+            return preReleaseVersions;
+          }
+
+          if (isIndependent) {
+            await tagIndependentNextReleases(bump, prereleaseBranch);
+          }
+
+          await execPromise("npx", [
+            "lerna",
+            "publish",
+            next,
+            "--dist-tag",
+            prereleaseBranch,
+            "--preid",
+            prereleaseBranch,
+            "--no-push",
+            // you always want a next version to publish
+            !isIndependent && "--force-publish",
+            ...(await getRegistryArgs()),
+            ...getLegacyAuthArgs(this.legacyAuth, { isMonorepo: true }),
+            // skip prompts
+            "--yes",
+            // do not add ^ to next versions, this can result in `npm i` resolving the wrong next version
+            "--exact",
+            "--no-commit-hooks",
+            ...verboseArgs,
+          ]);
+
+          // we do not want to commit the next version. this causes
+          // merge conflicts when merged into master. We also do not want
+          // to re-implement the magic lerna does. So instead we let lerna
+          // commit+tag the new version and roll back all the tags to the
+          // previous commit.
+          const tags = (
+            await execPromise("git", ["tag", "--points-at", "HEAD"])
+          ).split("\n");
+          await Promise.all(
+            // Move tags back one commit
+            tags.map((tag) =>
+              execPromise("git", ["tag", tag, "-f", "HEAD^", "-am", tag])
+            )
+          );
+          // Move branch back one commit
+          await execPromise("git", ["reset", "--hard", "HEAD~1"]);
+
+          auto.logger.verbose.info("Successfully published next version");
+
+          preReleaseVersions = [
+            ...preReleaseVersions,
+            ...(isIndependent ? tags : tags.map(auto.prefixRelease)),
+          ];
+        } else {
+          auto.logger.verbose.info("Detected single npm package");
+          const newVersion = determineNextVersion(
+            lastRelease,
+            latestTag,
+            bump,
+            prereleaseBranch
+          );
+
+          await execPromise("npm", [
+            "version",
+            newVersion,
+            // we do not want to commit the next version. this causes
+            // merge conflicts when merged into master
+            "--no-git-tag-version",
+            ...verboseArgs,
+          ]);
+
+          const { version, private: isPrivate } = await loadPackageJson();
+          const prefixedVersion = auto.prefixRelease(version!);
+
+          preReleaseVersions.push(prefixedVersion);
+
+          if (dryRun) {
+            await gitReset();
+            return preReleaseVersions;
+          }
+
+          await execPromise("git", [
+            "tag",
+            prefixedVersion,
+            "-m",
+            `"Update version to ${version}"`,
+          ]);
+
+          if (isPrivate) {
+            auto.logger.log.info(
+              `Package private, skipping prerelease publish to npm.`
+            );
+          } else {
+            await execPromise("npm", [
+              "publish",
+              "--tag",
+              prereleaseBranch,
+              ...verboseArgs,
+              ...getLegacyAuthArgs(this.legacyAuth),
+            ]);
+          }
+
+          auto.logger.verbose.info("Successfully published next version");
+        }
+
+        await execPromise("git", ["push", auto.remote, branch, "--tags"]);
+        return preReleaseVersions;
+      }
+    );
 
     auto.hooks.publish.tapPromise(this.name, async () => {
       const status = await execPromise("git", ["status", "--porcelain"]);
@@ -1221,17 +1380,34 @@ export default class NPMPlugin implements IPlugin {
       // Independent mode will create multiple releases on Github.
       // Each release will only contain the release notes for the
       // package + global changes.
-      if (!options.dryRun && isIndependent) {
-        auto.logger.log.info(`Releasing ${options.newVersion} to GitHub.`);
-
-        const changelog = await auto.release!.makeChangelog();
+      if (isIndependent) {
         const lernaPackages = await getLernaPackages();
         // Go through each new tag:
         const newTags = (
           await execPromise("git", ["tag", "--points-at", "HEAD"])
         ).split("\n");
 
-        this.monorepoChangelog = false;
+        if (options.dryRun) {
+          newTags.map(async (tag) => {
+            const lernaPackage = lernaPackages.find((p) =>
+              tag.includes(p.name)
+            );
+
+            if (!lernaPackage) {
+              return;
+            }
+
+            auto.logger.log.info(
+              `Would have created a release on GitHub for: ${tag}`
+            );
+          });
+
+          auto.logger.log.note(
+            "The above versions reflect the current git tags pointing at the HEAD commit. During the normal release flow these tags would reflect the latest released version."
+          );
+
+          return [];
+        }
 
         const packagePaths = lernaPackages.map((p) => p.path);
         const commitsAtRoot = options.commits.filter(
@@ -1240,6 +1416,9 @@ export default class NPMPlugin implements IPlugin {
               packagePaths.some((p) => inFolder(p, file))
             )
         );
+        auto.logger.log.info(`Releasing ${options.newVersion} to GitHub.`);
+        const changelog = await auto.release!.makeChangelog();
+        this.monorepoChangelog = false;
 
         const releases = await Promise.all(
           newTags.map(async (tag) => {

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -724,7 +724,7 @@ export default class NPMPlugin implements IPlugin {
 
     auto.hooks.onCreateChangelog.tap(
       this.name,
-      (changelog, version = SEMVER.patch) => {
+      (changelog, { bump = SEMVER.patch }) => {
         changelog.hooks.renderChangelogLine.tapPromise(
           "NPM - Monorepo",
           async (line, commit) => {
@@ -742,7 +742,7 @@ export default class NPMPlugin implements IPlugin {
                 this.releaseType !== "next" &&
                 getLernaJson().version === "independent",
               logger: auto.logger,
-              version,
+              version: bump,
             });
 
             const section = changedPackages?.length
@@ -1148,7 +1148,7 @@ export default class NPMPlugin implements IPlugin {
 
     auto.hooks.next.tapPromise(
       this.name,
-      async (preReleaseVersions, bump, { dryRun }) => {
+      async (preReleaseVersions, { bump, dryRun }) => {
         if (this.setRcToken) {
           await setTokenOnCI(auto.logger);
           auto.logger.verbose.info("Set CI NPM_TOKEN");

--- a/plugins/omit-release-notes/__tests__/omit-release-notes.test.ts
+++ b/plugins/omit-release-notes/__tests__/omit-release-notes.test.ts
@@ -13,10 +13,9 @@ const setup = (options: IReleaseNotesPluginOptions) => {
   const changelogHooks = makeChangelogHooks();
 
   plugin.apply({ hooks } as Auto);
-  hooks.onCreateChangelog.call(
-    { hooks: changelogHooks } as Changelog,
-    SEMVER.patch
-  );
+  hooks.onCreateChangelog.call({ hooks: changelogHooks } as Changelog, {
+    bump: SEMVER.patch,
+  });
 
   return changelogHooks;
 };


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v10.0.0-next.3`

<details>
  <summary>Changelog</summary>

  ### Release Notes
  
  _From #1609_
  
  This release simplifies some of the hooks arguements to allow for easier future extensibility.
  
  The following hooks have had their second argument converted to an object that takes a "context" of pertinent information:
  
  - `afterShipIt`
  - `onCreateChangelog`
  - `publish`
  -  `next`
  
  Please consult the docs or plugin implementations for further detail.
  
  _From #1604_
  
  Previously a lot of the hooks would not run during a dry run and `auto` would try to guess what they would do. This lead to the output versions of some commands to be off.
  
  With the release of v10 `auto` will call to the plugins for various hooks so they can control that.
  
  _From #1607_
  
  We were implementing the `renderChangelogLine` in a way that was more complex than needed
  
  Previously the hook took a tuple and had to return a tuple
  
  ```ts
  auto.hooks.onCreateChangelog.tapPromise('Stars', changelog =>
    changelog.hooks.renderChangelogLine.tapPromise(
      'Stars',
      async ([commit, line]) =>
        [commit, `${line.replace('-', ':star:')}
`]
    );
  );
  ```
  
  Now it can just return the rendered changelog line
  
  ```ts
  auto.hooks.onCreateChangelog.tapPromise('Stars', changelog =>
    changelog.hooks.renderChangelogLine.tapPromise(
      'Stars',
      async (line, commit) => `${line.replace('-', ':star:')}
`
    );
  );
  ```
  
  ---
  
  #### 💥 Breaking Change
  
  - `@auto-it/core`, `@auto-it/cocoapods`, `@auto-it/crates`, `@auto-it/docker`, `@auto-it/exec`, `@auto-it/first-time-contributor`, `@auto-it/gem`, `@auto-it/git-tag`, `@auto-it/jira`, `@auto-it/maven`, `@auto-it/npm`, `@auto-it/omit-release-notes`
    - simplify hook APIs for easier future extensibility [#1609](https://github.com/intuit/auto/pull/1609) ([@hipstersmoothie](https://github.com/hipstersmoothie))
  - `@auto-it/core`, `@auto-it/brew`, `@auto-it/chrome`, `@auto-it/cocoapods`, `@auto-it/crates`, `@auto-it/docker`, `@auto-it/exec`, `@auto-it/gem`, `@auto-it/git-tag`, `@auto-it/gradle`, `@auto-it/maven`, `@auto-it/npm`
    - Run various hooks in a --dry-run [#1604](https://github.com/intuit/auto/pull/1604) ([@hipstersmoothie](https://github.com/hipstersmoothie))
  - `@auto-it/core`, `@auto-it/jira`, `@auto-it/npm`
    - correct renderChangelogLine hook usage [#1607](https://github.com/intuit/auto/pull/1607) ([@hipstersmoothie](https://github.com/hipstersmoothie))
  - `@auto-it/core`, `@auto-it/all-contributors`
    - rename afterAddToChangelog hook to afterChangelog [#1606](https://github.com/intuit/auto/pull/1606) ([@hipstersmoothie](https://github.com/hipstersmoothie))
  
  #### 🐛 Bug Fix
  
  - `@auto-it/core`, `@auto-it/npm`
    - Git reset bugs on canary/next [#1618](https://github.com/intuit/auto/pull/1618) ([@hipstersmoothie](https://github.com/hipstersmoothie))
  
  #### Authors: 1
  
  - Andrew Lisowski ([@hipstersmoothie](https://github.com/hipstersmoothie))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
