### PR TITLE
default to patch for 0 non-auto labels on head PR

### DIFF
--- a/packages/core/src/__tests__/semver.test.ts
+++ b/packages/core/src/__tests__/semver.test.ts
@@ -48,6 +48,12 @@ describe("calculateSemVerBump", () => {
     );
   });
 
+  test("should release a patch for pr with non-auto labels", () => {
+    expect(calculateSemVerBump([["a", "b", "c"], []], semverMap)).toBe(
+      SEMVER.patch
+    );
+  });
+
   test("should be able to configure default label", () => {
     expect(
       calculateSemVerBump([[], ["documentation"]], semverMap, {

--- a/packages/core/src/semver.ts
+++ b/packages/core/src/semver.ts
@@ -192,16 +192,23 @@ export function calculateSemVerBump(
   const releaseTypes = new Set<ReleaseType>();
   const skipReleaseLabels = labelMap.get("skip") || [];
 
+  /** Find the release type + labels that match the given label */
+  const getLabelEntry = (label: string) =>
+    [...labelMap.entries()].find((pair) => pair[1].includes(label));
+
   prLabels.forEach((pr, index) => {
-    // If the head pr has no labels we default to a patch
-    if (pr.length === 0 && index === 0) {
+    // Default to a patch when:
+    // 1. No labels on HEAD PR
+    // 2. It has labels but none of them are auto labels
+    if (
+      index === 0 &&
+      (pr.length === 0 || !pr.find((label) => getLabelEntry(label)))
+    ) {
       releaseTypes.add(defaultReleaseType);
     }
 
     pr.forEach((label) => {
-      const userLabel = [...labelMap.entries()].find((pair) =>
-        pair[1].includes(label)
-      );
+      const userLabel = getLabelEntry(label);
 
       if (userLabel) {
         releaseTypes.add(userLabel[0]);


### PR DESCRIPTION
# What Changed

see title

## Why

`auto` defaults to `patch` for label-less PRs so the default release is a patch. Before this change adding any non-auto label would break this and no release would go out. In this case it should still create a patch release.

Todo:

- [ ] Add tests
- [x] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.5.1-canary.1703.20960.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.5.1-canary.1703.20960.0
  npm install @auto-canary/auto@10.5.1-canary.1703.20960.0
  npm install @auto-canary/core@10.5.1-canary.1703.20960.0
  npm install @auto-canary/package-json-utils@10.5.1-canary.1703.20960.0
  npm install @auto-canary/all-contributors@10.5.1-canary.1703.20960.0
  npm install @auto-canary/brew@10.5.1-canary.1703.20960.0
  npm install @auto-canary/chrome@10.5.1-canary.1703.20960.0
  npm install @auto-canary/cocoapods@10.5.1-canary.1703.20960.0
  npm install @auto-canary/conventional-commits@10.5.1-canary.1703.20960.0
  npm install @auto-canary/crates@10.5.1-canary.1703.20960.0
  npm install @auto-canary/docker@10.5.1-canary.1703.20960.0
  npm install @auto-canary/exec@10.5.1-canary.1703.20960.0
  npm install @auto-canary/first-time-contributor@10.5.1-canary.1703.20960.0
  npm install @auto-canary/gem@10.5.1-canary.1703.20960.0
  npm install @auto-canary/gh-pages@10.5.1-canary.1703.20960.0
  npm install @auto-canary/git-tag@10.5.1-canary.1703.20960.0
  npm install @auto-canary/gradle@10.5.1-canary.1703.20960.0
  npm install @auto-canary/jira@10.5.1-canary.1703.20960.0
  npm install @auto-canary/maven@10.5.1-canary.1703.20960.0
  npm install @auto-canary/microsoft-teams@10.5.1-canary.1703.20960.0
  npm install @auto-canary/npm@10.5.1-canary.1703.20960.0
  npm install @auto-canary/omit-commits@10.5.1-canary.1703.20960.0
  npm install @auto-canary/omit-release-notes@10.5.1-canary.1703.20960.0
  npm install @auto-canary/pr-body-labels@10.5.1-canary.1703.20960.0
  npm install @auto-canary/released@10.5.1-canary.1703.20960.0
  npm install @auto-canary/s3@10.5.1-canary.1703.20960.0
  npm install @auto-canary/slack@10.5.1-canary.1703.20960.0
  npm install @auto-canary/twitter@10.5.1-canary.1703.20960.0
  npm install @auto-canary/upload-assets@10.5.1-canary.1703.20960.0
  npm install @auto-canary/vscode@10.5.1-canary.1703.20960.0
  # or 
  yarn add @auto-canary/bot-list@10.5.1-canary.1703.20960.0
  yarn add @auto-canary/auto@10.5.1-canary.1703.20960.0
  yarn add @auto-canary/core@10.5.1-canary.1703.20960.0
  yarn add @auto-canary/package-json-utils@10.5.1-canary.1703.20960.0
  yarn add @auto-canary/all-contributors@10.5.1-canary.1703.20960.0
  yarn add @auto-canary/brew@10.5.1-canary.1703.20960.0
  yarn add @auto-canary/chrome@10.5.1-canary.1703.20960.0
  yarn add @auto-canary/cocoapods@10.5.1-canary.1703.20960.0
  yarn add @auto-canary/conventional-commits@10.5.1-canary.1703.20960.0
  yarn add @auto-canary/crates@10.5.1-canary.1703.20960.0
  yarn add @auto-canary/docker@10.5.1-canary.1703.20960.0
  yarn add @auto-canary/exec@10.5.1-canary.1703.20960.0
  yarn add @auto-canary/first-time-contributor@10.5.1-canary.1703.20960.0
  yarn add @auto-canary/gem@10.5.1-canary.1703.20960.0
  yarn add @auto-canary/gh-pages@10.5.1-canary.1703.20960.0
  yarn add @auto-canary/git-tag@10.5.1-canary.1703.20960.0
  yarn add @auto-canary/gradle@10.5.1-canary.1703.20960.0
  yarn add @auto-canary/jira@10.5.1-canary.1703.20960.0
  yarn add @auto-canary/maven@10.5.1-canary.1703.20960.0
  yarn add @auto-canary/microsoft-teams@10.5.1-canary.1703.20960.0
  yarn add @auto-canary/npm@10.5.1-canary.1703.20960.0
  yarn add @auto-canary/omit-commits@10.5.1-canary.1703.20960.0
  yarn add @auto-canary/omit-release-notes@10.5.1-canary.1703.20960.0
  yarn add @auto-canary/pr-body-labels@10.5.1-canary.1703.20960.0
  yarn add @auto-canary/released@10.5.1-canary.1703.20960.0
  yarn add @auto-canary/s3@10.5.1-canary.1703.20960.0
  yarn add @auto-canary/slack@10.5.1-canary.1703.20960.0
  yarn add @auto-canary/twitter@10.5.1-canary.1703.20960.0
  yarn add @auto-canary/upload-assets@10.5.1-canary.1703.20960.0
  yarn add @auto-canary/vscode@10.5.1-canary.1703.20960.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
