### PR TITLE
Add `@auto-it/magic-zero` Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Auto has an extensive plugin system and wide variety of official plugins. Make a
 
 - [brew](./plugins/brew) - Automate the creation of Homebrew formulae
 - [chrome](./plugins/chrome) - Publish code to Chrome Web Store
-- [crates](./plugins/crates) - Publish Rust crates
 - [cocoapods](./plugins/cocoapods) - Version your [Cocoapod](https://cocoapods.org/), and push to your specs repository!
+- [crates](./plugins/crates) - Publish Rust crates
 - [docker](./plugins/docker) - Publish images with Docker
 - [gem](./plugins/gem) - Publish ruby gems
 - [git-tag](./plugins/git-tag) - Manage your projects version through just a git tag (`default` when used with binary)
@@ -64,6 +64,7 @@ Auto has an extensive plugin system and wide variety of official plugins. Make a
 - [first-time-contributor](./plugins/first-time-contributor) - Thank first time contributors for their work right in your release notes.
 - [gh-pages](./plugins/gh-pages) - Automate publishing to your gh-pages documentation website
 - [jira](./plugins/jira) - Include Jira story links in the changelog
+- [magic-zero](./plugins/magic-zero) - A plugin that closely adheres to semver versioning for 0.0.x and 0.x.y releases
 - [omit-commits](./plugins/omit-commits) - Ignore commits base on name, email, subject, labels, and username
 - [omit-release-notes](./plugins/omit-release-notes) - Ignore release notes in PRs made by certain accounts
 - [pr-body-labels](./plugins/pr-body-labels) - Allow outside contributors to indicate what semver label should be applied to the Pull Request

--- a/docs/pages/docs/_sidebar.mdx
+++ b/docs/pages/docs/_sidebar.mdx
@@ -66,6 +66,7 @@ Functionality Plugins
 - [First Time Contributor](./generated/first-time-contributor)
 - [GitHub Pages](./generated/gh-pages)
 - [Jira](./generated/jira)
+- [Magic Zero](./generated/magic-zero)
 - [Omit Commits](./generated/omit-commits)
 - [Omit Release Notes](./generated/omit-release-notes)
 - [PR Body Labels](./generated/pr-body-labels)

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -12,7 +12,6 @@ import {
   AsyncParallelHook,
   AsyncSeriesBailHook,
   SyncHook,
-  SyncWaterfallHook,
   AsyncSeriesHook,
   AsyncSeriesWaterfallHook,
 } from "tapable";
@@ -139,7 +138,7 @@ type PublishResponse = RestEndpointMethodTypes["repos"]["createRelease"]["respon
 
 export interface IAutoHooks {
   /** Modify what is in the config. You must return the config in this hook. */
-  modifyConfig: SyncWaterfallHook<[LoadedAutoRc]>;
+  modifyConfig: AsyncSeriesWaterfallHook<[LoadedAutoRc]>;
   /** Validate what is in the config. You must return the config in this hook. */
   validateConfig: ValidatePluginHook;
   /** Happens before anything is done. This is a great place to check for platform specific secrets. */
@@ -552,7 +551,7 @@ export default class Auto {
     };
     this.loadPlugins(this.config!);
     this.loadDefaultBehavior();
-    this.config = this.hooks.modifyConfig.call(this.config!);
+    this.config = await this.hooks.modifyConfig.promise(this.config!);
     this.labels = this.config.labels;
     this.semVerLabels = getVersionMap(this.config.labels);
     await this.hooks.beforeRun.promise(this.config);

--- a/packages/core/src/utils/make-hooks.ts
+++ b/packages/core/src/utils/make-hooks.ts
@@ -3,7 +3,6 @@ import {
   AsyncSeriesBailHook,
   AsyncSeriesWaterfallHook,
   SyncHook,
-  SyncWaterfallHook,
   AsyncSeriesHook,
 } from "tapable";
 import { IAutoHooks } from "../auto";
@@ -15,7 +14,7 @@ import { InteractiveInitHooks } from "../init";
 /** Make the hooks for "auto" */
 export const makeHooks = (): IAutoHooks => ({
   beforeRun: new AsyncSeriesHook(["config"]),
-  modifyConfig: new SyncWaterfallHook(["config"]),
+  modifyConfig: new AsyncSeriesWaterfallHook(["config"]),
   validateConfig: new AsyncSeriesBailHook(["name", "options"]),
   beforeShipIt: new AsyncSeriesHook(["context"]),
   afterChangelog: new AsyncSeriesHook(["context"]),

--- a/plugins/cocoapods/__tests__/cocoapods.test.ts
+++ b/plugins/cocoapods/__tests__/cocoapods.test.ts
@@ -120,9 +120,9 @@ describe("Cocoapods Plugin", () => {
     });
   });
   describe("modifyConfig hook", () => {
-    test("should set noVersionPrefix to true", () => {
+    test("should set noVersionPrefix to true", async () => {
       const config = {};
-      expect(hooks.modifyConfig.call(config as any)).toStrictEqual({
+      expect(await hooks.modifyConfig.promise(config as any)).toStrictEqual({
         noVersionPrefix: true,
       });
     });

--- a/plugins/magic-zero/README.md
+++ b/plugins/magic-zero/README.md
@@ -1,0 +1,82 @@
+# Magic-Zero Plugin
+
+A plugin that closely adheres to semver versioning for 0.0.x and 0.x.y releases.
+
+In the default `auto` experience the `patch`, `minor`, and `major` only increment the corresponding digit in the version.
+The rules for incrementing version `< 1.0.0` are not as intuitive or [agreed upon](https://github.com/semver/semver/issues/221).
+This plugin adds a new label (`graduate`) and changes `auto`'s behavior to do the following:
+
+**0.0.x:**
+
+_Starting version:_ `0.0.1`
+
+`patch` => `0.0.2`  
+`minor` => `0.0.2`  
+`major` => `0.0.2`  
+`graduate` => `0.1.0`  
+
+**0.x.y:**
+
+_Starting version:_ `0.1.0`
+
+`patch` => `0.1.1`  
+`minor` => `0.1.1`  
+`major` => `0.2.0`  
+`graduate` => `1.0.0`  
+
+Once you're project is `>= 1.0.0` this plugin effectively does nothing.
+
+## Installation
+
+This plugin is not included with the `auto` CLI installed via NPM. To install:
+
+```bash
+npm i --save-dev @auto-it/magic-zero
+# or
+yarn add -D @auto-it/magic-zero
+```
+
+## Usage
+
+```json
+{
+  "plugins": [
+    "magic-zero"
+    // other plugins
+  ]
+}
+```
+
+## Options
+
+### `label`
+
+The label to graduate a version to the next left 0 digit.
+
+```json
+{
+  "plugins": [
+    ["magic-zero", { "label": "super major" }]
+    // other plugins
+  ]
+}
+```
+
+If you want to customize the label color/description you must define the label in your `.autorc`.
+
+```json
+{
+  "plugins": [
+    ["magic-zero", { "label": "super major" }]
+    // other plugins
+  ],
+  "labels": [
+    {
+      "name": "super major",
+      "description": "Graduate a version to the next left 0 digit",
+      "releaseType": "major",
+      "color": "#000"
+    }
+  ]
+}
+```

--- a/plugins/magic-zero/__tests__/magic-zero.test.ts
+++ b/plugins/magic-zero/__tests__/magic-zero.test.ts
@@ -1,0 +1,112 @@
+import { makeHooks } from "@auto-it/core/dist/utils/make-hooks";
+import { defaultLabels } from "@auto-it/core/dist/semver";
+
+import MagicZero from "../src";
+
+const setup = (version: string) => {
+  const plugin = new MagicZero();
+  const hooks = makeHooks();
+
+  hooks.getPreviousVersion.tap("test", () => version);
+
+  plugin.apply({
+    hooks,
+    git: { getLatestRelease: () => undefined },
+  } as any);
+
+  return hooks;
+};
+
+describe("Magic-Zero Plugin", () => {
+  test("should downgrade major/minor => patch for 0.0.x", async () => {
+    const hooks = setup("0.0.1");
+    const config = await hooks.modifyConfig.promise({
+      labels: [...defaultLabels],
+    } as any);
+
+    expect(config.labels).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "major",
+          releaseType: "patch",
+        }),
+        expect.objectContaining({
+          name: "minor",
+          releaseType: "patch",
+        }),
+        expect.objectContaining({
+          name: "graduate",
+          releaseType: "minor",
+        }),
+      ])
+    );
+  });
+
+  test("should downgrade major => minor for 0.x.y", async () => {
+    const hooks = setup("0.1.0");
+    const config = await hooks.modifyConfig.promise({
+      labels: [...defaultLabels],
+    } as any);
+
+    expect(config.labels).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "major",
+          releaseType: "minor",
+        }),
+        expect.objectContaining({
+          name: "graduate",
+          releaseType: "major",
+        }),
+      ])
+    );
+  });
+
+  test("should downgrade minor => patch for 0.x.y", async () => {
+    const hooks = setup("0.1.0");
+    const config = await hooks.modifyConfig.promise({
+      labels: [...defaultLabels],
+    } as any);
+
+    expect(config.labels).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "minor",
+          releaseType: "patch",
+        }),
+        expect.objectContaining({
+          name: "graduate",
+          releaseType: "major",
+        }),
+      ])
+    );
+  });
+
+  test("should do nothing for major/minor >= 1.0.0", async () => {
+    const hooks = setup("1.0.0");
+    const config = await hooks.modifyConfig.promise({
+      labels: [...defaultLabels],
+    } as any);
+
+    expect(config.labels).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "minor",
+          releaseType: "minor",
+        }),
+        expect.objectContaining({
+          name: "major",
+          releaseType: "major",
+        }),
+      ])
+    );
+
+    expect(config.labels).not.toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "graduate",
+        }),
+      ])
+    );
+  });
+});

--- a/plugins/magic-zero/package.json
+++ b/plugins/magic-zero/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@auto-it/magic-zero",
+  "version": "10.5.0",
+  "main": "dist/index.js",
+  "description": "A plugin that closely adheres to semver versioning for 0.0.x and 0.x.y releases",
+  "license": "MIT",
+  "author": {
+    "name": "Andrew Lisowski",
+    "email": "lisowski54@gmail.com"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/intuit/auto"
+  },
+  "files": [
+    "dist"
+  ],
+  "keywords": [
+    "automation",
+    "semantic",
+    "release",
+    "github",
+    "labels",
+    "automated",
+    "continuos integration",
+    "changelog"
+  ],
+  "scripts": {
+    "build": "tsc -b",
+    "start": "npm run build -- -w",
+    "lint": "eslint src --ext .ts",
+    "test": "jest --maxWorkers=2 --config ../../package.json"
+  },
+  "dependencies": {
+    "@auto-it/core": "link:../../packages/core",
+    "fp-ts": "^2.5.3",
+    "io-ts": "^2.1.2",
+    "tslib": "1.10.0"
+  }
+}

--- a/plugins/magic-zero/package.json
+++ b/plugins/magic-zero/package.json
@@ -39,6 +39,7 @@
     "@auto-it/core": "link:../../packages/core",
     "fp-ts": "^2.5.3",
     "io-ts": "^2.1.2",
+    "semver": "^7.0.0",
     "tslib": "1.10.0"
   }
 }

--- a/plugins/magic-zero/src/index.ts
+++ b/plugins/magic-zero/src/index.ts
@@ -1,0 +1,96 @@
+import {
+  Auto,
+  IPlugin,
+  SEMVER,
+  validatePluginConfiguration,
+} from "@auto-it/core";
+import { satisfies } from "semver";
+import * as t from "io-ts";
+
+const pluginOptions = t.partial({
+  /** The label to graduate a version to the next left 0 digit */
+  label: t.string,
+});
+
+export type IMagicZeroPluginOptions = t.TypeOf<typeof pluginOptions>;
+
+const defaultOptions: Required<IMagicZeroPluginOptions> = {
+  label: "graduate",
+};
+
+/** A plugin that closely adheres to semver versioning for 0.0.x and 0.x.y releases */
+export default class MagicZeroPlugin implements IPlugin {
+  /** The name of the plugin */
+  name = "magic-zero";
+
+  /** The options of the plugin */
+  readonly options: Required<IMagicZeroPluginOptions>;
+
+  /** Initialize the plugin with it's options */
+  constructor(options: IMagicZeroPluginOptions = {}) {
+    this.options = { ...defaultOptions, ...options };
+  }
+
+  /** Tap into auto plugin points. */
+  apply(auto: Auto) {
+    auto.hooks.validateConfig.tapPromise(this.name, async (name, options) => {
+      // If it's a string thats valid config
+      if (name === this.name && typeof options !== "string") {
+        return validatePluginConfiguration(this.name, pluginOptions, options);
+      }
+    });
+
+    auto.hooks.modifyConfig.tapPromise(this.name, async (config) => {
+      const current = await auto.hooks.getPreviousVersion.promise();
+
+      if (satisfies(current, "< 1.0.0")) {
+        // Add special label for graduating releases
+        if (!config.labels.find((l) => l.name === this.options.label)) {
+          config.labels.push({
+            name: this.options.label,
+            description: "Graduate a version to the next left 0 digit",
+            releaseType: SEMVER.major,
+          });
+        }
+
+        if (satisfies(current, "> 0.0.x")) {
+          // 0.x.y Versioning
+          // major resolves to minor
+          // minor resolves to patch
+          config.labels = config.labels.map((label) => {
+            let releaseType = label.releaseType;
+
+            if (label.name !== this.options.label) {
+              if (releaseType === SEMVER.minor) {
+                releaseType = SEMVER.patch;
+              } else if (releaseType === SEMVER.major) {
+                releaseType = SEMVER.minor;
+              }
+            }
+
+            return { ...label, releaseType };
+          });
+        } else {
+          // 0.0.x Versioning
+          // major/minor/patch all resolve to patch
+          config.labels = config.labels.map((label) => {
+            let releaseType = label.releaseType;
+
+            if (label.name === this.options.label) {
+              releaseType = SEMVER.minor;
+            } else if (
+              releaseType === SEMVER.minor ||
+              releaseType === SEMVER.major
+            ) {
+              releaseType = SEMVER.patch;
+            }
+
+            return { ...label, releaseType };
+          });
+        }
+      }
+
+      return config;
+    });
+  }
+}

--- a/plugins/magic-zero/tsconfig.json
+++ b/plugins/magic-zero/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*", "../../typings/**/*"],
+
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+
+  "references": [
+    {
+      "path": "../../packages/core"
+    }
+  ]
+}

--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -405,7 +405,7 @@ describe("modifyConfig", () => {
       logger,
     } as Auto.Auto);
 
-    expect(hooks.modifyConfig.call({} as any)).toStrictEqual({});
+    expect(await hooks.modifyConfig.promise({} as any)).toStrictEqual({});
   });
 
   test("should not modify config when tagVersionPrefix is not set", async () => {
@@ -428,7 +428,7 @@ describe("modifyConfig", () => {
       }
     `;
 
-    expect(hooks.modifyConfig.call({} as any)).toStrictEqual({});
+    expect(await hooks.modifyConfig.promise({} as any)).toStrictEqual({});
   });
 
   test("should modify config when tagVersionPrefix is set", async () => {
@@ -452,7 +452,7 @@ describe("modifyConfig", () => {
       logger,
     } as Auto.Auto);
 
-    expect(hooks.modifyConfig.call({} as any)).toStrictEqual({
+    expect(await hooks.modifyConfig.promise({} as any)).toStrictEqual({
       noVersionPrefix: true,
     });
   });

--- a/scripts/template-plugin/README.md
+++ b/scripts/template-plugin/README.md
@@ -17,7 +17,7 @@ yarn add -D @auto-it/{{kebab}}
 ```json
 {
   "plugins": [
-    ["{{kebab}}"]
+    "{{kebab}}"
     // other plugins
   ]
 }

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -82,6 +82,9 @@
     },
     {
       "path": "packages/package-json-utils"
+    },
+    {
+      "path": "plugins/magic-zero"
     }
   ]
 }


### PR DESCRIPTION
# What Changed

A plugin that closely adheres to semver versioning for 0.0.x and 0.x.y releases.

## Why

closes #1699 

Todo:

- [x] Add tests
- [x] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.5.1-canary.1701.20906.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.5.1-canary.1701.20906.0
  npm install @auto-canary/auto@10.5.1-canary.1701.20906.0
  npm install @auto-canary/core@10.5.1-canary.1701.20906.0
  npm install @auto-canary/package-json-utils@10.5.1-canary.1701.20906.0
  npm install @auto-canary/all-contributors@10.5.1-canary.1701.20906.0
  npm install @auto-canary/brew@10.5.1-canary.1701.20906.0
  npm install @auto-canary/chrome@10.5.1-canary.1701.20906.0
  npm install @auto-canary/cocoapods@10.5.1-canary.1701.20906.0
  npm install @auto-canary/conventional-commits@10.5.1-canary.1701.20906.0
  npm install @auto-canary/crates@10.5.1-canary.1701.20906.0
  npm install @auto-canary/docker@10.5.1-canary.1701.20906.0
  npm install @auto-canary/exec@10.5.1-canary.1701.20906.0
  npm install @auto-canary/first-time-contributor@10.5.1-canary.1701.20906.0
  npm install @auto-canary/gem@10.5.1-canary.1701.20906.0
  npm install @auto-canary/gh-pages@10.5.1-canary.1701.20906.0
  npm install @auto-canary/git-tag@10.5.1-canary.1701.20906.0
  npm install @auto-canary/gradle@10.5.1-canary.1701.20906.0
  npm install @auto-canary/jira@10.5.1-canary.1701.20906.0
  npm install @auto-canary/magic-zero@10.5.1-canary.1701.20906.0
  npm install @auto-canary/maven@10.5.1-canary.1701.20906.0
  npm install @auto-canary/microsoft-teams@10.5.1-canary.1701.20906.0
  npm install @auto-canary/npm@10.5.1-canary.1701.20906.0
  npm install @auto-canary/omit-commits@10.5.1-canary.1701.20906.0
  npm install @auto-canary/omit-release-notes@10.5.1-canary.1701.20906.0
  npm install @auto-canary/pr-body-labels@10.5.1-canary.1701.20906.0
  npm install @auto-canary/released@10.5.1-canary.1701.20906.0
  npm install @auto-canary/s3@10.5.1-canary.1701.20906.0
  npm install @auto-canary/slack@10.5.1-canary.1701.20906.0
  npm install @auto-canary/twitter@10.5.1-canary.1701.20906.0
  npm install @auto-canary/upload-assets@10.5.1-canary.1701.20906.0
  npm install @auto-canary/vscode@10.5.1-canary.1701.20906.0
  # or 
  yarn add @auto-canary/bot-list@10.5.1-canary.1701.20906.0
  yarn add @auto-canary/auto@10.5.1-canary.1701.20906.0
  yarn add @auto-canary/core@10.5.1-canary.1701.20906.0
  yarn add @auto-canary/package-json-utils@10.5.1-canary.1701.20906.0
  yarn add @auto-canary/all-contributors@10.5.1-canary.1701.20906.0
  yarn add @auto-canary/brew@10.5.1-canary.1701.20906.0
  yarn add @auto-canary/chrome@10.5.1-canary.1701.20906.0
  yarn add @auto-canary/cocoapods@10.5.1-canary.1701.20906.0
  yarn add @auto-canary/conventional-commits@10.5.1-canary.1701.20906.0
  yarn add @auto-canary/crates@10.5.1-canary.1701.20906.0
  yarn add @auto-canary/docker@10.5.1-canary.1701.20906.0
  yarn add @auto-canary/exec@10.5.1-canary.1701.20906.0
  yarn add @auto-canary/first-time-contributor@10.5.1-canary.1701.20906.0
  yarn add @auto-canary/gem@10.5.1-canary.1701.20906.0
  yarn add @auto-canary/gh-pages@10.5.1-canary.1701.20906.0
  yarn add @auto-canary/git-tag@10.5.1-canary.1701.20906.0
  yarn add @auto-canary/gradle@10.5.1-canary.1701.20906.0
  yarn add @auto-canary/jira@10.5.1-canary.1701.20906.0
  yarn add @auto-canary/magic-zero@10.5.1-canary.1701.20906.0
  yarn add @auto-canary/maven@10.5.1-canary.1701.20906.0
  yarn add @auto-canary/microsoft-teams@10.5.1-canary.1701.20906.0
  yarn add @auto-canary/npm@10.5.1-canary.1701.20906.0
  yarn add @auto-canary/omit-commits@10.5.1-canary.1701.20906.0
  yarn add @auto-canary/omit-release-notes@10.5.1-canary.1701.20906.0
  yarn add @auto-canary/pr-body-labels@10.5.1-canary.1701.20906.0
  yarn add @auto-canary/released@10.5.1-canary.1701.20906.0
  yarn add @auto-canary/s3@10.5.1-canary.1701.20906.0
  yarn add @auto-canary/slack@10.5.1-canary.1701.20906.0
  yarn add @auto-canary/twitter@10.5.1-canary.1701.20906.0
  yarn add @auto-canary/upload-assets@10.5.1-canary.1701.20906.0
  yarn add @auto-canary/vscode@10.5.1-canary.1701.20906.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
