### PR TITLE
feat: tag canaries for cocoapods plugin

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -307,7 +307,7 @@ const loadEnv = () => {
 };
 
 /** Get the pr number from user input or the CI env. */
-function getPrNumberFromEnv(pr?: number) {
+export function getPrNumberFromEnv(pr?: number) {
   const envPr = "pr" in env && Number(env.pr);
   const prNumber = pr || envPr;
 

--- a/plugins/cocoapods/__tests__/cocoapods.test.ts
+++ b/plugins/cocoapods/__tests__/cocoapods.test.ts
@@ -117,11 +117,9 @@ describe("Cocoapods Plugin", () => {
           throw new Error("Filesystem Error");
         });
 
-      await expect(
-        updatePodspecVersion("./Test.podspec", "0.0.2")
-      ).rejects.toThrowError(
-        "Error updating version in podspec: ./Test.podspec"
-      );
+      expect(
+        updatePodspecVersion.bind(null, "./Test.podspec", "0.0.2")
+      ).toThrowError("Error updating version in podspec: ./Test.podspec");
     });
     test("should successfully write new version", async () => {
       mockPodspec(specWithVersion("0.0.1"));
@@ -282,13 +280,8 @@ describe("Cocoapods Plugin", () => {
       });
 
       expect(newVersion).toBe("0.1.0-canary.1.1.1");
-      expect(exec).toBeCalledTimes(4);
-      expect(exec).toHaveBeenCalledWith("git", [
-        "commit",
-        "-am",
-        `"update version: 0.1.0-canary.1.1.1 [skip ci]"`,
-        "--no-verify",
-      ]);
+      expect(exec).toBeCalledTimes(3);
+      expect(exec).toHaveBeenCalledWith("git", ["checkout", "./Test.podspec"]);
 
       expect(mock).toHaveBeenLastCalledWith(
         expect.any(String),

--- a/plugins/cocoapods/__tests__/cocoapods.test.ts
+++ b/plugins/cocoapods/__tests__/cocoapods.test.ts
@@ -250,8 +250,7 @@ describe("Cocoapods Plugin", () => {
 
   describe("canary hook", () => {
     test("should tag with canary version", async () => {
-      // mockPodspec(specWithVersion("0.0.1"));
-
+      jest.spyOn(Auto, "getPrNumberFromEnv").mockReturnValue(1);
       let podSpec = specWithVersion("0.0.1");
       jest
         .spyOn(utilities, "getPodspecContents")
@@ -269,9 +268,17 @@ describe("Cocoapods Plugin", () => {
         prefixRelease,
         git: {
           getLatestRelease: async () => "0.0.1",
+          getPullRequest: async () => ({
+            data: {
+              head: {
+                repo: {
+                  clone_url: "https://github.com/intuit/auto.git",
+                },
+              },
+            },
+          }),
         },
         getCurrentVersion: async () => "0.0.1",
-        remote: "https://github.com/intuit/auto.git",
       } as unknown) as Auto.Auto);
 
       const newVersion = await hook.canary.promise({

--- a/plugins/cocoapods/__tests__/cocoapods.test.ts
+++ b/plugins/cocoapods/__tests__/cocoapods.test.ts
@@ -276,7 +276,7 @@ describe("Cocoapods Plugin", () => {
 
       const newVersion = await hook.canary.promise({
         bump: "minor" as Auto.SEMVER,
-        canaryIdentifier: "1.1.1",
+        canaryIdentifier: "canary.1.1.1",
       });
 
       expect(newVersion).toBe("0.1.0-canary.1.1.1");

--- a/plugins/cocoapods/src/index.ts
+++ b/plugins/cocoapods/src/index.ts
@@ -119,11 +119,10 @@ export function updatePodspecVersion(podspecPath: string, version: string) {
 }
 
 /**
- * Updates the version in the podspec to the supplied version
+ * Updates the source location to point to the current commit for the given remote
  *
  * @param podspecPath - The relative path to the podspec file
  * @param remote - The git remote that is being used
- * @param canary - Whether to update to the canary location or not
  */
 export async function updateSourceLocation(
   podspecPath: string,

--- a/plugins/cocoapods/src/index.ts
+++ b/plugins/cocoapods/src/index.ts
@@ -237,7 +237,7 @@ export default class CocoapodsPlugin implements IPlugin {
         const lastRelease = await auto.git.getLatestRelease();
         const current = await auto.getCurrentVersion(lastRelease);
         const nextVersion = inc(current, bump as ReleaseType);
-        const canaryVersion = `${nextVersion}-canary.${canaryIdentifier}`;
+        const canaryVersion = `${nextVersion}-${canaryIdentifier}`;
 
         if (dryRun) {
           if (quiet) {

--- a/plugins/cocoapods/src/index.ts
+++ b/plugins/cocoapods/src/index.ts
@@ -94,10 +94,7 @@ export function getSourceInfo(podspecPath: string): string {
  * @param podspecPath - The relative path to the podspec file
  * @param version - The version to update the podspec to
  */
-export async function updatePodspecVersion(
-  podspecPath: string,
-  version: string
-) {
+export function updatePodspecVersion(podspecPath: string, version: string) {
   const previousVersion = getVersion(podspecPath);
   const parsedContents = getParsedPodspecContents(podspecPath);
   const podspecContents = getPodspecContents(podspecPath);
@@ -114,13 +111,6 @@ export async function updatePodspecVersion(
       );
 
       writePodspecContents(podspecPath, newPodspec);
-
-      await execPromise("git", [
-        "commit",
-        "-am",
-        `"update version: ${version} [skip ci]"`,
-        "--no-verify",
-      ]);
     }
   } catch (error) {
     throw new Error(`Error updating version in podspec: ${podspecPath}`);
@@ -219,7 +209,14 @@ export default class CocoapodsPlugin implements IPlugin {
           );
         }
 
-        await updatePodspecVersion(this.options.podspecPath, releaseVersion);
+        updatePodspecVersion(this.options.podspecPath, releaseVersion);
+
+        await execPromise("git", [
+          "commit",
+          "-am",
+          `"update version: ${releaseVersion} [skip ci]"`,
+          "--no-verify",
+        ]);
 
         await execPromise("git", [
           "tag",
@@ -254,7 +251,7 @@ export default class CocoapodsPlugin implements IPlugin {
 
         await updateSourceLocation(this.options.podspecPath, auto.remote);
 
-        await updatePodspecVersion(this.options.podspecPath, canaryVersion);
+        updatePodspecVersion(this.options.podspecPath, canaryVersion);
 
         // Publish the canary podspec, committing it isn't needed for specs push
         await this.publishPodSpec(podLogLevel);

--- a/plugins/cocoapods/src/index.ts
+++ b/plugins/cocoapods/src/index.ts
@@ -2,7 +2,9 @@ import {
   Auto,
   IPlugin,
   execPromise,
+  getCurrentBranch,
   validatePluginConfiguration,
+  ILogger,
 } from "@auto-it/core";
 
 import { inc, ReleaseType } from "semver";
@@ -14,7 +16,7 @@ import { getPodspecContents, writePodspecContents } from "./utilities";
 const logPrefix = "[Cocoapods-Plugin]";
 
 /** Regex used to pull the version line from the spec */
-const versionRegex = /\.version\s*=\s*['|"](?<version>\d+\.\d+\.\d+)['|"]/;
+const versionRegex = /\.version\s*=\s*['|"](?<version>\d+\.\d+\.\d+.*?)['|"]/;
 /**
  * Wrapper to add logPrefix to messages
  *
@@ -113,6 +115,9 @@ export default class CocoapodsPlugin implements IPlugin {
   /** The name of the plugin */
   name = "cocoapods";
 
+  /** The auto logger */
+  logger?: ILogger;
+
   /** The options of the plugin */
   readonly options: ICocoapodsPluginOptions;
 
@@ -123,6 +128,7 @@ export default class CocoapodsPlugin implements IPlugin {
 
   /** Tap into auto plugin points. */
   apply(auto: Auto) {
+    this.logger = auto.logger;
     const isQuiet = auto.logger.logLevel === "quiet";
     const isVerbose =
       auto.logger.logLevel === "verbose" ||
@@ -144,34 +150,73 @@ export default class CocoapodsPlugin implements IPlugin {
       auto.prefixRelease(getVersion(this.options.podspecPath))
     );
 
-    auto.hooks.version.tapPromise(this.name, async ({ bump, dryRun, quiet }) => {
-      const previousVersion = getVersion(this.options.podspecPath);
-      const releaseVersion = inc(previousVersion, bump as ReleaseType);
+    auto.hooks.version.tapPromise(
+      this.name,
+      async ({ bump, dryRun, quiet }) => {
+        const previousVersion = getVersion(this.options.podspecPath);
+        const releaseVersion = inc(previousVersion, bump as ReleaseType);
 
-      if (dryRun && releaseVersion) {
-        if (quiet) {
-          console.log(releaseVersion);
-        } else {
-          auto.logger.log.info(`Would have published: ${releaseVersion}`);
+        if (dryRun && releaseVersion) {
+          if (quiet) {
+            console.log(releaseVersion);
+          } else {
+            auto.logger.log.info(`Would have published: ${releaseVersion}`);
+          }
+
+          return;
         }
 
-        return;
-      }
+        if (!releaseVersion) {
+          throw new Error(
+            `Could not increment previous version: ${previousVersion}`
+          );
+        }
 
-      if (!releaseVersion) {
-        throw new Error(
-          `Could not increment previous version: ${previousVersion}`
-        );
+        await updatePodspecVersion(this.options.podspecPath, releaseVersion);
+        await execPromise("git", [
+          "tag",
+          releaseVersion,
+          "-m",
+          `"Update version to ${releaseVersion}"`,
+        ]);
       }
+    );
 
-      await updatePodspecVersion(this.options.podspecPath, releaseVersion);
-      await execPromise("git", [
-        "tag",
-        releaseVersion,
-        "-m",
-        `"Update version to ${releaseVersion}"`,
-      ]);
-    });
+    auto.hooks.canary.tapPromise(
+      this.name,
+      async ({ bump, canaryIdentifier, dryRun, quiet }) => {
+        if (!auto.git) {
+          return;
+        }
+
+        const lastRelease = await auto.git.getLatestRelease();
+        const current = await auto.getCurrentVersion(lastRelease);
+        const nextVersion = inc(current, bump as ReleaseType);
+        const canaryVersion = `${nextVersion}-canary.${canaryIdentifier}`;
+        const branch = getCurrentBranch() || "";
+
+        if (dryRun) {
+          if (quiet) {
+            console.log(canaryVersion);
+          } else {
+            auto.logger.log.info(`Would have published: ${canaryVersion}`);
+          }
+
+          return;
+        }
+
+        await execPromise("git", [
+          "tag",
+          canaryVersion,
+          "-m",
+          `Update version to ${canaryVersion}`,
+        ]);
+        await execPromise("git", ["push", auto.remote, branch, "--tags"]);
+
+        await this.publishPodSpec(podLogLevel);
+        return canaryVersion;
+      }
+    );
 
     auto.hooks.beforeShipIt.tapPromise(this.name, async ({ dryRun }) => {
       if (dryRun) {
@@ -190,8 +235,6 @@ export default class CocoapodsPlugin implements IPlugin {
     });
 
     auto.hooks.publish.tapPromise(this.name, async () => {
-      const [pod, ...commands] = this.options.podCommand?.split(" ") || ["pod"];
-
       await execPromise("git", [
         "push",
         "--follow-tags",
@@ -199,73 +242,36 @@ export default class CocoapodsPlugin implements IPlugin {
         auto.remote,
         auto.baseBranch,
       ]);
+      await this.publishPodSpec(podLogLevel);
+    });
+  }
 
-      if (!this.options.specsRepo) {
-        auto.logger.log.info(logMessage(`Pushing to Cocoapods trunk`));
-        await execPromise(pod, [
-          ...commands,
-          "trunk",
-          "push",
-          ...(this.options.flags || []),
-          this.options.podspecPath,
-          ...podLogLevel,
-        ]);
-        return;
-      }
+  /**
+   *
+   */
+  async publishPodSpec(podLogLevel: string[]) {
+    const [pod, ...commands] = this.options.podCommand?.split(" ") || ["pod"];
+    if (!this.options.specsRepo) {
+      this.logger?.log.info(logMessage(`Pushing to Cocoapods trunk`));
+      await execPromise(pod, [
+        ...commands,
+        "trunk",
+        "push",
+        ...(this.options.flags || []),
+        this.options.podspecPath,
+        ...podLogLevel,
+      ]);
+      return;
+    }
 
-      try {
-        const existingRepos = await execPromise(pod, [
-          ...commands,
-          "repo",
-          "list",
-        ]);
-        if (existingRepos.indexOf("autoPublishRepo") !== -1) {
-          auto.logger.log.info("Removing existing autoPublishRepo");
-          await execPromise(pod, [
-            ...commands,
-            "repo",
-            "remove",
-            "autoPublishRepo",
-            ...podLogLevel,
-          ]);
-        }
-      } catch (error) {
-        auto.logger.log.warn(
-          `Error Checking for existing Specs repositories: ${error}`
-        );
-      }
-
-      try {
-        await execPromise(pod, [
-          ...commands,
-          "repo",
-          "add",
-          "autoPublishRepo",
-          this.options.specsRepo,
-          ...podLogLevel,
-        ]);
-
-        auto.logger.log.info(
-          logMessage(`Pushing to specs repo: ${this.options.specsRepo}`)
-        );
-
-        await execPromise(pod, [
-          ...commands,
-          "repo",
-          "push",
-          ...(this.options.flags || []),
-          "autoPublishRepo",
-          this.options.podspecPath,
-          ...podLogLevel,
-        ]);
-      } catch (error) {
-        auto.logger.log.error(
-          logMessage(
-            `Error pushing to specs repo: ${this.options.specsRepo}. Error: ${error}`
-          )
-        );
-        process.exit(1);
-      } finally {
+    try {
+      const existingRepos = await execPromise(pod, [
+        ...commands,
+        "repo",
+        "list",
+      ]);
+      if (existingRepos.indexOf("autoPublishRepo") !== -1) {
+        this.logger?.log.info("Removing existing autoPublishRepo");
         await execPromise(pod, [
           ...commands,
           "repo",
@@ -274,6 +280,50 @@ export default class CocoapodsPlugin implements IPlugin {
           ...podLogLevel,
         ]);
       }
-    });
+    } catch (error) {
+      this.logger?.log.warn(
+        `Error Checking for existing Specs repositories: ${error}`
+      );
+    }
+
+    try {
+      await execPromise(pod, [
+        ...commands,
+        "repo",
+        "add",
+        "autoPublishRepo",
+        this.options.specsRepo,
+        ...podLogLevel,
+      ]);
+
+      this.logger?.log.info(
+        logMessage(`Pushing to specs repo: ${this.options.specsRepo}`)
+      );
+
+      await execPromise(pod, [
+        ...commands,
+        "repo",
+        "push",
+        ...(this.options.flags || []),
+        "autoPublishRepo",
+        this.options.podspecPath,
+        ...podLogLevel,
+      ]);
+    } catch (error) {
+      this.logger?.log.error(
+        logMessage(
+          `Error pushing to specs repo: ${this.options.specsRepo}. Error: ${error}`
+        )
+      );
+      process.exit(1);
+    } finally {
+      await execPromise(pod, [
+        ...commands,
+        "repo",
+        "remove",
+        "autoPublishRepo",
+        ...podLogLevel,
+      ]);
+    }
   }
 }

--- a/plugins/cocoapods/src/index.ts
+++ b/plugins/cocoapods/src/index.ts
@@ -19,7 +19,7 @@ const logPrefix = "[Cocoapods-Plugin]";
 const versionRegex = /\.version\s*=\s*['|"](?<version>\d+\.\d+\.\d+.*?)['|"]/;
 
 /** Regex used to pull the source dictionary from the spec */
-const sourceLineRegex = /(?<specVar>\w+)\.source.*(?<source>\{\s*:\s*git.*\})/;
+const sourceLineRegex = /\.source.*(?<source>\{\s*:\s*git.*\})/;
 
 /**
  * Wrapper to add logPrefix to messages

--- a/plugins/cocoapods/src/index.ts
+++ b/plugins/cocoapods/src/index.ts
@@ -230,14 +230,23 @@ export default class CocoapodsPlugin implements IPlugin {
     auto.hooks.canary.tapPromise(
       this.name,
       async ({ bump, canaryIdentifier, dryRun, quiet }) => {
-        const pr = getPrNumberFromEnv();
-
-        if (!auto.git || !pr) {
+        if (!auto.git) {
           return;
         }
 
-        const remoteRepo = await (await auto.git.getPullRequest(pr)).data.head
-          .repo.clone_url;
+        const pr = getPrNumberFromEnv();
+
+        if (!pr) {
+          this.logger?.log.info(
+            logMessage(
+              `No PR number found, using ${auto.remote} as the remote for canary. Commit must be pushed for this to work.`
+            )
+          );
+        }
+
+        const remoteRepo = pr
+          ? await (await auto.git.getPullRequest(pr)).data.head.repo.clone_url
+          : auto.remote;
 
         const lastRelease = await auto.git.getLatestRelease();
         const current = await auto.getCurrentVersion(lastRelease);


### PR DESCRIPTION
# What Changed
Add canary support for cocoapods.

During canary hook, rewrite the source location in the podspec to the current remote pointing to the latest commit

then push it up and reset the podspec

i tested this out and committing the modified podspec isnt necessary (unless we'd need to read the version from it?)

## Why

canaries are useful

Todo:

- [x] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.5.1-canary.1702.20954.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.5.1-canary.1702.20954.0
  npm install @auto-canary/auto@10.5.1-canary.1702.20954.0
  npm install @auto-canary/core@10.5.1-canary.1702.20954.0
  npm install @auto-canary/all-contributors@10.5.1-canary.1702.20954.0
  npm install @auto-canary/brew@10.5.1-canary.1702.20954.0
  npm install @auto-canary/chrome@10.5.1-canary.1702.20954.0
  npm install @auto-canary/cocoapods@10.5.1-canary.1702.20954.0
  npm install @auto-canary/conventional-commits@10.5.1-canary.1702.20954.0
  npm install @auto-canary/crates@10.5.1-canary.1702.20954.0
  npm install @auto-canary/docker@10.5.1-canary.1702.20954.0
  npm install @auto-canary/exec@10.5.1-canary.1702.20954.0
  npm install @auto-canary/first-time-contributor@10.5.1-canary.1702.20954.0
  npm install @auto-canary/gem@10.5.1-canary.1702.20954.0
  npm install @auto-canary/gh-pages@10.5.1-canary.1702.20954.0
  npm install @auto-canary/git-tag@10.5.1-canary.1702.20954.0
  npm install @auto-canary/gradle@10.5.1-canary.1702.20954.0
  npm install @auto-canary/jira@10.5.1-canary.1702.20954.0
  npm install @auto-canary/maven@10.5.1-canary.1702.20954.0
  npm install @auto-canary/microsoft-teams@10.5.1-canary.1702.20954.0
  npm install @auto-canary/npm@10.5.1-canary.1702.20954.0
  npm install @auto-canary/omit-commits@10.5.1-canary.1702.20954.0
  npm install @auto-canary/omit-release-notes@10.5.1-canary.1702.20954.0
  npm install @auto-canary/pr-body-labels@10.5.1-canary.1702.20954.0
  npm install @auto-canary/released@10.5.1-canary.1702.20954.0
  npm install @auto-canary/s3@10.5.1-canary.1702.20954.0
  npm install @auto-canary/slack@10.5.1-canary.1702.20954.0
  npm install @auto-canary/twitter@10.5.1-canary.1702.20954.0
  npm install @auto-canary/upload-assets@10.5.1-canary.1702.20954.0
  # or 
  yarn add @auto-canary/bot-list@10.5.1-canary.1702.20954.0
  yarn add @auto-canary/auto@10.5.1-canary.1702.20954.0
  yarn add @auto-canary/core@10.5.1-canary.1702.20954.0
  yarn add @auto-canary/all-contributors@10.5.1-canary.1702.20954.0
  yarn add @auto-canary/brew@10.5.1-canary.1702.20954.0
  yarn add @auto-canary/chrome@10.5.1-canary.1702.20954.0
  yarn add @auto-canary/cocoapods@10.5.1-canary.1702.20954.0
  yarn add @auto-canary/conventional-commits@10.5.1-canary.1702.20954.0
  yarn add @auto-canary/crates@10.5.1-canary.1702.20954.0
  yarn add @auto-canary/docker@10.5.1-canary.1702.20954.0
  yarn add @auto-canary/exec@10.5.1-canary.1702.20954.0
  yarn add @auto-canary/first-time-contributor@10.5.1-canary.1702.20954.0
  yarn add @auto-canary/gem@10.5.1-canary.1702.20954.0
  yarn add @auto-canary/gh-pages@10.5.1-canary.1702.20954.0
  yarn add @auto-canary/git-tag@10.5.1-canary.1702.20954.0
  yarn add @auto-canary/gradle@10.5.1-canary.1702.20954.0
  yarn add @auto-canary/jira@10.5.1-canary.1702.20954.0
  yarn add @auto-canary/maven@10.5.1-canary.1702.20954.0
  yarn add @auto-canary/microsoft-teams@10.5.1-canary.1702.20954.0
  yarn add @auto-canary/npm@10.5.1-canary.1702.20954.0
  yarn add @auto-canary/omit-commits@10.5.1-canary.1702.20954.0
  yarn add @auto-canary/omit-release-notes@10.5.1-canary.1702.20954.0
  yarn add @auto-canary/pr-body-labels@10.5.1-canary.1702.20954.0
  yarn add @auto-canary/released@10.5.1-canary.1702.20954.0
  yarn add @auto-canary/s3@10.5.1-canary.1702.20954.0
  yarn add @auto-canary/slack@10.5.1-canary.1702.20954.0
  yarn add @auto-canary/twitter@10.5.1-canary.1702.20954.0
  yarn add @auto-canary/upload-assets@10.5.1-canary.1702.20954.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
