### PR TITLE
released plugin: handle PR numbers that dont exist

### DIFF
--- a/plugins/released/__tests__/released-label.test.ts
+++ b/plugins/released/__tests__/released-label.test.ts
@@ -144,6 +144,32 @@ describe("release label plugin", () => {
     expect(comment).not.toHaveBeenCalled();
   });
 
+  test("should do nothing with PR that doesn't exist", async () => {
+    const releasedLabel = new ReleasedLabelPlugin();
+    const autoHooks = makeHooks();
+    releasedLabel.apply(({
+      hooks: autoHooks,
+      labels: defaultLabels,
+      logger: dummyLog(),
+      options: {},
+      comment,
+      git,
+    } as unknown) as Auto);
+
+    getPr.mockRejectedValueOnce(new Error("PR dont exist"));
+    const commit = makeCommitFromMsg("normal commit with no bump (#123)");
+    await autoHooks.afterRelease.promise({
+      newVersion: "1.0.0",
+      lastRelease: "0.1.0",
+      commits: await log.normalizeCommits([commit]),
+      releaseNotes: "",
+      // @ts-ignore
+      response: mockResponse,
+    });
+
+    expect(comment).not.toHaveBeenCalled();
+  });
+
   test("should do nothing without commits", async () => {
     const releasedLabel = new ReleasedLabelPlugin();
     const autoHooks = makeHooks();


### PR DESCRIPTION
# What Changed

see title

## Why

If you include `#123` and it doesn't exist on the repo auto fails with errors.

Todo:

- [ ] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux-canary.1772.21738.gz](https://github.com/intuit/auto/releases/download/canary/auto-linux-canary.1772.21738.gz)  
[auto-macos-canary.1772.21738.gz](https://github.com/intuit/auto/releases/download/canary/auto-macos-canary.1772.21738.gz)  
[auto-win.exe-canary.1772.21738.gz](https://github.com/intuit/auto/releases/download/canary/auto-win.exe-canary.1772.21738.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.13.4-canary.1772.21738.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.13.4-canary.1772.21738.0
  npm install @auto-canary/auto@10.13.4-canary.1772.21738.0
  npm install @auto-canary/core@10.13.4-canary.1772.21738.0
  npm install @auto-canary/package-json-utils@10.13.4-canary.1772.21738.0
  npm install @auto-canary/all-contributors@10.13.4-canary.1772.21738.0
  npm install @auto-canary/brew@10.13.4-canary.1772.21738.0
  npm install @auto-canary/chrome@10.13.4-canary.1772.21738.0
  npm install @auto-canary/cocoapods@10.13.4-canary.1772.21738.0
  npm install @auto-canary/conventional-commits@10.13.4-canary.1772.21738.0
  npm install @auto-canary/crates@10.13.4-canary.1772.21738.0
  npm install @auto-canary/docker@10.13.4-canary.1772.21738.0
  npm install @auto-canary/exec@10.13.4-canary.1772.21738.0
  npm install @auto-canary/first-time-contributor@10.13.4-canary.1772.21738.0
  npm install @auto-canary/gem@10.13.4-canary.1772.21738.0
  npm install @auto-canary/gh-pages@10.13.4-canary.1772.21738.0
  npm install @auto-canary/git-tag@10.13.4-canary.1772.21738.0
  npm install @auto-canary/gradle@10.13.4-canary.1772.21738.0
  npm install @auto-canary/jira@10.13.4-canary.1772.21738.0
  npm install @auto-canary/magic-zero@10.13.4-canary.1772.21738.0
  npm install @auto-canary/maven@10.13.4-canary.1772.21738.0
  npm install @auto-canary/microsoft-teams@10.13.4-canary.1772.21738.0
  npm install @auto-canary/npm@10.13.4-canary.1772.21738.0
  npm install @auto-canary/omit-commits@10.13.4-canary.1772.21738.0
  npm install @auto-canary/omit-release-notes@10.13.4-canary.1772.21738.0
  npm install @auto-canary/pr-body-labels@10.13.4-canary.1772.21738.0
  npm install @auto-canary/released@10.13.4-canary.1772.21738.0
  npm install @auto-canary/s3@10.13.4-canary.1772.21738.0
  npm install @auto-canary/slack@10.13.4-canary.1772.21738.0
  npm install @auto-canary/twitter@10.13.4-canary.1772.21738.0
  npm install @auto-canary/upload-assets@10.13.4-canary.1772.21738.0
  npm install @auto-canary/vscode@10.13.4-canary.1772.21738.0
  # or 
  yarn add @auto-canary/bot-list@10.13.4-canary.1772.21738.0
  yarn add @auto-canary/auto@10.13.4-canary.1772.21738.0
  yarn add @auto-canary/core@10.13.4-canary.1772.21738.0
  yarn add @auto-canary/package-json-utils@10.13.4-canary.1772.21738.0
  yarn add @auto-canary/all-contributors@10.13.4-canary.1772.21738.0
  yarn add @auto-canary/brew@10.13.4-canary.1772.21738.0
  yarn add @auto-canary/chrome@10.13.4-canary.1772.21738.0
  yarn add @auto-canary/cocoapods@10.13.4-canary.1772.21738.0
  yarn add @auto-canary/conventional-commits@10.13.4-canary.1772.21738.0
  yarn add @auto-canary/crates@10.13.4-canary.1772.21738.0
  yarn add @auto-canary/docker@10.13.4-canary.1772.21738.0
  yarn add @auto-canary/exec@10.13.4-canary.1772.21738.0
  yarn add @auto-canary/first-time-contributor@10.13.4-canary.1772.21738.0
  yarn add @auto-canary/gem@10.13.4-canary.1772.21738.0
  yarn add @auto-canary/gh-pages@10.13.4-canary.1772.21738.0
  yarn add @auto-canary/git-tag@10.13.4-canary.1772.21738.0
  yarn add @auto-canary/gradle@10.13.4-canary.1772.21738.0
  yarn add @auto-canary/jira@10.13.4-canary.1772.21738.0
  yarn add @auto-canary/magic-zero@10.13.4-canary.1772.21738.0
  yarn add @auto-canary/maven@10.13.4-canary.1772.21738.0
  yarn add @auto-canary/microsoft-teams@10.13.4-canary.1772.21738.0
  yarn add @auto-canary/npm@10.13.4-canary.1772.21738.0
  yarn add @auto-canary/omit-commits@10.13.4-canary.1772.21738.0
  yarn add @auto-canary/omit-release-notes@10.13.4-canary.1772.21738.0
  yarn add @auto-canary/pr-body-labels@10.13.4-canary.1772.21738.0
  yarn add @auto-canary/released@10.13.4-canary.1772.21738.0
  yarn add @auto-canary/s3@10.13.4-canary.1772.21738.0
  yarn add @auto-canary/slack@10.13.4-canary.1772.21738.0
  yarn add @auto-canary/twitter@10.13.4-canary.1772.21738.0
  yarn add @auto-canary/upload-assets@10.13.4-canary.1772.21738.0
  yarn add @auto-canary/vscode@10.13.4-canary.1772.21738.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
