### PR TITLE
Add note about verifyAccess config

### DIFF
--- a/plugins/npm/README.md
+++ b/plugins/npm/README.md
@@ -50,6 +50,23 @@ No additional setup is required.
 > Do you have a package in your monorepo you don't want to publish but still want versioned?
 > Just set that `"private": true` you that package's `package.json`!
 
+### Using automation tokens from NPM
+
+If you have 2FA enabled and want to publish using an [automation token](https://github.blog/changelog/2020-10-02-npm-automation-tokens/) you _must_ add the following to your `lerna.json` for it to work.
+
+```json
+{
+  // ... other config here
+  "command": {
+    "publish": {
+      "verifyAccess": false
+    }
+  }
+}
+```
+
+Lerna's verify access step hits an npm api endpoint that treats automation tokens differently than regular user tokens. Disabling it will bypass that failure. See [this lerna issue](https://github.com/lerna/lerna/issues/2788) for more context.
+
 ## Options
 
 ### setRcToken


### PR DESCRIPTION
# What Changed

Added a doc update about needing to disable verifyAccess to publish with an NPM automation token. 

## Why

Not doing this will cause an inexplicable npm permissions failure that makes no sense and is practically impossible to debug. See https://github.com/lerna/lerna/issues/2788 for more context.

## Change Type

Indicate the type of change your pull request is:

- [x] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux-canary.1829.22540.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux-canary.1829.22540.gz)  
[auto-macos-canary.1829.22540.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos-canary.1829.22540.gz)  
[auto-win.exe-canary.1829.22540.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe-canary.1829.22540.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.16.8-canary.1829.22540.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.16.8-canary.1829.22540.0
  npm install @auto-canary/auto@10.16.8-canary.1829.22540.0
  npm install @auto-canary/core@10.16.8-canary.1829.22540.0
  npm install @auto-canary/package-json-utils@10.16.8-canary.1829.22540.0
  npm install @auto-canary/all-contributors@10.16.8-canary.1829.22540.0
  npm install @auto-canary/brew@10.16.8-canary.1829.22540.0
  npm install @auto-canary/chrome@10.16.8-canary.1829.22540.0
  npm install @auto-canary/cocoapods@10.16.8-canary.1829.22540.0
  npm install @auto-canary/conventional-commits@10.16.8-canary.1829.22540.0
  npm install @auto-canary/crates@10.16.8-canary.1829.22540.0
  npm install @auto-canary/docker@10.16.8-canary.1829.22540.0
  npm install @auto-canary/exec@10.16.8-canary.1829.22540.0
  npm install @auto-canary/first-time-contributor@10.16.8-canary.1829.22540.0
  npm install @auto-canary/gem@10.16.8-canary.1829.22540.0
  npm install @auto-canary/gh-pages@10.16.8-canary.1829.22540.0
  npm install @auto-canary/git-tag@10.16.8-canary.1829.22540.0
  npm install @auto-canary/gradle@10.16.8-canary.1829.22540.0
  npm install @auto-canary/jira@10.16.8-canary.1829.22540.0
  npm install @auto-canary/magic-zero@10.16.8-canary.1829.22540.0
  npm install @auto-canary/maven@10.16.8-canary.1829.22540.0
  npm install @auto-canary/microsoft-teams@10.16.8-canary.1829.22540.0
  npm install @auto-canary/npm@10.16.8-canary.1829.22540.0
  npm install @auto-canary/omit-commits@10.16.8-canary.1829.22540.0
  npm install @auto-canary/omit-release-notes@10.16.8-canary.1829.22540.0
  npm install @auto-canary/pr-body-labels@10.16.8-canary.1829.22540.0
  npm install @auto-canary/released@10.16.8-canary.1829.22540.0
  npm install @auto-canary/s3@10.16.8-canary.1829.22540.0
  npm install @auto-canary/slack@10.16.8-canary.1829.22540.0
  npm install @auto-canary/twitter@10.16.8-canary.1829.22540.0
  npm install @auto-canary/upload-assets@10.16.8-canary.1829.22540.0
  npm install @auto-canary/vscode@10.16.8-canary.1829.22540.0
  # or 
  yarn add @auto-canary/bot-list@10.16.8-canary.1829.22540.0
  yarn add @auto-canary/auto@10.16.8-canary.1829.22540.0
  yarn add @auto-canary/core@10.16.8-canary.1829.22540.0
  yarn add @auto-canary/package-json-utils@10.16.8-canary.1829.22540.0
  yarn add @auto-canary/all-contributors@10.16.8-canary.1829.22540.0
  yarn add @auto-canary/brew@10.16.8-canary.1829.22540.0
  yarn add @auto-canary/chrome@10.16.8-canary.1829.22540.0
  yarn add @auto-canary/cocoapods@10.16.8-canary.1829.22540.0
  yarn add @auto-canary/conventional-commits@10.16.8-canary.1829.22540.0
  yarn add @auto-canary/crates@10.16.8-canary.1829.22540.0
  yarn add @auto-canary/docker@10.16.8-canary.1829.22540.0
  yarn add @auto-canary/exec@10.16.8-canary.1829.22540.0
  yarn add @auto-canary/first-time-contributor@10.16.8-canary.1829.22540.0
  yarn add @auto-canary/gem@10.16.8-canary.1829.22540.0
  yarn add @auto-canary/gh-pages@10.16.8-canary.1829.22540.0
  yarn add @auto-canary/git-tag@10.16.8-canary.1829.22540.0
  yarn add @auto-canary/gradle@10.16.8-canary.1829.22540.0
  yarn add @auto-canary/jira@10.16.8-canary.1829.22540.0
  yarn add @auto-canary/magic-zero@10.16.8-canary.1829.22540.0
  yarn add @auto-canary/maven@10.16.8-canary.1829.22540.0
  yarn add @auto-canary/microsoft-teams@10.16.8-canary.1829.22540.0
  yarn add @auto-canary/npm@10.16.8-canary.1829.22540.0
  yarn add @auto-canary/omit-commits@10.16.8-canary.1829.22540.0
  yarn add @auto-canary/omit-release-notes@10.16.8-canary.1829.22540.0
  yarn add @auto-canary/pr-body-labels@10.16.8-canary.1829.22540.0
  yarn add @auto-canary/released@10.16.8-canary.1829.22540.0
  yarn add @auto-canary/s3@10.16.8-canary.1829.22540.0
  yarn add @auto-canary/slack@10.16.8-canary.1829.22540.0
  yarn add @auto-canary/twitter@10.16.8-canary.1829.22540.0
  yarn add @auto-canary/upload-assets@10.16.8-canary.1829.22540.0
  yarn add @auto-canary/vscode@10.16.8-canary.1829.22540.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
