### PR TITLE
simplify hook APIs for easier future extensibility

### DIFF
--- a/docs/pages/docs/plugins/changelog-hooks.mdx
+++ b/docs/pages/docs/plugins/changelog-hooks.mdx
@@ -21,6 +21,10 @@ The hooks it provides allow you to customize everything about how the changelog 
 This is where you hook into the changelog's hooks.
 See examples below.
 
+```ts
+auto.hooks.onCreateChangelog.tapPromise('Giphy', (changelog, { bump }) => {});
+```
+
 ## addToBody
 
 Add extra content to your changelogs.

--- a/docs/pages/docs/plugins/release-lifecycle-hooks.mdx
+++ b/docs/pages/docs/plugins/release-lifecycle-hooks.mdx
@@ -154,10 +154,10 @@ You must push the tags to github!
 This hooks is required for plugin that facilitate publishing.
 
 ```ts
-auto.hooks.publish.tapPromise("NPM", async (version: SEMVER) => {
+auto.hooks.publish.tapPromise("NPM", async ({ bump }) => {
   await execPromise("npm", [
     "version",
-    version,
+    bump,
     "-m",
     "Bump version to: %s [skip ci]",
   ]);
@@ -187,19 +187,26 @@ You can either return a string value of just the version or an object containing
 - `details` - The body of the details element
 
 ```ts
-auto.hooks.canary.tapPromise(this.name, async ({ bump, canaryIdentifier, dryRun, quiet }) => {
-  const lastRelease = await auto.git!.getLatestRelease();
-  const current = await auto.getCurrentVersion(lastRelease);
-  const nextVersion = inc(current, bump as ReleaseType);
-  const isScopedPackage = name.match(/@\S+\/\S+/);
-  const canaryVersion = `${nextVersion}-canary${canaryIdentifier}`;
+auto.hooks.canary.tapPromise(
+  this.name,
+  async ({ bump, canaryIdentifier, dryRun, quiet }) => {
+    const lastRelease = await auto.git!.getLatestRelease();
+    const current = await auto.getCurrentVersion(lastRelease);
+    const nextVersion = inc(current, bump as ReleaseType);
+    const isScopedPackage = name.match(/@\S+\/\S+/);
+    const canaryVersion = `${nextVersion}-canary${canaryIdentifier}`;
 
-  await execPromise("npm", ["version", canaryVersion, "--no-git-tag-version"]);
-  await execPromise("npm", ["publish", "--tag", "canary"]);
+    await execPromise("npm", [
+      "version",
+      canaryVersion,
+      "--no-git-tag-version",
+    ]);
+    await execPromise("npm", ["publish", "--tag", "canary"]);
 
-  auto.logger.verbose.info("Successfully published canary version");
-  return canaryVersion;
-});
+    auto.logger.verbose.info("Successfully published canary version");
+    return canaryVersion;
+  }
+);
 ```
 
 `canary` version should not produce any of the following:
@@ -230,7 +237,7 @@ import {
 
 auto.hooks.next.tapPromise(
   this.name,
-  async (preReleaseVersions, bump, { dryRun }) => {
+  async (preReleaseVersions, { bump, dryRun }) => {
     const branch = getCurrentBranch() || "";
     const lastRelease = await auto.git.getLatestRelease();
     const current =
@@ -328,18 +335,15 @@ _Other examples:_
 
 Ran after the `shipit` command has run.
 
-- `newVersion` - The new version that was release
-- `commits` - the commits in the release
 - `data`
+  - `newVersion` - The new version that was release
+  - `commits` - the commits in the release
   - `context` - The type of release that was created (`latest`, `next`, `canary`, or `old`)
 
 ```ts
-auto.hooks.afterShipIt.tap(
-  "MyPlugin",
-  async (newVersion, commits, { context }) => {
-    // do something
-  }
-);
+auto.hooks.afterShipIt.tap("MyPlugin", async ({ context }) => {
+  // do something
+});
 ```
 
 _Other examples:_

--- a/packages/core/src/utils/make-hooks.ts
+++ b/packages/core/src/utils/make-hooks.ts
@@ -20,7 +20,7 @@ export const makeHooks = (): IAutoHooks => ({
   beforeShipIt: new AsyncSeriesHook(["context"]),
   afterAddToChangelog: new AsyncSeriesHook(["context"]),
   beforeCommitChangelog: new AsyncSeriesHook(["context"]),
-  afterShipIt: new AsyncParallelHook(["version", "commits", "context"]),
+  afterShipIt: new AsyncParallelHook(["context"]),
   makeRelease: new AsyncSeriesBailHook(["releaseInfo"]),
   afterRelease: new AsyncParallelHook(["releaseInfo"]),
   onCreateRelease: new SyncHook(["options"]),
@@ -35,7 +35,7 @@ export const makeHooks = (): IAutoHooks => ({
   publish: new AsyncParallelHook(["version"]),
   afterPublish: new AsyncParallelHook(),
   canary: new AsyncSeriesBailHook(["canaryContext"]),
-  next: new AsyncSeriesWaterfallHook(["preReleaseVersions", "bump", "context"]),
+  next: new AsyncSeriesWaterfallHook(["preReleaseVersions", "context"]),
 });
 
 /** Make the hooks for "Release" */

--- a/plugins/cocoapods/__tests__/cocoapods.test.ts
+++ b/plugins/cocoapods/__tests__/cocoapods.test.ts
@@ -247,7 +247,7 @@ describe("Cocoapods Plugin", () => {
         prefixRelease,
       } as Auto.Auto);
 
-      await hook.publish.promise(Auto.SEMVER.patch);
+      await hook.publish.promise({ bump: Auto.SEMVER.patch });
 
       expect(exec).toBeCalledTimes(2);
       expect(exec).lastCalledWith("pod", ["trunk", "push", "./Test.podspec"]);
@@ -264,7 +264,7 @@ describe("Cocoapods Plugin", () => {
         prefixRelease,
       } as Auto.Auto);
 
-      await hook.publish.promise(Auto.SEMVER.patch);
+      await hook.publish.promise({ bump: Auto.SEMVER.patch });
 
       expect(exec).toBeCalledTimes(2);
       expect(exec).lastCalledWith("notpod", [
@@ -288,7 +288,7 @@ describe("Cocoapods Plugin", () => {
         prefixRelease,
       } as Auto.Auto);
 
-      await hook.publish.promise(Auto.SEMVER.patch);
+      await hook.publish.promise({ bump: Auto.SEMVER.patch });
 
       expect(exec).toBeCalledTimes(2);
       expect(exec).lastCalledWith("bundle", [
@@ -317,7 +317,7 @@ describe("Cocoapods Plugin", () => {
         prefixRelease,
       } as Auto.Auto);
 
-      await hook.publish.promise(Auto.SEMVER.patch);
+      await hook.publish.promise({ bump: Auto.SEMVER.patch });
 
       expect(exec).toBeCalledTimes(2);
       expect(exec).lastCalledWith("pod", [
@@ -347,7 +347,7 @@ describe("Cocoapods Plugin", () => {
         prefixRelease,
       } as Auto.Auto);
 
-      await hook.publish.promise(Auto.SEMVER.patch);
+      await hook.publish.promise({ bump: Auto.SEMVER.patch });
 
       expect(exec).toBeCalledTimes(5);
       expect(exec).toHaveBeenNthCalledWith(2, "pod", ["repo", "list"]);
@@ -391,7 +391,7 @@ describe("Cocoapods Plugin", () => {
         prefixRelease,
       } as Auto.Auto);
 
-      await hook.publish.promise(Auto.SEMVER.patch);
+      await hook.publish.promise({ bump: Auto.SEMVER.patch });
 
       expect(exec).toBeCalledTimes(5);
       expect(exec).toHaveBeenNthCalledWith(2, "pod", ["repo", "list"]);
@@ -454,7 +454,7 @@ trunk
         prefixRelease,
       } as Auto.Auto);
 
-      await hook.publish.promise(Auto.SEMVER.patch);
+      await hook.publish.promise({ bump: Auto.SEMVER.patch });
 
       expect(exec).toBeCalledTimes(6);
       expect(exec).toHaveBeenNthCalledWith(2, "pod", ["repo", "list"]);

--- a/plugins/crates/__tests__/crates.test.ts
+++ b/plugins/crates/__tests__/crates.test.ts
@@ -226,7 +226,7 @@ describe("CratesPlugin", () => {
           remote: "origin",
           baseBranch: "master",
         } as Auto.Auto);
-        await hooks.publish.promise(Auto.SEMVER.patch);
+        await hooks.publish.promise({ bump: Auto.SEMVER.patch });
         expect(exec).toHaveBeenCalledWith("cargo", ["publish"]);
         expect(exec).toHaveBeenCalledWith("git", [
           "push",

--- a/plugins/docker/__tests__/docker.test.ts
+++ b/plugins/docker/__tests__/docker.test.ts
@@ -165,7 +165,7 @@ describe("Docker Plugin", () => {
   describe("canary", () => {
     test("should do nothing without git", async () => {
       const hooks = setup();
-      await hooks.next.promise([], Auto.SEMVER.patch, {} as any);
+      await hooks.next.promise([], { bump: Auto.SEMVER.patch } as any);
       expect(exec).not.toHaveBeenCalled();
     });
 
@@ -223,7 +223,7 @@ describe("Docker Plugin", () => {
   describe("next", () => {
     test("should do nothing without git", async () => {
       const hooks = setup();
-      await hooks.next.promise([], Auto.SEMVER.patch, {} as any);
+      await hooks.next.promise([], { bump: Auto.SEMVER.patch } as any);
       expect(exec).not.toHaveBeenCalled();
     });
 
@@ -237,7 +237,7 @@ describe("Docker Plugin", () => {
         { registry, image: sourceImage }
       );
 
-      await hooks.next.promise([], Auto.SEMVER.patch, {} as any);
+      await hooks.next.promise([], { bump: Auto.SEMVER.patch } as any);
 
       expect(exec).toHaveBeenCalledWith("git", [
         "tag",
@@ -273,7 +273,8 @@ describe("Docker Plugin", () => {
       );
 
       expect(
-        await hooks.next.promise([], Auto.SEMVER.patch, {
+        await hooks.next.promise([], {
+          bump: Auto.SEMVER.patch,
           dryRun: true,
           quiet: true,
         } as any)
@@ -295,7 +296,7 @@ describe("Docker Plugin", () => {
       );
       await hooks.version.promise({ bump: Auto.SEMVER.patch });
 
-      await hooks.publish.promise(Auto.SEMVER.patch);
+      await hooks.publish.promise({ bump: Auto.SEMVER.patch });
       expect(exec).toHaveBeenCalledWith("docker", [
         "push",
         `${registry}:1.0.1`,
@@ -314,7 +315,7 @@ describe("Docker Plugin", () => {
       );
       await hooks.version.promise({ bump: Auto.SEMVER.patch });
 
-      await hooks.publish.promise(Auto.SEMVER.patch);
+      await hooks.publish.promise({ bump: Auto.SEMVER.patch });
       expect(exec).toHaveBeenCalledWith("docker", [
         "push",
         `${registry}:1.0.1`,

--- a/plugins/docker/src/index.ts
+++ b/plugins/docker/src/index.ts
@@ -162,7 +162,7 @@ export default class DockerPlugin implements IPlugin {
 
     auto.hooks.next.tapPromise(
       this.name,
-      async (preReleaseVersions, bump, { dryRun }) => {
+      async (preReleaseVersions, { bump, dryRun }) => {
         if (!auto.git) {
           return preReleaseVersions;
         }

--- a/plugins/exec/__tests__/exec.test.ts
+++ b/plugins/exec/__tests__/exec.test.ts
@@ -192,7 +192,7 @@ describe("Exec Plugin", () => {
       plugins.apply({ hooks } as Auto);
       hooks.onCreateChangelog.call(
         { hooks: changelogHooks } as any,
-        SEMVER.patch
+        { bump: SEMVER.patch }
       );
 
       expect(

--- a/plugins/first-time-contributor/__tests__/first-time-contributor.test.ts
+++ b/plugins/first-time-contributor/__tests__/first-time-contributor.test.ts
@@ -13,8 +13,9 @@ const graphql = jest.fn();
 const exec = jest.fn();
 exec.mockReturnValue("");
 // @ts-ignore
-jest.mock("../../../packages/core/dist/utils/exec-promise", () => (...args: any[]) =>
-  exec(...args)
+jest.mock(
+  "../../../packages/core/dist/utils/exec-promise",
+  () => (...args: any[]) => exec(...args)
 );
 
 const setup = (
@@ -45,7 +46,7 @@ const setup = (
       hooks: changelogHooks,
       options: { baseUrl: "https://github.com" },
     } as Changelog,
-    Auto.SEMVER.patch
+    { bump: Auto.SEMVER.patch }
   );
 
   return changelogHooks;

--- a/plugins/gem/__tests__/gem.test.ts
+++ b/plugins/gem/__tests__/gem.test.ts
@@ -277,7 +277,7 @@ describe("Gem Plugin", () => {
       const hooks = makeHooks();
 
       plugin.apply({ hooks, logger } as any);
-      await hooks.publish.promise(SEMVER.minor);
+      await hooks.publish.promise({ bump: SEMVER.minor });
 
       expect(execSpy).toHaveBeenCalledWith("bundle", ["exec", "rake", "build"]);
     });
@@ -296,7 +296,7 @@ describe("Gem Plugin", () => {
       const hooks = makeHooks();
 
       plugin.apply({ hooks, logger } as any);
-      await hooks.publish.promise(SEMVER.minor);
+      await hooks.publish.promise({ bump: SEMVER.minor });
 
       expect(execSyncSpy).toHaveBeenCalledWith("gem release --tag --push", {
         stdio: "inherit",

--- a/plugins/git-tag/__tests__/git-tag.test.ts
+++ b/plugins/git-tag/__tests__/git-tag.test.ts
@@ -88,7 +88,7 @@ describe("Git Tag Plugin", () => {
   describe("next", () => {
     test("should do nothing without git", async () => {
       const hooks = setup();
-      await hooks.next.promise([], Auto.SEMVER.patch, {} as any);
+      await hooks.next.promise([], { bump: Auto.SEMVER.patch } as any);
       expect(exec).not.toHaveBeenCalled();
     });
 
@@ -98,7 +98,7 @@ describe("Git Tag Plugin", () => {
         getLastTagNotInBaseBranch: () => "v1.0.0",
       });
 
-      await hooks.next.promise([], Auto.SEMVER.patch, {} as any);
+      await hooks.next.promise([], { bump: Auto.SEMVER.patch } as any);
 
       expect(exec).toHaveBeenCalledWith("git", [
         "tag",
@@ -121,7 +121,10 @@ describe("Git Tag Plugin", () => {
       });
 
       expect(
-        await hooks.next.promise([], Auto.SEMVER.patch, { dryRun: true } as any)
+        await hooks.next.promise([], {
+          bump: Auto.SEMVER.patch,
+          dryRun: true,
+        } as any)
       ).toStrictEqual(["v1.0.1-next.0"]);
 
       expect(exec).not.toHaveBeenCalled();

--- a/plugins/git-tag/src/index.ts
+++ b/plugins/git-tag/src/index.ts
@@ -73,7 +73,7 @@ export default class GitTagPlugin implements IPlugin {
 
     auto.hooks.next.tapPromise(
       this.name,
-      async (preReleaseVersions, bump, { dryRun }) => {
+      async (preReleaseVersions, { bump, dryRun }) => {
         if (!auto.git) {
           return preReleaseVersions;
         }

--- a/plugins/jira/__tests__/jira.test.ts
+++ b/plugins/jira/__tests__/jira.test.ts
@@ -77,7 +77,7 @@ describe("render jira", () => {
     plugin.apply({ hooks, logger: dummyLog() } as Auto);
     await hooks.onCreateChangelog.promise(
       { hooks: changelogHooks } as Changelog,
-      SEMVER.patch
+      { bump: SEMVER.patch }
     );
 
     expect(
@@ -93,7 +93,7 @@ describe("render jira", () => {
     plugin.apply({ hooks, logger: dummyLog() } as Auto);
     await hooks.onCreateChangelog.promise(
       { hooks: changelogHooks } as Changelog,
-      SEMVER.patch
+      { bump: SEMVER.patch }
     );
 
     const [, line] = await changelogHooks.renderChangelogLine.promise([
@@ -123,7 +123,7 @@ test("should create note for jira commits without PR title", async () => {
   const autoHooks = makeHooks();
 
   plugin.apply({ hooks: autoHooks } as Auto);
-  await autoHooks.onCreateChangelog.promise(changelog, SEMVER.patch);
+  await autoHooks.onCreateChangelog.promise(changelog, { bump: SEMVER.patch });
   changelog.loadDefaultHooks();
 
   const normalized = await logParse.normalizeCommits([
@@ -139,7 +139,7 @@ test("should create note for JIRA commits", async () => {
   const autoHooks = makeHooks();
 
   plugin.apply({ hooks: autoHooks } as Auto);
-  await autoHooks.onCreateChangelog.promise(changelog, SEMVER.patch);
+  await autoHooks.onCreateChangelog.promise(changelog, { bump: SEMVER.patch });
   changelog.loadDefaultHooks();
 
   const normalized = await logParse.normalizeCommits([

--- a/plugins/maven/__tests__/maven.test.ts
+++ b/plugins/maven/__tests__/maven.test.ts
@@ -462,7 +462,7 @@ describe("maven", () => {
 
       await hooks.beforeRun.promise({} as any);
 
-      await hooks.publish.promise(Auto.SEMVER.patch);
+      await hooks.publish.promise({ bump: Auto.SEMVER.patch });
 
       expect(exec.mock.calls[0][1]).toContain("deploy");
     });

--- a/plugins/npm/__tests__/monorepo-log.test.ts
+++ b/plugins/npm/__tests__/monorepo-log.test.ts
@@ -112,7 +112,7 @@ test("should group sections for packages", async () => {
     hooks,
     logger: dummyLog(),
   } as Auto.Auto);
-  hooks.onCreateChangelog.call(changelog, Auto.SEMVER.patch);
+  hooks.onCreateChangelog.call(changelog, { bump: Auto.SEMVER.patch });
   changelog.loadDefaultHooks();
 
   const commits = await commitsPromise;
@@ -176,7 +176,7 @@ test("should create sections for packages", async () => {
     hooks,
     logger: dummyLog(),
   } as Auto.Auto);
-  hooks.onCreateChangelog.call(changelog, Auto.SEMVER.patch);
+  hooks.onCreateChangelog.call(changelog, { bump: Auto.SEMVER.patch });
   changelog.loadDefaultHooks();
 
   const commits = await commitsPromise;
@@ -236,7 +236,7 @@ test("should be able to disable sections for packages", async () => {
     hooks,
     logger: dummyLog(),
   } as Auto.Auto);
-  hooks.onCreateChangelog.call(changelog, Auto.SEMVER.patch);
+  hooks.onCreateChangelog.call(changelog, { bump: Auto.SEMVER.patch });
   changelog.loadDefaultHooks();
 
   const commits = await commitsPromise;
@@ -296,7 +296,7 @@ test("should add versions for independent packages", async () => {
     hooks,
     logger: dummyLog(),
   } as Auto.Auto);
-  hooks.onCreateChangelog.call(changelog, Auto.SEMVER.patch);
+  hooks.onCreateChangelog.call(changelog, { bump: Auto.SEMVER.patch });
   changelog.loadDefaultHooks();
 
   const commits = await commitsPromise;

--- a/plugins/npm/__tests__/npm-next.test.ts
+++ b/plugins/npm/__tests__/npm-next.test.ts
@@ -85,7 +85,7 @@ describe("next", () => {
     `;
 
     expect(
-      await hooks.next.promise([], Auto.SEMVER.patch, {} as any)
+      await hooks.next.promise([], { bump: Auto.SEMVER.patch } as any)
     ).toStrictEqual(["1.2.4-next.0"]);
 
     expect(execPromise).toHaveBeenCalledWith("npm", [
@@ -138,7 +138,10 @@ describe("next", () => {
     `;
 
     expect(
-      await hooks.next.promise([], Auto.SEMVER.patch, { dryRun: true } as any)
+      await hooks.next.promise([], {
+        bump: Auto.SEMVER.patch,
+        dryRun: true,
+      } as any)
     ).toStrictEqual(["1.2.4-next.0"]);
     expect(execPromise).not.toHaveBeenCalledWith("npm");
   });
@@ -170,7 +173,7 @@ describe("next", () => {
     `;
 
     expect(
-      await hooks.next.promise([], Auto.SEMVER.patch, {} as any)
+      await hooks.next.promise([], { bump: Auto.SEMVER.patch } as any)
     ).toStrictEqual(["1.2.4-next.0"]);
 
     expect(execPromise).toHaveBeenCalledWith("git", [
@@ -213,7 +216,7 @@ describe("next", () => {
     `;
 
     expect(
-      await hooks.next.promise([], Auto.SEMVER.patch, {} as any)
+      await hooks.next.promise([], { bump: Auto.SEMVER.patch } as any)
     ).toStrictEqual(["1.2.4-next.0"]);
 
     expect(execPromise).toHaveBeenCalledWith("npm", [
@@ -267,7 +270,7 @@ describe("next", () => {
     } as unknown) as Auto.Auto);
 
     expect(
-      await hooks.next.promise([], Auto.SEMVER.patch, {} as any)
+      await hooks.next.promise([], { bump: Auto.SEMVER.patch } as any)
     ).toStrictEqual(["1.2.4-next.0"]);
 
     expect(execPromise).toHaveBeenCalledWith(
@@ -307,7 +310,10 @@ describe("next", () => {
     } as unknown) as Auto.Auto);
 
     expect(
-      await hooks.next.promise([], Auto.SEMVER.patch, { dryRun: true } as any)
+      await hooks.next.promise([], {
+        bump: Auto.SEMVER.patch,
+        dryRun: true,
+      } as any)
     ).toStrictEqual(["1.2.4-next.0"]);
 
     expect(execPromise).not.toHaveBeenCalledWith(
@@ -348,7 +354,7 @@ describe("next", () => {
     } as unknown) as Auto.Auto);
 
     expect(
-      await hooks.next.promise([], Auto.SEMVER.patch, {} as any)
+      await hooks.next.promise([], { bump: Auto.SEMVER.patch } as any)
     ).toStrictEqual(["1.2.4-next.0"]);
 
     expect(execPromise).toHaveBeenCalledWith(
@@ -414,7 +420,7 @@ describe("next", () => {
     } as unknown) as Auto.Auto);
 
     expect(
-      await hooks.next.promise([], Auto.SEMVER.patch, {} as any)
+      await hooks.next.promise([], { bump: Auto.SEMVER.patch } as any)
     ).toStrictEqual(["@foo/foo@1.0.0-next.0", "@foo/foo-bar@2.0.0-next.0"]);
 
     expect(execPromise).toHaveBeenCalledWith(
@@ -474,7 +480,10 @@ describe("next", () => {
     } as unknown) as Auto.Auto);
 
     expect(
-      await hooks.next.promise([], Auto.SEMVER.patch, { dryRun: true } as any)
+      await hooks.next.promise([], {
+        bump: Auto.SEMVER.patch,
+        dryRun: true,
+      } as any)
     ).toStrictEqual(["@foo/foo@1.0.0-next.1", "@foo/foo-bar@2.0.0-next.1"]);
 
     expect(execPromise).not.toHaveBeenCalledWith(
@@ -528,7 +537,7 @@ describe("next", () => {
     } as unknown) as Auto.Auto);
 
     expect(
-      await hooks.next.promise([], Auto.SEMVER.patch, {} as any)
+      await hooks.next.promise([], { bump: Auto.SEMVER.patch } as any)
     ).toStrictEqual(["@foo/foo@1.0.0-next.0"]);
   });
 });

--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -633,7 +633,7 @@ describe("publish", () => {
     execPromise.mockClear();
     existsSync.mockReturnValueOnce(true);
 
-    await hooks.publish.promise(Auto.SEMVER.patch);
+    await hooks.publish.promise({ bump: Auto.SEMVER.patch });
     expect(execPromise).toHaveBeenCalledWith("npx", [
       "lerna",
       "publish",
@@ -657,7 +657,7 @@ describe("publish", () => {
 
     existsSync.mockReturnValueOnce(true);
 
-    await hooks.publish.promise(Auto.SEMVER.patch);
+    await hooks.publish.promise({ bump: Auto.SEMVER.patch });
     expect(execPromise).toHaveBeenCalledWith("npx", [
       "lerna",
       "publish",
@@ -682,7 +682,7 @@ describe("publish", () => {
 
     existsSync.mockReturnValueOnce(true);
 
-    await hooks.publish.promise(Auto.SEMVER.patch);
+    await hooks.publish.promise({ bump: Auto.SEMVER.patch });
     expect(execPromise).toHaveBeenCalledWith("npx", [
       "lerna",
       "publish",
@@ -716,7 +716,7 @@ describe("publish", () => {
       }
     `;
 
-    await hooks.publish.promise(Auto.SEMVER.patch);
+    await hooks.publish.promise({ bump: Auto.SEMVER.patch });
     expect(execPromise).toHaveBeenCalledWith("npm", [
       "publish",
       "--_auth",
@@ -811,7 +811,7 @@ describe("publish", () => {
       }
     `;
 
-    await hooks.publish.promise(Auto.SEMVER.patch);
+    await hooks.publish.promise({ bump: Auto.SEMVER.patch });
     expect(execPromise).not.toHaveBeenCalledWith("npm", ["publish"]);
     expect(execPromise).toHaveBeenCalledWith("git", [
       "push",

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -724,7 +724,7 @@ export default class NPMPlugin implements IPlugin {
 
     auto.hooks.onCreateChangelog.tap(
       this.name,
-      (changelog, version = SEMVER.patch) => {
+      (changelog, { bump = SEMVER.patch }) => {
         changelog.hooks.renderChangelogLine.tapPromise(
           "NPM - Monorepo",
           async ([commit, line]) => {
@@ -742,7 +742,7 @@ export default class NPMPlugin implements IPlugin {
                 this.releaseType !== "next" &&
                 getLernaJson().version === "independent",
               logger: auto.logger,
-              version,
+              version: bump,
             });
 
             const section = changedPackages?.length
@@ -1148,7 +1148,7 @@ export default class NPMPlugin implements IPlugin {
 
     auto.hooks.next.tapPromise(
       this.name,
-      async (preReleaseVersions, bump, { dryRun }) => {
+      async (preReleaseVersions, { bump, dryRun }) => {
         if (this.setRcToken) {
           await setTokenOnCI(auto.logger);
           auto.logger.verbose.info("Set CI NPM_TOKEN");

--- a/plugins/omit-release-notes/__tests__/omit-release-notes.test.ts
+++ b/plugins/omit-release-notes/__tests__/omit-release-notes.test.ts
@@ -13,10 +13,9 @@ const setup = (options: IReleaseNotesPluginOptions) => {
   const changelogHooks = makeChangelogHooks();
 
   plugin.apply({ hooks } as Auto);
-  hooks.onCreateChangelog.call(
-    { hooks: changelogHooks } as Changelog,
-    SEMVER.patch
-  );
+  hooks.onCreateChangelog.call({ hooks: changelogHooks } as Changelog, {
+    bump: SEMVER.patch,
+  });
 
   return changelogHooks;
 };


### PR DESCRIPTION
## Release Notes

This release simplifies some of the hooks arguements to allow for easier future extensibility.

The following hooks have had their second argument converted to an object that takes a "context" of pertinent information:

- `afterShipIt`
- `onCreateChangelog`
- `publish`
-  `next`

Please consult the docs or plugin implementations for further detail.

## Why

closes #1156

Todo:

- [ ] Add tests
- [x] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [ ] `minor`
- [x] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@9.60.2-canary.1609.19803.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@9.60.2-canary.1609.19803.0
  npm install @auto-canary/auto@9.60.2-canary.1609.19803.0
  npm install @auto-canary/core@9.60.2-canary.1609.19803.0
  npm install @auto-canary/all-contributors@9.60.2-canary.1609.19803.0
  npm install @auto-canary/brew@9.60.2-canary.1609.19803.0
  npm install @auto-canary/chrome@9.60.2-canary.1609.19803.0
  npm install @auto-canary/cocoapods@9.60.2-canary.1609.19803.0
  npm install @auto-canary/conventional-commits@9.60.2-canary.1609.19803.0
  npm install @auto-canary/crates@9.60.2-canary.1609.19803.0
  npm install @auto-canary/docker@9.60.2-canary.1609.19803.0
  npm install @auto-canary/exec@9.60.2-canary.1609.19803.0
  npm install @auto-canary/first-time-contributor@9.60.2-canary.1609.19803.0
  npm install @auto-canary/gem@9.60.2-canary.1609.19803.0
  npm install @auto-canary/gh-pages@9.60.2-canary.1609.19803.0
  npm install @auto-canary/git-tag@9.60.2-canary.1609.19803.0
  npm install @auto-canary/gradle@9.60.2-canary.1609.19803.0
  npm install @auto-canary/jira@9.60.2-canary.1609.19803.0
  npm install @auto-canary/maven@9.60.2-canary.1609.19803.0
  npm install @auto-canary/npm@9.60.2-canary.1609.19803.0
  npm install @auto-canary/omit-commits@9.60.2-canary.1609.19803.0
  npm install @auto-canary/omit-release-notes@9.60.2-canary.1609.19803.0
  npm install @auto-canary/pr-body-labels@9.60.2-canary.1609.19803.0
  npm install @auto-canary/released@9.60.2-canary.1609.19803.0
  npm install @auto-canary/s3@9.60.2-canary.1609.19803.0
  npm install @auto-canary/slack@9.60.2-canary.1609.19803.0
  npm install @auto-canary/twitter@9.60.2-canary.1609.19803.0
  npm install @auto-canary/upload-assets@9.60.2-canary.1609.19803.0
  # or 
  yarn add @auto-canary/bot-list@9.60.2-canary.1609.19803.0
  yarn add @auto-canary/auto@9.60.2-canary.1609.19803.0
  yarn add @auto-canary/core@9.60.2-canary.1609.19803.0
  yarn add @auto-canary/all-contributors@9.60.2-canary.1609.19803.0
  yarn add @auto-canary/brew@9.60.2-canary.1609.19803.0
  yarn add @auto-canary/chrome@9.60.2-canary.1609.19803.0
  yarn add @auto-canary/cocoapods@9.60.2-canary.1609.19803.0
  yarn add @auto-canary/conventional-commits@9.60.2-canary.1609.19803.0
  yarn add @auto-canary/crates@9.60.2-canary.1609.19803.0
  yarn add @auto-canary/docker@9.60.2-canary.1609.19803.0
  yarn add @auto-canary/exec@9.60.2-canary.1609.19803.0
  yarn add @auto-canary/first-time-contributor@9.60.2-canary.1609.19803.0
  yarn add @auto-canary/gem@9.60.2-canary.1609.19803.0
  yarn add @auto-canary/gh-pages@9.60.2-canary.1609.19803.0
  yarn add @auto-canary/git-tag@9.60.2-canary.1609.19803.0
  yarn add @auto-canary/gradle@9.60.2-canary.1609.19803.0
  yarn add @auto-canary/jira@9.60.2-canary.1609.19803.0
  yarn add @auto-canary/maven@9.60.2-canary.1609.19803.0
  yarn add @auto-canary/npm@9.60.2-canary.1609.19803.0
  yarn add @auto-canary/omit-commits@9.60.2-canary.1609.19803.0
  yarn add @auto-canary/omit-release-notes@9.60.2-canary.1609.19803.0
  yarn add @auto-canary/pr-body-labels@9.60.2-canary.1609.19803.0
  yarn add @auto-canary/released@9.60.2-canary.1609.19803.0
  yarn add @auto-canary/s3@9.60.2-canary.1609.19803.0
  yarn add @auto-canary/slack@9.60.2-canary.1609.19803.0
  yarn add @auto-canary/twitter@9.60.2-canary.1609.19803.0
  yarn add @auto-canary/upload-assets@9.60.2-canary.1609.19803.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
