### PR TITLE
take into account labels on next+canary PRs

### DIFF
--- a/packages/core/src/__tests__/auto-in-pr-ci.test.ts
+++ b/packages/core/src/__tests__/auto-in-pr-ci.test.ts
@@ -36,6 +36,10 @@ jest.mock("@octokit/rest", () => {
       get: jest.fn().mockReturnValue({}),
     };
 
+    issues = {
+      listLabelsOnIssue: jest.fn().mockReturnValue({ data: []}),
+    };
+
     hook = {
       error: () => undefined,
     };

--- a/packages/core/src/__tests__/auto-in-pr-ci.test.ts
+++ b/packages/core/src/__tests__/auto-in-pr-ci.test.ts
@@ -222,4 +222,24 @@ describe("next in ci", () => {
       `,
     });
   });
+
+  test("should use labels on next branch PR", async () => {
+    const auto = new Auto({ ...defaults, plugins: [] });
+
+    auto.logger = dummyLog();
+    await auto.loadConfig();
+
+    // @ts-ignore
+    auto.inPrereleaseBranch = () => true;
+    // @ts-ignore
+    jest.spyOn(console, "log").mockImplementation();
+    auto.git!.getLatestTagInBranch = () => Promise.resolve("1.4.0-next.0");
+    auto.release!.getSemverBump = () => Promise.resolve(SEMVER.patch);
+    
+    auto.git!.getLabels = () => Promise.resolve([]);
+    expect(await auto.getVersion()).toBe(SEMVER.prepatch);
+
+    auto.git!.getLabels = () => Promise.resolve([SEMVER.major]);
+    expect(await auto.getVersion()).toBe(SEMVER.premajor);
+  });
 });

--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -52,6 +52,10 @@ jest.mock("@octokit/rest", () => {
       error: () => undefined,
     };
 
+    issues = {
+      listLabelsOnIssue: jest.fn().mockReturnValue({ data: [] }),
+    };
+
     users = {
       getAuthenticated: jest.fn().mockResolvedValue({}),
     };

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1159,6 +1159,7 @@ export default class Auto {
   }
 
   /** Create a canary (or test) version of the project */
+  // eslint-disable-next-line complexity
   async canary(args: ICanaryOptions = {}): Promise<ShipitInfo | undefined> {
     const options = { ...this.getCommandDefault("canary"), ...args };
 
@@ -1187,7 +1188,16 @@ export default class Auto {
 
     const from = (await this.git.shaExists("HEAD^")) ? "HEAD^" : "HEAD";
     const commitsInRelease = await this.release.getCommitsInRelease(from);
+
+    this.logger.veryVerbose.info('Found commits in canary release', commitsInRelease);
+
     const labels = commitsInRelease.map((commit) => commit.labels);
+
+    if (pr) {
+      const prLabels = await this.git.getLabels(Number(pr));
+      labels.push(prLabels);
+    }
+
     let bump = calculateSemVerBump(labels, this.semVerLabels!, this.config);
 
     if (bump === SEMVER.noVersion) {

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -256,7 +256,7 @@ export default class Git {
 
   /** Get the labels for a PR */
   @memoize()
-  async getLabels(prNumber: number) {
+  async getLabels(prNumber: number): Promise<string[]> {
     this.logger.verbose.info(`Getting labels for PR: ${prNumber}`);
 
     const args: RestEndpointMethodTypes["issues"]["listLabelsOnIssue"]["parameters"] = {


### PR DESCRIPTION
# What Changed

See title

## Why

If you were to open a PR from `next` into `master` the version bump calculation would not take into account any labels on the PR

Todo:

- [x] Add tests

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.10.0-canary.1722.21167.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.10.0-canary.1722.21167.0
  npm install @auto-canary/auto@10.10.0-canary.1722.21167.0
  npm install @auto-canary/core@10.10.0-canary.1722.21167.0
  npm install @auto-canary/package-json-utils@10.10.0-canary.1722.21167.0
  npm install @auto-canary/all-contributors@10.10.0-canary.1722.21167.0
  npm install @auto-canary/brew@10.10.0-canary.1722.21167.0
  npm install @auto-canary/chrome@10.10.0-canary.1722.21167.0
  npm install @auto-canary/cocoapods@10.10.0-canary.1722.21167.0
  npm install @auto-canary/conventional-commits@10.10.0-canary.1722.21167.0
  npm install @auto-canary/crates@10.10.0-canary.1722.21167.0
  npm install @auto-canary/docker@10.10.0-canary.1722.21167.0
  npm install @auto-canary/exec@10.10.0-canary.1722.21167.0
  npm install @auto-canary/first-time-contributor@10.10.0-canary.1722.21167.0
  npm install @auto-canary/gem@10.10.0-canary.1722.21167.0
  npm install @auto-canary/gh-pages@10.10.0-canary.1722.21167.0
  npm install @auto-canary/git-tag@10.10.0-canary.1722.21167.0
  npm install @auto-canary/gradle@10.10.0-canary.1722.21167.0
  npm install @auto-canary/jira@10.10.0-canary.1722.21167.0
  npm install @auto-canary/maven@10.10.0-canary.1722.21167.0
  npm install @auto-canary/microsoft-teams@10.10.0-canary.1722.21167.0
  npm install @auto-canary/npm@10.10.0-canary.1722.21167.0
  npm install @auto-canary/omit-commits@10.10.0-canary.1722.21167.0
  npm install @auto-canary/omit-release-notes@10.10.0-canary.1722.21167.0
  npm install @auto-canary/pr-body-labels@10.10.0-canary.1722.21167.0
  npm install @auto-canary/released@10.10.0-canary.1722.21167.0
  npm install @auto-canary/s3@10.10.0-canary.1722.21167.0
  npm install @auto-canary/slack@10.10.0-canary.1722.21167.0
  npm install @auto-canary/twitter@10.10.0-canary.1722.21167.0
  npm install @auto-canary/upload-assets@10.10.0-canary.1722.21167.0
  npm install @auto-canary/vscode@10.10.0-canary.1722.21167.0
  # or 
  yarn add @auto-canary/bot-list@10.10.0-canary.1722.21167.0
  yarn add @auto-canary/auto@10.10.0-canary.1722.21167.0
  yarn add @auto-canary/core@10.10.0-canary.1722.21167.0
  yarn add @auto-canary/package-json-utils@10.10.0-canary.1722.21167.0
  yarn add @auto-canary/all-contributors@10.10.0-canary.1722.21167.0
  yarn add @auto-canary/brew@10.10.0-canary.1722.21167.0
  yarn add @auto-canary/chrome@10.10.0-canary.1722.21167.0
  yarn add @auto-canary/cocoapods@10.10.0-canary.1722.21167.0
  yarn add @auto-canary/conventional-commits@10.10.0-canary.1722.21167.0
  yarn add @auto-canary/crates@10.10.0-canary.1722.21167.0
  yarn add @auto-canary/docker@10.10.0-canary.1722.21167.0
  yarn add @auto-canary/exec@10.10.0-canary.1722.21167.0
  yarn add @auto-canary/first-time-contributor@10.10.0-canary.1722.21167.0
  yarn add @auto-canary/gem@10.10.0-canary.1722.21167.0
  yarn add @auto-canary/gh-pages@10.10.0-canary.1722.21167.0
  yarn add @auto-canary/git-tag@10.10.0-canary.1722.21167.0
  yarn add @auto-canary/gradle@10.10.0-canary.1722.21167.0
  yarn add @auto-canary/jira@10.10.0-canary.1722.21167.0
  yarn add @auto-canary/maven@10.10.0-canary.1722.21167.0
  yarn add @auto-canary/microsoft-teams@10.10.0-canary.1722.21167.0
  yarn add @auto-canary/npm@10.10.0-canary.1722.21167.0
  yarn add @auto-canary/omit-commits@10.10.0-canary.1722.21167.0
  yarn add @auto-canary/omit-release-notes@10.10.0-canary.1722.21167.0
  yarn add @auto-canary/pr-body-labels@10.10.0-canary.1722.21167.0
  yarn add @auto-canary/released@10.10.0-canary.1722.21167.0
  yarn add @auto-canary/s3@10.10.0-canary.1722.21167.0
  yarn add @auto-canary/slack@10.10.0-canary.1722.21167.0
  yarn add @auto-canary/twitter@10.10.0-canary.1722.21167.0
  yarn add @auto-canary/upload-assets@10.10.0-canary.1722.21167.0
  yarn add @auto-canary/vscode@10.10.0-canary.1722.21167.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
