### PR TITLE
default `name` and `email` to the token user if no author config is found in autorc or plugin

### DIFF
--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -51,6 +51,10 @@ jest.mock("@octokit/rest", () => {
     hook = {
       error: () => undefined,
     };
+
+    users = {
+      getAuthenticated: jest.fn().mockResolvedValue({}),
+    };
   };
 
   return { Octokit };

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1962,10 +1962,11 @@ export default class Auto {
       this.logger.verbose.warn(
         `Got author from options: email: ${email}, name ${name}`
       );
-      const packageAuthor = await this.hooks.getAuthor.promise();
+      const packageAuthor = (await this.hooks.getAuthor.promise()) || {};
+      const tokenUser = await this.git?.getUser();
 
-      email = !email && packageAuthor ? packageAuthor.email : email;
-      name = !name && packageAuthor ? packageAuthor.name : name;
+      email = email || packageAuthor.email || tokenUser?.email;
+      name = name || packageAuthor.name || tokenUser?.name;
 
       this.logger.verbose.warn(`Using author: ${name} <${email}>`);
 


### PR DESCRIPTION
# What Changed

see title

## Why

I realized that these values could be extracted from the token. In a future release I might deprecate `name`, `email`, and `author` altogether and just rely on extracting it from the token.

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`
