### PR TITLE
fix npm plugin git tag splitting

### DIFF
--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -1268,7 +1268,9 @@ export default class NPMPlugin implements IPlugin {
 
           const tags = (
             await execPromise("git", ["tag", "--points-at", "HEAD"])
-          ).split("\n");
+          )
+            .split("\n")
+            .filter((tag) => tag.trim() !== "");
 
           if (!this.commitNextVersion) {
             // we do not want to commit the next version. this causes


### PR DESCRIPTION
# What Changed
Gets rid of empty tags when getting current repo tags in the npm plugin.
## Why
fixes: #1704 

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
