### PR TITLE
Git reset bugs on canary/next

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1150,9 +1150,7 @@ export default class Auto {
       process.exit(0);
     }
 
-    if (!args.dryRun) {
-      await this.checkClean();
-    }
+    await this.checkClean();
 
     let { pr, build } = await this.getPrEnvInfo();
     pr = options.pr ? String(options.pr) : pr;
@@ -1268,10 +1266,7 @@ export default class Auto {
       process.exit(0);
     }
 
-    if (!args.dryRun) {
-      await this.checkClean();
-    }
-
+    await this.checkClean();
     await this.setGitUser();
 
     this.hooks.onCreateLogParse.tap("Omit merges from master", (logParse) => {
@@ -1591,9 +1586,7 @@ export default class Auto {
       noCommit: options.noChangelog,
     });
 
-    if (!options.dryRun) {
-      await this.checkClean();
-    }
+    await this.checkClean();
 
     this.logger.verbose.info("Calling version hook");
     await this.hooks.version.promise({


### PR DESCRIPTION
# What Changed

1. Remove an unnecessary git reset for single npm packages
2. Run git clean checks for `next` and `canary` dry runs

## Why

2 is mostly because we need `lerna` to actually run, which will change files, which we need to reset. So now we just run the clean check. I could have stashed/popped but I think it's better that the dry run tells you more of what would actually happen.

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.0.0-canary.1618.19907.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.0.0-canary.1618.19907.0
  npm install @auto-canary/auto@10.0.0-canary.1618.19907.0
  npm install @auto-canary/core@10.0.0-canary.1618.19907.0
  npm install @auto-canary/all-contributors@10.0.0-canary.1618.19907.0
  npm install @auto-canary/brew@10.0.0-canary.1618.19907.0
  npm install @auto-canary/chrome@10.0.0-canary.1618.19907.0
  npm install @auto-canary/cocoapods@10.0.0-canary.1618.19907.0
  npm install @auto-canary/conventional-commits@10.0.0-canary.1618.19907.0
  npm install @auto-canary/crates@10.0.0-canary.1618.19907.0
  npm install @auto-canary/docker@10.0.0-canary.1618.19907.0
  npm install @auto-canary/exec@10.0.0-canary.1618.19907.0
  npm install @auto-canary/first-time-contributor@10.0.0-canary.1618.19907.0
  npm install @auto-canary/gem@10.0.0-canary.1618.19907.0
  npm install @auto-canary/gh-pages@10.0.0-canary.1618.19907.0
  npm install @auto-canary/git-tag@10.0.0-canary.1618.19907.0
  npm install @auto-canary/gradle@10.0.0-canary.1618.19907.0
  npm install @auto-canary/jira@10.0.0-canary.1618.19907.0
  npm install @auto-canary/maven@10.0.0-canary.1618.19907.0
  npm install @auto-canary/npm@10.0.0-canary.1618.19907.0
  npm install @auto-canary/omit-commits@10.0.0-canary.1618.19907.0
  npm install @auto-canary/omit-release-notes@10.0.0-canary.1618.19907.0
  npm install @auto-canary/pr-body-labels@10.0.0-canary.1618.19907.0
  npm install @auto-canary/released@10.0.0-canary.1618.19907.0
  npm install @auto-canary/s3@10.0.0-canary.1618.19907.0
  npm install @auto-canary/slack@10.0.0-canary.1618.19907.0
  npm install @auto-canary/twitter@10.0.0-canary.1618.19907.0
  npm install @auto-canary/upload-assets@10.0.0-canary.1618.19907.0
  # or 
  yarn add @auto-canary/bot-list@10.0.0-canary.1618.19907.0
  yarn add @auto-canary/auto@10.0.0-canary.1618.19907.0
  yarn add @auto-canary/core@10.0.0-canary.1618.19907.0
  yarn add @auto-canary/all-contributors@10.0.0-canary.1618.19907.0
  yarn add @auto-canary/brew@10.0.0-canary.1618.19907.0
  yarn add @auto-canary/chrome@10.0.0-canary.1618.19907.0
  yarn add @auto-canary/cocoapods@10.0.0-canary.1618.19907.0
  yarn add @auto-canary/conventional-commits@10.0.0-canary.1618.19907.0
  yarn add @auto-canary/crates@10.0.0-canary.1618.19907.0
  yarn add @auto-canary/docker@10.0.0-canary.1618.19907.0
  yarn add @auto-canary/exec@10.0.0-canary.1618.19907.0
  yarn add @auto-canary/first-time-contributor@10.0.0-canary.1618.19907.0
  yarn add @auto-canary/gem@10.0.0-canary.1618.19907.0
  yarn add @auto-canary/gh-pages@10.0.0-canary.1618.19907.0
  yarn add @auto-canary/git-tag@10.0.0-canary.1618.19907.0
  yarn add @auto-canary/gradle@10.0.0-canary.1618.19907.0
  yarn add @auto-canary/jira@10.0.0-canary.1618.19907.0
  yarn add @auto-canary/maven@10.0.0-canary.1618.19907.0
  yarn add @auto-canary/npm@10.0.0-canary.1618.19907.0
  yarn add @auto-canary/omit-commits@10.0.0-canary.1618.19907.0
  yarn add @auto-canary/omit-release-notes@10.0.0-canary.1618.19907.0
  yarn add @auto-canary/pr-body-labels@10.0.0-canary.1618.19907.0
  yarn add @auto-canary/released@10.0.0-canary.1618.19907.0
  yarn add @auto-canary/s3@10.0.0-canary.1618.19907.0
  yarn add @auto-canary/slack@10.0.0-canary.1618.19907.0
  yarn add @auto-canary/twitter@10.0.0-canary.1618.19907.0
  yarn add @auto-canary/upload-assets@10.0.0-canary.1618.19907.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
