### PR TITLE
fix commit message when using npx in non-monorepo

### DIFF
--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -489,7 +489,7 @@ describe("publish", () => {
       Auto.SEMVER.patch,
       "--no-commit-hooks",
       "-m",
-      "Bump version to: %s [skip ci]",
+      "'\"Bump version to: %s [skip ci]\"'",
       "--loglevel",
       "silly",
     ]);
@@ -519,7 +519,7 @@ describe("publish", () => {
       Auto.SEMVER.patch,
       "--no-commit-hooks",
       "-m",
-      "Bump version to: %s [skip ci]",
+      "'\"Bump version to: %s [skip ci]\"'",
     ]);
   });
 
@@ -554,7 +554,7 @@ describe("publish", () => {
       "--yes",
       "--no-push",
       "-m",
-      '\'"Bump version to: %s [skip ci]"\'',
+      "'\"Bump version to: %s [skip ci]\"'",
       false,
     ]);
   });
@@ -590,7 +590,7 @@ describe("publish", () => {
       "--yes",
       "--no-push",
       "-m",
-      '\'"Bump version to: %s [skip ci]"\'',
+      "'\"Bump version to: %s [skip ci]\"'",
       false,
     ]);
   });
@@ -626,7 +626,7 @@ describe("publish", () => {
       "--yes",
       "--no-push",
       "-m",
-      '\'"Bump version to: %s [skip ci]"\'',
+      "'\"Bump version to: %s [skip ci]\"'",
       "--exact",
     ]);
 
@@ -750,7 +750,7 @@ describe("publish", () => {
       "1.0.1",
       "--no-commit-hooks",
       "-m",
-      "Bump version to: %s [skip ci]",
+      "'\"Bump version to: %s [skip ci]\"'",
     ]);
   });
 
@@ -786,7 +786,7 @@ describe("publish", () => {
       "--yes",
       "--no-push",
       "-m",
-      '\'"Bump version to: %s [skip ci]"\'',
+      "'\"Bump version to: %s [skip ci]\"'",
       false,
     ]);
   });

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -35,7 +35,7 @@ import setTokenOnCI, { getRegistry, DEFAULT_REGISTRY } from "./set-npm-token";
 import { writeFile, isMonorepo, readFile, getLernaJson } from "./utils";
 
 const { isCi } = envCi();
-const VERSION_COMMIT_MESSAGE = "Bump version to: %s [skip ci]";
+const VERSION_COMMIT_MESSAGE = `'"Bump version to: %s [skip ci]"'`;
 
 /** Get the last published version for a npm package */
 async function getPublishedVersion(name: string) {
@@ -947,7 +947,7 @@ export default class NPMPlugin implements IPlugin {
             "-m",
             isIndependent
               ? '"Bump independent versions [skip ci]"'
-              : `'"${VERSION_COMMIT_MESSAGE}"'`,
+              : VERSION_COMMIT_MESSAGE,
             this.exact && "--exact",
             ...verboseArgs,
           ]);


### PR DESCRIPTION
## Why

closes #1761 

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux-canary.1762.21656.gz](https://github.com/intuit/auto/releases/download/canary/auto-linux-canary.1762.21656.gz)  
[auto-macos-canary.1762.21656.gz](https://github.com/intuit/auto/releases/download/canary/auto-macos-canary.1762.21656.gz)  
[auto-win.exe-canary.1762.21656.gz](https://github.com/intuit/auto/releases/download/canary/auto-win.exe-canary.1762.21656.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.13.3-canary.1762.21656.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.13.3-canary.1762.21656.0
  npm install @auto-canary/auto@10.13.3-canary.1762.21656.0
  npm install @auto-canary/core@10.13.3-canary.1762.21656.0
  npm install @auto-canary/package-json-utils@10.13.3-canary.1762.21656.0
  npm install @auto-canary/all-contributors@10.13.3-canary.1762.21656.0
  npm install @auto-canary/brew@10.13.3-canary.1762.21656.0
  npm install @auto-canary/chrome@10.13.3-canary.1762.21656.0
  npm install @auto-canary/cocoapods@10.13.3-canary.1762.21656.0
  npm install @auto-canary/conventional-commits@10.13.3-canary.1762.21656.0
  npm install @auto-canary/crates@10.13.3-canary.1762.21656.0
  npm install @auto-canary/docker@10.13.3-canary.1762.21656.0
  npm install @auto-canary/exec@10.13.3-canary.1762.21656.0
  npm install @auto-canary/first-time-contributor@10.13.3-canary.1762.21656.0
  npm install @auto-canary/gem@10.13.3-canary.1762.21656.0
  npm install @auto-canary/gh-pages@10.13.3-canary.1762.21656.0
  npm install @auto-canary/git-tag@10.13.3-canary.1762.21656.0
  npm install @auto-canary/gradle@10.13.3-canary.1762.21656.0
  npm install @auto-canary/jira@10.13.3-canary.1762.21656.0
  npm install @auto-canary/magic-zero@10.13.3-canary.1762.21656.0
  npm install @auto-canary/maven@10.13.3-canary.1762.21656.0
  npm install @auto-canary/microsoft-teams@10.13.3-canary.1762.21656.0
  npm install @auto-canary/npm@10.13.3-canary.1762.21656.0
  npm install @auto-canary/omit-commits@10.13.3-canary.1762.21656.0
  npm install @auto-canary/omit-release-notes@10.13.3-canary.1762.21656.0
  npm install @auto-canary/pr-body-labels@10.13.3-canary.1762.21656.0
  npm install @auto-canary/released@10.13.3-canary.1762.21656.0
  npm install @auto-canary/s3@10.13.3-canary.1762.21656.0
  npm install @auto-canary/slack@10.13.3-canary.1762.21656.0
  npm install @auto-canary/twitter@10.13.3-canary.1762.21656.0
  npm install @auto-canary/upload-assets@10.13.3-canary.1762.21656.0
  npm install @auto-canary/vscode@10.13.3-canary.1762.21656.0
  # or 
  yarn add @auto-canary/bot-list@10.13.3-canary.1762.21656.0
  yarn add @auto-canary/auto@10.13.3-canary.1762.21656.0
  yarn add @auto-canary/core@10.13.3-canary.1762.21656.0
  yarn add @auto-canary/package-json-utils@10.13.3-canary.1762.21656.0
  yarn add @auto-canary/all-contributors@10.13.3-canary.1762.21656.0
  yarn add @auto-canary/brew@10.13.3-canary.1762.21656.0
  yarn add @auto-canary/chrome@10.13.3-canary.1762.21656.0
  yarn add @auto-canary/cocoapods@10.13.3-canary.1762.21656.0
  yarn add @auto-canary/conventional-commits@10.13.3-canary.1762.21656.0
  yarn add @auto-canary/crates@10.13.3-canary.1762.21656.0
  yarn add @auto-canary/docker@10.13.3-canary.1762.21656.0
  yarn add @auto-canary/exec@10.13.3-canary.1762.21656.0
  yarn add @auto-canary/first-time-contributor@10.13.3-canary.1762.21656.0
  yarn add @auto-canary/gem@10.13.3-canary.1762.21656.0
  yarn add @auto-canary/gh-pages@10.13.3-canary.1762.21656.0
  yarn add @auto-canary/git-tag@10.13.3-canary.1762.21656.0
  yarn add @auto-canary/gradle@10.13.3-canary.1762.21656.0
  yarn add @auto-canary/jira@10.13.3-canary.1762.21656.0
  yarn add @auto-canary/magic-zero@10.13.3-canary.1762.21656.0
  yarn add @auto-canary/maven@10.13.3-canary.1762.21656.0
  yarn add @auto-canary/microsoft-teams@10.13.3-canary.1762.21656.0
  yarn add @auto-canary/npm@10.13.3-canary.1762.21656.0
  yarn add @auto-canary/omit-commits@10.13.3-canary.1762.21656.0
  yarn add @auto-canary/omit-release-notes@10.13.3-canary.1762.21656.0
  yarn add @auto-canary/pr-body-labels@10.13.3-canary.1762.21656.0
  yarn add @auto-canary/released@10.13.3-canary.1762.21656.0
  yarn add @auto-canary/s3@10.13.3-canary.1762.21656.0
  yarn add @auto-canary/slack@10.13.3-canary.1762.21656.0
  yarn add @auto-canary/twitter@10.13.3-canary.1762.21656.0
  yarn add @auto-canary/upload-assets@10.13.3-canary.1762.21656.0
  yarn add @auto-canary/vscode@10.13.3-canary.1762.21656.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
