### PR TITLE
Truncate commit hash for shorter canary versions

### DIFF
--- a/packages/core/src/__tests__/auto-canary-local.test.ts
+++ b/packages/core/src/__tests__/auto-canary-local.test.ts
@@ -39,7 +39,7 @@ test("shipit should publish canary in locally when not on master", async () => {
   await auto.loadConfig();
 
   auto.git!.getLatestRelease = () => Promise.resolve("1.2.3");
-  auto.git!.getSha = () => Promise.resolve("abc");
+  auto.git!.getSha = () => Promise.resolve("abcdefghijklmnop");
   jest.spyOn(auto.git!, "createComment").mockImplementation();
   auto.release!.getCommitsInRelease = () => Promise.resolve([]);
   auto.release!.getCommits = () => Promise.resolve([]);
@@ -50,7 +50,7 @@ test("shipit should publish canary in locally when not on master", async () => {
   expect(canary).toHaveBeenCalledWith(
     expect.objectContaining({
       bump: SEMVER.patch,
-      canaryIdentifier: "canary.abc",
+      canaryIdentifier: "canary.abcdefg",
     })
   );
 });

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1194,7 +1194,9 @@ export default class Auto {
     }
 
     if (!pr || !build) {
-      canaryIdentifier = `${canaryIdentifier}.${await this.git.getSha(true)}`;
+      canaryIdentifier = `${canaryIdentifier}.${(
+        await this.git.getSha(true)
+      ).slice(0, 7)}`;
     }
 
     canaryIdentifier = `canary${canaryIdentifier}`;


### PR DESCRIPTION
# What Changed

Make the commit hashes shorter in canary versions where no build or PR is detected

## Why

The full commit hash is a little much

Todo:

- [x] Add tests

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.2.4-canary.1635.20175.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.2.4-canary.1635.20175.0
  npm install @auto-canary/auto@10.2.4-canary.1635.20175.0
  npm install @auto-canary/core@10.2.4-canary.1635.20175.0
  npm install @auto-canary/all-contributors@10.2.4-canary.1635.20175.0
  npm install @auto-canary/brew@10.2.4-canary.1635.20175.0
  npm install @auto-canary/chrome@10.2.4-canary.1635.20175.0
  npm install @auto-canary/cocoapods@10.2.4-canary.1635.20175.0
  npm install @auto-canary/conventional-commits@10.2.4-canary.1635.20175.0
  npm install @auto-canary/crates@10.2.4-canary.1635.20175.0
  npm install @auto-canary/docker@10.2.4-canary.1635.20175.0
  npm install @auto-canary/exec@10.2.4-canary.1635.20175.0
  npm install @auto-canary/first-time-contributor@10.2.4-canary.1635.20175.0
  npm install @auto-canary/gem@10.2.4-canary.1635.20175.0
  npm install @auto-canary/gh-pages@10.2.4-canary.1635.20175.0
  npm install @auto-canary/git-tag@10.2.4-canary.1635.20175.0
  npm install @auto-canary/gradle@10.2.4-canary.1635.20175.0
  npm install @auto-canary/jira@10.2.4-canary.1635.20175.0
  npm install @auto-canary/maven@10.2.4-canary.1635.20175.0
  npm install @auto-canary/microsoft-teams@10.2.4-canary.1635.20175.0
  npm install @auto-canary/npm@10.2.4-canary.1635.20175.0
  npm install @auto-canary/omit-commits@10.2.4-canary.1635.20175.0
  npm install @auto-canary/omit-release-notes@10.2.4-canary.1635.20175.0
  npm install @auto-canary/pr-body-labels@10.2.4-canary.1635.20175.0
  npm install @auto-canary/released@10.2.4-canary.1635.20175.0
  npm install @auto-canary/s3@10.2.4-canary.1635.20175.0
  npm install @auto-canary/slack@10.2.4-canary.1635.20175.0
  npm install @auto-canary/twitter@10.2.4-canary.1635.20175.0
  npm install @auto-canary/upload-assets@10.2.4-canary.1635.20175.0
  # or 
  yarn add @auto-canary/bot-list@10.2.4-canary.1635.20175.0
  yarn add @auto-canary/auto@10.2.4-canary.1635.20175.0
  yarn add @auto-canary/core@10.2.4-canary.1635.20175.0
  yarn add @auto-canary/all-contributors@10.2.4-canary.1635.20175.0
  yarn add @auto-canary/brew@10.2.4-canary.1635.20175.0
  yarn add @auto-canary/chrome@10.2.4-canary.1635.20175.0
  yarn add @auto-canary/cocoapods@10.2.4-canary.1635.20175.0
  yarn add @auto-canary/conventional-commits@10.2.4-canary.1635.20175.0
  yarn add @auto-canary/crates@10.2.4-canary.1635.20175.0
  yarn add @auto-canary/docker@10.2.4-canary.1635.20175.0
  yarn add @auto-canary/exec@10.2.4-canary.1635.20175.0
  yarn add @auto-canary/first-time-contributor@10.2.4-canary.1635.20175.0
  yarn add @auto-canary/gem@10.2.4-canary.1635.20175.0
  yarn add @auto-canary/gh-pages@10.2.4-canary.1635.20175.0
  yarn add @auto-canary/git-tag@10.2.4-canary.1635.20175.0
  yarn add @auto-canary/gradle@10.2.4-canary.1635.20175.0
  yarn add @auto-canary/jira@10.2.4-canary.1635.20175.0
  yarn add @auto-canary/maven@10.2.4-canary.1635.20175.0
  yarn add @auto-canary/microsoft-teams@10.2.4-canary.1635.20175.0
  yarn add @auto-canary/npm@10.2.4-canary.1635.20175.0
  yarn add @auto-canary/omit-commits@10.2.4-canary.1635.20175.0
  yarn add @auto-canary/omit-release-notes@10.2.4-canary.1635.20175.0
  yarn add @auto-canary/pr-body-labels@10.2.4-canary.1635.20175.0
  yarn add @auto-canary/released@10.2.4-canary.1635.20175.0
  yarn add @auto-canary/s3@10.2.4-canary.1635.20175.0
  yarn add @auto-canary/slack@10.2.4-canary.1635.20175.0
  yarn add @auto-canary/twitter@10.2.4-canary.1635.20175.0
  yarn add @auto-canary/upload-assets@10.2.4-canary.1635.20175.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
