### PR TITLE
Don't add release comment to PRs created by bots

### DIFF
--- a/plugins/released/README.md
+++ b/plugins/released/README.md
@@ -94,3 +94,13 @@ Lock issues that have been merged in PRs.
   "plugins": [["released", { "lockIssues": true }]]
 }
 ```
+
+### Include Bot Prs
+
+Whether to comment on PRs made by bots.
+
+```json
+{
+  "plugins": [["released", { "includeBotPrs": true }]]
+}
+```

--- a/plugins/released/__tests__/released-label.test.ts
+++ b/plugins/released/__tests__/released-label.test.ts
@@ -8,6 +8,7 @@ import {
   makeHooks,
   makeLogParseHooks,
 } from "@auto-it/core/dist/utils/make-hooks";
+import botList from "@auto-it/bot-list";
 
 import ReleasedLabelPlugin from "../src";
 
@@ -137,6 +138,32 @@ describe("release label plugin", () => {
     await autoHooks.afterRelease.promise({
       lastRelease: "0.1.0",
       commits: [commit],
+      releaseNotes: "",
+    });
+
+    expect(comment).not.toHaveBeenCalled();
+  });
+
+  test("should do nothing for bots", async () => {
+    const releasedLabel = new ReleasedLabelPlugin();
+    const autoHooks = makeHooks();
+    releasedLabel.apply(({
+      hooks: autoHooks,
+      labels: defaultLabels,
+      logger: dummyLog(),
+      options: {},
+      comment,
+      git,
+    } as unknown) as Auto);
+
+    const commit = makeCommitFromMsg("normal commit with no bump");
+    commit.authors[0].username = botList[0];
+    const commit2 = makeCommitFromMsg("normal commit with no bump");
+    commit.authors[0].type = "Bot";
+
+    await autoHooks.afterRelease.promise({
+      lastRelease: "0.1.0",
+      commits: [commit, commit2],
       releaseNotes: "",
     });
 

--- a/plugins/released/package.json
+++ b/plugins/released/package.json
@@ -38,6 +38,7 @@
     "test": "jest --maxWorkers=2 --config ../../package.json"
   },
   "dependencies": {
+    "@auto-it/bot-list": "link:../../packages/bot-list",
     "@auto-it/core": "link:../../packages/core",
     "deepmerge": "^4.0.0",
     "fp-ts": "^2.5.3",

--- a/plugins/released/src/index.ts
+++ b/plugins/released/src/index.ts
@@ -1,6 +1,7 @@
 import { Auto, IPlugin, validatePluginConfiguration } from "@auto-it/core";
 import { IExtendedCommit } from "@auto-it/core/dist/log-parse";
 import { RestEndpointMethodTypes } from "@octokit/rest";
+import botList from "@auto-it/bot-list";
 
 import merge from "deepmerge";
 import * as t from "io-ts";
@@ -126,6 +127,17 @@ export default class ReleasedLabelPlugin implements IPlugin {
       const branch = pr?.data.head.ref;
 
       if (branch && auto.config?.prereleaseBranches.includes(branch)) {
+        return;
+      }
+
+      if (
+        commit.authors.some(
+          (author) =>
+            (author.name && botList.includes(author.name)) ||
+            (author.username && botList.includes(author.username)) ||
+            author.type === "Bot"
+        )
+      ) {
         return;
       }
 

--- a/plugins/released/src/index.ts
+++ b/plugins/released/src/index.ts
@@ -15,6 +15,8 @@ const pluginOptions = t.partial({
   prereleaseLabel: t.string,
   /** Whether to lock the issue once the pull request has been released */
   lockIssues: t.boolean,
+  /** Whether to comment on PRs made by bots */
+  includeBotPrs: t.boolean,
 });
 
 export type IReleasedLabelPluginOptions = t.TypeOf<typeof pluginOptions>;
@@ -25,6 +27,7 @@ const defaultOptions: Required<IReleasedLabelPluginOptions> = {
   label: "released",
   prereleaseLabel: "prerelease",
   lockIssues: false,
+  includeBotPrs: false,
   message: `:rocket: ${TYPE} was released in ${VERSION} :rocket:`,
 };
 
@@ -131,6 +134,7 @@ export default class ReleasedLabelPlugin implements IPlugin {
       }
 
       if (
+        !this.options.includeBotPrs &&
         commit.authors.some(
           (author) =>
             (author.name && botList.includes(author.name)) ||


### PR DESCRIPTION
# What Changed

see title

## Why

closes #1634

Todo:

- [x] Add tests
- [x] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.2.6-canary.1637.20209.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.2.6-canary.1637.20209.0
  npm install @auto-canary/auto@10.2.6-canary.1637.20209.0
  npm install @auto-canary/core@10.2.6-canary.1637.20209.0
  npm install @auto-canary/all-contributors@10.2.6-canary.1637.20209.0
  npm install @auto-canary/brew@10.2.6-canary.1637.20209.0
  npm install @auto-canary/chrome@10.2.6-canary.1637.20209.0
  npm install @auto-canary/cocoapods@10.2.6-canary.1637.20209.0
  npm install @auto-canary/conventional-commits@10.2.6-canary.1637.20209.0
  npm install @auto-canary/crates@10.2.6-canary.1637.20209.0
  npm install @auto-canary/docker@10.2.6-canary.1637.20209.0
  npm install @auto-canary/exec@10.2.6-canary.1637.20209.0
  npm install @auto-canary/first-time-contributor@10.2.6-canary.1637.20209.0
  npm install @auto-canary/gem@10.2.6-canary.1637.20209.0
  npm install @auto-canary/gh-pages@10.2.6-canary.1637.20209.0
  npm install @auto-canary/git-tag@10.2.6-canary.1637.20209.0
  npm install @auto-canary/gradle@10.2.6-canary.1637.20209.0
  npm install @auto-canary/jira@10.2.6-canary.1637.20209.0
  npm install @auto-canary/maven@10.2.6-canary.1637.20209.0
  npm install @auto-canary/microsoft-teams@10.2.6-canary.1637.20209.0
  npm install @auto-canary/npm@10.2.6-canary.1637.20209.0
  npm install @auto-canary/omit-commits@10.2.6-canary.1637.20209.0
  npm install @auto-canary/omit-release-notes@10.2.6-canary.1637.20209.0
  npm install @auto-canary/pr-body-labels@10.2.6-canary.1637.20209.0
  npm install @auto-canary/released@10.2.6-canary.1637.20209.0
  npm install @auto-canary/s3@10.2.6-canary.1637.20209.0
  npm install @auto-canary/slack@10.2.6-canary.1637.20209.0
  npm install @auto-canary/twitter@10.2.6-canary.1637.20209.0
  npm install @auto-canary/upload-assets@10.2.6-canary.1637.20209.0
  # or 
  yarn add @auto-canary/bot-list@10.2.6-canary.1637.20209.0
  yarn add @auto-canary/auto@10.2.6-canary.1637.20209.0
  yarn add @auto-canary/core@10.2.6-canary.1637.20209.0
  yarn add @auto-canary/all-contributors@10.2.6-canary.1637.20209.0
  yarn add @auto-canary/brew@10.2.6-canary.1637.20209.0
  yarn add @auto-canary/chrome@10.2.6-canary.1637.20209.0
  yarn add @auto-canary/cocoapods@10.2.6-canary.1637.20209.0
  yarn add @auto-canary/conventional-commits@10.2.6-canary.1637.20209.0
  yarn add @auto-canary/crates@10.2.6-canary.1637.20209.0
  yarn add @auto-canary/docker@10.2.6-canary.1637.20209.0
  yarn add @auto-canary/exec@10.2.6-canary.1637.20209.0
  yarn add @auto-canary/first-time-contributor@10.2.6-canary.1637.20209.0
  yarn add @auto-canary/gem@10.2.6-canary.1637.20209.0
  yarn add @auto-canary/gh-pages@10.2.6-canary.1637.20209.0
  yarn add @auto-canary/git-tag@10.2.6-canary.1637.20209.0
  yarn add @auto-canary/gradle@10.2.6-canary.1637.20209.0
  yarn add @auto-canary/jira@10.2.6-canary.1637.20209.0
  yarn add @auto-canary/maven@10.2.6-canary.1637.20209.0
  yarn add @auto-canary/microsoft-teams@10.2.6-canary.1637.20209.0
  yarn add @auto-canary/npm@10.2.6-canary.1637.20209.0
  yarn add @auto-canary/omit-commits@10.2.6-canary.1637.20209.0
  yarn add @auto-canary/omit-release-notes@10.2.6-canary.1637.20209.0
  yarn add @auto-canary/pr-body-labels@10.2.6-canary.1637.20209.0
  yarn add @auto-canary/released@10.2.6-canary.1637.20209.0
  yarn add @auto-canary/s3@10.2.6-canary.1637.20209.0
  yarn add @auto-canary/slack@10.2.6-canary.1637.20209.0
  yarn add @auto-canary/twitter@10.2.6-canary.1637.20209.0
  yarn add @auto-canary/upload-assets@10.2.6-canary.1637.20209.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
