### PR TITLE
fix: add debugging and error handling to exec

### DIFF
--- a/plugins/exec/package.json
+++ b/plugins/exec/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@auto-it/core": "link:../../packages/core",
+    "endent": "^2.0.1",
     "fp-ts": "^2.5.3",
     "fromentries": "^1.2.0",
     "io-ts": "^2.1.2",

--- a/plugins/exec/src/index.ts
+++ b/plugins/exec/src/index.ts
@@ -77,10 +77,10 @@ const runExecSync = (
   try {
     auto.logger.verbose.info(`Running command: ${command}`);
     auto.logger.veryVerbose.info(endent`
-    Supplied Environment:
+    Supplied Environment (name and char size):
     
     ${Object.entries(options?.env || {})
-      .map(([key, value]) => `\t${key}=${value}`)
+      .map(([key, value]) => `\t${key}=${value ? value.length : 0}`)
       .join("\n")}
     `);
 
@@ -95,8 +95,10 @@ const runExecSync = (
         Please consider disabling your 'auto-exec' usage and following this issue for updates: https://github.com/intuit/auto/issues/1294
       `);
     } else {
-      throw e;
+      auto.logger.log.error(e);
     }
+
+    process.exit(1);
   }
 
   return execResult;

--- a/plugins/exec/src/index.ts
+++ b/plugins/exec/src/index.ts
@@ -9,7 +9,8 @@ import {
 } from "@auto-it/core/dist/utils/make-hooks";
 import * as t from "io-ts";
 import fromEntries from "fromentries";
-import { execSync } from "child_process";
+import endent from "endent";
+import { execSync, ExecSyncOptionsWithStringEncoding } from "child_process";
 
 type CommandMap = Record<string, string | undefined>;
 
@@ -65,8 +66,44 @@ const createEnv = (args: any[]) => ({
   ),
 });
 
+/** Wraps execSync around debugging and error handling */
+const runExecSync = (
+  command: string,
+  options: ExecSyncOptionsWithStringEncoding | undefined,
+  auto: Auto
+): string | undefined => {
+  let execResult;
+
+  try {
+    auto.logger.verbose.info(`Running command: ${command}`);
+    auto.logger.veryVerbose.info(endent`
+    Supplied Environment:
+    
+    ${Object.entries(options?.env || {})
+      .map(([key, value]) => `\t${key}=${value}`)
+      .join("\n")}
+    `);
+
+    execResult = trim(execSync(command, options));
+  } catch (e) {
+    if (e && e.code === "E2BIG") {
+      auto.logger.log.error(endent`
+        Received E2BIG from execSync.
+
+        This usually occurs when the argument list is too large for the command you are trying to run. 
+        
+        Please consider disabling your 'auto-exec' usage and following this issue for updates: https://github.com/intuit/auto/issues/1294
+      `);
+    } else {
+      throw e;
+    }
+  }
+
+  return execResult;
+};
+
 /** Tap a hook if possible */
-const tapHook = (name: string, hook: any, command: string) => {
+const tapHook = (name: string, hook: any, command: string, auto: Auto) => {
   if (!hook) {
     return;
   }
@@ -89,11 +126,15 @@ const tapHook = (name: string, hook: any, command: string) => {
   ) {
     hook.tap(`exec ${name}`, (...args: any[]) => {
       const value = trim(
-        execSync(command, {
-          stdio: ["ignore", "pipe", "inherit"],
-          encoding: "utf8",
-          env: createEnv(args),
-        })
+        runExecSync(
+          command,
+          {
+            stdio: ["ignore", "pipe", "inherit"],
+            encoding: "utf8",
+            env: createEnv(args),
+          },
+          auto
+        )
       );
 
       if (!value) {
@@ -114,11 +155,15 @@ const tapHook = (name: string, hook: any, command: string) => {
   } else if (name === "omitCommit" || name === "omitReleaseNotes") {
     hook.tap(`exec ${name}`, (...args: any[]) => {
       const value = trim(
-        execSync(command, {
-          stdio: ["ignore", "pipe", "inherit"],
-          encoding: "utf8",
-          env: createEnv(args),
-        })
+        runExecSync(
+          command,
+          {
+            stdio: ["ignore", "pipe", "inherit"],
+            encoding: "utf8",
+            env: createEnv(args),
+          },
+          auto
+        )
       );
 
       if (value === "true") {
@@ -134,14 +179,18 @@ const tapHook = (name: string, hook: any, command: string) => {
   ) {
     hook.tap(`exec ${name}`, (...args: any[]) =>
       trim(
-        execSync(command, {
-          encoding: "utf8",
-          env: createEnv(args),
-          stdio:
-            name === "createChangelogTitle" || name === "getPreviousVersion"
-              ? ["ignore", "pipe", "inherit"]
-              : "inherit",
-        })
+        runExecSync(
+          command,
+          {
+            encoding: "utf8",
+            env: createEnv(args),
+            stdio:
+              name === "createChangelogTitle" || name === "getPreviousVersion"
+                ? ["ignore", "pipe", "inherit"]
+                : "inherit",
+          },
+          auto
+        )
       )
     );
   }
@@ -186,7 +235,8 @@ export default class ExecPlugin implements IPlugin {
             tapHook(
               key,
               release.hooks[key as keyof typeof release.hooks],
-              command
+              command,
+              auto
             )
         );
       });
@@ -198,7 +248,8 @@ export default class ExecPlugin implements IPlugin {
             tapHook(
               key,
               changelog.hooks[key as keyof typeof changelog.hooks],
-              command
+              command,
+              auto
             )
         );
       });
@@ -210,12 +261,13 @@ export default class ExecPlugin implements IPlugin {
             tapHook(
               key,
               logParse.hooks[key as keyof typeof logParse.hooks],
-              command
+              command,
+              auto
             )
         );
       });
     } else {
-      tapHook(name, auto.hooks[name], command as string);
+      tapHook(name, auto.hooks[name], command as string, auto);
     }
   }
 }


### PR DESCRIPTION
# What Changed

Added some error handling for `E2BIG` errors as well as some debugging details to assist in fixing the current issue with `auto-exec`

## Why

(From #1294) We observe an argument list overflow causing issues with the `execSpawn` command from child_process. We would like to adjust this such that we do not provide too much environment details. My hope is that this debugging can help us find out what we can strip from the environment to avoid the buffer overflow.

Todo:

- [x] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
