### PR TITLE
tap the next hook and tag prerelease versions for cocoapods

### DIFF
--- a/plugins/cocoapods/__tests__/cocoapods.test.ts
+++ b/plugins/cocoapods/__tests__/cocoapods.test.ts
@@ -473,7 +473,7 @@ describe("Cocoapods Plugin", () => {
       });
 
       expect(versions).toContain("1.0.0-next.0");
-      expect(exec).toBeCalledTimes(3);
+      expect(exec).toBeCalledTimes(4);
       expect(exec).toHaveBeenCalledWith("git", ["checkout", "./Test.podspec"]);
 
       expect(mock).toHaveBeenLastCalledWith(

--- a/plugins/cocoapods/__tests__/cocoapods.test.ts
+++ b/plugins/cocoapods/__tests__/cocoapods.test.ts
@@ -473,7 +473,7 @@ describe("Cocoapods Plugin", () => {
       });
 
       expect(versions).toContain("1.0.0-next.0");
-      expect(exec).toBeCalledTimes(2);
+      expect(exec).toBeCalledTimes(3);
       expect(exec).toHaveBeenCalledWith("git", ["checkout", "./Test.podspec"]);
 
       expect(mock).toHaveBeenLastCalledWith(

--- a/plugins/cocoapods/__tests__/cocoapods.test.ts
+++ b/plugins/cocoapods/__tests__/cocoapods.test.ts
@@ -78,6 +78,7 @@ describe("Cocoapods Plugin", () => {
       logger: logger,
       prefixRelease,
       git: {
+        getLastTagNotInBaseBranch: async () => undefined,
         getLatestRelease: async () => "0.0.1",
         getPullRequest: async () => ({
           data: {
@@ -434,6 +435,50 @@ describe("Cocoapods Plugin", () => {
           "0.1.0-canary.1.1.1",
           "{ :git => 'https://github.com/intuit/auto.git', :commit => 'undefined' }"
         )
+      );
+    });
+  });
+
+  describe("next hook", () => {
+    test("should return prerelease versions on dryrun", async () => {
+      mockPodspec(specWithVersion("0.0.1"));
+
+      const versions = await hooks.next.promise(["0.0.1", "0.0.2"], {
+        bump: Auto.SEMVER.minor,
+        dryRun: true,
+        commits: [],
+        fullReleaseNotes: "",
+        releaseNotes: "",
+      });
+      expect(versions).toStrictEqual(["0.0.1", "0.0.2", "0.1.0-next.0"]);
+    });
+    test("should tag with next version", async () => {
+      jest.spyOn(Auto, "getCurrentBranch").mockReturnValue("next");
+      let podSpec = specWithVersion("0.0.1");
+      jest
+        .spyOn(utilities, "getPodspecContents")
+        .mockImplementation(() => podSpec);
+      const mock = jest
+        .spyOn(utilities, "writePodspecContents")
+        .mockImplementation((path, contents) => {
+          podSpec = contents;
+        });
+
+      const versions = await hooks.next.promise([], {
+        bump: Auto.SEMVER.major,
+        dryRun: false,
+        commits: [],
+        fullReleaseNotes: "",
+        releaseNotes: "",
+      });
+
+      expect(versions).toContain("1.0.0-next.0");
+      expect(exec).toBeCalledTimes(2);
+      expect(exec).toHaveBeenCalledWith("git", ["checkout", "./Test.podspec"]);
+
+      expect(mock).toHaveBeenLastCalledWith(
+        expect.any(String),
+        specWithVersion("1.0.0-next.0")
       );
     });
   });

--- a/plugins/cocoapods/src/index.ts
+++ b/plugins/cocoapods/src/index.ts
@@ -319,6 +319,9 @@ export default class CocoapodsPlugin implements IPlugin {
 
         updatePodspecVersion(this.options.podspecPath, prerelease);
 
+        // Publish the next podspec, committing it isn't needed for specs push
+        await this.publishPodSpec(podLogLevel);
+
         // Reset changes to podspec file since it doesn't need to be committed
         await execPromise("git", ["checkout", this.options.podspecPath]);
 

--- a/plugins/cocoapods/src/index.ts
+++ b/plugins/cocoapods/src/index.ts
@@ -317,6 +317,8 @@ export default class CocoapodsPlugin implements IPlugin {
           `"Tag pre-release: ${prerelease}"`,
         ]);
 
+        await execPromise("git", ["push", auto.remote, branch, "--tags"]);
+
         updatePodspecVersion(this.options.podspecPath, prerelease);
 
         // Publish the next podspec, committing it isn't needed for specs push

--- a/plugins/cocoapods/src/index.ts
+++ b/plugins/cocoapods/src/index.ts
@@ -5,6 +5,9 @@ import {
   validatePluginConfiguration,
   ILogger,
   getPrNumberFromEnv,
+  DEFAULT_PRERELEASE_BRANCHES,
+  getCurrentBranch,
+  determineNextVersion,
 } from "@auto-it/core";
 
 import { inc, ReleaseType } from "semver";
@@ -274,6 +277,52 @@ export default class CocoapodsPlugin implements IPlugin {
         await execPromise("git", ["checkout", this.options.podspecPath]);
 
         return canaryVersion;
+      }
+    );
+
+    auto.hooks.next.tapPromise(
+      this.name,
+      async (preReleaseVersions, { bump, dryRun }) => {
+        if (!auto.git) {
+          return preReleaseVersions;
+        }
+
+        const prereleaseBranches =
+          auto.config?.prereleaseBranches ?? DEFAULT_PRERELEASE_BRANCHES;
+        const branch = getCurrentBranch() || "";
+        const prereleaseBranch = prereleaseBranches.includes(branch)
+          ? branch
+          : prereleaseBranches[0];
+        const lastRelease = await auto.git.getLatestRelease();
+        const current =
+          (await auto.git.getLastTagNotInBaseBranch(prereleaseBranch)) ||
+          (await auto.getCurrentVersion(lastRelease));
+        const prerelease = determineNextVersion(
+          lastRelease,
+          current,
+          bump,
+          prereleaseBranch
+        );
+
+        preReleaseVersions.push(prerelease);
+
+        if (dryRun) {
+          return preReleaseVersions;
+        }
+
+        await execPromise("git", [
+          "tag",
+          prerelease,
+          "-m",
+          `"Tag pre-release: ${prerelease}"`,
+        ]);
+
+        updatePodspecVersion(this.options.podspecPath, prerelease);
+
+        // Reset changes to podspec file since it doesn't need to be committed
+        await execPromise("git", ["checkout", this.options.podspecPath]);
+
+        return preReleaseVersions;
       }
     );
 


### PR DESCRIPTION
# What Changed

Add `next` support for cocoapods plugin.

Mostly just ported the `next` code from the docker plugin since the workflow is almost the same

## Why

Trying to make the plugin as full featured as i can, next branches/releases are quite useful

Todo:

- [x] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.6.2-canary.1713.21050.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.6.2-canary.1713.21050.0
  npm install @auto-canary/auto@10.6.2-canary.1713.21050.0
  npm install @auto-canary/core@10.6.2-canary.1713.21050.0
  npm install @auto-canary/package-json-utils@10.6.2-canary.1713.21050.0
  npm install @auto-canary/all-contributors@10.6.2-canary.1713.21050.0
  npm install @auto-canary/brew@10.6.2-canary.1713.21050.0
  npm install @auto-canary/chrome@10.6.2-canary.1713.21050.0
  npm install @auto-canary/cocoapods@10.6.2-canary.1713.21050.0
  npm install @auto-canary/conventional-commits@10.6.2-canary.1713.21050.0
  npm install @auto-canary/crates@10.6.2-canary.1713.21050.0
  npm install @auto-canary/docker@10.6.2-canary.1713.21050.0
  npm install @auto-canary/exec@10.6.2-canary.1713.21050.0
  npm install @auto-canary/first-time-contributor@10.6.2-canary.1713.21050.0
  npm install @auto-canary/gem@10.6.2-canary.1713.21050.0
  npm install @auto-canary/gh-pages@10.6.2-canary.1713.21050.0
  npm install @auto-canary/git-tag@10.6.2-canary.1713.21050.0
  npm install @auto-canary/gradle@10.6.2-canary.1713.21050.0
  npm install @auto-canary/jira@10.6.2-canary.1713.21050.0
  npm install @auto-canary/maven@10.6.2-canary.1713.21050.0
  npm install @auto-canary/microsoft-teams@10.6.2-canary.1713.21050.0
  npm install @auto-canary/npm@10.6.2-canary.1713.21050.0
  npm install @auto-canary/omit-commits@10.6.2-canary.1713.21050.0
  npm install @auto-canary/omit-release-notes@10.6.2-canary.1713.21050.0
  npm install @auto-canary/pr-body-labels@10.6.2-canary.1713.21050.0
  npm install @auto-canary/released@10.6.2-canary.1713.21050.0
  npm install @auto-canary/s3@10.6.2-canary.1713.21050.0
  npm install @auto-canary/slack@10.6.2-canary.1713.21050.0
  npm install @auto-canary/twitter@10.6.2-canary.1713.21050.0
  npm install @auto-canary/upload-assets@10.6.2-canary.1713.21050.0
  npm install @auto-canary/vscode@10.6.2-canary.1713.21050.0
  # or 
  yarn add @auto-canary/bot-list@10.6.2-canary.1713.21050.0
  yarn add @auto-canary/auto@10.6.2-canary.1713.21050.0
  yarn add @auto-canary/core@10.6.2-canary.1713.21050.0
  yarn add @auto-canary/package-json-utils@10.6.2-canary.1713.21050.0
  yarn add @auto-canary/all-contributors@10.6.2-canary.1713.21050.0
  yarn add @auto-canary/brew@10.6.2-canary.1713.21050.0
  yarn add @auto-canary/chrome@10.6.2-canary.1713.21050.0
  yarn add @auto-canary/cocoapods@10.6.2-canary.1713.21050.0
  yarn add @auto-canary/conventional-commits@10.6.2-canary.1713.21050.0
  yarn add @auto-canary/crates@10.6.2-canary.1713.21050.0
  yarn add @auto-canary/docker@10.6.2-canary.1713.21050.0
  yarn add @auto-canary/exec@10.6.2-canary.1713.21050.0
  yarn add @auto-canary/first-time-contributor@10.6.2-canary.1713.21050.0
  yarn add @auto-canary/gem@10.6.2-canary.1713.21050.0
  yarn add @auto-canary/gh-pages@10.6.2-canary.1713.21050.0
  yarn add @auto-canary/git-tag@10.6.2-canary.1713.21050.0
  yarn add @auto-canary/gradle@10.6.2-canary.1713.21050.0
  yarn add @auto-canary/jira@10.6.2-canary.1713.21050.0
  yarn add @auto-canary/maven@10.6.2-canary.1713.21050.0
  yarn add @auto-canary/microsoft-teams@10.6.2-canary.1713.21050.0
  yarn add @auto-canary/npm@10.6.2-canary.1713.21050.0
  yarn add @auto-canary/omit-commits@10.6.2-canary.1713.21050.0
  yarn add @auto-canary/omit-release-notes@10.6.2-canary.1713.21050.0
  yarn add @auto-canary/pr-body-labels@10.6.2-canary.1713.21050.0
  yarn add @auto-canary/released@10.6.2-canary.1713.21050.0
  yarn add @auto-canary/s3@10.6.2-canary.1713.21050.0
  yarn add @auto-canary/slack@10.6.2-canary.1713.21050.0
  yarn add @auto-canary/twitter@10.6.2-canary.1713.21050.0
  yarn add @auto-canary/upload-assets@10.6.2-canary.1713.21050.0
  yarn add @auto-canary/vscode@10.6.2-canary.1713.21050.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
