### PR TITLE
Fix conventional commits releaseType calculation to include all conventionally committed commits in PR

### DIFF
--- a/plugins/conventional-commits/package.json
+++ b/plugins/conventional-commits/package.json
@@ -42,6 +42,7 @@
     "conventional-changelog-core": "^4.2.0",
     "conventional-changelog-preset-loader": "^2.3.4",
     "conventional-commits-parser": "^3.1.0",
+    "endent": "^2.0.1",
     "fp-ts": "^2.5.3",
     "io-ts": "^2.1.2",
     "tslib": "2.1.0"


### PR DESCRIPTION
# What Changed

Fix various conventional commit issues

## Why

closes #1719 
closes #1910

Todo:

- [x] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.23.0--canary.1723.23574.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.23.0--canary.1723.23574.0
  npm install @auto-canary/auto@10.23.0--canary.1723.23574.0
  npm install @auto-canary/core@10.23.0--canary.1723.23574.0
  npm install @auto-canary/package-json-utils@10.23.0--canary.1723.23574.0
  npm install @auto-canary/all-contributors@10.23.0--canary.1723.23574.0
  npm install @auto-canary/brew@10.23.0--canary.1723.23574.0
  npm install @auto-canary/chrome@10.23.0--canary.1723.23574.0
  npm install @auto-canary/cocoapods@10.23.0--canary.1723.23574.0
  npm install @auto-canary/conventional-commits@10.23.0--canary.1723.23574.0
  npm install @auto-canary/crates@10.23.0--canary.1723.23574.0
  npm install @auto-canary/docker@10.23.0--canary.1723.23574.0
  npm install @auto-canary/exec@10.23.0--canary.1723.23574.0
  npm install @auto-canary/first-time-contributor@10.23.0--canary.1723.23574.0
  npm install @auto-canary/gem@10.23.0--canary.1723.23574.0
  npm install @auto-canary/gh-pages@10.23.0--canary.1723.23574.0
  npm install @auto-canary/git-tag@10.23.0--canary.1723.23574.0
  npm install @auto-canary/gradle@10.23.0--canary.1723.23574.0
  npm install @auto-canary/jira@10.23.0--canary.1723.23574.0
  npm install @auto-canary/magic-zero@10.23.0--canary.1723.23574.0
  npm install @auto-canary/maven@10.23.0--canary.1723.23574.0
  npm install @auto-canary/microsoft-teams@10.23.0--canary.1723.23574.0
  npm install @auto-canary/npm@10.23.0--canary.1723.23574.0
  npm install @auto-canary/omit-commits@10.23.0--canary.1723.23574.0
  npm install @auto-canary/omit-release-notes@10.23.0--canary.1723.23574.0
  npm install @auto-canary/pr-body-labels@10.23.0--canary.1723.23574.0
  npm install @auto-canary/released@10.23.0--canary.1723.23574.0
  npm install @auto-canary/s3@10.23.0--canary.1723.23574.0
  npm install @auto-canary/slack@10.23.0--canary.1723.23574.0
  npm install @auto-canary/twitter@10.23.0--canary.1723.23574.0
  npm install @auto-canary/upload-assets@10.23.0--canary.1723.23574.0
  npm install @auto-canary/vscode@10.23.0--canary.1723.23574.0
  # or 
  yarn add @auto-canary/bot-list@10.23.0--canary.1723.23574.0
  yarn add @auto-canary/auto@10.23.0--canary.1723.23574.0
  yarn add @auto-canary/core@10.23.0--canary.1723.23574.0
  yarn add @auto-canary/package-json-utils@10.23.0--canary.1723.23574.0
  yarn add @auto-canary/all-contributors@10.23.0--canary.1723.23574.0
  yarn add @auto-canary/brew@10.23.0--canary.1723.23574.0
  yarn add @auto-canary/chrome@10.23.0--canary.1723.23574.0
  yarn add @auto-canary/cocoapods@10.23.0--canary.1723.23574.0
  yarn add @auto-canary/conventional-commits@10.23.0--canary.1723.23574.0
  yarn add @auto-canary/crates@10.23.0--canary.1723.23574.0
  yarn add @auto-canary/docker@10.23.0--canary.1723.23574.0
  yarn add @auto-canary/exec@10.23.0--canary.1723.23574.0
  yarn add @auto-canary/first-time-contributor@10.23.0--canary.1723.23574.0
  yarn add @auto-canary/gem@10.23.0--canary.1723.23574.0
  yarn add @auto-canary/gh-pages@10.23.0--canary.1723.23574.0
  yarn add @auto-canary/git-tag@10.23.0--canary.1723.23574.0
  yarn add @auto-canary/gradle@10.23.0--canary.1723.23574.0
  yarn add @auto-canary/jira@10.23.0--canary.1723.23574.0
  yarn add @auto-canary/magic-zero@10.23.0--canary.1723.23574.0
  yarn add @auto-canary/maven@10.23.0--canary.1723.23574.0
  yarn add @auto-canary/microsoft-teams@10.23.0--canary.1723.23574.0
  yarn add @auto-canary/npm@10.23.0--canary.1723.23574.0
  yarn add @auto-canary/omit-commits@10.23.0--canary.1723.23574.0
  yarn add @auto-canary/omit-release-notes@10.23.0--canary.1723.23574.0
  yarn add @auto-canary/pr-body-labels@10.23.0--canary.1723.23574.0
  yarn add @auto-canary/released@10.23.0--canary.1723.23574.0
  yarn add @auto-canary/s3@10.23.0--canary.1723.23574.0
  yarn add @auto-canary/slack@10.23.0--canary.1723.23574.0
  yarn add @auto-canary/twitter@10.23.0--canary.1723.23574.0
  yarn add @auto-canary/upload-assets@10.23.0--canary.1723.23574.0
  yarn add @auto-canary/vscode@10.23.0--canary.1723.23574.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux--canary.1723.23574.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux--canary.1723.23574.gz)  
[auto-macos--canary.1723.23574.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos--canary.1723.23574.gz)  
[auto-win.exe--canary.1723.23574.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe--canary.1723.23574.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->
