### PR TITLE
add "commitNextVersion" option to NPM plugin

### DIFF
--- a/plugins/npm/README.md
+++ b/plugins/npm/README.md
@@ -139,6 +139,24 @@ You can disable this behavior by using the `monorepoChangelog` option.
 }
 ```
 
+### commitNextVersion
+
+Whether to create a commit for "next" version.
+The default behavior will only create the tags.
+
+```json
+{
+  "plugins": [
+    [
+      "npm",
+      {
+        "commitNextVersion": true
+      }
+    ]
+  ]
+}
+```
+
 ### legacyAuth
 
 When publishing packages that require authentication but you are working with an internally hosted npm registry that only uses the legacy Base64 version of username:password.


### PR DESCRIPTION
# What Changed

Add option to NPM plugin to commit the `next` versions 

## Why

closes #1628

Todo:

- [x] Add tests
- [x] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.1.1-canary.1630.20092.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.1.1-canary.1630.20092.0
  npm install @auto-canary/auto@10.1.1-canary.1630.20092.0
  npm install @auto-canary/core@10.1.1-canary.1630.20092.0
  npm install @auto-canary/all-contributors@10.1.1-canary.1630.20092.0
  npm install @auto-canary/brew@10.1.1-canary.1630.20092.0
  npm install @auto-canary/chrome@10.1.1-canary.1630.20092.0
  npm install @auto-canary/cocoapods@10.1.1-canary.1630.20092.0
  npm install @auto-canary/conventional-commits@10.1.1-canary.1630.20092.0
  npm install @auto-canary/crates@10.1.1-canary.1630.20092.0
  npm install @auto-canary/docker@10.1.1-canary.1630.20092.0
  npm install @auto-canary/exec@10.1.1-canary.1630.20092.0
  npm install @auto-canary/first-time-contributor@10.1.1-canary.1630.20092.0
  npm install @auto-canary/gem@10.1.1-canary.1630.20092.0
  npm install @auto-canary/gh-pages@10.1.1-canary.1630.20092.0
  npm install @auto-canary/git-tag@10.1.1-canary.1630.20092.0
  npm install @auto-canary/gradle@10.1.1-canary.1630.20092.0
  npm install @auto-canary/jira@10.1.1-canary.1630.20092.0
  npm install @auto-canary/maven@10.1.1-canary.1630.20092.0
  npm install @auto-canary/microsoft-teams@10.1.1-canary.1630.20092.0
  npm install @auto-canary/npm@10.1.1-canary.1630.20092.0
  npm install @auto-canary/omit-commits@10.1.1-canary.1630.20092.0
  npm install @auto-canary/omit-release-notes@10.1.1-canary.1630.20092.0
  npm install @auto-canary/pr-body-labels@10.1.1-canary.1630.20092.0
  npm install @auto-canary/released@10.1.1-canary.1630.20092.0
  npm install @auto-canary/s3@10.1.1-canary.1630.20092.0
  npm install @auto-canary/slack@10.1.1-canary.1630.20092.0
  npm install @auto-canary/twitter@10.1.1-canary.1630.20092.0
  npm install @auto-canary/upload-assets@10.1.1-canary.1630.20092.0
  # or 
  yarn add @auto-canary/bot-list@10.1.1-canary.1630.20092.0
  yarn add @auto-canary/auto@10.1.1-canary.1630.20092.0
  yarn add @auto-canary/core@10.1.1-canary.1630.20092.0
  yarn add @auto-canary/all-contributors@10.1.1-canary.1630.20092.0
  yarn add @auto-canary/brew@10.1.1-canary.1630.20092.0
  yarn add @auto-canary/chrome@10.1.1-canary.1630.20092.0
  yarn add @auto-canary/cocoapods@10.1.1-canary.1630.20092.0
  yarn add @auto-canary/conventional-commits@10.1.1-canary.1630.20092.0
  yarn add @auto-canary/crates@10.1.1-canary.1630.20092.0
  yarn add @auto-canary/docker@10.1.1-canary.1630.20092.0
  yarn add @auto-canary/exec@10.1.1-canary.1630.20092.0
  yarn add @auto-canary/first-time-contributor@10.1.1-canary.1630.20092.0
  yarn add @auto-canary/gem@10.1.1-canary.1630.20092.0
  yarn add @auto-canary/gh-pages@10.1.1-canary.1630.20092.0
  yarn add @auto-canary/git-tag@10.1.1-canary.1630.20092.0
  yarn add @auto-canary/gradle@10.1.1-canary.1630.20092.0
  yarn add @auto-canary/jira@10.1.1-canary.1630.20092.0
  yarn add @auto-canary/maven@10.1.1-canary.1630.20092.0
  yarn add @auto-canary/microsoft-teams@10.1.1-canary.1630.20092.0
  yarn add @auto-canary/npm@10.1.1-canary.1630.20092.0
  yarn add @auto-canary/omit-commits@10.1.1-canary.1630.20092.0
  yarn add @auto-canary/omit-release-notes@10.1.1-canary.1630.20092.0
  yarn add @auto-canary/pr-body-labels@10.1.1-canary.1630.20092.0
  yarn add @auto-canary/released@10.1.1-canary.1630.20092.0
  yarn add @auto-canary/s3@10.1.1-canary.1630.20092.0
  yarn add @auto-canary/slack@10.1.1-canary.1630.20092.0
  yarn add @auto-canary/twitter@10.1.1-canary.1630.20092.0
  yarn add @auto-canary/upload-assets@10.1.1-canary.1630.20092.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
