### PR TITLE
improve GitHub actions docs + remove unnecessary warning

### DIFF
--- a/docs/pages/docs/build-platforms/github-actions.mdx
+++ b/docs/pages/docs/build-platforms/github-actions.mdx
@@ -77,7 +77,7 @@ If you are publishing to the Github Package Registry you will need to change a f
     npx auto shipit
 ```
 
-The `NODE_AUTH_TOKEN` variable is required the `.npmrc` that `actions/setup-node@v1` sets up.
+The `NODE_AUTH_TOKEN` variable is required for the `.npmrc` that `actions/setup-node@v1` sets up.
 If you aren't using `actions/setup-node@v1` replace the variable name `NODE_AUTH_TOKEN` with `NPM_TOKEN` and the `.npmrc` `auto` will handle authentication instead.
 
 ## Troubleshooting
@@ -98,7 +98,7 @@ steps:
   - uses: actions/checkout@v2
     with:
       # Ensure that git uses your token with admin access to the repo
-      token: ${{ secrets.GH_TOKEN }}
+      token: ${{ secrets.ADMIN_TOKEN }}
 
   - name: Prepare repository
     # Fetch full git history and tags

--- a/docs/pages/docs/build-platforms/github-actions.mdx
+++ b/docs/pages/docs/build-platforms/github-actions.mdx
@@ -51,7 +51,20 @@ jobs:
 
 ### NPM: Github Package Registry
 
-If you are publishing to the Github Package Registry you will need to change the `NPM_TOKEN` token secret to match the following:
+If you are publishing to the Github Package Registry you will need to change a few things.
+
+1. Modify the node action to use the Github Package Registry and your user scope.
+
+```yml
+- name: Use Node.js 12.x
+  uses: actions/setup-node@v1
+  with:
+    node-version: 12.x
+    registry-url: "https://npm.pkg.github.com"
+    scope: "@your-username-scope"
+```
+
+2. Use the `GITHUB_TOKEN` as the `NODE_AUTH_TOKEN` to publish to the Github Package Registry.
 
 ```yml
 - name: Create Release
@@ -64,7 +77,6 @@ If you are publishing to the Github Package Registry you will need to change the
     npx auto shipit
 ```
 
-This will use your `GITHUB_TOKEN` to publish to the Github Package Registry.
 The `NODE_AUTH_TOKEN` variable is required the `.npmrc` that `actions/setup-node@v1` sets up.
 If you aren't using `actions/setup-node@v1` replace the variable name `NODE_AUTH_TOKEN` with `NPM_TOKEN` and the `.npmrc` `auto` will handle authentication instead.
 
@@ -78,12 +90,14 @@ If you are having problems make sure you have done the following:
 ### Running With Branch Protection
 
 GitHub actions require a little more setup to use `auto` with branch protection.
+We can't use the `GITHUB_TOKEN` to commit to the branch because it does not have high enough permissions.
+You will need to create a token with admin access to your repo and modify your build config like the following:
 
 ```yml
 steps:
   - uses: actions/checkout@v2
     with:
-      # Ensure that git uses your token with write access to the repo
+      # Ensure that git uses your token with admin access to the repo
       token: ${{ secrets.GH_TOKEN }}
 
   - name: Prepare repository

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -707,7 +707,10 @@ export default class NPMPlugin implements IPlugin {
         return;
       }
 
-      auto.checkEnv(this.name, "NPM_TOKEN");
+      // gh-action + node action uses NODE_AUTH_TOKEN and we should warn about NPM_TOKEN
+      if (!process.env.NODE_AUTH_TOKEN) {
+        auto.checkEnv(this.name, "NPM_TOKEN");
+      }
     });
 
     auto.hooks.getAuthor.tapPromise(this.name, async () => {


### PR DESCRIPTION
# What Changed

- add more docs
- remove that NPM_TOKEN since it doesn't matter
- Add context around the admin token for branch protection

## Why

closes #1821 

Todo:

- [x] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux-canary.1828.22528.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux-canary.1828.22528.gz)  
[auto-macos-canary.1828.22528.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos-canary.1828.22528.gz)  
[auto-win.exe-canary.1828.22528.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe-canary.1828.22528.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.16.8-canary.1828.22528.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.16.8-canary.1828.22528.0
  npm install @auto-canary/auto@10.16.8-canary.1828.22528.0
  npm install @auto-canary/core@10.16.8-canary.1828.22528.0
  npm install @auto-canary/package-json-utils@10.16.8-canary.1828.22528.0
  npm install @auto-canary/all-contributors@10.16.8-canary.1828.22528.0
  npm install @auto-canary/brew@10.16.8-canary.1828.22528.0
  npm install @auto-canary/chrome@10.16.8-canary.1828.22528.0
  npm install @auto-canary/cocoapods@10.16.8-canary.1828.22528.0
  npm install @auto-canary/conventional-commits@10.16.8-canary.1828.22528.0
  npm install @auto-canary/crates@10.16.8-canary.1828.22528.0
  npm install @auto-canary/docker@10.16.8-canary.1828.22528.0
  npm install @auto-canary/exec@10.16.8-canary.1828.22528.0
  npm install @auto-canary/first-time-contributor@10.16.8-canary.1828.22528.0
  npm install @auto-canary/gem@10.16.8-canary.1828.22528.0
  npm install @auto-canary/gh-pages@10.16.8-canary.1828.22528.0
  npm install @auto-canary/git-tag@10.16.8-canary.1828.22528.0
  npm install @auto-canary/gradle@10.16.8-canary.1828.22528.0
  npm install @auto-canary/jira@10.16.8-canary.1828.22528.0
  npm install @auto-canary/magic-zero@10.16.8-canary.1828.22528.0
  npm install @auto-canary/maven@10.16.8-canary.1828.22528.0
  npm install @auto-canary/microsoft-teams@10.16.8-canary.1828.22528.0
  npm install @auto-canary/npm@10.16.8-canary.1828.22528.0
  npm install @auto-canary/omit-commits@10.16.8-canary.1828.22528.0
  npm install @auto-canary/omit-release-notes@10.16.8-canary.1828.22528.0
  npm install @auto-canary/pr-body-labels@10.16.8-canary.1828.22528.0
  npm install @auto-canary/released@10.16.8-canary.1828.22528.0
  npm install @auto-canary/s3@10.16.8-canary.1828.22528.0
  npm install @auto-canary/slack@10.16.8-canary.1828.22528.0
  npm install @auto-canary/twitter@10.16.8-canary.1828.22528.0
  npm install @auto-canary/upload-assets@10.16.8-canary.1828.22528.0
  npm install @auto-canary/vscode@10.16.8-canary.1828.22528.0
  # or 
  yarn add @auto-canary/bot-list@10.16.8-canary.1828.22528.0
  yarn add @auto-canary/auto@10.16.8-canary.1828.22528.0
  yarn add @auto-canary/core@10.16.8-canary.1828.22528.0
  yarn add @auto-canary/package-json-utils@10.16.8-canary.1828.22528.0
  yarn add @auto-canary/all-contributors@10.16.8-canary.1828.22528.0
  yarn add @auto-canary/brew@10.16.8-canary.1828.22528.0
  yarn add @auto-canary/chrome@10.16.8-canary.1828.22528.0
  yarn add @auto-canary/cocoapods@10.16.8-canary.1828.22528.0
  yarn add @auto-canary/conventional-commits@10.16.8-canary.1828.22528.0
  yarn add @auto-canary/crates@10.16.8-canary.1828.22528.0
  yarn add @auto-canary/docker@10.16.8-canary.1828.22528.0
  yarn add @auto-canary/exec@10.16.8-canary.1828.22528.0
  yarn add @auto-canary/first-time-contributor@10.16.8-canary.1828.22528.0
  yarn add @auto-canary/gem@10.16.8-canary.1828.22528.0
  yarn add @auto-canary/gh-pages@10.16.8-canary.1828.22528.0
  yarn add @auto-canary/git-tag@10.16.8-canary.1828.22528.0
  yarn add @auto-canary/gradle@10.16.8-canary.1828.22528.0
  yarn add @auto-canary/jira@10.16.8-canary.1828.22528.0
  yarn add @auto-canary/magic-zero@10.16.8-canary.1828.22528.0
  yarn add @auto-canary/maven@10.16.8-canary.1828.22528.0
  yarn add @auto-canary/microsoft-teams@10.16.8-canary.1828.22528.0
  yarn add @auto-canary/npm@10.16.8-canary.1828.22528.0
  yarn add @auto-canary/omit-commits@10.16.8-canary.1828.22528.0
  yarn add @auto-canary/omit-release-notes@10.16.8-canary.1828.22528.0
  yarn add @auto-canary/pr-body-labels@10.16.8-canary.1828.22528.0
  yarn add @auto-canary/released@10.16.8-canary.1828.22528.0
  yarn add @auto-canary/s3@10.16.8-canary.1828.22528.0
  yarn add @auto-canary/slack@10.16.8-canary.1828.22528.0
  yarn add @auto-canary/twitter@10.16.8-canary.1828.22528.0
  yarn add @auto-canary/upload-assets@10.16.8-canary.1828.22528.0
  yarn add @auto-canary/vscode@10.16.8-canary.1828.22528.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
