### PR TITLE
fix running version on prerelease branch with no reachable tags

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1755,9 +1755,10 @@ export default class Auto {
     }
 
     const isPrerelease = this.inPrereleaseBranch();
+    const [, latestTagInBranch] = await on(this.git.getLatestTagInBranch());
     const lastRelease =
       from ||
-      (isPrerelease && (await this.git.getLatestTagInBranch())) ||
+      (isPrerelease && latestTagInBranch) ||
       (await this.git.getLatestRelease());
     let calculatedBump = await this.release.getSemverBump(lastRelease);
 


### PR DESCRIPTION
# What Changed

see title

## Why

If there were no reachable tags on the next branch `auto version` would fail.

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux-canary.1792.21988.gz](https://github.com/intuit/auto/releases/download/canary/auto-linux-canary.1792.21988.gz)  
[auto-macos-canary.1792.21988.gz](https://github.com/intuit/auto/releases/download/canary/auto-macos-canary.1792.21988.gz)  
[auto-win.exe-canary.1792.21988.gz](https://github.com/intuit/auto/releases/download/canary/auto-win.exe-canary.1792.21988.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->
