### PR TITLE
NPM: independent next releases update dependency versions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -98,6 +98,7 @@
     {
       "files": ["*.test.*"],
       "rules": {
+        "import/no-extraneous-dependencies": 0,
         "import/namespace": 0,
         "no-import-assign": 0,
         "@typescript-eslint/no-empty-function": 0,

--- a/plugins/npm/__tests__/npm-next.test.ts
+++ b/plugins/npm/__tests__/npm-next.test.ts
@@ -1,3 +1,4 @@
+import endent from "endent";
 import { execSync } from "child_process";
 
 import * as Auto from "@auto-it/core";
@@ -277,7 +278,11 @@ describe("next", () => {
       "npx",
       expect.arrayContaining(["lerna", "publish", "1.2.4-next.0"])
     );
-    expect(execPromise).toHaveBeenCalledWith("git", ["reset", "--hard", "HEAD~1"]);
+    expect(execPromise).toHaveBeenCalledWith("git", [
+      "reset",
+      "--hard",
+      "HEAD~1",
+    ]);
     expect(execPromise).toHaveBeenCalledWith("git", [
       "push",
       "origin",
@@ -318,7 +323,11 @@ describe("next", () => {
       "npx",
       expect.arrayContaining(["lerna", "publish", "1.2.4-next.0"])
     );
-    expect(execPromise).not.toHaveBeenCalledWith("git", ["reset", "--hard", "HEAD~1"]);
+    expect(execPromise).not.toHaveBeenCalledWith("git", [
+      "reset",
+      "--hard",
+      "HEAD~1",
+    ]);
   });
 
   test("works in dry run in monorepo", async () => {
@@ -422,10 +431,12 @@ describe("next", () => {
       {
         name: "@foo/foo",
         path: "/path/to/1",
+        version: "0.45.0",
       },
       {
         name: "@foo/foo-bar",
         path: "/path/to/2",
+        version: "0.50.0",
       },
     ]);
     execPromise.mockImplementation((command, args) => {
@@ -455,6 +466,16 @@ describe("next", () => {
       },
     } as unknown) as Auto.Auto);
 
+    readResult = `
+      {
+        "name": "@foo/foo",
+        "version": "1.0.0-next.0",
+        "dependencies": {
+          "@foo/foo-bar": "0.50.0"
+        }
+      }
+    `;
+
     expect(
       await hooks.next.promise([], { bump: Auto.SEMVER.patch } as any)
     ).toStrictEqual(["@foo/foo@1.0.0-next.0", "@foo/foo-bar@2.0.0-next.0"]);
@@ -469,6 +490,16 @@ describe("next", () => {
       "next",
       "--tags",
     ]);
+    expect(writeSpy).toHaveBeenCalledWith(
+      "/path/to/1/package.json",
+      endent`{
+        "name": "@foo/foo",
+        "version": "1.0.0-next.1",
+        "dependencies": {
+          "@foo/foo-bar": "2.0.0-next.1"
+        }
+      }`
+    );
   });
 
   test("works in dry run in monorepo - independent", async () => {


### PR DESCRIPTION
# What Changed

When creating `next` release in an independent lerna monorepo also update dependency versions. 

## Why

closes #1628 

Todo:

- [x] Add tests

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.2.1-canary.1631.20111.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.2.1-canary.1631.20111.0
  npm install @auto-canary/auto@10.2.1-canary.1631.20111.0
  npm install @auto-canary/core@10.2.1-canary.1631.20111.0
  npm install @auto-canary/all-contributors@10.2.1-canary.1631.20111.0
  npm install @auto-canary/brew@10.2.1-canary.1631.20111.0
  npm install @auto-canary/chrome@10.2.1-canary.1631.20111.0
  npm install @auto-canary/cocoapods@10.2.1-canary.1631.20111.0
  npm install @auto-canary/conventional-commits@10.2.1-canary.1631.20111.0
  npm install @auto-canary/crates@10.2.1-canary.1631.20111.0
  npm install @auto-canary/docker@10.2.1-canary.1631.20111.0
  npm install @auto-canary/exec@10.2.1-canary.1631.20111.0
  npm install @auto-canary/first-time-contributor@10.2.1-canary.1631.20111.0
  npm install @auto-canary/gem@10.2.1-canary.1631.20111.0
  npm install @auto-canary/gh-pages@10.2.1-canary.1631.20111.0
  npm install @auto-canary/git-tag@10.2.1-canary.1631.20111.0
  npm install @auto-canary/gradle@10.2.1-canary.1631.20111.0
  npm install @auto-canary/jira@10.2.1-canary.1631.20111.0
  npm install @auto-canary/maven@10.2.1-canary.1631.20111.0
  npm install @auto-canary/microsoft-teams@10.2.1-canary.1631.20111.0
  npm install @auto-canary/npm@10.2.1-canary.1631.20111.0
  npm install @auto-canary/omit-commits@10.2.1-canary.1631.20111.0
  npm install @auto-canary/omit-release-notes@10.2.1-canary.1631.20111.0
  npm install @auto-canary/pr-body-labels@10.2.1-canary.1631.20111.0
  npm install @auto-canary/released@10.2.1-canary.1631.20111.0
  npm install @auto-canary/s3@10.2.1-canary.1631.20111.0
  npm install @auto-canary/slack@10.2.1-canary.1631.20111.0
  npm install @auto-canary/twitter@10.2.1-canary.1631.20111.0
  npm install @auto-canary/upload-assets@10.2.1-canary.1631.20111.0
  # or 
  yarn add @auto-canary/bot-list@10.2.1-canary.1631.20111.0
  yarn add @auto-canary/auto@10.2.1-canary.1631.20111.0
  yarn add @auto-canary/core@10.2.1-canary.1631.20111.0
  yarn add @auto-canary/all-contributors@10.2.1-canary.1631.20111.0
  yarn add @auto-canary/brew@10.2.1-canary.1631.20111.0
  yarn add @auto-canary/chrome@10.2.1-canary.1631.20111.0
  yarn add @auto-canary/cocoapods@10.2.1-canary.1631.20111.0
  yarn add @auto-canary/conventional-commits@10.2.1-canary.1631.20111.0
  yarn add @auto-canary/crates@10.2.1-canary.1631.20111.0
  yarn add @auto-canary/docker@10.2.1-canary.1631.20111.0
  yarn add @auto-canary/exec@10.2.1-canary.1631.20111.0
  yarn add @auto-canary/first-time-contributor@10.2.1-canary.1631.20111.0
  yarn add @auto-canary/gem@10.2.1-canary.1631.20111.0
  yarn add @auto-canary/gh-pages@10.2.1-canary.1631.20111.0
  yarn add @auto-canary/git-tag@10.2.1-canary.1631.20111.0
  yarn add @auto-canary/gradle@10.2.1-canary.1631.20111.0
  yarn add @auto-canary/jira@10.2.1-canary.1631.20111.0
  yarn add @auto-canary/maven@10.2.1-canary.1631.20111.0
  yarn add @auto-canary/microsoft-teams@10.2.1-canary.1631.20111.0
  yarn add @auto-canary/npm@10.2.1-canary.1631.20111.0
  yarn add @auto-canary/omit-commits@10.2.1-canary.1631.20111.0
  yarn add @auto-canary/omit-release-notes@10.2.1-canary.1631.20111.0
  yarn add @auto-canary/pr-body-labels@10.2.1-canary.1631.20111.0
  yarn add @auto-canary/released@10.2.1-canary.1631.20111.0
  yarn add @auto-canary/s3@10.2.1-canary.1631.20111.0
  yarn add @auto-canary/slack@10.2.1-canary.1631.20111.0
  yarn add @auto-canary/twitter@10.2.1-canary.1631.20111.0
  yarn add @auto-canary/upload-assets@10.2.1-canary.1631.20111.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
