### PR TITLE
docs: fix broken link on all-contributors page

### DIFF
--- a/plugins/all-contributors/README.md
+++ b/plugins/all-contributors/README.md
@@ -2,7 +2,7 @@
 
 Automatically add contributors as changelogs are produced.
 
-This plugin maps one of the [contribution type](vhttps://allcontributors.org/docs/en/emoji-key) to a glob or array of globs.
+This plugin maps one of the [contribution type](https://allcontributors.org/docs/en/emoji-key) to a glob or array of globs.
 Out of the box the plugin will only detect the following contribution types:
 
 - 📖 `doc` - Edits to any README `['**/*.mdx', '**/*.md', '**/docs/**/*', '**/documentation/**/*']`


### PR DESCRIPTION
# What Changed

Broken link fixed on https://intuit.github.io/auto/docs/generated/all-contributors

## Why

Cause it made me 😢 but then I saw the `vhttp://`!

## Change Type

Indicate the type of change your pull request is:

- [x] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
