### PR TITLE
feat: conventional commit plugin will label an unlabeled PR

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -2226,7 +2226,8 @@ export { IPlugin } from "./utils/load-plugins";
 export { ICommitAuthor, IExtendedCommit } from "./log-parse";
 
 export { default as Auto } from "./auto";
-export { default as SEMVER, VersionLabel } from "./semver";
+export { default as SEMVER } from "./semver";
+export * from "./semver";
 export { default as execPromise } from "./utils/exec-promise";
 export {
   default as getLernaPackages,

--- a/packages/core/src/semver.ts
+++ b/packages/core/src/semver.ts
@@ -164,7 +164,7 @@ export function getHigherSemverTag(left: SEMVER, right: SEMVER): SEMVER {
 }
 
 /** Get the semver bump for a release type */
-const getBump = (releaseType?: ReleaseType) =>
+export const getReleaseType = (releaseType?: ReleaseType) =>
   releaseType === "none" || releaseType === "skip"
     ? SEMVER.noVersion
     : releaseType === "release"
@@ -202,7 +202,7 @@ export function calculateSemVerBump(
     // 2. It has labels but none of them are auto labels
     if (
       index === 0 &&
-      (pr.length === 0 || !pr.find((label) => getLabelEntry(label)))
+      (pr.length === 0 || !pr.some((label) => Boolean(getLabelEntry(label))))
     ) {
       releaseTypes.add(defaultReleaseType);
     }
@@ -238,6 +238,6 @@ export function calculateSemVerBump(
   }
 
   return [...releaseTypes]
-    .map(getBump)
-    .reduce(getHigherSemverTag, getBump(defaultReleaseType));
+    .map(getReleaseType)
+    .reduce(getHigherSemverTag, getReleaseType(defaultReleaseType));
 }

--- a/plugins/conventional-commits/__tests__/conventional-commits.test.ts
+++ b/plugins/conventional-commits/__tests__/conventional-commits.test.ts
@@ -392,46 +392,47 @@ test("should add correct semver label to pr - one commit", async () => {
   expect(addLabelToPr).toHaveBeenCalledWith(1, "patch");
 });
 
-// test("should add correct semver label to pr - custom labels", async () => {
-//   const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
-//   const customLabels = [
-//     ...defaultLabels,
-//     { name: "my-major", releaseType: SEMVER.major } as any,
-//   ];
-//   const versionLabelsCustom = getVersionMap(customLabels);
-//   const autoHooks = makeHooks();
-//   const addLabelToPr = jest.fn();
-//   const auto = ({
-//     hooks: autoHooks,
-//     labels: customLabels,
-//     semVerLabels: versionLabelsCustom,
-//     logger: dummyLog(),
-//     git: {
-//       getLabels: async () => ['my-major'],
-//       getCommitsForPR: async () => {
-//         return [
-//           {
-//             sha: "1234",
-//             commit: {
-//               message: "normal commit",
-//             },
-//           },
-//         ];
-//       },
-//       addLabelToPr,
-//     },
-//   } as unknown) as Auto;
+test("should add correct semver label to pr - custom labels", async () => {
+  const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
+  const customLabels = [
+    // Only use the custom major label
+    ...defaultLabels.filter((l) => l.name !== "major"),
+    { name: "my-major", releaseType: SEMVER.major } as any,
+  ];
+  const versionLabelsCustom = getVersionMap(customLabels);
+  const autoHooks = makeHooks();
+  const addLabelToPr = jest.fn();
+  const auto = ({
+    hooks: autoHooks,
+    labels: customLabels,
+    semVerLabels: versionLabelsCustom,
+    logger: dummyLog(),
+    git: {
+      getLabels: async () => [],
+      getCommitsForPR: async () => {
+        return [
+          {
+            sha: "1234",
+            commit: {
+              message: "BREAKING: normal commit",
+            },
+          },
+        ];
+      },
+      addLabelToPr,
+    },
+  } as unknown) as Auto;
 
-//   conventionalCommitsPlugin.apply(auto);
+  conventionalCommitsPlugin.apply(auto);
 
-//   await auto.hooks.prCheck.promise({
-//     pr: {
-//       number: 1,
-//     } as any,
-//   });
+  await auto.hooks.prCheck.promise({
+    pr: {
+      number: 1,
+    } as any,
+  });
 
-//   expect(addLabelToPr).toHaveBeenCalledWith(1, "my-major");
-// });
+  expect(addLabelToPr).toHaveBeenCalledWith(1, "my-major");
+});
 
 test("should add correct semver label to pr - multiple commit", async () => {
   const conventionalCommitsPlugin = new ConventionalCommitsPlugin();

--- a/plugins/conventional-commits/__tests__/conventional-commits.test.ts
+++ b/plugins/conventional-commits/__tests__/conventional-commits.test.ts
@@ -408,13 +408,13 @@ test("should add correct semver label to pr - multiple commit", async () => {
           {
             sha: "12345",
             commit: {
-              message: "minor: normal commit",
+              message: "feat: normal commit",
             },
           },
           {
             sha: "123456",
             commit: {
-              message: "minor: normal commit",
+              message: "feat: normal commit",
             },
           },
         ];
@@ -431,5 +431,5 @@ test("should add correct semver label to pr - multiple commit", async () => {
     } as any,
   });
 
-  expect(addLabelToPr).toHaveBeenCalledWith(1, "patch");
+  expect(addLabelToPr).toHaveBeenCalledWith(1, "minor");
 });

--- a/plugins/conventional-commits/__tests__/conventional-commits.test.ts
+++ b/plugins/conventional-commits/__tests__/conventional-commits.test.ts
@@ -19,465 +19,488 @@ const config = {
   labels: defaultLabels,
 };
 
-test("should do nothing when conventional commit message is not present", async () => {
-  const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
-  const autoHooks = makeHooks();
-  conventionalCommitsPlugin.apply({
-    hooks: autoHooks,
-    labels: defaultLabels,
-    semVerLabels: versionLabels,
-    logger: dummyLog(),
-  } as Auto);
+describe("parseCommit", () => {
+  test("should do nothing when conventional commit message is not present", async () => {
+    const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
+    const autoHooks = makeHooks();
+    conventionalCommitsPlugin.apply({
+      hooks: autoHooks,
+      labels: defaultLabels,
+      semVerLabels: versionLabels,
+      logger: dummyLog(),
+    } as Auto);
 
-  const logParseHooks = makeLogParseHooks();
-  autoHooks.onCreateLogParse.call({
-    hooks: logParseHooks,
-  } as LogParse);
+    const logParseHooks = makeLogParseHooks();
+    autoHooks.onCreateLogParse.call({
+      hooks: logParseHooks,
+    } as LogParse);
 
-  const commit = makeCommitFromMsg("normal commit with no bump");
-  expect(await logParseHooks.parseCommit.promise({ ...commit })).toStrictEqual(
-    commit
-  );
-});
+    const commit = makeCommitFromMsg("normal commit with no bump");
+    expect(
+      await logParseHooks.parseCommit.promise({ ...commit })
+    ).toStrictEqual(commit);
+  });
 
-test("should add correct semver label to commit", async () => {
-  const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
-  const autoHooks = makeHooks();
-  conventionalCommitsPlugin.apply({
-    hooks: autoHooks,
-    labels: defaultLabels,
-    semVerLabels: versionLabels,
-    logger: dummyLog(),
-  } as Auto);
+  test("should add correct semver label to commit", async () => {
+    const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
+    const autoHooks = makeHooks();
+    conventionalCommitsPlugin.apply({
+      hooks: autoHooks,
+      labels: defaultLabels,
+      semVerLabels: versionLabels,
+      logger: dummyLog(),
+    } as Auto);
 
-  const logParseHooks = makeLogParseHooks();
-  autoHooks.onCreateLogParse.call({
-    hooks: logParseHooks,
-  } as LogParse);
+    const logParseHooks = makeLogParseHooks();
+    autoHooks.onCreateLogParse.call({
+      hooks: logParseHooks,
+    } as LogParse);
 
-  const commit = makeCommitFromMsg("fix: normal commit with no bump");
-  expect(await logParseHooks.parseCommit.promise({ ...commit })).toStrictEqual({
-    ...commit,
-    labels: ["patch"],
+    const commit = makeCommitFromMsg("fix: normal commit with no bump");
+    expect(
+      await logParseHooks.parseCommit.promise({ ...commit })
+    ).toStrictEqual({
+      ...commit,
+      labels: ["patch"],
+    });
+  });
+
+  test("should add correct semver label to commit - feat", async () => {
+    const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
+    const autoHooks = makeHooks();
+    conventionalCommitsPlugin.apply({
+      hooks: autoHooks,
+      labels: defaultLabels,
+      semVerLabels: versionLabels,
+      logger: dummyLog(),
+    } as Auto);
+
+    const logParseHooks = makeLogParseHooks();
+    autoHooks.onCreateLogParse.call({
+      hooks: logParseHooks,
+    } as LogParse);
+
+    const commit = makeCommitFromMsg("feat: normal commit with no bump");
+    expect(
+      await logParseHooks.parseCommit.promise({ ...commit })
+    ).toStrictEqual({
+      ...commit,
+      labels: ["minor"],
+    });
+  });
+
+  test("should add major semver label to commit", async () => {
+    const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
+    const autoHooks = makeHooks();
+    conventionalCommitsPlugin.apply({
+      hooks: autoHooks,
+      labels: defaultLabels,
+      semVerLabels: versionLabels,
+      logger: dummyLog(),
+    } as Auto);
+
+    const logParseHooks = makeLogParseHooks();
+    autoHooks.onCreateLogParse.call({
+      hooks: logParseHooks,
+    } as LogParse);
+
+    const commit = makeCommitFromMsg("BREAKING: normal commit with no bump");
+    expect(
+      await logParseHooks.parseCommit.promise({ ...commit })
+    ).toStrictEqual({
+      ...commit,
+      labels: ["major"],
+    });
+  });
+
+  test("should add major semver label to commit - !", async () => {
+    const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
+    const autoHooks = makeHooks();
+    conventionalCommitsPlugin.apply({
+      hooks: autoHooks,
+      labels: defaultLabels,
+      semVerLabels: versionLabels,
+      logger: dummyLog(),
+    } as Auto);
+
+    const logParseHooks = makeLogParseHooks();
+    autoHooks.onCreateLogParse.call({
+      hooks: logParseHooks,
+    } as LogParse);
+
+    const commit = makeCommitFromMsg("feat!: normal commit with no bump");
+    expect(
+      await logParseHooks.parseCommit.promise({ ...commit })
+    ).toStrictEqual({
+      ...commit,
+      labels: ["major"],
+    });
+  });
+
+  test("should skip when not a fix/feat/breaking change commit", async () => {
+    const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
+    const autoHooks = makeHooks();
+    conventionalCommitsPlugin.apply({
+      hooks: autoHooks,
+      labels: defaultLabels,
+      semVerLabels: versionLabels,
+      logger: dummyLog(),
+    } as Auto);
+
+    const logParseHooks = makeLogParseHooks();
+    autoHooks.onCreateLogParse.call({
+      hooks: logParseHooks,
+    } as LogParse);
+
+    const commit = makeCommitFromMsg("chore: i should not trigger a release");
+    expect(
+      await logParseHooks.parseCommit.promise({ ...commit })
+    ).toStrictEqual({
+      ...commit,
+      labels: ["skip-release"],
+    });
   });
 });
 
-test("should add correct semver label to commit - feat", async () => {
-  const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
-  const autoHooks = makeHooks();
-  conventionalCommitsPlugin.apply({
-    hooks: autoHooks,
-    labels: defaultLabels,
-    semVerLabels: versionLabels,
-    logger: dummyLog(),
-  } as Auto);
+describe("normalizeCommit", () => {
+  test("should not include label-less head commit if any other commit in PR has conventional commit message", async () => {
+    const commit = makeCommitFromMsg(
+      "Merge pull request #123 from some-pr\n\n"
+    );
+    const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
+    const logParse = new LogParse();
+    const autoHooks = makeHooks();
+    const mockGit = ({
+      getUserByEmail: jest.fn(),
+      searchRepo: jest.fn(),
+      getCommitDate: jest.fn(),
+      getFirstCommit: jest.fn(),
+      getPr: jest.fn(),
+      getCommitsForPR: () =>
+        Promise.resolve([
+          { sha: "1", commit: { message: "fix: child commit" } },
+        ]),
+    } as unknown) as Git;
+    conventionalCommitsPlugin.apply({
+      hooks: autoHooks,
+      labels: defaultLabels,
+      semVerLabels: versionLabels,
+      logger: dummyLog(),
+      git: mockGit,
+      release: new Release(mockGit, config),
+    } as Auto);
 
-  const logParseHooks = makeLogParseHooks();
-  autoHooks.onCreateLogParse.call({
-    hooks: logParseHooks,
-  } as LogParse);
+    autoHooks.onCreateLogParse.call(logParse);
 
-  const commit = makeCommitFromMsg("feat: normal commit with no bump");
-  expect(await logParseHooks.parseCommit.promise({ ...commit })).toStrictEqual({
-    ...commit,
-    labels: ["minor"],
+    const result = await logParse.normalizeCommit(commit);
+    expect(result).toBeUndefined();
+  });
+
+  test("should include labeled head commit", async () => {
+    const commit = makeCommitFromMsg(
+      "Merge pull request #123 from some-pr\n\n",
+      {
+        labels: ["major"],
+      }
+    );
+    const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
+    const logParse = new LogParse();
+    const autoHooks = makeHooks();
+    const mockGit = ({
+      getUserByEmail: jest.fn(),
+      searchRepo: jest.fn(),
+      getCommitDate: jest.fn(),
+      getFirstCommit: jest.fn(),
+      getPr: jest.fn(),
+      getLatestRelease: () => Promise.resolve("1.2.3"),
+      getGitLog: () =>
+        Promise.resolve([
+          commit,
+          makeCommitFromMsg("fix: child commit", { hash: "1" }),
+          makeCommitFromMsg("unrelated", { hash: "2" }),
+        ]),
+      getCommitsForPR: () => Promise.resolve([{ sha: "1" }]),
+    } as unknown) as Git;
+    conventionalCommitsPlugin.apply({
+      hooks: autoHooks,
+      labels: defaultLabels,
+      semVerLabels: versionLabels,
+      logger: dummyLog(),
+      git: mockGit,
+      release: new Release(mockGit, config),
+    } as Auto);
+
+    autoHooks.onCreateLogParse.call(logParse);
+
+    const result = await logParse.normalizeCommit(commit);
+    expect(result?.hash).toBe("foo");
+  });
+
+  test("should respect PR label if SEMVER", async () => {
+    const commit = makeCommitFromMsg("fix: a test", {
+      labels: ["major"],
+    });
+    const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
+    const logParse = new LogParse();
+    const autoHooks = makeHooks();
+    const mockGit = ({
+      getUserByEmail: jest.fn(),
+      searchRepo: jest.fn(),
+      getCommitDate: jest.fn(),
+      getFirstCommit: jest.fn(),
+      getPr: jest.fn(),
+      getLatestRelease: () => Promise.resolve("1.2.3"),
+      getGitLog: () => Promise.resolve([commit]),
+      getCommitsForPR: () => Promise.resolve([{ sha: "1" }]),
+    } as unknown) as Git;
+
+    conventionalCommitsPlugin.apply({
+      hooks: autoHooks,
+      labels: defaultLabels,
+      semVerLabels: versionLabels,
+      logger: dummyLog(),
+      git: mockGit,
+      release: new Release(mockGit, config),
+    } as Auto);
+
+    autoHooks.onCreateLogParse.call(logParse);
+
+    const result = await logParse.normalizeCommit(commit);
+    expect(result?.labels).toStrictEqual(["major"]);
+  });
+
+  test("should add conventional commit label if none/skip", async () => {
+    const commit = makeCommitFromMsg("fix: a test", {
+      labels: ["skip-release", "internal"],
+    });
+    const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
+    const logParse = new LogParse();
+    const autoHooks = makeHooks();
+    const mockGit = ({
+      getUserByEmail: jest.fn(),
+      searchRepo: jest.fn(),
+      getCommitDate: jest.fn(),
+      getFirstCommit: jest.fn(),
+      getPr: jest.fn(),
+      getLatestRelease: () => Promise.resolve("1.2.3"),
+      getGitLog: () => Promise.resolve([commit]),
+      getCommitsForPR: () => Promise.resolve([{ sha: "1" }]),
+    } as unknown) as Git;
+
+    conventionalCommitsPlugin.apply({
+      hooks: autoHooks,
+      labels: defaultLabels,
+      semVerLabels: versionLabels,
+      logger: dummyLog(),
+      git: mockGit,
+      release: new Release(mockGit, config),
+    } as Auto);
+
+    autoHooks.onCreateLogParse.call(logParse);
+
+    const result = await logParse.normalizeCommit(commit);
+    expect(result?.labels).toStrictEqual(["skip-release", "internal", "patch"]);
+  });
+
+  test("should not add skip when a non skip commit is present with a skip commit", async () => {
+    const commit = makeCommitFromMsg("fix: a test");
+    const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
+    const logParse = new LogParse();
+    const autoHooks = makeHooks();
+    const mockGit = ({
+      getUserByEmail: jest.fn(),
+      searchRepo: jest.fn(),
+      getCommitDate: jest.fn(),
+      getFirstCommit: jest.fn(),
+      getPr: jest.fn(),
+      getLatestRelease: () => Promise.resolve("1.2.3"),
+      getGitLog: () =>
+        Promise.resolve([commit, makeCommitFromMsg("chore: a test 2")]),
+      getCommitsForPR: () => Promise.resolve([{ sha: "1" }]),
+    } as unknown) as Git;
+
+    conventionalCommitsPlugin.apply({
+      hooks: autoHooks,
+      labels: defaultLabels,
+      semVerLabels: versionLabels,
+      logger: dummyLog(),
+      git: mockGit,
+      release: new Release(mockGit, config),
+    } as Auto);
+
+    autoHooks.onCreateLogParse.call(logParse);
+
+    const result = await logParse.normalizeCommit(commit);
+    expect(result?.labels).toStrictEqual(["patch"]);
   });
 });
 
-test("should add major semver label to commit", async () => {
-  const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
-  const autoHooks = makeHooks();
-  conventionalCommitsPlugin.apply({
-    hooks: autoHooks,
-    labels: defaultLabels,
-    semVerLabels: versionLabels,
-    logger: dummyLog(),
-  } as Auto);
+describe("prCheck", () => {
+  test("should not add semver label to pr if semver label exists", async () => {
+    const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
+    const autoHooks = makeHooks();
+    const addLabelToPr = jest.fn();
+    const customLabels = [
+      ...defaultLabels,
+      { name: "my-major", releaseType: SEMVER.major } as any,
+    ];
+    const versionLabelsCustom = getVersionMap(customLabels);
 
-  const logParseHooks = makeLogParseHooks();
-  autoHooks.onCreateLogParse.call({
-    hooks: logParseHooks,
-  } as LogParse);
-
-  const commit = makeCommitFromMsg("BREAKING: normal commit with no bump");
-  expect(await logParseHooks.parseCommit.promise({ ...commit })).toStrictEqual({
-    ...commit,
-    labels: ["major"],
-  });
-});
-
-test("should add major semver label to commit - !", async () => {
-  const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
-  const autoHooks = makeHooks();
-  conventionalCommitsPlugin.apply({
-    hooks: autoHooks,
-    labels: defaultLabels,
-    semVerLabels: versionLabels,
-    logger: dummyLog(),
-  } as Auto);
-
-  const logParseHooks = makeLogParseHooks();
-  autoHooks.onCreateLogParse.call({
-    hooks: logParseHooks,
-  } as LogParse);
-
-  const commit = makeCommitFromMsg("feat!: normal commit with no bump");
-  expect(await logParseHooks.parseCommit.promise({ ...commit })).toStrictEqual({
-    ...commit,
-    labels: ["major"],
-  });
-});
-
-test("should not include label-less head commit if any other commit in PR has conventional commit message", async () => {
-  const commit = makeCommitFromMsg("Merge pull request #123 from some-pr\n\n");
-  const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
-  const logParse = new LogParse();
-  const autoHooks = makeHooks();
-  const mockGit = ({
-    getUserByEmail: jest.fn(),
-    searchRepo: jest.fn(),
-    getCommitDate: jest.fn(),
-    getFirstCommit: jest.fn(),
-    getPr: jest.fn(),
-    getCommitsForPR: () =>
-      Promise.resolve([{ sha: "1", commit: { message: "fix: child commit" } }]),
-  } as unknown) as Git;
-  conventionalCommitsPlugin.apply({
-    hooks: autoHooks,
-    labels: defaultLabels,
-    semVerLabels: versionLabels,
-    logger: dummyLog(),
-    git: mockGit,
-    release: new Release(mockGit, config),
-  } as Auto);
-
-  autoHooks.onCreateLogParse.call(logParse);
-
-  const result = await logParse.normalizeCommit(commit);
-  expect(result).toBeUndefined();
-});
-
-test("should include labeled head commit", async () => {
-  const commit = makeCommitFromMsg("Merge pull request #123 from some-pr\n\n", {
-    labels: ["major"],
-  });
-  const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
-  const logParse = new LogParse();
-  const autoHooks = makeHooks();
-  const mockGit = ({
-    getUserByEmail: jest.fn(),
-    searchRepo: jest.fn(),
-    getCommitDate: jest.fn(),
-    getFirstCommit: jest.fn(),
-    getPr: jest.fn(),
-    getLatestRelease: () => Promise.resolve("1.2.3"),
-    getGitLog: () =>
-      Promise.resolve([
-        commit,
-        makeCommitFromMsg("fix: child commit", { hash: "1" }),
-        makeCommitFromMsg("unrelated", { hash: "2" }),
-      ]),
-    getCommitsForPR: () => Promise.resolve([{ sha: "1" }]),
-  } as unknown) as Git;
-  conventionalCommitsPlugin.apply({
-    hooks: autoHooks,
-    labels: defaultLabels,
-    semVerLabels: versionLabels,
-    logger: dummyLog(),
-    git: mockGit,
-    release: new Release(mockGit, config),
-  } as Auto);
-
-  autoHooks.onCreateLogParse.call(logParse);
-
-  const result = await logParse.normalizeCommit(commit);
-  expect(result?.hash).toBe("foo");
-});
-
-test("should respect PR label if SEMVER", async () => {
-  const commit = makeCommitFromMsg("fix: a test", {
-    labels: ["major"],
-  });
-  const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
-  const logParse = new LogParse();
-  const autoHooks = makeHooks();
-  const mockGit = ({
-    getUserByEmail: jest.fn(),
-    searchRepo: jest.fn(),
-    getCommitDate: jest.fn(),
-    getFirstCommit: jest.fn(),
-    getPr: jest.fn(),
-    getLatestRelease: () => Promise.resolve("1.2.3"),
-    getGitLog: () => Promise.resolve([commit]),
-    getCommitsForPR: () => Promise.resolve([{ sha: "1" }]),
-  } as unknown) as Git;
-
-  conventionalCommitsPlugin.apply({
-    hooks: autoHooks,
-    labels: defaultLabels,
-    semVerLabels: versionLabels,
-    logger: dummyLog(),
-    git: mockGit,
-    release: new Release(mockGit, config),
-  } as Auto);
-
-  autoHooks.onCreateLogParse.call(logParse);
-
-  const result = await logParse.normalizeCommit(commit);
-  expect(result?.labels).toStrictEqual(["major"]);
-});
-
-test("should add conventional commit label if none/skip", async () => {
-  const commit = makeCommitFromMsg("fix: a test", {
-    labels: ["skip-release", "internal"],
-  });
-  const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
-  const logParse = new LogParse();
-  const autoHooks = makeHooks();
-  const mockGit = ({
-    getUserByEmail: jest.fn(),
-    searchRepo: jest.fn(),
-    getCommitDate: jest.fn(),
-    getFirstCommit: jest.fn(),
-    getPr: jest.fn(),
-    getLatestRelease: () => Promise.resolve("1.2.3"),
-    getGitLog: () => Promise.resolve([commit]),
-    getCommitsForPR: () => Promise.resolve([{ sha: "1" }]),
-  } as unknown) as Git;
-
-  conventionalCommitsPlugin.apply({
-    hooks: autoHooks,
-    labels: defaultLabels,
-    semVerLabels: versionLabels,
-    logger: dummyLog(),
-    git: mockGit,
-    release: new Release(mockGit, config),
-  } as Auto);
-
-  autoHooks.onCreateLogParse.call(logParse);
-
-  const result = await logParse.normalizeCommit(commit);
-  expect(result?.labels).toStrictEqual(["skip-release", "internal", "patch"]);
-});
-
-test("should not add skip when a non skip commit is present with a skip commit", async () => {
-  const commit = makeCommitFromMsg("fix: a test");
-  const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
-  const logParse = new LogParse();
-  const autoHooks = makeHooks();
-  const mockGit = ({
-    getUserByEmail: jest.fn(),
-    searchRepo: jest.fn(),
-    getCommitDate: jest.fn(),
-    getFirstCommit: jest.fn(),
-    getPr: jest.fn(),
-    getLatestRelease: () => Promise.resolve("1.2.3"),
-    getGitLog: () =>
-      Promise.resolve([commit, makeCommitFromMsg("chore: a test 2")]),
-    getCommitsForPR: () => Promise.resolve([{ sha: "1" }]),
-  } as unknown) as Git;
-
-  conventionalCommitsPlugin.apply({
-    hooks: autoHooks,
-    labels: defaultLabels,
-    semVerLabels: versionLabels,
-    logger: dummyLog(),
-    git: mockGit,
-    release: new Release(mockGit, config),
-  } as Auto);
-
-  autoHooks.onCreateLogParse.call(logParse);
-
-  const result = await logParse.normalizeCommit(commit);
-  expect(result?.labels).toStrictEqual(["patch"]);
-});
-
-test("should skip when not a fix/feat/breaking change commit", async () => {
-  const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
-  const autoHooks = makeHooks();
-  conventionalCommitsPlugin.apply({
-    hooks: autoHooks,
-    labels: defaultLabels,
-    semVerLabels: versionLabels,
-    logger: dummyLog(),
-  } as Auto);
-
-  const logParseHooks = makeLogParseHooks();
-  autoHooks.onCreateLogParse.call({
-    hooks: logParseHooks,
-  } as LogParse);
-
-  const commit = makeCommitFromMsg("chore: i should not trigger a release");
-  expect(await logParseHooks.parseCommit.promise({ ...commit })).toStrictEqual({
-    ...commit,
-    labels: ["skip-release"],
-  });
-});
-
-test("should not add semver label to pr if semver label exists", async () => {
-  const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
-  const autoHooks = makeHooks();
-  const addLabelToPr = jest.fn();
-  const customLabels = [
-    ...defaultLabels,
-    { name: "my-major", releaseType: SEMVER.major } as any,
-  ];
-  const versionLabelsCustom = getVersionMap(customLabels);
-
-  const auto = ({
-    hooks: autoHooks,
-    labels: customLabels,
-    semVerLabels: versionLabelsCustom,
-    logger: dummyLog(),
-    git: {
-      getLabels: async () => ["my-major"],
-      getCommitsForPR: async () => {
-        return [
-          {
-            sha: "1234",
-            commit: {
-              message: "fix: normal commit",
+    const auto = ({
+      hooks: autoHooks,
+      labels: customLabels,
+      semVerLabels: versionLabelsCustom,
+      logger: dummyLog(),
+      git: {
+        getLabels: async () => ["my-major"],
+        getCommitsForPR: async () => {
+          return [
+            {
+              sha: "1234",
+              commit: {
+                message: "fix: normal commit",
+              },
             },
-          },
-        ];
+          ];
+        },
+        addLabelToPr,
       },
-      addLabelToPr,
-    },
-  } as unknown) as Auto;
+    } as unknown) as Auto;
 
-  conventionalCommitsPlugin.apply(auto);
+    conventionalCommitsPlugin.apply(auto);
 
-  await auto.hooks.prCheck.promise({
-    pr: {
-      number: 1,
-    } as any,
+    await auto.hooks.prCheck.promise({
+      pr: {
+        number: 1,
+      } as any,
+    });
+
+    expect(addLabelToPr).toHaveBeenCalledTimes(0);
   });
 
-  expect(addLabelToPr).toHaveBeenCalledTimes(0);
-});
-
-test("should add correct semver label to pr - one commit", async () => {
-  const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
-  const autoHooks = makeHooks();
-  const addLabelToPr = jest.fn();
-  const auto = ({
-    hooks: autoHooks,
-    labels: defaultLabels,
-    semVerLabels: versionLabels,
-    logger: dummyLog(),
-    git: {
-      getLabels: async () => [],
-      getCommitsForPR: async () => {
-        return [
-          {
-            sha: "1234",
-            commit: {
-              message: "fix: normal commit",
+  test("should add correct semver label to pr - one commit", async () => {
+    const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
+    const autoHooks = makeHooks();
+    const addLabelToPr = jest.fn();
+    const auto = ({
+      hooks: autoHooks,
+      labels: defaultLabels,
+      semVerLabels: versionLabels,
+      logger: dummyLog(),
+      git: {
+        getLabels: async () => [],
+        getCommitsForPR: async () => {
+          return [
+            {
+              sha: "1234",
+              commit: {
+                message: "fix: normal commit",
+              },
             },
-          },
-        ];
+          ];
+        },
+        addLabelToPr,
       },
-      addLabelToPr,
-    },
-  } as unknown) as Auto;
+    } as unknown) as Auto;
 
-  conventionalCommitsPlugin.apply(auto);
+    conventionalCommitsPlugin.apply(auto);
 
-  await auto.hooks.prCheck.promise({
-    pr: {
-      number: 1,
-    } as any,
+    await auto.hooks.prCheck.promise({
+      pr: {
+        number: 1,
+      } as any,
+    });
+
+    expect(addLabelToPr).toHaveBeenCalledWith(1, "patch");
   });
 
-  expect(addLabelToPr).toHaveBeenCalledWith(1, "patch");
-});
-
-test("should add correct semver label to pr - custom labels", async () => {
-  const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
-  const customLabels = [
-    // Only use the custom major label
-    ...defaultLabels.filter((l) => l.name !== "major"),
-    { name: "my-major", releaseType: SEMVER.major } as any,
-  ];
-  const versionLabelsCustom = getVersionMap(customLabels);
-  const autoHooks = makeHooks();
-  const addLabelToPr = jest.fn();
-  const auto = ({
-    hooks: autoHooks,
-    labels: customLabels,
-    semVerLabels: versionLabelsCustom,
-    logger: dummyLog(),
-    git: {
-      getLabels: async () => [],
-      getCommitsForPR: async () => {
-        return [
-          {
-            sha: "1234",
-            commit: {
-              message: "BREAKING: normal commit",
+  test("should add correct semver label to pr - custom labels", async () => {
+    const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
+    const customLabels = [
+      // Only use the custom major label
+      ...defaultLabels.filter((l) => l.name !== "major"),
+      { name: "my-major", releaseType: SEMVER.major } as any,
+    ];
+    const versionLabelsCustom = getVersionMap(customLabels);
+    const autoHooks = makeHooks();
+    const addLabelToPr = jest.fn();
+    const auto = ({
+      hooks: autoHooks,
+      labels: customLabels,
+      semVerLabels: versionLabelsCustom,
+      logger: dummyLog(),
+      git: {
+        getLabels: async () => [],
+        getCommitsForPR: async () => {
+          return [
+            {
+              sha: "1234",
+              commit: {
+                message: "BREAKING: normal commit",
+              },
             },
-          },
-        ];
+          ];
+        },
+        addLabelToPr,
       },
-      addLabelToPr,
-    },
-  } as unknown) as Auto;
+    } as unknown) as Auto;
 
-  conventionalCommitsPlugin.apply(auto);
+    conventionalCommitsPlugin.apply(auto);
 
-  await auto.hooks.prCheck.promise({
-    pr: {
-      number: 1,
-    } as any,
+    await auto.hooks.prCheck.promise({
+      pr: {
+        number: 1,
+      } as any,
+    });
+
+    expect(addLabelToPr).toHaveBeenCalledWith(1, "my-major");
   });
 
-  expect(addLabelToPr).toHaveBeenCalledWith(1, "my-major");
-});
-
-test("should add correct semver label to pr - multiple commit", async () => {
-  const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
-  const autoHooks = makeHooks();
-  const addLabelToPr = jest.fn();
-  const auto = ({
-    hooks: autoHooks,
-    labels: defaultLabels,
-    semVerLabels: versionLabels,
-    logger: dummyLog(),
-    git: {
-      getLabels: async () => [],
-      getCommitsForPR: async () => {
-        return [
-          {
-            sha: "1234",
-            commit: {
-              message: "fix: normal commit",
+  test("should add correct semver label to pr - multiple commit", async () => {
+    const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
+    const autoHooks = makeHooks();
+    const addLabelToPr = jest.fn();
+    const auto = ({
+      hooks: autoHooks,
+      labels: defaultLabels,
+      semVerLabels: versionLabels,
+      logger: dummyLog(),
+      git: {
+        getLabels: async () => [],
+        getCommitsForPR: async () => {
+          return [
+            {
+              sha: "1234",
+              commit: {
+                message: "fix: normal commit",
+              },
             },
-          },
-          {
-            sha: "12345",
-            commit: {
-              message: "feat: normal commit",
+            {
+              sha: "12345",
+              commit: {
+                message: "feat: normal commit",
+              },
             },
-          },
-          {
-            sha: "123456",
-            commit: {
-              message: "feat: normal commit",
+            {
+              sha: "123456",
+              commit: {
+                message: "feat: normal commit",
+              },
             },
-          },
-        ];
+          ];
+        },
+        addLabelToPr,
       },
-      addLabelToPr,
-    },
-  } as unknown) as Auto;
+    } as unknown) as Auto;
 
-  conventionalCommitsPlugin.apply(auto);
+    conventionalCommitsPlugin.apply(auto);
 
-  await auto.hooks.prCheck.promise({
-    pr: {
-      number: 1,
-    } as any,
+    await auto.hooks.prCheck.promise({
+      pr: {
+        number: 1,
+      } as any,
+    });
+
+    expect(addLabelToPr).toHaveBeenCalledWith(1, "minor");
   });
-
-  expect(addLabelToPr).toHaveBeenCalledWith(1, "minor");
 });

--- a/plugins/conventional-commits/package.json
+++ b/plugins/conventional-commits/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@auto-it/core": "link:../../packages/core",
+    "array.prototype.flatmap": "^1.2.2",
     "conventional-changelog-core": "^4.2.0",
     "conventional-changelog-preset-loader": "^2.3.4",
     "conventional-commits-parser": "^3.1.0",

--- a/plugins/conventional-commits/src/index.ts
+++ b/plugins/conventional-commits/src/index.ts
@@ -137,9 +137,10 @@ export default class ConventionalCommitsPlugin implements IPlugin {
       }
 
       const labels = await auto.git.getLabels(pr.number);
+      const semVerLabels = [...auto.semVerLabels!.values()].flat();
 
       // check if semver label is already on PR
-      if (labels.filter((l) => auto.semVerLabels?.get(l as any)).length > 0) {
+      if (labels.some((l) => semVerLabels.includes(l))) {
         return;
       }
 


### PR DESCRIPTION
# What Changed

Tap the `prCheck` hook in conventional-commits plugin to add the semver label to the PR based on the commits if no semver label exists

## Why

Discussion in slack, seemed like a useful feature for it to be more automatic when using conventional commits

Todo:

- [x] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux-canary.1758.21676.gz](https://github.com/intuit/auto/releases/download/canary/auto-linux-canary.1758.21676.gz)  
[auto-macos-canary.1758.21676.gz](https://github.com/intuit/auto/releases/download/canary/auto-macos-canary.1758.21676.gz)  
[auto-win.exe-canary.1758.21676.gz](https://github.com/intuit/auto/releases/download/canary/auto-win.exe-canary.1758.21676.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.14.0-canary.1758.21676.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.14.0-canary.1758.21676.0
  npm install @auto-canary/auto@10.14.0-canary.1758.21676.0
  npm install @auto-canary/core@10.14.0-canary.1758.21676.0
  npm install @auto-canary/package-json-utils@10.14.0-canary.1758.21676.0
  npm install @auto-canary/all-contributors@10.14.0-canary.1758.21676.0
  npm install @auto-canary/brew@10.14.0-canary.1758.21676.0
  npm install @auto-canary/chrome@10.14.0-canary.1758.21676.0
  npm install @auto-canary/cocoapods@10.14.0-canary.1758.21676.0
  npm install @auto-canary/conventional-commits@10.14.0-canary.1758.21676.0
  npm install @auto-canary/crates@10.14.0-canary.1758.21676.0
  npm install @auto-canary/docker@10.14.0-canary.1758.21676.0
  npm install @auto-canary/exec@10.14.0-canary.1758.21676.0
  npm install @auto-canary/first-time-contributor@10.14.0-canary.1758.21676.0
  npm install @auto-canary/gem@10.14.0-canary.1758.21676.0
  npm install @auto-canary/gh-pages@10.14.0-canary.1758.21676.0
  npm install @auto-canary/git-tag@10.14.0-canary.1758.21676.0
  npm install @auto-canary/gradle@10.14.0-canary.1758.21676.0
  npm install @auto-canary/jira@10.14.0-canary.1758.21676.0
  npm install @auto-canary/magic-zero@10.14.0-canary.1758.21676.0
  npm install @auto-canary/maven@10.14.0-canary.1758.21676.0
  npm install @auto-canary/microsoft-teams@10.14.0-canary.1758.21676.0
  npm install @auto-canary/npm@10.14.0-canary.1758.21676.0
  npm install @auto-canary/omit-commits@10.14.0-canary.1758.21676.0
  npm install @auto-canary/omit-release-notes@10.14.0-canary.1758.21676.0
  npm install @auto-canary/pr-body-labels@10.14.0-canary.1758.21676.0
  npm install @auto-canary/released@10.14.0-canary.1758.21676.0
  npm install @auto-canary/s3@10.14.0-canary.1758.21676.0
  npm install @auto-canary/slack@10.14.0-canary.1758.21676.0
  npm install @auto-canary/twitter@10.14.0-canary.1758.21676.0
  npm install @auto-canary/upload-assets@10.14.0-canary.1758.21676.0
  npm install @auto-canary/vscode@10.14.0-canary.1758.21676.0
  # or 
  yarn add @auto-canary/bot-list@10.14.0-canary.1758.21676.0
  yarn add @auto-canary/auto@10.14.0-canary.1758.21676.0
  yarn add @auto-canary/core@10.14.0-canary.1758.21676.0
  yarn add @auto-canary/package-json-utils@10.14.0-canary.1758.21676.0
  yarn add @auto-canary/all-contributors@10.14.0-canary.1758.21676.0
  yarn add @auto-canary/brew@10.14.0-canary.1758.21676.0
  yarn add @auto-canary/chrome@10.14.0-canary.1758.21676.0
  yarn add @auto-canary/cocoapods@10.14.0-canary.1758.21676.0
  yarn add @auto-canary/conventional-commits@10.14.0-canary.1758.21676.0
  yarn add @auto-canary/crates@10.14.0-canary.1758.21676.0
  yarn add @auto-canary/docker@10.14.0-canary.1758.21676.0
  yarn add @auto-canary/exec@10.14.0-canary.1758.21676.0
  yarn add @auto-canary/first-time-contributor@10.14.0-canary.1758.21676.0
  yarn add @auto-canary/gem@10.14.0-canary.1758.21676.0
  yarn add @auto-canary/gh-pages@10.14.0-canary.1758.21676.0
  yarn add @auto-canary/git-tag@10.14.0-canary.1758.21676.0
  yarn add @auto-canary/gradle@10.14.0-canary.1758.21676.0
  yarn add @auto-canary/jira@10.14.0-canary.1758.21676.0
  yarn add @auto-canary/magic-zero@10.14.0-canary.1758.21676.0
  yarn add @auto-canary/maven@10.14.0-canary.1758.21676.0
  yarn add @auto-canary/microsoft-teams@10.14.0-canary.1758.21676.0
  yarn add @auto-canary/npm@10.14.0-canary.1758.21676.0
  yarn add @auto-canary/omit-commits@10.14.0-canary.1758.21676.0
  yarn add @auto-canary/omit-release-notes@10.14.0-canary.1758.21676.0
  yarn add @auto-canary/pr-body-labels@10.14.0-canary.1758.21676.0
  yarn add @auto-canary/released@10.14.0-canary.1758.21676.0
  yarn add @auto-canary/s3@10.14.0-canary.1758.21676.0
  yarn add @auto-canary/slack@10.14.0-canary.1758.21676.0
  yarn add @auto-canary/twitter@10.14.0-canary.1758.21676.0
  yarn add @auto-canary/upload-assets@10.14.0-canary.1758.21676.0
  yarn add @auto-canary/vscode@10.14.0-canary.1758.21676.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
