### PR TITLE
Do not execute gh-pages build during a dry run

### DIFF
--- a/plugins/gh-pages/__tests__/gh-pages.test.ts
+++ b/plugins/gh-pages/__tests__/gh-pages.test.ts
@@ -45,6 +45,14 @@ describe("Gh-Pages Plugin", () => {
       expect(execSpy).not.toHaveBeenCalled();
     });
 
+    test("should not release on anything on a dry run", async () => {
+      const hooks = createTest({ dir: "test" });
+
+      await hooks.beforeShipIt.promise({ releaseType: "latest", dryRun: true });
+
+      expect(execSpy).not.toHaveBeenCalled();
+    });
+
     test("should not release if there is a version bump", async () => {
       const hooks = createTest({ dir: "test" }, { getVersion: () => "patch" });
 


### PR DESCRIPTION
# What Changed

see title

## Why

I broke my own [build](https://app.circleci.com/pipelines/github/intuit/auto/5805/workflows/c279e2d5-74ad-4091-b73f-67763d175386/jobs/22018)!

Todo:

- [x] Add tests

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux-canary.1797.22024.gz](https://github.com/intuit/auto/releases/download/canary/auto-linux-canary.1797.22024.gz)  
[auto-macos-canary.1797.22024.gz](https://github.com/intuit/auto/releases/download/canary/auto-macos-canary.1797.22024.gz)  
[auto-win.exe-canary.1797.22024.gz](https://github.com/intuit/auto/releases/download/canary/auto-win.exe-canary.1797.22024.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.16.2-canary.1797.22024.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.16.2-canary.1797.22024.0
  npm install @auto-canary/auto@10.16.2-canary.1797.22024.0
  npm install @auto-canary/core@10.16.2-canary.1797.22024.0
  npm install @auto-canary/package-json-utils@10.16.2-canary.1797.22024.0
  npm install @auto-canary/all-contributors@10.16.2-canary.1797.22024.0
  npm install @auto-canary/brew@10.16.2-canary.1797.22024.0
  npm install @auto-canary/chrome@10.16.2-canary.1797.22024.0
  npm install @auto-canary/cocoapods@10.16.2-canary.1797.22024.0
  npm install @auto-canary/conventional-commits@10.16.2-canary.1797.22024.0
  npm install @auto-canary/crates@10.16.2-canary.1797.22024.0
  npm install @auto-canary/docker@10.16.2-canary.1797.22024.0
  npm install @auto-canary/exec@10.16.2-canary.1797.22024.0
  npm install @auto-canary/first-time-contributor@10.16.2-canary.1797.22024.0
  npm install @auto-canary/gem@10.16.2-canary.1797.22024.0
  npm install @auto-canary/gh-pages@10.16.2-canary.1797.22024.0
  npm install @auto-canary/git-tag@10.16.2-canary.1797.22024.0
  npm install @auto-canary/gradle@10.16.2-canary.1797.22024.0
  npm install @auto-canary/jira@10.16.2-canary.1797.22024.0
  npm install @auto-canary/magic-zero@10.16.2-canary.1797.22024.0
  npm install @auto-canary/maven@10.16.2-canary.1797.22024.0
  npm install @auto-canary/microsoft-teams@10.16.2-canary.1797.22024.0
  npm install @auto-canary/npm@10.16.2-canary.1797.22024.0
  npm install @auto-canary/omit-commits@10.16.2-canary.1797.22024.0
  npm install @auto-canary/omit-release-notes@10.16.2-canary.1797.22024.0
  npm install @auto-canary/pr-body-labels@10.16.2-canary.1797.22024.0
  npm install @auto-canary/released@10.16.2-canary.1797.22024.0
  npm install @auto-canary/s3@10.16.2-canary.1797.22024.0
  npm install @auto-canary/slack@10.16.2-canary.1797.22024.0
  npm install @auto-canary/twitter@10.16.2-canary.1797.22024.0
  npm install @auto-canary/upload-assets@10.16.2-canary.1797.22024.0
  npm install @auto-canary/vscode@10.16.2-canary.1797.22024.0
  # or 
  yarn add @auto-canary/bot-list@10.16.2-canary.1797.22024.0
  yarn add @auto-canary/auto@10.16.2-canary.1797.22024.0
  yarn add @auto-canary/core@10.16.2-canary.1797.22024.0
  yarn add @auto-canary/package-json-utils@10.16.2-canary.1797.22024.0
  yarn add @auto-canary/all-contributors@10.16.2-canary.1797.22024.0
  yarn add @auto-canary/brew@10.16.2-canary.1797.22024.0
  yarn add @auto-canary/chrome@10.16.2-canary.1797.22024.0
  yarn add @auto-canary/cocoapods@10.16.2-canary.1797.22024.0
  yarn add @auto-canary/conventional-commits@10.16.2-canary.1797.22024.0
  yarn add @auto-canary/crates@10.16.2-canary.1797.22024.0
  yarn add @auto-canary/docker@10.16.2-canary.1797.22024.0
  yarn add @auto-canary/exec@10.16.2-canary.1797.22024.0
  yarn add @auto-canary/first-time-contributor@10.16.2-canary.1797.22024.0
  yarn add @auto-canary/gem@10.16.2-canary.1797.22024.0
  yarn add @auto-canary/gh-pages@10.16.2-canary.1797.22024.0
  yarn add @auto-canary/git-tag@10.16.2-canary.1797.22024.0
  yarn add @auto-canary/gradle@10.16.2-canary.1797.22024.0
  yarn add @auto-canary/jira@10.16.2-canary.1797.22024.0
  yarn add @auto-canary/magic-zero@10.16.2-canary.1797.22024.0
  yarn add @auto-canary/maven@10.16.2-canary.1797.22024.0
  yarn add @auto-canary/microsoft-teams@10.16.2-canary.1797.22024.0
  yarn add @auto-canary/npm@10.16.2-canary.1797.22024.0
  yarn add @auto-canary/omit-commits@10.16.2-canary.1797.22024.0
  yarn add @auto-canary/omit-release-notes@10.16.2-canary.1797.22024.0
  yarn add @auto-canary/pr-body-labels@10.16.2-canary.1797.22024.0
  yarn add @auto-canary/released@10.16.2-canary.1797.22024.0
  yarn add @auto-canary/s3@10.16.2-canary.1797.22024.0
  yarn add @auto-canary/slack@10.16.2-canary.1797.22024.0
  yarn add @auto-canary/twitter@10.16.2-canary.1797.22024.0
  yarn add @auto-canary/upload-assets@10.16.2-canary.1797.22024.0
  yarn add @auto-canary/vscode@10.16.2-canary.1797.22024.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
