### PR TITLE
handle case where auto isn't used in a git repo

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -349,15 +349,19 @@ function escapeRegExp(str: string) {
 
 /** Check if a repo has a branch */
 function hasBranch(branch: string) {
-  const branches = execSync("git branch --list --all", {
-    encoding: "utf-8",
-  }).split("\n");
+  try {
+    const branches = execSync("git branch --list --all", {
+      encoding: "utf-8",
+    }).split("\n");
 
-  return branches.some((b) => {
-    const parts = b.split("/");
+    return branches.some((b) => {
+      const parts = b.split("/");
 
-    return b === branch || parts[parts.length - 1] === branch;
-  });
+      return b === branch || parts[parts.length - 1] === branch;
+    });
+  } catch (error) {
+    return false;
+  }
 }
 
 /** The Error that gets thrown when a label existence check fails */


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux-canary.1739.21392.gz](https://github.com/intuit/auto/releases/download/canary/auto-linux-canary.1739.21392.gz)  
[auto-macos-canary.1739.21392.gz](https://github.com/intuit/auto/releases/download/canary/auto-macos-canary.1739.21392.gz)  
[auto-win.exe-canary.1739.21392.gz](https://github.com/intuit/auto/releases/download/canary/auto-win.exe-canary.1739.21392.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->
