### PR TITLE
add --force flag/config option to "next" command

### DIFF
--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -216,6 +216,13 @@ const noChangelog: AutoOption = {
   config: true,
 };
 
+const force: AutoOption = {
+  name: "force",
+  type: Boolean,
+  group: "main",
+  config: true,
+};
+
 interface AutoCommand extends Command {
   /** Options for the command */
   options?: AutoOption[];
@@ -566,12 +573,9 @@ export const commands: AutoCommand[] = [
         config: true,
       },
       {
-        name: "force",
-        type: Boolean,
-        group: "main",
+        ...force,
         description:
-          "Force a canary release, even if the PR is marked to skip the release",
-        config: true,
+          "Force a next release, even if the last commit is marked to skip the release",
       },
       quiet,
     ],
@@ -595,6 +599,11 @@ export const commands: AutoCommand[] = [
         description:
           "The message used when attaching the prerelease version to a PR",
         config: true,
+      },
+      {
+        ...force,
+        description:
+          "Force a canary release, even if the PR is marked to skip the release",
       },
       quiet,
     ],

--- a/packages/core/src/auto-args.ts
+++ b/packages/core/src/auto-args.ts
@@ -154,7 +154,12 @@ export type IShipItOptions = ILatestOptions & {
   onlyGraduateWithReleaseLabel?: boolean;
 };
 
-export type ICanaryOptions = QuietOption & {
+interface ForceOption {
+  /** Always deploy even if marked as skip release */
+  force?: boolean;
+}
+
+export type ICanaryOptions = QuietOption & ForceOption & {
   /** Do not actually do anything */
   dryRun?: boolean;
   /** THe PR to attach the canary to */
@@ -163,11 +168,9 @@ export type ICanaryOptions = QuietOption & {
   build?: number;
   /** The message used when attaching the canary version to a PR */
   message?: string | "false";
-  /** Always deploy a canary, even if the PR is marked as skip release */
-  force?: boolean;
 };
 
-export type INextOptions = QuietOption & {
+export type INextOptions = QuietOption & ForceOption & {
   /** Do not actually do anything */
   dryRun?: boolean;
   /** The message used when attaching the prerelease version to a PR */

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1390,11 +1390,15 @@ export default class Auto {
     const commits = await this.release.getCommitsInRelease(lastTag);
     const releaseNotes = await this.release.generateReleaseNotes(lastTag);
     const labels = commits.map((commit) => commit.labels);
-    const bump = calculateSemVerBump(labels, this.semVerLabels!, this.config);
+    let bump = calculateSemVerBump(labels, this.semVerLabels!, this.config);
 
-    if (bump === "") {
-      this.logger.log.info("No version published.");
-      return;
+    if (bump === SEMVER.noVersion) {
+      if (options.force) {
+        bump = SEMVER.patch;
+      } else {;
+        this.logger.log.info("No version published.");
+        return;
+      }
     }
 
     if (!args.quiet) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -102,6 +102,7 @@ export const globalOptions = t.partial({
   }),
   /** Options to pass to "auto next" */
   next: t.partial({
+    force: t.boolean,
     message: t.string,
   }),
 });


### PR DESCRIPTION
# What Changed

see title

## Why

With #1737 we will skip publishing a prerelease branch if a `skip-release` is found.
This is just like the `canary` command. #962
This PR add the `--force` flag from the `canary` command to `next` that acts in the same way. #993

Todo:

- [x] Add tests
- [x] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux-canary.1776.21894.gz](https://github.com/intuit/auto/releases/download/canary/auto-linux-canary.1776.21894.gz)  
[auto-macos-canary.1776.21894.gz](https://github.com/intuit/auto/releases/download/canary/auto-macos-canary.1776.21894.gz)  
[auto-win.exe-canary.1776.21894.gz](https://github.com/intuit/auto/releases/download/canary/auto-win.exe-canary.1776.21894.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.15.0-canary.1776.21894.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.15.0-canary.1776.21894.0
  npm install @auto-canary/auto@10.15.0-canary.1776.21894.0
  npm install @auto-canary/core@10.15.0-canary.1776.21894.0
  npm install @auto-canary/package-json-utils@10.15.0-canary.1776.21894.0
  npm install @auto-canary/all-contributors@10.15.0-canary.1776.21894.0
  npm install @auto-canary/brew@10.15.0-canary.1776.21894.0
  npm install @auto-canary/chrome@10.15.0-canary.1776.21894.0
  npm install @auto-canary/cocoapods@10.15.0-canary.1776.21894.0
  npm install @auto-canary/conventional-commits@10.15.0-canary.1776.21894.0
  npm install @auto-canary/crates@10.15.0-canary.1776.21894.0
  npm install @auto-canary/docker@10.15.0-canary.1776.21894.0
  npm install @auto-canary/exec@10.15.0-canary.1776.21894.0
  npm install @auto-canary/first-time-contributor@10.15.0-canary.1776.21894.0
  npm install @auto-canary/gem@10.15.0-canary.1776.21894.0
  npm install @auto-canary/gh-pages@10.15.0-canary.1776.21894.0
  npm install @auto-canary/git-tag@10.15.0-canary.1776.21894.0
  npm install @auto-canary/gradle@10.15.0-canary.1776.21894.0
  npm install @auto-canary/jira@10.15.0-canary.1776.21894.0
  npm install @auto-canary/magic-zero@10.15.0-canary.1776.21894.0
  npm install @auto-canary/maven@10.15.0-canary.1776.21894.0
  npm install @auto-canary/microsoft-teams@10.15.0-canary.1776.21894.0
  npm install @auto-canary/npm@10.15.0-canary.1776.21894.0
  npm install @auto-canary/omit-commits@10.15.0-canary.1776.21894.0
  npm install @auto-canary/omit-release-notes@10.15.0-canary.1776.21894.0
  npm install @auto-canary/pr-body-labels@10.15.0-canary.1776.21894.0
  npm install @auto-canary/released@10.15.0-canary.1776.21894.0
  npm install @auto-canary/s3@10.15.0-canary.1776.21894.0
  npm install @auto-canary/slack@10.15.0-canary.1776.21894.0
  npm install @auto-canary/twitter@10.15.0-canary.1776.21894.0
  npm install @auto-canary/upload-assets@10.15.0-canary.1776.21894.0
  npm install @auto-canary/vscode@10.15.0-canary.1776.21894.0
  # or 
  yarn add @auto-canary/bot-list@10.15.0-canary.1776.21894.0
  yarn add @auto-canary/auto@10.15.0-canary.1776.21894.0
  yarn add @auto-canary/core@10.15.0-canary.1776.21894.0
  yarn add @auto-canary/package-json-utils@10.15.0-canary.1776.21894.0
  yarn add @auto-canary/all-contributors@10.15.0-canary.1776.21894.0
  yarn add @auto-canary/brew@10.15.0-canary.1776.21894.0
  yarn add @auto-canary/chrome@10.15.0-canary.1776.21894.0
  yarn add @auto-canary/cocoapods@10.15.0-canary.1776.21894.0
  yarn add @auto-canary/conventional-commits@10.15.0-canary.1776.21894.0
  yarn add @auto-canary/crates@10.15.0-canary.1776.21894.0
  yarn add @auto-canary/docker@10.15.0-canary.1776.21894.0
  yarn add @auto-canary/exec@10.15.0-canary.1776.21894.0
  yarn add @auto-canary/first-time-contributor@10.15.0-canary.1776.21894.0
  yarn add @auto-canary/gem@10.15.0-canary.1776.21894.0
  yarn add @auto-canary/gh-pages@10.15.0-canary.1776.21894.0
  yarn add @auto-canary/git-tag@10.15.0-canary.1776.21894.0
  yarn add @auto-canary/gradle@10.15.0-canary.1776.21894.0
  yarn add @auto-canary/jira@10.15.0-canary.1776.21894.0
  yarn add @auto-canary/magic-zero@10.15.0-canary.1776.21894.0
  yarn add @auto-canary/maven@10.15.0-canary.1776.21894.0
  yarn add @auto-canary/microsoft-teams@10.15.0-canary.1776.21894.0
  yarn add @auto-canary/npm@10.15.0-canary.1776.21894.0
  yarn add @auto-canary/omit-commits@10.15.0-canary.1776.21894.0
  yarn add @auto-canary/omit-release-notes@10.15.0-canary.1776.21894.0
  yarn add @auto-canary/pr-body-labels@10.15.0-canary.1776.21894.0
  yarn add @auto-canary/released@10.15.0-canary.1776.21894.0
  yarn add @auto-canary/s3@10.15.0-canary.1776.21894.0
  yarn add @auto-canary/slack@10.15.0-canary.1776.21894.0
  yarn add @auto-canary/twitter@10.15.0-canary.1776.21894.0
  yarn add @auto-canary/upload-assets@10.15.0-canary.1776.21894.0
  yarn add @auto-canary/vscode@10.15.0-canary.1776.21894.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
