### PR TITLE
fix url pr-check uses for auto's CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
           at: ~/auto
       - run:
           name: Check for SemVer Label
-          command: yarn auto pr-check --url $CIRCLE_PULL_REQUEST
+          command: yarn auto pr-check --url $CIRCLE_BUILD_URL
 
   test:
     <<: *defaults


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.4.2-canary.1663.20441.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.4.2-canary.1663.20441.0
  npm install @auto-canary/auto@10.4.2-canary.1663.20441.0
  npm install @auto-canary/core@10.4.2-canary.1663.20441.0
  npm install @auto-canary/all-contributors@10.4.2-canary.1663.20441.0
  npm install @auto-canary/brew@10.4.2-canary.1663.20441.0
  npm install @auto-canary/chrome@10.4.2-canary.1663.20441.0
  npm install @auto-canary/cocoapods@10.4.2-canary.1663.20441.0
  npm install @auto-canary/conventional-commits@10.4.2-canary.1663.20441.0
  npm install @auto-canary/crates@10.4.2-canary.1663.20441.0
  npm install @auto-canary/docker@10.4.2-canary.1663.20441.0
  npm install @auto-canary/exec@10.4.2-canary.1663.20441.0
  npm install @auto-canary/first-time-contributor@10.4.2-canary.1663.20441.0
  npm install @auto-canary/gem@10.4.2-canary.1663.20441.0
  npm install @auto-canary/gh-pages@10.4.2-canary.1663.20441.0
  npm install @auto-canary/git-tag@10.4.2-canary.1663.20441.0
  npm install @auto-canary/gradle@10.4.2-canary.1663.20441.0
  npm install @auto-canary/jira@10.4.2-canary.1663.20441.0
  npm install @auto-canary/maven@10.4.2-canary.1663.20441.0
  npm install @auto-canary/microsoft-teams@10.4.2-canary.1663.20441.0
  npm install @auto-canary/npm@10.4.2-canary.1663.20441.0
  npm install @auto-canary/omit-commits@10.4.2-canary.1663.20441.0
  npm install @auto-canary/omit-release-notes@10.4.2-canary.1663.20441.0
  npm install @auto-canary/pr-body-labels@10.4.2-canary.1663.20441.0
  npm install @auto-canary/released@10.4.2-canary.1663.20441.0
  npm install @auto-canary/s3@10.4.2-canary.1663.20441.0
  npm install @auto-canary/slack@10.4.2-canary.1663.20441.0
  npm install @auto-canary/twitter@10.4.2-canary.1663.20441.0
  npm install @auto-canary/upload-assets@10.4.2-canary.1663.20441.0
  # or 
  yarn add @auto-canary/bot-list@10.4.2-canary.1663.20441.0
  yarn add @auto-canary/auto@10.4.2-canary.1663.20441.0
  yarn add @auto-canary/core@10.4.2-canary.1663.20441.0
  yarn add @auto-canary/all-contributors@10.4.2-canary.1663.20441.0
  yarn add @auto-canary/brew@10.4.2-canary.1663.20441.0
  yarn add @auto-canary/chrome@10.4.2-canary.1663.20441.0
  yarn add @auto-canary/cocoapods@10.4.2-canary.1663.20441.0
  yarn add @auto-canary/conventional-commits@10.4.2-canary.1663.20441.0
  yarn add @auto-canary/crates@10.4.2-canary.1663.20441.0
  yarn add @auto-canary/docker@10.4.2-canary.1663.20441.0
  yarn add @auto-canary/exec@10.4.2-canary.1663.20441.0
  yarn add @auto-canary/first-time-contributor@10.4.2-canary.1663.20441.0
  yarn add @auto-canary/gem@10.4.2-canary.1663.20441.0
  yarn add @auto-canary/gh-pages@10.4.2-canary.1663.20441.0
  yarn add @auto-canary/git-tag@10.4.2-canary.1663.20441.0
  yarn add @auto-canary/gradle@10.4.2-canary.1663.20441.0
  yarn add @auto-canary/jira@10.4.2-canary.1663.20441.0
  yarn add @auto-canary/maven@10.4.2-canary.1663.20441.0
  yarn add @auto-canary/microsoft-teams@10.4.2-canary.1663.20441.0
  yarn add @auto-canary/npm@10.4.2-canary.1663.20441.0
  yarn add @auto-canary/omit-commits@10.4.2-canary.1663.20441.0
  yarn add @auto-canary/omit-release-notes@10.4.2-canary.1663.20441.0
  yarn add @auto-canary/pr-body-labels@10.4.2-canary.1663.20441.0
  yarn add @auto-canary/released@10.4.2-canary.1663.20441.0
  yarn add @auto-canary/s3@10.4.2-canary.1663.20441.0
  yarn add @auto-canary/slack@10.4.2-canary.1663.20441.0
  yarn add @auto-canary/twitter@10.4.2-canary.1663.20441.0
  yarn add @auto-canary/upload-assets@10.4.2-canary.1663.20441.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
