### PR TITLE
handle multiple spaces in "lerna changed" output

### DIFF
--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -386,7 +386,7 @@ const getIndependentNextReleases = async (
   );
   const changedPackages = changedPackagesResult
     .split("\n")
-    .map((changedPackage) => changedPackage.replace(" (PRIVATE)", ""))
+    .map((changedPackage) => changedPackage.replace("(PRIVATE)", "").trim())
     .filter((changedPackage) =>
       packages.some((p) => p.name === changedPackage)
     );
@@ -452,7 +452,7 @@ const updateDependencies = (
     const depUpdate = updates.find((update) => update.name === name);
 
     if (depUpdate && version.includes(depUpdate.version)) {
-      deps[name] = version.replace(depUpdate.version, depUpdate.newVersion)
+      deps[name] = version.replace(depUpdate.version, depUpdate.newVersion);
     }
   });
 };
@@ -485,8 +485,8 @@ const tagIndependentNextReleases = async (
 
       packageJson.version = lernaPackage.newVersion;
 
-      updateDependencies(packageJson, 'dependencies', updates)
-      updateDependencies(packageJson, 'devDependencies', updates)
+      updateDependencies(packageJson, "dependencies", updates);
+      updateDependencies(packageJson, "devDependencies", updates);
 
       await writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
     })


### PR DESCRIPTION
# What Changed

see title

## Why

the extra space broke change detection for some pacakges

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.2.2-canary.1633.20142.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.2.2-canary.1633.20142.0
  npm install @auto-canary/auto@10.2.2-canary.1633.20142.0
  npm install @auto-canary/core@10.2.2-canary.1633.20142.0
  npm install @auto-canary/all-contributors@10.2.2-canary.1633.20142.0
  npm install @auto-canary/brew@10.2.2-canary.1633.20142.0
  npm install @auto-canary/chrome@10.2.2-canary.1633.20142.0
  npm install @auto-canary/cocoapods@10.2.2-canary.1633.20142.0
  npm install @auto-canary/conventional-commits@10.2.2-canary.1633.20142.0
  npm install @auto-canary/crates@10.2.2-canary.1633.20142.0
  npm install @auto-canary/docker@10.2.2-canary.1633.20142.0
  npm install @auto-canary/exec@10.2.2-canary.1633.20142.0
  npm install @auto-canary/first-time-contributor@10.2.2-canary.1633.20142.0
  npm install @auto-canary/gem@10.2.2-canary.1633.20142.0
  npm install @auto-canary/gh-pages@10.2.2-canary.1633.20142.0
  npm install @auto-canary/git-tag@10.2.2-canary.1633.20142.0
  npm install @auto-canary/gradle@10.2.2-canary.1633.20142.0
  npm install @auto-canary/jira@10.2.2-canary.1633.20142.0
  npm install @auto-canary/maven@10.2.2-canary.1633.20142.0
  npm install @auto-canary/microsoft-teams@10.2.2-canary.1633.20142.0
  npm install @auto-canary/npm@10.2.2-canary.1633.20142.0
  npm install @auto-canary/omit-commits@10.2.2-canary.1633.20142.0
  npm install @auto-canary/omit-release-notes@10.2.2-canary.1633.20142.0
  npm install @auto-canary/pr-body-labels@10.2.2-canary.1633.20142.0
  npm install @auto-canary/released@10.2.2-canary.1633.20142.0
  npm install @auto-canary/s3@10.2.2-canary.1633.20142.0
  npm install @auto-canary/slack@10.2.2-canary.1633.20142.0
  npm install @auto-canary/twitter@10.2.2-canary.1633.20142.0
  npm install @auto-canary/upload-assets@10.2.2-canary.1633.20142.0
  # or 
  yarn add @auto-canary/bot-list@10.2.2-canary.1633.20142.0
  yarn add @auto-canary/auto@10.2.2-canary.1633.20142.0
  yarn add @auto-canary/core@10.2.2-canary.1633.20142.0
  yarn add @auto-canary/all-contributors@10.2.2-canary.1633.20142.0
  yarn add @auto-canary/brew@10.2.2-canary.1633.20142.0
  yarn add @auto-canary/chrome@10.2.2-canary.1633.20142.0
  yarn add @auto-canary/cocoapods@10.2.2-canary.1633.20142.0
  yarn add @auto-canary/conventional-commits@10.2.2-canary.1633.20142.0
  yarn add @auto-canary/crates@10.2.2-canary.1633.20142.0
  yarn add @auto-canary/docker@10.2.2-canary.1633.20142.0
  yarn add @auto-canary/exec@10.2.2-canary.1633.20142.0
  yarn add @auto-canary/first-time-contributor@10.2.2-canary.1633.20142.0
  yarn add @auto-canary/gem@10.2.2-canary.1633.20142.0
  yarn add @auto-canary/gh-pages@10.2.2-canary.1633.20142.0
  yarn add @auto-canary/git-tag@10.2.2-canary.1633.20142.0
  yarn add @auto-canary/gradle@10.2.2-canary.1633.20142.0
  yarn add @auto-canary/jira@10.2.2-canary.1633.20142.0
  yarn add @auto-canary/maven@10.2.2-canary.1633.20142.0
  yarn add @auto-canary/microsoft-teams@10.2.2-canary.1633.20142.0
  yarn add @auto-canary/npm@10.2.2-canary.1633.20142.0
  yarn add @auto-canary/omit-commits@10.2.2-canary.1633.20142.0
  yarn add @auto-canary/omit-release-notes@10.2.2-canary.1633.20142.0
  yarn add @auto-canary/pr-body-labels@10.2.2-canary.1633.20142.0
  yarn add @auto-canary/released@10.2.2-canary.1633.20142.0
  yarn add @auto-canary/s3@10.2.2-canary.1633.20142.0
  yarn add @auto-canary/slack@10.2.2-canary.1633.20142.0
  yarn add @auto-canary/twitter@10.2.2-canary.1633.20142.0
  yarn add @auto-canary/upload-assets@10.2.2-canary.1633.20142.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
