### PR TITLE
When calculating "next" lastTag, fallback to latest tag in baseBranch before first commit

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1384,9 +1384,14 @@ export default class Auto {
     const [, latestTagInBranch] = await on(
       this.git.getLatestTagInBranch(currentBranch)
     );
+    const [, tagsInBaseBranch] = await on(
+      this.git.getTags(`origin/${this.baseBranch}`)
+    );
+    const [latestTagInBaseBranch] = (tagsInBaseBranch || []).reverse();
     const lastTag =
       lastTagNotInBaseBranch ||
       latestTagInBranch ||
+      latestTagInBaseBranch ||
       (await this.git.getFirstCommit());
 
     const fullReleaseNotes = await this.release.generateReleaseNotes(
@@ -1400,7 +1405,7 @@ export default class Auto {
     if (bump === SEMVER.noVersion) {
       if (options.force) {
         bump = SEMVER.patch;
-      } else {;
+      } else {
         this.logger.log.info("No version published.");
         return;
       }


### PR DESCRIPTION
# What Changed

see title

## Why

Falling back to the first commit includes too many commits, the last tag in baseBranch is a better starting point if it exists.

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux-canary.1791.21987.gz](https://github.com/intuit/auto/releases/download/canary/auto-linux-canary.1791.21987.gz)  
[auto-macos-canary.1791.21987.gz](https://github.com/intuit/auto/releases/download/canary/auto-macos-canary.1791.21987.gz)  
[auto-win.exe-canary.1791.21987.gz](https://github.com/intuit/auto/releases/download/canary/auto-win.exe-canary.1791.21987.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.16.1-canary.1791.21987.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.16.1-canary.1791.21987.0
  npm install @auto-canary/auto@10.16.1-canary.1791.21987.0
  npm install @auto-canary/core@10.16.1-canary.1791.21987.0
  npm install @auto-canary/package-json-utils@10.16.1-canary.1791.21987.0
  npm install @auto-canary/all-contributors@10.16.1-canary.1791.21987.0
  npm install @auto-canary/brew@10.16.1-canary.1791.21987.0
  npm install @auto-canary/chrome@10.16.1-canary.1791.21987.0
  npm install @auto-canary/cocoapods@10.16.1-canary.1791.21987.0
  npm install @auto-canary/conventional-commits@10.16.1-canary.1791.21987.0
  npm install @auto-canary/crates@10.16.1-canary.1791.21987.0
  npm install @auto-canary/docker@10.16.1-canary.1791.21987.0
  npm install @auto-canary/exec@10.16.1-canary.1791.21987.0
  npm install @auto-canary/first-time-contributor@10.16.1-canary.1791.21987.0
  npm install @auto-canary/gem@10.16.1-canary.1791.21987.0
  npm install @auto-canary/gh-pages@10.16.1-canary.1791.21987.0
  npm install @auto-canary/git-tag@10.16.1-canary.1791.21987.0
  npm install @auto-canary/gradle@10.16.1-canary.1791.21987.0
  npm install @auto-canary/jira@10.16.1-canary.1791.21987.0
  npm install @auto-canary/magic-zero@10.16.1-canary.1791.21987.0
  npm install @auto-canary/maven@10.16.1-canary.1791.21987.0
  npm install @auto-canary/microsoft-teams@10.16.1-canary.1791.21987.0
  npm install @auto-canary/npm@10.16.1-canary.1791.21987.0
  npm install @auto-canary/omit-commits@10.16.1-canary.1791.21987.0
  npm install @auto-canary/omit-release-notes@10.16.1-canary.1791.21987.0
  npm install @auto-canary/pr-body-labels@10.16.1-canary.1791.21987.0
  npm install @auto-canary/released@10.16.1-canary.1791.21987.0
  npm install @auto-canary/s3@10.16.1-canary.1791.21987.0
  npm install @auto-canary/slack@10.16.1-canary.1791.21987.0
  npm install @auto-canary/twitter@10.16.1-canary.1791.21987.0
  npm install @auto-canary/upload-assets@10.16.1-canary.1791.21987.0
  npm install @auto-canary/vscode@10.16.1-canary.1791.21987.0
  # or 
  yarn add @auto-canary/bot-list@10.16.1-canary.1791.21987.0
  yarn add @auto-canary/auto@10.16.1-canary.1791.21987.0
  yarn add @auto-canary/core@10.16.1-canary.1791.21987.0
  yarn add @auto-canary/package-json-utils@10.16.1-canary.1791.21987.0
  yarn add @auto-canary/all-contributors@10.16.1-canary.1791.21987.0
  yarn add @auto-canary/brew@10.16.1-canary.1791.21987.0
  yarn add @auto-canary/chrome@10.16.1-canary.1791.21987.0
  yarn add @auto-canary/cocoapods@10.16.1-canary.1791.21987.0
  yarn add @auto-canary/conventional-commits@10.16.1-canary.1791.21987.0
  yarn add @auto-canary/crates@10.16.1-canary.1791.21987.0
  yarn add @auto-canary/docker@10.16.1-canary.1791.21987.0
  yarn add @auto-canary/exec@10.16.1-canary.1791.21987.0
  yarn add @auto-canary/first-time-contributor@10.16.1-canary.1791.21987.0
  yarn add @auto-canary/gem@10.16.1-canary.1791.21987.0
  yarn add @auto-canary/gh-pages@10.16.1-canary.1791.21987.0
  yarn add @auto-canary/git-tag@10.16.1-canary.1791.21987.0
  yarn add @auto-canary/gradle@10.16.1-canary.1791.21987.0
  yarn add @auto-canary/jira@10.16.1-canary.1791.21987.0
  yarn add @auto-canary/magic-zero@10.16.1-canary.1791.21987.0
  yarn add @auto-canary/maven@10.16.1-canary.1791.21987.0
  yarn add @auto-canary/microsoft-teams@10.16.1-canary.1791.21987.0
  yarn add @auto-canary/npm@10.16.1-canary.1791.21987.0
  yarn add @auto-canary/omit-commits@10.16.1-canary.1791.21987.0
  yarn add @auto-canary/omit-release-notes@10.16.1-canary.1791.21987.0
  yarn add @auto-canary/pr-body-labels@10.16.1-canary.1791.21987.0
  yarn add @auto-canary/released@10.16.1-canary.1791.21987.0
  yarn add @auto-canary/s3@10.16.1-canary.1791.21987.0
  yarn add @auto-canary/slack@10.16.1-canary.1791.21987.0
  yarn add @auto-canary/twitter@10.16.1-canary.1791.21987.0
  yarn add @auto-canary/upload-assets@10.16.1-canary.1791.21987.0
  yarn add @auto-canary/vscode@10.16.1-canary.1791.21987.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
