### PR TITLE
add dry-run info to afterShipIt hook

### DIFF
--- a/docs/pages/docs/plugins/release-lifecycle-hooks.mdx
+++ b/docs/pages/docs/plugins/release-lifecycle-hooks.mdx
@@ -339,6 +339,7 @@ Ran after the `shipit` command has run.
   - `newVersion` - The new version that was release
   - `commits` - the commits in the release
   - `context` - The type of release that was created (`latest`, `next`, `canary`, or `old`)
+  - `dryRun` - Whether the run is a dry run
 
 ```ts
 auto.hooks.afterShipIt.tap("MyPlugin", async ({ context }) => {

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -153,7 +153,7 @@ export interface IAutoHooks {
   /** Ran after the `shipit` command has run. */
   afterShipIt: AsyncParallelHook<
     [
-      {
+      DryRunOption & {
         /** The version published in the shipit run */
         newVersion: string | undefined;
         /** The commits the version was published for */
@@ -1532,6 +1532,7 @@ export default class Auto {
       newVersion,
       commitsInRelease,
       context,
+      dryRun: args.dryRun,
     });
   }
 

--- a/plugins/gradle/src/index.ts
+++ b/plugins/gradle/src/index.ts
@@ -238,8 +238,8 @@ export default class GradleReleasePluginPlugin implements IPlugin {
       ]);
     });
 
-    auto.hooks.afterShipIt.tapPromise(this.name, async () => {
-      if (!this.snapshotRelease) {
+    auto.hooks.afterShipIt.tapPromise(this.name, async ({ dryRun }) => {
+      if (!this.snapshotRelease || dryRun) {
         return;
       }
 

--- a/plugins/maven/src/index.ts
+++ b/plugins/maven/src/index.ts
@@ -277,8 +277,8 @@ export default class MavenPlugin implements IPlugin {
       ]);
     });
 
-    auto.hooks.afterShipIt.tapPromise(this.name, async () => {
-      if (!this.snapshotRelease) {
+    auto.hooks.afterShipIt.tapPromise(this.name, async ({ dryRun }) => {
+      if (!this.snapshotRelease || dryRun) {
         return;
       }
 


### PR DESCRIPTION
# What Changed

see title 

## Why

closes  #1649

Todo:

- [ ] Add tests
- [x] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.3.1-canary.1650.20352.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.3.1-canary.1650.20352.0
  npm install @auto-canary/auto@10.3.1-canary.1650.20352.0
  npm install @auto-canary/core@10.3.1-canary.1650.20352.0
  npm install @auto-canary/all-contributors@10.3.1-canary.1650.20352.0
  npm install @auto-canary/brew@10.3.1-canary.1650.20352.0
  npm install @auto-canary/chrome@10.3.1-canary.1650.20352.0
  npm install @auto-canary/cocoapods@10.3.1-canary.1650.20352.0
  npm install @auto-canary/conventional-commits@10.3.1-canary.1650.20352.0
  npm install @auto-canary/crates@10.3.1-canary.1650.20352.0
  npm install @auto-canary/docker@10.3.1-canary.1650.20352.0
  npm install @auto-canary/exec@10.3.1-canary.1650.20352.0
  npm install @auto-canary/first-time-contributor@10.3.1-canary.1650.20352.0
  npm install @auto-canary/gem@10.3.1-canary.1650.20352.0
  npm install @auto-canary/gh-pages@10.3.1-canary.1650.20352.0
  npm install @auto-canary/git-tag@10.3.1-canary.1650.20352.0
  npm install @auto-canary/gradle@10.3.1-canary.1650.20352.0
  npm install @auto-canary/jira@10.3.1-canary.1650.20352.0
  npm install @auto-canary/maven@10.3.1-canary.1650.20352.0
  npm install @auto-canary/microsoft-teams@10.3.1-canary.1650.20352.0
  npm install @auto-canary/npm@10.3.1-canary.1650.20352.0
  npm install @auto-canary/omit-commits@10.3.1-canary.1650.20352.0
  npm install @auto-canary/omit-release-notes@10.3.1-canary.1650.20352.0
  npm install @auto-canary/pr-body-labels@10.3.1-canary.1650.20352.0
  npm install @auto-canary/released@10.3.1-canary.1650.20352.0
  npm install @auto-canary/s3@10.3.1-canary.1650.20352.0
  npm install @auto-canary/slack@10.3.1-canary.1650.20352.0
  npm install @auto-canary/twitter@10.3.1-canary.1650.20352.0
  npm install @auto-canary/upload-assets@10.3.1-canary.1650.20352.0
  # or 
  yarn add @auto-canary/bot-list@10.3.1-canary.1650.20352.0
  yarn add @auto-canary/auto@10.3.1-canary.1650.20352.0
  yarn add @auto-canary/core@10.3.1-canary.1650.20352.0
  yarn add @auto-canary/all-contributors@10.3.1-canary.1650.20352.0
  yarn add @auto-canary/brew@10.3.1-canary.1650.20352.0
  yarn add @auto-canary/chrome@10.3.1-canary.1650.20352.0
  yarn add @auto-canary/cocoapods@10.3.1-canary.1650.20352.0
  yarn add @auto-canary/conventional-commits@10.3.1-canary.1650.20352.0
  yarn add @auto-canary/crates@10.3.1-canary.1650.20352.0
  yarn add @auto-canary/docker@10.3.1-canary.1650.20352.0
  yarn add @auto-canary/exec@10.3.1-canary.1650.20352.0
  yarn add @auto-canary/first-time-contributor@10.3.1-canary.1650.20352.0
  yarn add @auto-canary/gem@10.3.1-canary.1650.20352.0
  yarn add @auto-canary/gh-pages@10.3.1-canary.1650.20352.0
  yarn add @auto-canary/git-tag@10.3.1-canary.1650.20352.0
  yarn add @auto-canary/gradle@10.3.1-canary.1650.20352.0
  yarn add @auto-canary/jira@10.3.1-canary.1650.20352.0
  yarn add @auto-canary/maven@10.3.1-canary.1650.20352.0
  yarn add @auto-canary/microsoft-teams@10.3.1-canary.1650.20352.0
  yarn add @auto-canary/npm@10.3.1-canary.1650.20352.0
  yarn add @auto-canary/omit-commits@10.3.1-canary.1650.20352.0
  yarn add @auto-canary/omit-release-notes@10.3.1-canary.1650.20352.0
  yarn add @auto-canary/pr-body-labels@10.3.1-canary.1650.20352.0
  yarn add @auto-canary/released@10.3.1-canary.1650.20352.0
  yarn add @auto-canary/s3@10.3.1-canary.1650.20352.0
  yarn add @auto-canary/slack@10.3.1-canary.1650.20352.0
  yarn add @auto-canary/twitter@10.3.1-canary.1650.20352.0
  yarn add @auto-canary/upload-assets@10.3.1-canary.1650.20352.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
