### PR TITLE
add title option

### DIFF
--- a/plugins/slack/README.md
+++ b/plugins/slack/README.md
@@ -36,9 +36,13 @@ To use the plugin include it in your `.autorc`.
 
 This URL should be to you webhook. Store it in `SLACK_WEBHOOK_URL` for more security. If you require a token to post to a slack hook, make sure you have a `SLACK_TOKEN` variable available on your environment. This token will be added to eh URL as a query string parameter.
 
-### Next
+## Options
 
-If you are using a `prerelease` branch like `next`, Slack will not post a message by default. This is done to avoid spamming your consumers every time you make a preview release. However, if you would like to configure it such that Slack _does_ post on prerelease, you can add the `publishPreRelease` to your `.autorc` like so:
+### publishPreRelease
+
+If you are using a `prerelease` branch like `next`, Slack will not post a message by default.
+This is done to avoid spamming your consumers every time you make a preview release.
+However, if you would like to configure it such that Slack _does_ post on prerelease, you can add the `publishPreRelease` to your `.autorc` like so:
 
 ```json
 {
@@ -47,17 +51,21 @@ If you are using a `prerelease` branch like `next`, Slack will not post a messag
       "slack",
       { "url": "https://url-to-your-slack-hook.com", "publishPreRelease": true }
     ],
-    // or
-    ["slack", "https://url-to-your-slack-hook.com"],
-    // or
+  ]
+}
+```
+
+### title
+
+Additional Title to add at the start of the slack message.
+
+```json
+{
+  "plugins": [
     [
       "slack",
-      {
-        "url": "https://url-to-your-slack-hook.com",
-        "atTarget": "here",
-        "publishPreRelease": true
-      }
-    ]
+      { "url": "https://url-to-your-slack-hook.com", "title": "My Cool Project" }
+    ],
   ]
 }
 ```

--- a/plugins/slack/__tests__/__snapshots__/slack.test.ts.snap
+++ b/plugins/slack/__tests__/__snapshots__/slack.test.ts.snap
@@ -4,6 +4,8 @@ exports[`postToSlack should add more indents to nested lists - 2 spaces 1`] = `"
 
 exports[`postToSlack should add more indents to nested lists 1`] = `"{\\"text\\":\\"@channel: New release *<https://git.hub/some/project/releases/v1.0.0|v1.0.0>*\\\\n*My Notes*\\\\n• PR <google.com|some link>\\\\n   • Another note\\",\\"link_names\\":1}"`;
 
+exports[`postToSlack should add title 1`] = `"{\\"text\\":\\"My Cool Project\\\\n\\\\n@channel: New release *<https://git.hub/some/project/releases/v1.0.0|v1.0.0>*\\\\n*My Notes*\\\\n• PR <google.com|some link>\\",\\"link_names\\":1}"`;
+
 exports[`postToSlack should call slack api 1`] = `"{\\"text\\":\\"@channel: New release *<https://git.hub/some/project/releases/v1.0.0|v1.0.0>*\\\\n*My Notes*\\\\n• PR <google.com|some link>\\",\\"link_names\\":1}"`;
 
 exports[`postToSlack should call slack api in env var 1`] = `"{\\"text\\":\\"@channel: New release *<https://git.hub/some/project/releases/v1.0.0|v1.0.0>*\\\\n*My Notes*\\\\n• PR <google.com|some link>\\",\\"link_names\\":1}"`;

--- a/plugins/slack/__tests__/slack.test.ts
+++ b/plugins/slack/__tests__/slack.test.ts
@@ -208,7 +208,7 @@ describe("postToSlack", () => {
     await plugin.createPost(
       { ...mockAuto, logger } as Auto,
       sanitizeMarkdown("# My Notes\n- PR [some link](google.com)"),
-      '',
+      "",
       undefined
     );
 
@@ -222,7 +222,7 @@ describe("postToSlack", () => {
     await plugin.createPost(
       mockAuto,
       sanitizeMarkdown("# My Notes\n- PR [some link](google.com)"),
-      '*<https://git.hub/some/project/releases/v1.0.0|v1.0.0>*',
+      "*<https://git.hub/some/project/releases/v1.0.0|v1.0.0>*",
       undefined
     );
 
@@ -240,8 +240,10 @@ describe("postToSlack", () => {
 
     await plugin.createPost(
       mockAuto,
-      sanitizeMarkdown("# My Notes\n- PR [some link](google.com)\n - Another note"),
-      '*<https://git.hub/some/project/releases/v1.0.0|v1.0.0>*',
+      sanitizeMarkdown(
+        "# My Notes\n- PR [some link](google.com)\n - Another note"
+      ),
+      "*<https://git.hub/some/project/releases/v1.0.0|v1.0.0>*",
       undefined
     );
 
@@ -259,8 +261,10 @@ describe("postToSlack", () => {
 
     await plugin.createPost(
       mockAuto,
-      sanitizeMarkdown("# My Notes\n- PR [some link](google.com)\n  - Another note"),
-      '*<https://git.hub/some/project/releases/v1.0.0|v1.0.0>*',
+      sanitizeMarkdown(
+        "# My Notes\n- PR [some link](google.com)\n  - Another note"
+      ),
+      "*<https://git.hub/some/project/releases/v1.0.0|v1.0.0>*",
       undefined
     );
 
@@ -280,8 +284,8 @@ describe("postToSlack", () => {
     await plugin.createPost(
       mockAuto,
       sanitizeMarkdown("# My Notes\n- PR [some link](google.com)"),
-      '*<https://git.hub/some/project/releases/v1.0.0|v1.0.0>*',
-      createHttpsProxyAgent('mock-url')
+      "*<https://git.hub/some/project/releases/v1.0.0|v1.0.0>*",
+      createHttpsProxyAgent("mock-url")
     );
 
     expect(fetchSpy).toHaveBeenCalled();
@@ -298,8 +302,10 @@ describe("postToSlack", () => {
 
     await plugin.createPost(
       mockAuto,
-      sanitizeMarkdown(`# My Notes\n\`\`\`json\n{ "foo": "bar" }\`\`\`\n- PR [some link](google.com)`),
-      '*<https://git.hub/some/project/releases/v1.0.0|v1.0.0>*',
+      sanitizeMarkdown(
+        `# My Notes\n\`\`\`json\n{ "foo": "bar" }\`\`\`\n- PR [some link](google.com)`
+      ),
+      "*<https://git.hub/some/project/releases/v1.0.0|v1.0.0>*",
       undefined
     );
 
@@ -314,8 +320,8 @@ describe("postToSlack", () => {
     await plugin.createPost(
       mockAuto,
       sanitizeMarkdown("# My Notes\n- PR [some link](google.com)"),
-      '*<https://git.hub/some/project/releases/v1.0.0|v1.0.0>*',
-      createHttpsProxyAgent('mock-url')
+      "*<https://git.hub/some/project/releases/v1.0.0|v1.0.0>*",
+      createHttpsProxyAgent("mock-url")
     );
 
     expect(fetchSpy).toHaveBeenCalled();
@@ -392,6 +398,26 @@ describe("postToSlack", () => {
 
     expect(fetchSpy).toHaveBeenCalled();
     expect(fetchSpy.mock.calls[0][0]).toBe("https://foo.bar?token=MY_TOKEN");
+    expect(fetchSpy.mock.calls[0][1].body).toMatchSnapshot();
+  });
+
+  test("should add title", async () => {
+    process.env.SLACK_WEBHOOK_URL = "https://foo.bar";
+    const plugin = new SlackPlugin({ title: "My Cool Project" });
+    const hooks = makeHooks();
+    process.env.SLACK_TOKEN = "MY_TOKEN";
+    plugin.apply({ hooks, options: {}, ...mockAuto } as Auto);
+
+    await hooks.afterRelease.promise({
+      newVersion: "1.0.0",
+      lastRelease: "0.1.0",
+      commits: [makeCommitFromMsg("a patch")],
+      releaseNotes: "# My Notes\n- PR [some link](google.com)",
+      // @ts-ignore
+      response: mockResponse,
+    });
+
+    expect(fetchSpy).toHaveBeenCalled();
     expect(fetchSpy.mock.calls[0][1].body).toMatchSnapshot();
   });
 });

--- a/plugins/slack/src/index.ts
+++ b/plugins/slack/src/index.ts
@@ -44,6 +44,8 @@ const pluginOptions = t.partial({
   atTarget: t.string,
   /** Allow users to opt into having prereleases posted to slack */
   publishPreRelease: t.boolean,
+  /** Additional Title to add at the start of the slack message */
+  title: t.string,
 });
 
 export type ISlackPluginOptions = t.TypeOf<typeof pluginOptions>;
@@ -62,6 +64,7 @@ export default class SlackPlugin implements IPlugin {
       this.options = { url: options, atTarget: "channel" };
     } else {
       this.options = {
+        ...options,
         url: process.env.SLACK_WEBHOOK_URL || options.url || "",
         atTarget: options.atTarget ? options.atTarget : "channel",
         publishPreRelease: options.publishPreRelease
@@ -178,7 +181,9 @@ export default class SlackPlugin implements IPlugin {
       method: "POST",
       body: JSON.stringify({
         text: [
-          `@${this.options.atTarget}: New release ${releaseUrl}`,
+          `${this.options.title ? `${this.options.title}\n\n` : ""}@${
+            this.options.atTarget
+          }: New release ${releaseUrl}`,
           releaseNotes,
         ].join("\n"),
         link_names: 1,


### PR DESCRIPTION
# What Changed

see title

## Why

Sometimes you want to use 1 slack token for multiple project. This option makes it easier to discern between them

Todo:

- [x] Add tests
- [x] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux-canary.1777.21908.gz](https://github.com/intuit/auto/releases/download/canary/auto-linux-canary.1777.21908.gz)  
[auto-macos-canary.1777.21908.gz](https://github.com/intuit/auto/releases/download/canary/auto-macos-canary.1777.21908.gz)  
[auto-win.exe-canary.1777.21908.gz](https://github.com/intuit/auto/releases/download/canary/auto-win.exe-canary.1777.21908.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.16.0-canary.1777.21908.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.16.0-canary.1777.21908.0
  npm install @auto-canary/auto@10.16.0-canary.1777.21908.0
  npm install @auto-canary/core@10.16.0-canary.1777.21908.0
  npm install @auto-canary/package-json-utils@10.16.0-canary.1777.21908.0
  npm install @auto-canary/all-contributors@10.16.0-canary.1777.21908.0
  npm install @auto-canary/brew@10.16.0-canary.1777.21908.0
  npm install @auto-canary/chrome@10.16.0-canary.1777.21908.0
  npm install @auto-canary/cocoapods@10.16.0-canary.1777.21908.0
  npm install @auto-canary/conventional-commits@10.16.0-canary.1777.21908.0
  npm install @auto-canary/crates@10.16.0-canary.1777.21908.0
  npm install @auto-canary/docker@10.16.0-canary.1777.21908.0
  npm install @auto-canary/exec@10.16.0-canary.1777.21908.0
  npm install @auto-canary/first-time-contributor@10.16.0-canary.1777.21908.0
  npm install @auto-canary/gem@10.16.0-canary.1777.21908.0
  npm install @auto-canary/gh-pages@10.16.0-canary.1777.21908.0
  npm install @auto-canary/git-tag@10.16.0-canary.1777.21908.0
  npm install @auto-canary/gradle@10.16.0-canary.1777.21908.0
  npm install @auto-canary/jira@10.16.0-canary.1777.21908.0
  npm install @auto-canary/magic-zero@10.16.0-canary.1777.21908.0
  npm install @auto-canary/maven@10.16.0-canary.1777.21908.0
  npm install @auto-canary/microsoft-teams@10.16.0-canary.1777.21908.0
  npm install @auto-canary/npm@10.16.0-canary.1777.21908.0
  npm install @auto-canary/omit-commits@10.16.0-canary.1777.21908.0
  npm install @auto-canary/omit-release-notes@10.16.0-canary.1777.21908.0
  npm install @auto-canary/pr-body-labels@10.16.0-canary.1777.21908.0
  npm install @auto-canary/released@10.16.0-canary.1777.21908.0
  npm install @auto-canary/s3@10.16.0-canary.1777.21908.0
  npm install @auto-canary/slack@10.16.0-canary.1777.21908.0
  npm install @auto-canary/twitter@10.16.0-canary.1777.21908.0
  npm install @auto-canary/upload-assets@10.16.0-canary.1777.21908.0
  npm install @auto-canary/vscode@10.16.0-canary.1777.21908.0
  # or 
  yarn add @auto-canary/bot-list@10.16.0-canary.1777.21908.0
  yarn add @auto-canary/auto@10.16.0-canary.1777.21908.0
  yarn add @auto-canary/core@10.16.0-canary.1777.21908.0
  yarn add @auto-canary/package-json-utils@10.16.0-canary.1777.21908.0
  yarn add @auto-canary/all-contributors@10.16.0-canary.1777.21908.0
  yarn add @auto-canary/brew@10.16.0-canary.1777.21908.0
  yarn add @auto-canary/chrome@10.16.0-canary.1777.21908.0
  yarn add @auto-canary/cocoapods@10.16.0-canary.1777.21908.0
  yarn add @auto-canary/conventional-commits@10.16.0-canary.1777.21908.0
  yarn add @auto-canary/crates@10.16.0-canary.1777.21908.0
  yarn add @auto-canary/docker@10.16.0-canary.1777.21908.0
  yarn add @auto-canary/exec@10.16.0-canary.1777.21908.0
  yarn add @auto-canary/first-time-contributor@10.16.0-canary.1777.21908.0
  yarn add @auto-canary/gem@10.16.0-canary.1777.21908.0
  yarn add @auto-canary/gh-pages@10.16.0-canary.1777.21908.0
  yarn add @auto-canary/git-tag@10.16.0-canary.1777.21908.0
  yarn add @auto-canary/gradle@10.16.0-canary.1777.21908.0
  yarn add @auto-canary/jira@10.16.0-canary.1777.21908.0
  yarn add @auto-canary/magic-zero@10.16.0-canary.1777.21908.0
  yarn add @auto-canary/maven@10.16.0-canary.1777.21908.0
  yarn add @auto-canary/microsoft-teams@10.16.0-canary.1777.21908.0
  yarn add @auto-canary/npm@10.16.0-canary.1777.21908.0
  yarn add @auto-canary/omit-commits@10.16.0-canary.1777.21908.0
  yarn add @auto-canary/omit-release-notes@10.16.0-canary.1777.21908.0
  yarn add @auto-canary/pr-body-labels@10.16.0-canary.1777.21908.0
  yarn add @auto-canary/released@10.16.0-canary.1777.21908.0
  yarn add @auto-canary/s3@10.16.0-canary.1777.21908.0
  yarn add @auto-canary/slack@10.16.0-canary.1777.21908.0
  yarn add @auto-canary/twitter@10.16.0-canary.1777.21908.0
  yarn add @auto-canary/upload-assets@10.16.0-canary.1777.21908.0
  yarn add @auto-canary/vscode@10.16.0-canary.1777.21908.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
