### PR TITLE
make canary assets tag at the start of history to avoid tag calculation bugs

### DIFF
--- a/plugins/upload-assets/__tests__/upload-assets-ci.test.ts
+++ b/plugins/upload-assets/__tests__/upload-assets-ci.test.ts
@@ -43,6 +43,7 @@ describe("Upload Assets Plugin", () => {
       prefixRelease: (v) => v,
       git: {
         options,
+        getFirstCommit: () => 'abc',
         addToPrBody,
         github: {
           repos: { uploadReleaseAsset, createRelease },

--- a/plugins/upload-assets/__tests__/upload-assets.test.ts
+++ b/plugins/upload-assets/__tests__/upload-assets.test.ts
@@ -115,6 +115,7 @@ describe("Upload Assets Plugin", () => {
       logger: dummyLog(),
       prefixRelease: (v) => v,
       git: {
+        getFirstCommit: () => 'abc',
         options,
         github: {
           repos: { uploadReleaseAsset, createRelease },
@@ -192,6 +193,7 @@ describe("Upload Assets Plugin", () => {
       prefixRelease: (v) => v,
       git: {
         options,
+        getFirstCommit: () => 'abc',
         github: {
           repos: { uploadReleaseAsset, createRelease },
           paginate: jest.fn().mockResolvedValue([]),
@@ -226,6 +228,7 @@ describe("Upload Assets Plugin", () => {
       prefixRelease: (v) => v,
       git: {
         options,
+        getFirstCommit: () => 'abc',
         github: {
           repos: { uploadReleaseAsset, createRelease },
           paginate: jest.fn().mockResolvedValue([]),

--- a/plugins/upload-assets/src/index.ts
+++ b/plugins/upload-assets/src/index.ts
@@ -262,6 +262,7 @@ export default class UploadAssetsPlugin implements IPlugin {
         name: "Canary Assets",
         prerelease: true,
         body: `This release contains preview assets of Pull Requests.`,
+        target_commitish: await auto.git?.getFirstCommit()
       });
 
       return canaryRelease.data;


### PR DESCRIPTION
# What Changed

see title

## Why

Previously the canary asset tag was created at the tip of baseBranch. With this change we now tag the very first commit in the repo with `0.0.0-canary`, this way any commands that find the latest tag in a branch don't accidentally find the canary assets tag.

Todo:

- [x] Add tests

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux-canary.1803.22158.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux-canary.1803.22158.gz)  
[auto-macos-canary.1803.22158.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos-canary.1803.22158.gz)  
[auto-win.exe-canary.1803.22158.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe-canary.1803.22158.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.16.4-canary.1803.22158.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.16.4-canary.1803.22158.0
  npm install @auto-canary/auto@10.16.4-canary.1803.22158.0
  npm install @auto-canary/core@10.16.4-canary.1803.22158.0
  npm install @auto-canary/package-json-utils@10.16.4-canary.1803.22158.0
  npm install @auto-canary/all-contributors@10.16.4-canary.1803.22158.0
  npm install @auto-canary/brew@10.16.4-canary.1803.22158.0
  npm install @auto-canary/chrome@10.16.4-canary.1803.22158.0
  npm install @auto-canary/cocoapods@10.16.4-canary.1803.22158.0
  npm install @auto-canary/conventional-commits@10.16.4-canary.1803.22158.0
  npm install @auto-canary/crates@10.16.4-canary.1803.22158.0
  npm install @auto-canary/docker@10.16.4-canary.1803.22158.0
  npm install @auto-canary/exec@10.16.4-canary.1803.22158.0
  npm install @auto-canary/first-time-contributor@10.16.4-canary.1803.22158.0
  npm install @auto-canary/gem@10.16.4-canary.1803.22158.0
  npm install @auto-canary/gh-pages@10.16.4-canary.1803.22158.0
  npm install @auto-canary/git-tag@10.16.4-canary.1803.22158.0
  npm install @auto-canary/gradle@10.16.4-canary.1803.22158.0
  npm install @auto-canary/jira@10.16.4-canary.1803.22158.0
  npm install @auto-canary/magic-zero@10.16.4-canary.1803.22158.0
  npm install @auto-canary/maven@10.16.4-canary.1803.22158.0
  npm install @auto-canary/microsoft-teams@10.16.4-canary.1803.22158.0
  npm install @auto-canary/npm@10.16.4-canary.1803.22158.0
  npm install @auto-canary/omit-commits@10.16.4-canary.1803.22158.0
  npm install @auto-canary/omit-release-notes@10.16.4-canary.1803.22158.0
  npm install @auto-canary/pr-body-labels@10.16.4-canary.1803.22158.0
  npm install @auto-canary/released@10.16.4-canary.1803.22158.0
  npm install @auto-canary/s3@10.16.4-canary.1803.22158.0
  npm install @auto-canary/slack@10.16.4-canary.1803.22158.0
  npm install @auto-canary/twitter@10.16.4-canary.1803.22158.0
  npm install @auto-canary/upload-assets@10.16.4-canary.1803.22158.0
  npm install @auto-canary/vscode@10.16.4-canary.1803.22158.0
  # or 
  yarn add @auto-canary/bot-list@10.16.4-canary.1803.22158.0
  yarn add @auto-canary/auto@10.16.4-canary.1803.22158.0
  yarn add @auto-canary/core@10.16.4-canary.1803.22158.0
  yarn add @auto-canary/package-json-utils@10.16.4-canary.1803.22158.0
  yarn add @auto-canary/all-contributors@10.16.4-canary.1803.22158.0
  yarn add @auto-canary/brew@10.16.4-canary.1803.22158.0
  yarn add @auto-canary/chrome@10.16.4-canary.1803.22158.0
  yarn add @auto-canary/cocoapods@10.16.4-canary.1803.22158.0
  yarn add @auto-canary/conventional-commits@10.16.4-canary.1803.22158.0
  yarn add @auto-canary/crates@10.16.4-canary.1803.22158.0
  yarn add @auto-canary/docker@10.16.4-canary.1803.22158.0
  yarn add @auto-canary/exec@10.16.4-canary.1803.22158.0
  yarn add @auto-canary/first-time-contributor@10.16.4-canary.1803.22158.0
  yarn add @auto-canary/gem@10.16.4-canary.1803.22158.0
  yarn add @auto-canary/gh-pages@10.16.4-canary.1803.22158.0
  yarn add @auto-canary/git-tag@10.16.4-canary.1803.22158.0
  yarn add @auto-canary/gradle@10.16.4-canary.1803.22158.0
  yarn add @auto-canary/jira@10.16.4-canary.1803.22158.0
  yarn add @auto-canary/magic-zero@10.16.4-canary.1803.22158.0
  yarn add @auto-canary/maven@10.16.4-canary.1803.22158.0
  yarn add @auto-canary/microsoft-teams@10.16.4-canary.1803.22158.0
  yarn add @auto-canary/npm@10.16.4-canary.1803.22158.0
  yarn add @auto-canary/omit-commits@10.16.4-canary.1803.22158.0
  yarn add @auto-canary/omit-release-notes@10.16.4-canary.1803.22158.0
  yarn add @auto-canary/pr-body-labels@10.16.4-canary.1803.22158.0
  yarn add @auto-canary/released@10.16.4-canary.1803.22158.0
  yarn add @auto-canary/s3@10.16.4-canary.1803.22158.0
  yarn add @auto-canary/slack@10.16.4-canary.1803.22158.0
  yarn add @auto-canary/twitter@10.16.4-canary.1803.22158.0
  yarn add @auto-canary/upload-assets@10.16.4-canary.1803.22158.0
  yarn add @auto-canary/vscode@10.16.4-canary.1803.22158.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
