### PR TITLE
improve pr-check usage + don't fail on runs in CI base branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,12 +78,7 @@ jobs:
           at: ~/auto
       - run:
           name: Check for SemVer Label
-          command: | 
-            if [ ! -z "$CIRCLE_PR_NUMBER" ]; then
-              yarn auto pr-check --url $CIRCLE_PULL_REQUEST
-            else
-              echo "No pull request, not checking for semver label"
-            fi
+          command: yarn auto pr-check --url $CIRCLE_PULL_REQUEST
 
   test:
     <<: *defaults

--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -317,7 +317,8 @@ export const commands: AutoCommand[] = [
   {
     name: "pr-check",
     group: "Pull Request Interaction Commands",
-    description: "Check that a pull request has a SemVer label",
+    description:
+      "Check that a pull request has a SemVer label and run all pr-check plugins.",
     require: ["url"],
     options: [
       pr,

--- a/packages/core/src/__tests__/auto-ci-base-branch.test.ts
+++ b/packages/core/src/__tests__/auto-ci-base-branch.test.ts
@@ -1,0 +1,73 @@
+import envCi from "env-ci";
+import { dummyLog } from "../utils/logger";
+
+jest.mock("env-ci");
+
+const envSpy = envCi as jest.Mock;
+envSpy.mockImplementation(() => ({
+  isCi: true,
+  branch: "master",
+}));
+
+import { Auto } from "../auto";
+
+const defaults = {
+  owner: "foo",
+  repo: "bar",
+};
+
+jest.mock("@octokit/rest", () => {
+  const Octokit = class MockOctokit {
+    static plugin = () => Octokit;
+
+    authenticate = () => undefined;
+
+    search = {
+      issuesAndPullRequests: () => ({ data: { items: [] } }),
+    };
+
+    repos = {
+      get: jest.fn().mockReturnValue({}),
+    };
+
+    hook = {
+      error: () => undefined,
+    };
+  };
+
+  return { Octokit };
+});
+
+describe("Auto", () => {
+  describe("pr-check", () => {
+    jest.setTimeout(10 * 1000);
+    let createStatus: jest.Mock;
+
+    beforeEach(() => {
+      createStatus = jest.fn();
+    });
+
+    const required = {
+      url: "https://google.com",
+    };
+
+    test("should exit successfully if ran from master + CI", async () => {
+      const auto = new Auto(defaults);
+      const exit = jest.fn();
+
+      envSpy.mockImplementationOnce(() => ({
+        isCi: true,
+        branch: "master",
+      }));
+
+      // @ts-ignore
+      process.exit = exit;
+      auto.logger = dummyLog();
+      await auto.loadConfig();
+      auto.git!.createStatus = createStatus;
+
+      await auto.prCheck({ ...required });
+      expect(exit).toHaveBeenCalledWith(0);
+    });
+  });
+});

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -928,7 +928,27 @@ export default class Auto {
     this.logger.verbose.info(`Using command: 'pr-check' for '${url}'`);
 
     const target_url = url;
-    const prNumber = this.getPrNumber("prCheck", pr);
+    const prNumber = getPrNumberFromEnv(pr);
+
+    if (!prNumber) {
+      // If pr-check is ran on CI on master then we exit successfully since
+      // running pr-check in this scenario wouldn't make sense anyway. Enables
+      // adding this command without resorting to bash if/else statements.
+      if (env.isCi && env.branch === "master") {
+        process.exit(0);
+      }
+
+      // Otherwise the command should fail since no PR number was provided or found
+      this.logger.log.error(
+        endent`
+          Could not detect PR number. pr-check must be run from either a PR or have the PR number supplied via the --pr flag.
+          
+          In some CIs your branch might be built before you open a PR and posting the canary version will fail. In this case subsequent builds should succeed. 
+        `
+      );
+      process.exit(1);
+    }
+
     let msg;
     let sha;
 
@@ -1139,7 +1159,6 @@ export default class Auto {
   }
 
   /** Create a canary (or test) version of the project */
-  // eslint-disable-next-line complexity
   async canary(args: ICanaryOptions = {}): Promise<ShipitInfo | undefined> {
     const options = { ...this.getCommandDefault("canary"), ...args };
 

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -934,7 +934,7 @@ export default class Auto {
       // If pr-check is ran on CI on master then we exit successfully since
       // running pr-check in this scenario wouldn't make sense anyway. Enables
       // adding this command without resorting to bash if/else statements.
-      if (env.isCi && env.branch === "master") {
+      if (env.isCi && (env.branch === "master" || this.inPrereleaseBranch())) {
         process.exit(0);
       }
 


### PR DESCRIPTION
# Release Notes

Previously when using `auto pr-check` you would have to check that you were running the command from a PR with bash scripting so it didn't fail when running on master.

This PR simplifies this workflow so that you can run `auto pr-check` without any logic. On CI + base branch `pr-check` will exit successfully, otherwise it will check for a PR number and fail accordingly.

## Why

Less config + more automation = happy `auto` consumers

Todo:

- [ ] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.2.5-canary.1636.20195.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.2.5-canary.1636.20195.0
  npm install @auto-canary/auto@10.2.5-canary.1636.20195.0
  npm install @auto-canary/core@10.2.5-canary.1636.20195.0
  npm install @auto-canary/all-contributors@10.2.5-canary.1636.20195.0
  npm install @auto-canary/brew@10.2.5-canary.1636.20195.0
  npm install @auto-canary/chrome@10.2.5-canary.1636.20195.0
  npm install @auto-canary/cocoapods@10.2.5-canary.1636.20195.0
  npm install @auto-canary/conventional-commits@10.2.5-canary.1636.20195.0
  npm install @auto-canary/crates@10.2.5-canary.1636.20195.0
  npm install @auto-canary/docker@10.2.5-canary.1636.20195.0
  npm install @auto-canary/exec@10.2.5-canary.1636.20195.0
  npm install @auto-canary/first-time-contributor@10.2.5-canary.1636.20195.0
  npm install @auto-canary/gem@10.2.5-canary.1636.20195.0
  npm install @auto-canary/gh-pages@10.2.5-canary.1636.20195.0
  npm install @auto-canary/git-tag@10.2.5-canary.1636.20195.0
  npm install @auto-canary/gradle@10.2.5-canary.1636.20195.0
  npm install @auto-canary/jira@10.2.5-canary.1636.20195.0
  npm install @auto-canary/maven@10.2.5-canary.1636.20195.0
  npm install @auto-canary/microsoft-teams@10.2.5-canary.1636.20195.0
  npm install @auto-canary/npm@10.2.5-canary.1636.20195.0
  npm install @auto-canary/omit-commits@10.2.5-canary.1636.20195.0
  npm install @auto-canary/omit-release-notes@10.2.5-canary.1636.20195.0
  npm install @auto-canary/pr-body-labels@10.2.5-canary.1636.20195.0
  npm install @auto-canary/released@10.2.5-canary.1636.20195.0
  npm install @auto-canary/s3@10.2.5-canary.1636.20195.0
  npm install @auto-canary/slack@10.2.5-canary.1636.20195.0
  npm install @auto-canary/twitter@10.2.5-canary.1636.20195.0
  npm install @auto-canary/upload-assets@10.2.5-canary.1636.20195.0
  # or 
  yarn add @auto-canary/bot-list@10.2.5-canary.1636.20195.0
  yarn add @auto-canary/auto@10.2.5-canary.1636.20195.0
  yarn add @auto-canary/core@10.2.5-canary.1636.20195.0
  yarn add @auto-canary/all-contributors@10.2.5-canary.1636.20195.0
  yarn add @auto-canary/brew@10.2.5-canary.1636.20195.0
  yarn add @auto-canary/chrome@10.2.5-canary.1636.20195.0
  yarn add @auto-canary/cocoapods@10.2.5-canary.1636.20195.0
  yarn add @auto-canary/conventional-commits@10.2.5-canary.1636.20195.0
  yarn add @auto-canary/crates@10.2.5-canary.1636.20195.0
  yarn add @auto-canary/docker@10.2.5-canary.1636.20195.0
  yarn add @auto-canary/exec@10.2.5-canary.1636.20195.0
  yarn add @auto-canary/first-time-contributor@10.2.5-canary.1636.20195.0
  yarn add @auto-canary/gem@10.2.5-canary.1636.20195.0
  yarn add @auto-canary/gh-pages@10.2.5-canary.1636.20195.0
  yarn add @auto-canary/git-tag@10.2.5-canary.1636.20195.0
  yarn add @auto-canary/gradle@10.2.5-canary.1636.20195.0
  yarn add @auto-canary/jira@10.2.5-canary.1636.20195.0
  yarn add @auto-canary/maven@10.2.5-canary.1636.20195.0
  yarn add @auto-canary/microsoft-teams@10.2.5-canary.1636.20195.0
  yarn add @auto-canary/npm@10.2.5-canary.1636.20195.0
  yarn add @auto-canary/omit-commits@10.2.5-canary.1636.20195.0
  yarn add @auto-canary/omit-release-notes@10.2.5-canary.1636.20195.0
  yarn add @auto-canary/pr-body-labels@10.2.5-canary.1636.20195.0
  yarn add @auto-canary/released@10.2.5-canary.1636.20195.0
  yarn add @auto-canary/s3@10.2.5-canary.1636.20195.0
  yarn add @auto-canary/slack@10.2.5-canary.1636.20195.0
  yarn add @auto-canary/twitter@10.2.5-canary.1636.20195.0
  yarn add @auto-canary/upload-assets@10.2.5-canary.1636.20195.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
