### PR TITLE
Don't create "Canary Release Assets" during non-canary builds + Change that releases tag to valid semver

### DIFF
--- a/plugins/upload-assets/__tests__/upload-assets-ci.test.ts
+++ b/plugins/upload-assets/__tests__/upload-assets-ci.test.ts
@@ -29,19 +29,18 @@ describe("Upload Assets Plugin", () => {
       path.join(__dirname, "./test-assets/macos"),
     ]);
     const hooks = makeHooks();
-    const uploadReleaseAsset = jest
-      .fn()
-      .mockImplementation(({ name }) =>
-        Promise.resolve({
-          data: { id: 2, name, browser_download_url: `http://${name}` },
-        })
-      );
+    const uploadReleaseAsset = jest.fn().mockImplementation(({ name }) =>
+      Promise.resolve({
+        data: { id: 2, name, browser_download_url: `http://${name}` },
+      })
+    );
     const createRelease = jest.fn().mockResolvedValue({ data: { id: 1 } });
     const addToPrBody = jest.fn();
 
     plugin.apply(({
       hooks,
       logger: dummyLog(),
+      prefixRelease: (v) => v,
       git: {
         options,
         addToPrBody,

--- a/plugins/upload-assets/__tests__/upload-assets.test.ts
+++ b/plugins/upload-assets/__tests__/upload-assets.test.ts
@@ -93,6 +93,7 @@ describe("Upload Assets Plugin", () => {
         release_id: "123",
       })
     );
+    expect(createRelease).not.toHaveBeenCalled();
   });
 
   test("should upload a single canary asset", async () => {
@@ -196,7 +197,7 @@ describe("Upload Assets Plugin", () => {
     await hooks.canary.promise({
       canaryIdentifier: "canary.123",
       bump: SEMVER.patch,
-      dryRun: true
+      dryRun: true,
     });
 
     expect(uploadReleaseAsset).not.toHaveBeenCalled();

--- a/plugins/upload-assets/__tests__/upload-assets.test.ts
+++ b/plugins/upload-assets/__tests__/upload-assets.test.ts
@@ -34,6 +34,7 @@ describe("Upload Assets Plugin", () => {
     plugin.apply(({
       hooks,
       logger: dummyLog(),
+      prefixRelease: (v) => v,
       git: {
         options,
         github: {
@@ -64,6 +65,7 @@ describe("Upload Assets Plugin", () => {
     plugin.apply(({
       hooks,
       logger: dummyLog(),
+      prefixRelease: (v) => v,
       git: {
         options,
         github: {
@@ -111,6 +113,7 @@ describe("Upload Assets Plugin", () => {
     plugin.apply(({
       hooks,
       logger: dummyLog(),
+      prefixRelease: (v) => v,
       git: {
         options,
         github: {
@@ -148,6 +151,7 @@ describe("Upload Assets Plugin", () => {
     plugin.apply(({
       hooks,
       logger: dummyLog(),
+      prefixRelease: (v) => v,
       git: {
         options,
         github: {
@@ -185,6 +189,7 @@ describe("Upload Assets Plugin", () => {
     plugin.apply(({
       hooks,
       logger: dummyLog(),
+      prefixRelease: (v) => v,
       git: {
         options,
         github: {
@@ -218,6 +223,7 @@ describe("Upload Assets Plugin", () => {
     plugin.apply(({
       hooks,
       logger: dummyLog(),
+      prefixRelease: (v) => v,
       git: {
         options,
         github: {
@@ -251,6 +257,7 @@ describe("Upload Assets Plugin", () => {
     plugin.apply(({
       hooks,
       logger: dummyLog(),
+      prefixRelease: (v) => v,
       git: {
         options: { ...options, baseUrl: "https://github.my.com/api/v3" },
         github: {
@@ -297,6 +304,7 @@ describe("Upload Assets Plugin", () => {
     plugin.apply(({
       hooks,
       logger: dummyLog(),
+      prefixRelease: (v) => v,
       git: {
         options,
         github: {
@@ -330,6 +338,7 @@ describe("Upload Assets Plugin", () => {
     plugin.apply(({
       hooks,
       logger: dummyLog(),
+      prefixRelease: (v) => v,
       git: {
         options,
         github: {
@@ -373,6 +382,7 @@ describe("Upload Assets Plugin", () => {
     plugin.apply(({
       hooks,
       logger: dummyLog(),
+      prefixRelease: (v) => v,
       git: {
         options,
         github: {
@@ -405,15 +415,16 @@ describe("Upload Assets Plugin", () => {
     const hooks = makeHooks();
     const deleteReleaseAsset = jest.fn();
     const uploadReleaseAsset = jest.fn().mockResolvedValue({});
-    const createRelease = jest.fn().mockResolvedValue({ data: { id: 1 } });
+    const getReleaseByTag = jest.fn().mockResolvedValue({ data: { id: 1 } });
 
     plugin.apply(({
       hooks,
       logger: dummyLog(),
+      prefixRelease: (v) => v,
       git: {
         options,
         github: {
-          repos: { uploadReleaseAsset, createRelease, deleteReleaseAsset },
+          repos: { uploadReleaseAsset, getReleaseByTag, deleteReleaseAsset },
           paginate: jest.fn().mockResolvedValue(new Array(303).fill({})),
         },
       },
@@ -443,15 +454,16 @@ describe("Upload Assets Plugin", () => {
     const hooks = makeHooks();
     const deleteReleaseAsset = jest.fn();
     const uploadReleaseAsset = jest.fn().mockResolvedValue({});
-    const createRelease = jest.fn().mockResolvedValue({ data: { id: 1 } });
+    const getReleaseByTag = jest.fn().mockResolvedValue({ data: { id: 1 } });
 
     plugin.apply(({
       hooks,
       logger: dummyLog(),
+      prefixRelease: (v) => v,
       git: {
         options,
         github: {
-          repos: { uploadReleaseAsset, createRelease, deleteReleaseAsset },
+          repos: { uploadReleaseAsset, getReleaseByTag, deleteReleaseAsset },
           paginate: jest.fn().mockResolvedValue(new Array(300).fill({})),
         },
       },

--- a/plugins/upload-assets/src/index.ts
+++ b/plugins/upload-assets/src/index.ts
@@ -15,6 +15,7 @@ import link from "terminal-link";
 import * as t from "io-ts";
 
 type AssetResponse = RestEndpointMethodTypes["repos"]["uploadReleaseAsset"]["response"]["data"];
+type GitHubRelease = RestEndpointMethodTypes["repos"]["getReleaseByTag"]["response"]["data"];
 
 const stat = promisify(fs.stat);
 const readFile = promisify(fs.readFile);
@@ -80,7 +81,7 @@ export default class UploadAssetsPlugin implements IPlugin {
     auto.hooks.canary.tapPromise(
       this.name,
       async ({ canaryIdentifier, dryRun }) => {
-        const canaryRelease = await this.getCanaryGitHubRelease(auto);
+        const canaryRelease = await this.getCanaryGitHubRelease(auto, true);
 
         auto.logger.log.info(endent`${
           dryRun ? "Would update" : "Updating"
@@ -233,8 +234,13 @@ export default class UploadAssetsPlugin implements IPlugin {
       .reduce((acc, item) => [...acc, ...item], []);
   }
 
+  // prettier-ignore
+  private async getCanaryGitHubRelease(auto: Auto): Promise<GitHubRelease | undefined>
+  // prettier-ignore
+  private async getCanaryGitHubRelease(auto: Auto, create: true): Promise<GitHubRelease>
+  // prettier-ignore
   /** Get the release all the canaries are stored in */
-  private async getCanaryGitHubRelease(auto: Auto) {
+  private async getCanaryGitHubRelease(auto: Auto, create = false): Promise<GitHubRelease | undefined> {
     try {
       const canaryRelease = await auto.git!.github.repos.getReleaseByTag({
         repo: auto.git!.options.repo,
@@ -244,6 +250,10 @@ export default class UploadAssetsPlugin implements IPlugin {
 
       return canaryRelease.data;
     } catch (error) {
+      if (!create) {
+        return;
+      }
+
       const canaryRelease = await auto.git!.github.repos.createRelease({
         repo: auto.git!.options.repo,
         owner: auto.git!.options.owner,
@@ -260,6 +270,11 @@ export default class UploadAssetsPlugin implements IPlugin {
   /** Delete old canary asset */
   private async cleanupCanaryAssets(auto: Auto) {
     const canaryRelease = await this.getCanaryGitHubRelease(auto);
+
+    if (!canaryRelease) {
+      return;
+    }
+
     const canaryReleaseAssets = await auto.git!.github.paginate(
       auto.git!.github.repos.listReleaseAssets,
       {

--- a/plugins/upload-assets/src/index.ts
+++ b/plugins/upload-assets/src/index.ts
@@ -19,6 +19,7 @@ type GitHubRelease = RestEndpointMethodTypes["repos"]["getReleaseByTag"]["respon
 
 const stat = promisify(fs.stat);
 const readFile = promisify(fs.readFile);
+const canaryTag = "0.0.0-canary";
 
 const requiredPluginOptions = t.interface({
   /** Paths to assets to upload */
@@ -245,7 +246,7 @@ export default class UploadAssetsPlugin implements IPlugin {
       const canaryRelease = await auto.git!.github.repos.getReleaseByTag({
         repo: auto.git!.options.repo,
         owner: auto.git!.options.owner,
-        tag: "canary",
+        tag: auto.prefixRelease(canaryTag),
       });
 
       return canaryRelease.data;
@@ -257,7 +258,7 @@ export default class UploadAssetsPlugin implements IPlugin {
       const canaryRelease = await auto.git!.github.repos.createRelease({
         repo: auto.git!.options.repo,
         owner: auto.git!.options.owner,
-        tag_name: "canary",
+        tag_name:  auto.prefixRelease(canaryTag),
         name: "Canary Assets",
         prerelease: true,
         body: `This release contains preview assets of Pull Requests.`,


### PR DESCRIPTION
# Release Notes

This release changes the tag used for the "Canary Releases Assets" created by the `upload-assets` plugin to be `0.0.0-canary`.
This new tag is a valid semantic version and can be used with other auto commands.

If you already have a canary release assets releases this change will create another under a different tag.
This mean you'll have an old "Canary Releases Assets" release that never updates, feel free to delete the tag/release or just ignore it if you want the urls to the old assets to still exist.

# What Changed

- When cleaning up the canary asset we were unintentionally creating the canary asset release
- Change the tag the canary assets use to be a valid semver. If no tags in the project exist it will fall back to the canary tag in some cases, and that tag must be valid semver

## Why

closes #1790

Todo:

- [x] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux-canary.1802.22144.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux-canary.1802.22144.gz)  
[auto-macos-canary.1802.22144.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos-canary.1802.22144.gz)  
[auto-win.exe-canary.1802.22144.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe-canary.1802.22144.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.16.3-canary.1802.22144.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.16.3-canary.1802.22144.0
  npm install @auto-canary/auto@10.16.3-canary.1802.22144.0
  npm install @auto-canary/core@10.16.3-canary.1802.22144.0
  npm install @auto-canary/package-json-utils@10.16.3-canary.1802.22144.0
  npm install @auto-canary/all-contributors@10.16.3-canary.1802.22144.0
  npm install @auto-canary/brew@10.16.3-canary.1802.22144.0
  npm install @auto-canary/chrome@10.16.3-canary.1802.22144.0
  npm install @auto-canary/cocoapods@10.16.3-canary.1802.22144.0
  npm install @auto-canary/conventional-commits@10.16.3-canary.1802.22144.0
  npm install @auto-canary/crates@10.16.3-canary.1802.22144.0
  npm install @auto-canary/docker@10.16.3-canary.1802.22144.0
  npm install @auto-canary/exec@10.16.3-canary.1802.22144.0
  npm install @auto-canary/first-time-contributor@10.16.3-canary.1802.22144.0
  npm install @auto-canary/gem@10.16.3-canary.1802.22144.0
  npm install @auto-canary/gh-pages@10.16.3-canary.1802.22144.0
  npm install @auto-canary/git-tag@10.16.3-canary.1802.22144.0
  npm install @auto-canary/gradle@10.16.3-canary.1802.22144.0
  npm install @auto-canary/jira@10.16.3-canary.1802.22144.0
  npm install @auto-canary/magic-zero@10.16.3-canary.1802.22144.0
  npm install @auto-canary/maven@10.16.3-canary.1802.22144.0
  npm install @auto-canary/microsoft-teams@10.16.3-canary.1802.22144.0
  npm install @auto-canary/npm@10.16.3-canary.1802.22144.0
  npm install @auto-canary/omit-commits@10.16.3-canary.1802.22144.0
  npm install @auto-canary/omit-release-notes@10.16.3-canary.1802.22144.0
  npm install @auto-canary/pr-body-labels@10.16.3-canary.1802.22144.0
  npm install @auto-canary/released@10.16.3-canary.1802.22144.0
  npm install @auto-canary/s3@10.16.3-canary.1802.22144.0
  npm install @auto-canary/slack@10.16.3-canary.1802.22144.0
  npm install @auto-canary/twitter@10.16.3-canary.1802.22144.0
  npm install @auto-canary/upload-assets@10.16.3-canary.1802.22144.0
  npm install @auto-canary/vscode@10.16.3-canary.1802.22144.0
  # or 
  yarn add @auto-canary/bot-list@10.16.3-canary.1802.22144.0
  yarn add @auto-canary/auto@10.16.3-canary.1802.22144.0
  yarn add @auto-canary/core@10.16.3-canary.1802.22144.0
  yarn add @auto-canary/package-json-utils@10.16.3-canary.1802.22144.0
  yarn add @auto-canary/all-contributors@10.16.3-canary.1802.22144.0
  yarn add @auto-canary/brew@10.16.3-canary.1802.22144.0
  yarn add @auto-canary/chrome@10.16.3-canary.1802.22144.0
  yarn add @auto-canary/cocoapods@10.16.3-canary.1802.22144.0
  yarn add @auto-canary/conventional-commits@10.16.3-canary.1802.22144.0
  yarn add @auto-canary/crates@10.16.3-canary.1802.22144.0
  yarn add @auto-canary/docker@10.16.3-canary.1802.22144.0
  yarn add @auto-canary/exec@10.16.3-canary.1802.22144.0
  yarn add @auto-canary/first-time-contributor@10.16.3-canary.1802.22144.0
  yarn add @auto-canary/gem@10.16.3-canary.1802.22144.0
  yarn add @auto-canary/gh-pages@10.16.3-canary.1802.22144.0
  yarn add @auto-canary/git-tag@10.16.3-canary.1802.22144.0
  yarn add @auto-canary/gradle@10.16.3-canary.1802.22144.0
  yarn add @auto-canary/jira@10.16.3-canary.1802.22144.0
  yarn add @auto-canary/magic-zero@10.16.3-canary.1802.22144.0
  yarn add @auto-canary/maven@10.16.3-canary.1802.22144.0
  yarn add @auto-canary/microsoft-teams@10.16.3-canary.1802.22144.0
  yarn add @auto-canary/npm@10.16.3-canary.1802.22144.0
  yarn add @auto-canary/omit-commits@10.16.3-canary.1802.22144.0
  yarn add @auto-canary/omit-release-notes@10.16.3-canary.1802.22144.0
  yarn add @auto-canary/pr-body-labels@10.16.3-canary.1802.22144.0
  yarn add @auto-canary/released@10.16.3-canary.1802.22144.0
  yarn add @auto-canary/s3@10.16.3-canary.1802.22144.0
  yarn add @auto-canary/slack@10.16.3-canary.1802.22144.0
  yarn add @auto-canary/twitter@10.16.3-canary.1802.22144.0
  yarn add @auto-canary/upload-assets@10.16.3-canary.1802.22144.0
  yarn add @auto-canary/vscode@10.16.3-canary.1802.22144.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
