### PR TITLE
Use mock-fs for npm tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.12.1",
     "@fortawesome/react-fontawesome": "^0.1.9",
     "@types/jest": "^26.0.0",
+    "@types/mock-fs": "^4.13.0",
     "@types/parse-github-url": "1.0.0",
     "@typescript-eslint/eslint-plugin": "^4.1.1",
     "@typescript-eslint/parser": "^4.1.1",
@@ -67,6 +68,7 @@
     "jest-snapshot-serializer-ansi": "^1.0.0",
     "lerna": "^3.22.1",
     "lint-staged": "^10.0.7",
+    "mock-fs": "^4.13.0",
     "next-ignite": "^0.9.20",
     "patch-package": "^6.2.2",
     "prettier": "^2.2.1",
@@ -95,6 +97,9 @@
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
+    "setupFiles": [
+      "./scripts/jest-setup.js"
+    ],
     "moduleFileExtensions": [
       "ts",
       "js",

--- a/plugins/npm/__tests__/npm-next.test.ts
+++ b/plugins/npm/__tests__/npm-next.test.ts
@@ -547,7 +547,7 @@ describe("next", () => {
     ]);
     expect(
       JSON.parse(fs.readFileSync("packages/foo/package.json", "utf-8"))
-    ).toEqual({
+    ).toStrictEqual({
       name: "@foo/foo",
       version: "1.0.0-next.1",
       dependencies: {

--- a/plugins/npm/__tests__/npm-next.test.ts
+++ b/plugins/npm/__tests__/npm-next.test.ts
@@ -1,5 +1,6 @@
-import endent from "endent";
+import mockFs from "mock-fs";
 import { execSync } from "child_process";
+import fs from "fs";
 
 import * as Auto from "@auto-it/core";
 import { dummyLog } from "@auto-it/core/dist/utils/logger";
@@ -10,18 +11,12 @@ const exec = jest.fn();
 const execPromise = jest.fn();
 const getLernaPackages = jest.fn();
 const monorepoPackages = jest.fn();
-const existsSync = jest.fn();
-const readFileSync = jest.fn();
-const writeSpy = jest.fn();
 
 jest.mock("child_process");
 // @ts-ignore
 execSync.mockImplementation(exec);
 exec.mockReturnValue("");
 execPromise.mockResolvedValue("");
-
-let readResult = "{}";
-readFileSync.mockReturnValue("{}");
 
 jest.mock(
   "../../../packages/core/dist/utils/exec-promise",
@@ -36,24 +31,11 @@ jest.mock(
 );
 jest.mock("env-ci", () => () => ({ isCi: false }));
 jest.mock("get-monorepo-packages", () => () => monorepoPackages());
-jest.mock("fs", () => ({
-  // @ts-ignore
-  existsSync: (...args) => existsSync(...args),
-  // @ts-ignore
-  readFile: (a, b, cb) => {
-    cb(undefined, readResult);
-  },
-  // @ts-ignore
-  readFileSync: (...args) => readFileSync(...args),
-  ReadStream: function () {},
-  WriteStream: function () {},
-  // @ts-ignore
-  closeSync: () => undefined,
-  // @ts-ignore
-  writeFile: (file, data, cb) => {
-    cb(undefined, writeSpy(file, data));
-  },
-}));
+jest.mock("registry-url", () => () => "https://registry.npm.org");
+
+afterEach(() => {
+  mockFs.restore();
+});
 
 describe("next", () => {
   beforeEach(() => {
@@ -61,6 +43,14 @@ describe("next", () => {
   });
 
   test("works in single package", async () => {
+    mockFs({
+      "package.json": `
+      {
+        "name": "test",
+        "version": "1.2.4-next.0"
+      }
+      `,
+    });
     const plugin = new NPMPlugin();
     const hooks = makeHooks();
 
@@ -77,13 +67,6 @@ describe("next", () => {
         getLastTagNotInBaseBranch: () => "1.2.3",
       },
     } as unknown) as Auto.Auto);
-
-    readResult = `
-      {
-        "name": "test",
-        "version": "1.2.4-next.0"
-      }
-    `;
 
     expect(
       await hooks.next.promise([], { bump: Auto.SEMVER.patch } as any)
@@ -114,6 +97,14 @@ describe("next", () => {
   });
 
   test("works for dry run in single package", async () => {
+    mockFs({
+      "package.json": `
+      {
+        "name": "test",
+        "version": "1.2.4-next.0"
+      }
+      `,
+    });
     const plugin = new NPMPlugin();
     const hooks = makeHooks();
 
@@ -130,13 +121,6 @@ describe("next", () => {
         getLastTagNotInBaseBranch: () => "1.2.3",
       },
     } as unknown) as Auto.Auto);
-
-    readResult = `
-      {
-        "name": "test",
-        "version": "1.2.4-next.0"
-      }
-    `;
 
     expect(
       await hooks.next.promise([], {
@@ -148,6 +132,15 @@ describe("next", () => {
   });
 
   test("skips publish for private package", async () => {
+    mockFs({
+      "package.json": `
+        {
+          "name": "test",
+          "version": "1.2.4-next.0",
+          "private": true
+        }
+      `,
+    });
     const plugin = new NPMPlugin();
     const hooks = makeHooks();
 
@@ -164,14 +157,6 @@ describe("next", () => {
         getLastTagNotInBaseBranch: () => "1.2.3",
       },
     } as unknown) as Auto.Auto);
-
-    readResult = `
-      {
-        "name": "test",
-        "version": "1.2.4-next.0",
-        "private": true
-      }
-    `;
 
     expect(
       await hooks.next.promise([], { bump: Auto.SEMVER.patch } as any)
@@ -191,6 +176,14 @@ describe("next", () => {
   });
 
   test("works with legacy auth", async () => {
+    mockFs({
+      "package.json": `
+      {
+        "name": "test",
+        "version": "1.2.4-next.0"
+      }
+      `,
+    });
     process.env.NPM_TOKEN = "abcd";
     const plugin = new NPMPlugin({ legacyAuth: true });
     const hooks = makeHooks();
@@ -208,13 +201,6 @@ describe("next", () => {
         getLastTagNotInBaseBranch: () => "1.2.3",
       },
     } as unknown) as Auto.Auto);
-
-    readResult = `
-      {
-        "name": "test",
-        "version": "1.2.4-next.0"
-      }
-    `;
 
     expect(
       await hooks.next.promise([], { bump: Auto.SEMVER.patch } as any)
@@ -246,12 +232,35 @@ describe("next", () => {
   });
 
   test("works in monorepo", async () => {
+    mockFs({
+      "package.json": `
+      {
+        "name": "test",
+        "version": "1.2.3"
+      }
+      `,
+      "lerna.json": `
+        {
+          "version": "1.2.3"
+        }
+      `,
+    });
     const plugin = new NPMPlugin();
     const hooks = makeHooks();
 
     // isMonorepo
-    existsSync.mockReturnValueOnce(true);
-    readFileSync.mockReturnValue('{ "version": "1.2.3" }');
+    monorepoPackages.mockReturnValueOnce([
+      {
+        path: "packages/a",
+        name: "@packages/a",
+        package: { version: "1.2.3" },
+      },
+      {
+        path: "packages/b",
+        name: "@packages/b",
+        package: { version: "1.2.4-next.0" },
+      },
+    ]);
     execPromise.mockResolvedValueOnce("");
     execPromise.mockResolvedValueOnce("1.2.4-next.0");
 
@@ -291,12 +300,35 @@ describe("next", () => {
   });
 
   test("optionally commits version", async () => {
+    mockFs({
+      "package.json": `
+      {
+        "name": "test",
+        "version": "1.2.3"
+      }
+      `,
+      "lerna.json": `
+        {
+          "version": "1.2.3"
+        }
+      `,
+    });
     const plugin = new NPMPlugin({ commitNextVersion: true });
     const hooks = makeHooks();
 
+    monorepoPackages.mockReturnValueOnce([
+      {
+        path: "packages/a",
+        name: "@packages/a",
+        package: { version: "1.2.3" },
+      },
+      {
+        path: "packages/b",
+        name: "@packages/b",
+        package: { version: "1.2.4-next.0" },
+      },
+    ]);
     // isMonorepo
-    existsSync.mockReturnValueOnce(true);
-    readFileSync.mockReturnValue('{ "version": "1.2.3" }');
     execPromise.mockResolvedValueOnce("");
     execPromise.mockResolvedValueOnce("1.2.4-next.0");
 
@@ -330,12 +362,23 @@ describe("next", () => {
   });
 
   test("works in dry run in monorepo", async () => {
+    mockFs({
+      "package.json": `
+      {
+        "name": "test",
+        "version": "1.2.3"
+      }
+      `,
+      "lerna.json": `
+        {
+          "version": "1.2.3"
+        }
+      `,
+    });
     const plugin = new NPMPlugin();
     const hooks = makeHooks();
 
     // isMonorepo
-    existsSync.mockReturnValueOnce(true);
-    readFileSync.mockReturnValue('{ "version": "1.2.3" }');
     execPromise.mockResolvedValueOnce("");
     execPromise.mockResolvedValueOnce("1.2.4-next.0");
 
@@ -378,8 +421,8 @@ describe("next", () => {
     const hooks = makeHooks();
 
     // isMonorepo
-    existsSync.mockReturnValueOnce(true);
-    readFileSync.mockReturnValue('{ "version": "1.2.3" }');
+    // existsSync.mockReturnValueOnce(true);
+    // readFileSync.mockReturnValue('{ "version": "1.2.3" }');
     execPromise.mockResolvedValueOnce("");
     execPromise.mockResolvedValueOnce("1.2.4-next.0");
 
@@ -420,21 +463,44 @@ describe("next", () => {
   });
 
   test("works in monorepo - independent", async () => {
+    mockFs({
+      "package.json": `
+      {
+        "name": "@foo/foo",
+        "dependencies": {
+          "@foo/foo-bar": "0.50.0"
+        }
+      }
+      `,
+      "lerna.json": `
+        {
+          "version": "independent"
+        }
+      `,
+      "packages/foo/package.json": `
+        {
+          "name": "@foo/foo",
+          "version": "1.0.0-next.0",
+          "dependencies": {
+            "@foo/foo-bar": "0.50.0"
+          }
+        }
+      `,
+      "packages/foo-bar/package.json": "{}",
+    });
     const plugin = new NPMPlugin();
     const hooks = makeHooks();
 
     // isMonorepo
-    existsSync.mockReturnValueOnce(true);
-    readFileSync.mockReturnValue('{ "version": "independent" }');
     getLernaPackages.mockResolvedValueOnce([
       {
         name: "@foo/foo",
-        path: "/path/to/1",
+        path: "packages/foo",
         version: "0.45.0",
       },
       {
         name: "@foo/foo-bar",
-        path: "/path/to/2",
+        path: "packages/foo-bar",
         version: "0.50.0",
       },
     ]);
@@ -465,16 +531,6 @@ describe("next", () => {
       },
     } as unknown) as Auto.Auto);
 
-    readResult = `
-      {
-        "name": "@foo/foo",
-        "version": "1.0.0-next.0",
-        "dependencies": {
-          "@foo/foo-bar": "0.50.0"
-        }
-      }
-    `;
-
     expect(
       await hooks.next.promise([], { bump: Auto.SEMVER.patch } as any)
     ).toStrictEqual(["@foo/foo@1.0.0-next.0", "@foo/foo-bar@2.0.0-next.0"]);
@@ -489,25 +545,38 @@ describe("next", () => {
       "next",
       "--tags",
     ]);
-    expect(writeSpy).toHaveBeenCalledWith(
-      "/path/to/1/package.json",
-      endent`{
-        "name": "@foo/foo",
-        "version": "1.0.0-next.1",
-        "dependencies": {
-          "@foo/foo-bar": "2.0.0-next.1"
-        }
-      }`
-    );
+    expect(
+      JSON.parse(fs.readFileSync("packages/foo/package.json", "utf-8"))
+    ).toEqual({
+      name: "@foo/foo",
+      version: "1.0.0-next.1",
+      dependencies: {
+        "@foo/foo-bar": "2.0.0-next.1",
+      },
+    });
   });
 
   test("works in dry run in monorepo - independent", async () => {
+    mockFs({
+      "package.json": `
+      {
+        "name": "@foo/foo",
+        "version": "1.0.0-next.0",
+        "dependencies": {
+          "@foo/foo-bar": "0.50.0"
+        }
+      }
+      `,
+      "lerna.json": `
+        {
+          "version": "independent"
+        }
+      `,
+    });
     const plugin = new NPMPlugin();
     const hooks = makeHooks();
 
     // isMonorepo
-    existsSync.mockReturnValueOnce(true);
-    readFileSync.mockReturnValue('{ "version": "independent" }');
     getLernaPackages.mockResolvedValueOnce([
       {
         name: "@foo/foo",
@@ -565,16 +634,29 @@ describe("next", () => {
   });
 
   test("works in monorepo - independent - private package", async () => {
+    mockFs({
+      "package.json": `
+      {
+        "name": "@foo/foo",
+        "version": "1.0.0-next.0",
+        "private": true
+      }
+      `,
+      "lerna.json": `
+        {
+          "version": "independent"
+        }
+      `,
+      "packages/foo/package.json": `{}`,
+    });
     const plugin = new NPMPlugin();
     const hooks = makeHooks();
 
     // isMonorepo
-    existsSync.mockReturnValueOnce(true);
-    readFileSync.mockReturnValue('{ "version": "independent" }');
     getLernaPackages.mockResolvedValueOnce([
       {
         name: "@foo/foo",
-        path: "/path/to/1",
+        path: "packages/foo",
       },
     ]);
     execPromise.mockImplementation((command, args) => {

--- a/scripts/jest-setup.js
+++ b/scripts/jest-setup.js
@@ -1,0 +1,1 @@
+require("mock-fs");

--- a/yarn.lock
+++ b/yarn.lock
@@ -3189,6 +3189,13 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"
   integrity sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=
 
+"@types/mock-fs@^4.13.0":
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/@types/mock-fs/-/mock-fs-4.13.0.tgz#b8b01cd2db588668b2532ecd21b1babd3fffb2c0"
+  integrity sha512-FUqxhURwqFtFBCuUj3uQMp7rPSQs//b3O9XecAVxhqS9y4/W8SIJEZFq2mmpnFVZBXwR/2OyPLE97CpyYiB8Mw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/node-fetch@2.5.8":
   version "2.5.8"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.8.tgz#e199c835d234c7eb0846f6618012e558544ee2fb"
@@ -10766,6 +10773,11 @@ mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3:
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
+
+mock-fs@^4.13.0:
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-4.13.0.tgz#31c02263673ec3789f90eb7b6963676aa407a598"
+  integrity sha512-DD0vOdofJdoaRNtnWcrXe6RQbpHkPPmtqGq14uRX0F8ZKJ5nv89CVTYl/BZdppDxBDaV0hl75htg3abpEWlPZA==
 
 modern-normalize@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
# What Changed

Instead of individually mocked fs methods the npm plugin tests now use mockFs to do their work. This largely makes the tests more robust as we care less about what fs calls are happening and more about the shape of the filesystem data. 

## Why

I needed it for the .npmrc refactor since that updates utils which adds/removes fs calls which made a lot of these tests break when they shouldn't have. 

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
- [x] `internal`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux-canary.1827.22516.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux-canary.1827.22516.gz)  
[auto-macos-canary.1827.22516.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos-canary.1827.22516.gz)  
[auto-win.exe-canary.1827.22516.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe-canary.1827.22516.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.16.8-canary.1827.22516.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.16.8-canary.1827.22516.0
  npm install @auto-canary/auto@10.16.8-canary.1827.22516.0
  npm install @auto-canary/core@10.16.8-canary.1827.22516.0
  npm install @auto-canary/package-json-utils@10.16.8-canary.1827.22516.0
  npm install @auto-canary/all-contributors@10.16.8-canary.1827.22516.0
  npm install @auto-canary/brew@10.16.8-canary.1827.22516.0
  npm install @auto-canary/chrome@10.16.8-canary.1827.22516.0
  npm install @auto-canary/cocoapods@10.16.8-canary.1827.22516.0
  npm install @auto-canary/conventional-commits@10.16.8-canary.1827.22516.0
  npm install @auto-canary/crates@10.16.8-canary.1827.22516.0
  npm install @auto-canary/docker@10.16.8-canary.1827.22516.0
  npm install @auto-canary/exec@10.16.8-canary.1827.22516.0
  npm install @auto-canary/first-time-contributor@10.16.8-canary.1827.22516.0
  npm install @auto-canary/gem@10.16.8-canary.1827.22516.0
  npm install @auto-canary/gh-pages@10.16.8-canary.1827.22516.0
  npm install @auto-canary/git-tag@10.16.8-canary.1827.22516.0
  npm install @auto-canary/gradle@10.16.8-canary.1827.22516.0
  npm install @auto-canary/jira@10.16.8-canary.1827.22516.0
  npm install @auto-canary/magic-zero@10.16.8-canary.1827.22516.0
  npm install @auto-canary/maven@10.16.8-canary.1827.22516.0
  npm install @auto-canary/microsoft-teams@10.16.8-canary.1827.22516.0
  npm install @auto-canary/npm@10.16.8-canary.1827.22516.0
  npm install @auto-canary/omit-commits@10.16.8-canary.1827.22516.0
  npm install @auto-canary/omit-release-notes@10.16.8-canary.1827.22516.0
  npm install @auto-canary/pr-body-labels@10.16.8-canary.1827.22516.0
  npm install @auto-canary/released@10.16.8-canary.1827.22516.0
  npm install @auto-canary/s3@10.16.8-canary.1827.22516.0
  npm install @auto-canary/slack@10.16.8-canary.1827.22516.0
  npm install @auto-canary/twitter@10.16.8-canary.1827.22516.0
  npm install @auto-canary/upload-assets@10.16.8-canary.1827.22516.0
  npm install @auto-canary/vscode@10.16.8-canary.1827.22516.0
  # or 
  yarn add @auto-canary/bot-list@10.16.8-canary.1827.22516.0
  yarn add @auto-canary/auto@10.16.8-canary.1827.22516.0
  yarn add @auto-canary/core@10.16.8-canary.1827.22516.0
  yarn add @auto-canary/package-json-utils@10.16.8-canary.1827.22516.0
  yarn add @auto-canary/all-contributors@10.16.8-canary.1827.22516.0
  yarn add @auto-canary/brew@10.16.8-canary.1827.22516.0
  yarn add @auto-canary/chrome@10.16.8-canary.1827.22516.0
  yarn add @auto-canary/cocoapods@10.16.8-canary.1827.22516.0
  yarn add @auto-canary/conventional-commits@10.16.8-canary.1827.22516.0
  yarn add @auto-canary/crates@10.16.8-canary.1827.22516.0
  yarn add @auto-canary/docker@10.16.8-canary.1827.22516.0
  yarn add @auto-canary/exec@10.16.8-canary.1827.22516.0
  yarn add @auto-canary/first-time-contributor@10.16.8-canary.1827.22516.0
  yarn add @auto-canary/gem@10.16.8-canary.1827.22516.0
  yarn add @auto-canary/gh-pages@10.16.8-canary.1827.22516.0
  yarn add @auto-canary/git-tag@10.16.8-canary.1827.22516.0
  yarn add @auto-canary/gradle@10.16.8-canary.1827.22516.0
  yarn add @auto-canary/jira@10.16.8-canary.1827.22516.0
  yarn add @auto-canary/magic-zero@10.16.8-canary.1827.22516.0
  yarn add @auto-canary/maven@10.16.8-canary.1827.22516.0
  yarn add @auto-canary/microsoft-teams@10.16.8-canary.1827.22516.0
  yarn add @auto-canary/npm@10.16.8-canary.1827.22516.0
  yarn add @auto-canary/omit-commits@10.16.8-canary.1827.22516.0
  yarn add @auto-canary/omit-release-notes@10.16.8-canary.1827.22516.0
  yarn add @auto-canary/pr-body-labels@10.16.8-canary.1827.22516.0
  yarn add @auto-canary/released@10.16.8-canary.1827.22516.0
  yarn add @auto-canary/s3@10.16.8-canary.1827.22516.0
  yarn add @auto-canary/slack@10.16.8-canary.1827.22516.0
  yarn add @auto-canary/twitter@10.16.8-canary.1827.22516.0
  yarn add @auto-canary/upload-assets@10.16.8-canary.1827.22516.0
  yarn add @auto-canary/vscode@10.16.8-canary.1827.22516.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
