### PR TITLE
Properly setting env var _auth for legacyAuth case for npm publish

### DIFF
--- a/plugins/npm/__tests__/npm-next.test.ts
+++ b/plugins/npm/__tests__/npm-next.test.ts
@@ -241,8 +241,7 @@ describe("next", () => {
       "publish",
       "--tag",
       "next",
-      "--_auth",
-      "abcd",
+      "--_auth=abcd",
     ]);
   });
 

--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -719,8 +719,7 @@ describe("publish", () => {
     await hooks.publish.promise({ bump: Auto.SEMVER.patch });
     expect(execPromise).toHaveBeenCalledWith("npm", [
       "publish",
-      "--_auth",
-      "abcd",
+      "--_auth=abcd",
     ]);
   });
 
@@ -996,8 +995,7 @@ describe("canary", () => {
       "publish",
       "--tag",
       "canary",
-      "--_auth",
-      "abcd",
+      "--_auth=abcd",
     ]);
   });
 

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -25,15 +25,14 @@ import {
 } from "@auto-it/core";
 import getPackages from "get-monorepo-packages";
 import { gt, gte, inc, ReleaseType } from "semver";
-import { loadPackageJson, getRepo, getAuthor } from "@auto-it/package-json-utils";
+import {
+  loadPackageJson,
+  getRepo,
+  getAuthor,
+} from "@auto-it/package-json-utils";
 
 import setTokenOnCI, { getRegistry, DEFAULT_REGISTRY } from "./set-npm-token";
-import {
-  writeFile,
-  isMonorepo,
-  readFile,
-  getLernaJson,
-} from "./utils";
+import { writeFile, isMonorepo, readFile, getLernaJson } from "./utils";
 
 const { isCi } = envCi();
 const VERSION_COMMIT_MESSAGE = '"Bump version to: %s [skip ci]"';
@@ -212,10 +211,9 @@ function getLegacyAuthArgs(
     return [];
   }
 
-  return [
-    options.isMonorepo ? "--legacy-auth" : "--_auth",
-    process.env.NPM_TOKEN,
-  ];
+  return options.isMonorepo
+    ? ["--legacy-auth", process.env.NPM_TOKEN]
+    : [`--_auth=${process.env.NPM_TOKEN}`];
 }
 
 /** Get the args to set the registry. Only used with lerna */


### PR DESCRIPTION
Fixes #1734 

# What Changed

When setting environment variable of `_auth` for `legacyAuth` case, it requires an `=` sign when using `npm` cli.

I don't think the monorepo case needs this:
https://github.com/lerna/lerna/blob/main/commands/publish/index.js#L119

## Why

Todo:

- [x] Update tests

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux-canary.1735.21333.gz](https://github.com/intuit/auto/releases/download/canary/auto-linux-canary.1735.21333.gz)  
[auto-macos-canary.1735.21333.gz](https://github.com/intuit/auto/releases/download/canary/auto-macos-canary.1735.21333.gz)  
[auto-win.exe-canary.1735.21333.gz](https://github.com/intuit/auto/releases/download/canary/auto-win.exe-canary.1735.21333.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.11.0-canary.1735.21333.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.11.0-canary.1735.21333.0
  npm install @auto-canary/auto@10.11.0-canary.1735.21333.0
  npm install @auto-canary/core@10.11.0-canary.1735.21333.0
  npm install @auto-canary/package-json-utils@10.11.0-canary.1735.21333.0
  npm install @auto-canary/all-contributors@10.11.0-canary.1735.21333.0
  npm install @auto-canary/brew@10.11.0-canary.1735.21333.0
  npm install @auto-canary/chrome@10.11.0-canary.1735.21333.0
  npm install @auto-canary/cocoapods@10.11.0-canary.1735.21333.0
  npm install @auto-canary/conventional-commits@10.11.0-canary.1735.21333.0
  npm install @auto-canary/crates@10.11.0-canary.1735.21333.0
  npm install @auto-canary/docker@10.11.0-canary.1735.21333.0
  npm install @auto-canary/exec@10.11.0-canary.1735.21333.0
  npm install @auto-canary/first-time-contributor@10.11.0-canary.1735.21333.0
  npm install @auto-canary/gem@10.11.0-canary.1735.21333.0
  npm install @auto-canary/gh-pages@10.11.0-canary.1735.21333.0
  npm install @auto-canary/git-tag@10.11.0-canary.1735.21333.0
  npm install @auto-canary/gradle@10.11.0-canary.1735.21333.0
  npm install @auto-canary/jira@10.11.0-canary.1735.21333.0
  npm install @auto-canary/maven@10.11.0-canary.1735.21333.0
  npm install @auto-canary/microsoft-teams@10.11.0-canary.1735.21333.0
  npm install @auto-canary/npm@10.11.0-canary.1735.21333.0
  npm install @auto-canary/omit-commits@10.11.0-canary.1735.21333.0
  npm install @auto-canary/omit-release-notes@10.11.0-canary.1735.21333.0
  npm install @auto-canary/pr-body-labels@10.11.0-canary.1735.21333.0
  npm install @auto-canary/released@10.11.0-canary.1735.21333.0
  npm install @auto-canary/s3@10.11.0-canary.1735.21333.0
  npm install @auto-canary/slack@10.11.0-canary.1735.21333.0
  npm install @auto-canary/twitter@10.11.0-canary.1735.21333.0
  npm install @auto-canary/upload-assets@10.11.0-canary.1735.21333.0
  npm install @auto-canary/vscode@10.11.0-canary.1735.21333.0
  # or 
  yarn add @auto-canary/bot-list@10.11.0-canary.1735.21333.0
  yarn add @auto-canary/auto@10.11.0-canary.1735.21333.0
  yarn add @auto-canary/core@10.11.0-canary.1735.21333.0
  yarn add @auto-canary/package-json-utils@10.11.0-canary.1735.21333.0
  yarn add @auto-canary/all-contributors@10.11.0-canary.1735.21333.0
  yarn add @auto-canary/brew@10.11.0-canary.1735.21333.0
  yarn add @auto-canary/chrome@10.11.0-canary.1735.21333.0
  yarn add @auto-canary/cocoapods@10.11.0-canary.1735.21333.0
  yarn add @auto-canary/conventional-commits@10.11.0-canary.1735.21333.0
  yarn add @auto-canary/crates@10.11.0-canary.1735.21333.0
  yarn add @auto-canary/docker@10.11.0-canary.1735.21333.0
  yarn add @auto-canary/exec@10.11.0-canary.1735.21333.0
  yarn add @auto-canary/first-time-contributor@10.11.0-canary.1735.21333.0
  yarn add @auto-canary/gem@10.11.0-canary.1735.21333.0
  yarn add @auto-canary/gh-pages@10.11.0-canary.1735.21333.0
  yarn add @auto-canary/git-tag@10.11.0-canary.1735.21333.0
  yarn add @auto-canary/gradle@10.11.0-canary.1735.21333.0
  yarn add @auto-canary/jira@10.11.0-canary.1735.21333.0
  yarn add @auto-canary/maven@10.11.0-canary.1735.21333.0
  yarn add @auto-canary/microsoft-teams@10.11.0-canary.1735.21333.0
  yarn add @auto-canary/npm@10.11.0-canary.1735.21333.0
  yarn add @auto-canary/omit-commits@10.11.0-canary.1735.21333.0
  yarn add @auto-canary/omit-release-notes@10.11.0-canary.1735.21333.0
  yarn add @auto-canary/pr-body-labels@10.11.0-canary.1735.21333.0
  yarn add @auto-canary/released@10.11.0-canary.1735.21333.0
  yarn add @auto-canary/s3@10.11.0-canary.1735.21333.0
  yarn add @auto-canary/slack@10.11.0-canary.1735.21333.0
  yarn add @auto-canary/twitter@10.11.0-canary.1735.21333.0
  yarn add @auto-canary/upload-assets@10.11.0-canary.1735.21333.0
  yarn add @auto-canary/vscode@10.11.0-canary.1735.21333.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
