### PR TITLE
respect `skip` and `none` releases for prereleases

### DIFF
--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -1355,6 +1355,33 @@ describe("Auto", () => {
       await auto.next({});
       expect(afterRelease).toHaveBeenCalled();
     });
+
+    test("respects none release labels", async () => {
+      const auto = new Auto({ ...defaults, plugins: [] });
+
+      // @ts-ignore
+      auto.checkClean = () => Promise.resolve(true);
+      auto.logger = dummyLog();
+      await auto.loadConfig();
+      auto.remote = "origin";
+      auto.git!.publish = () => Promise.resolve({ data: {} } as any);
+      auto.git!.getLastTagNotInBaseBranch = () =>
+        Promise.reject(new Error("Test"));
+      auto.git!.getLatestTagInBranch = () => Promise.reject(new Error("Test"));
+      auto.git!.getLatestRelease = () => Promise.resolve("abcd");
+      auto.release!.generateReleaseNotes = () => Promise.resolve("notes");
+      auto.release!.getCommitsInRelease = () =>
+        Promise.resolve([
+          makeCommitFromMsg("Test Commit", { labels: ["skip-release"] }),
+        ]);
+
+      const next = jest.fn();
+      auto.hooks.next.tap("test", next);
+      jest.spyOn(auto.release!, "getCommits").mockImplementation();
+
+      await auto.next({});
+      expect(next).not.toHaveBeenCalled();
+    });
   });
 
   describe("shipit", () => {

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1383,9 +1383,12 @@ export default class Auto {
     const commits = await this.release.getCommitsInRelease(lastTag);
     const releaseNotes = await this.release.generateReleaseNotes(lastTag);
     const labels = commits.map((commit) => commit.labels);
-    const bump =
-      calculateSemVerBump(labels, this.semVerLabels!, this.config) ||
-      SEMVER.patch;
+    const bump = calculateSemVerBump(labels, this.semVerLabels!, this.config);
+
+    if (bump === "") {
+      this.logger.log.info("No version published.");
+      return;
+    }
 
     if (!args.quiet) {
       this.logger.log.info("Full Release notes for next release:");


### PR DESCRIPTION
# What Changed

see title

## Why

closes #1737 

Todo:

- [x] Add tests

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux-canary.1738.21372.gz](https://github.com/intuit/auto/releases/download/canary/auto-linux-canary.1738.21372.gz)  
[auto-macos-canary.1738.21372.gz](https://github.com/intuit/auto/releases/download/canary/auto-macos-canary.1738.21372.gz)  
[auto-win.exe-canary.1738.21372.gz](https://github.com/intuit/auto/releases/download/canary/auto-win.exe-canary.1738.21372.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.12.1-canary.1738.21372.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.12.1-canary.1738.21372.0
  npm install @auto-canary/auto@10.12.1-canary.1738.21372.0
  npm install @auto-canary/core@10.12.1-canary.1738.21372.0
  npm install @auto-canary/package-json-utils@10.12.1-canary.1738.21372.0
  npm install @auto-canary/all-contributors@10.12.1-canary.1738.21372.0
  npm install @auto-canary/brew@10.12.1-canary.1738.21372.0
  npm install @auto-canary/chrome@10.12.1-canary.1738.21372.0
  npm install @auto-canary/cocoapods@10.12.1-canary.1738.21372.0
  npm install @auto-canary/conventional-commits@10.12.1-canary.1738.21372.0
  npm install @auto-canary/crates@10.12.1-canary.1738.21372.0
  npm install @auto-canary/docker@10.12.1-canary.1738.21372.0
  npm install @auto-canary/exec@10.12.1-canary.1738.21372.0
  npm install @auto-canary/first-time-contributor@10.12.1-canary.1738.21372.0
  npm install @auto-canary/gem@10.12.1-canary.1738.21372.0
  npm install @auto-canary/gh-pages@10.12.1-canary.1738.21372.0
  npm install @auto-canary/git-tag@10.12.1-canary.1738.21372.0
  npm install @auto-canary/gradle@10.12.1-canary.1738.21372.0
  npm install @auto-canary/jira@10.12.1-canary.1738.21372.0
  npm install @auto-canary/maven@10.12.1-canary.1738.21372.0
  npm install @auto-canary/microsoft-teams@10.12.1-canary.1738.21372.0
  npm install @auto-canary/npm@10.12.1-canary.1738.21372.0
  npm install @auto-canary/omit-commits@10.12.1-canary.1738.21372.0
  npm install @auto-canary/omit-release-notes@10.12.1-canary.1738.21372.0
  npm install @auto-canary/pr-body-labels@10.12.1-canary.1738.21372.0
  npm install @auto-canary/released@10.12.1-canary.1738.21372.0
  npm install @auto-canary/s3@10.12.1-canary.1738.21372.0
  npm install @auto-canary/slack@10.12.1-canary.1738.21372.0
  npm install @auto-canary/twitter@10.12.1-canary.1738.21372.0
  npm install @auto-canary/upload-assets@10.12.1-canary.1738.21372.0
  npm install @auto-canary/vscode@10.12.1-canary.1738.21372.0
  # or 
  yarn add @auto-canary/bot-list@10.12.1-canary.1738.21372.0
  yarn add @auto-canary/auto@10.12.1-canary.1738.21372.0
  yarn add @auto-canary/core@10.12.1-canary.1738.21372.0
  yarn add @auto-canary/package-json-utils@10.12.1-canary.1738.21372.0
  yarn add @auto-canary/all-contributors@10.12.1-canary.1738.21372.0
  yarn add @auto-canary/brew@10.12.1-canary.1738.21372.0
  yarn add @auto-canary/chrome@10.12.1-canary.1738.21372.0
  yarn add @auto-canary/cocoapods@10.12.1-canary.1738.21372.0
  yarn add @auto-canary/conventional-commits@10.12.1-canary.1738.21372.0
  yarn add @auto-canary/crates@10.12.1-canary.1738.21372.0
  yarn add @auto-canary/docker@10.12.1-canary.1738.21372.0
  yarn add @auto-canary/exec@10.12.1-canary.1738.21372.0
  yarn add @auto-canary/first-time-contributor@10.12.1-canary.1738.21372.0
  yarn add @auto-canary/gem@10.12.1-canary.1738.21372.0
  yarn add @auto-canary/gh-pages@10.12.1-canary.1738.21372.0
  yarn add @auto-canary/git-tag@10.12.1-canary.1738.21372.0
  yarn add @auto-canary/gradle@10.12.1-canary.1738.21372.0
  yarn add @auto-canary/jira@10.12.1-canary.1738.21372.0
  yarn add @auto-canary/maven@10.12.1-canary.1738.21372.0
  yarn add @auto-canary/microsoft-teams@10.12.1-canary.1738.21372.0
  yarn add @auto-canary/npm@10.12.1-canary.1738.21372.0
  yarn add @auto-canary/omit-commits@10.12.1-canary.1738.21372.0
  yarn add @auto-canary/omit-release-notes@10.12.1-canary.1738.21372.0
  yarn add @auto-canary/pr-body-labels@10.12.1-canary.1738.21372.0
  yarn add @auto-canary/released@10.12.1-canary.1738.21372.0
  yarn add @auto-canary/s3@10.12.1-canary.1738.21372.0
  yarn add @auto-canary/slack@10.12.1-canary.1738.21372.0
  yarn add @auto-canary/twitter@10.12.1-canary.1738.21372.0
  yarn add @auto-canary/upload-assets@10.12.1-canary.1738.21372.0
  yarn add @auto-canary/vscode@10.12.1-canary.1738.21372.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
