### PR TITLE
Update env param name to GH_TOKEN

### DIFF
--- a/docs/pages/docs/build-platforms/github-actions.mdx
+++ b/docs/pages/docs/build-platforms/github-actions.mdx
@@ -41,7 +41,7 @@ jobs:
 
       - name: Create Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           yarn install --frozen-lockfile
@@ -69,7 +69,7 @@ If you are publishing to the Github Package Registry you will need to change a f
 ```yml
 - name: Create Release
   env:
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   run: |
     yarn install --frozen-lockfile


### PR DESCRIPTION
# What Changed
The Github Actions example was using GITHUB_TOKEN, I propose to change it to GH_TOKEN.
 
## Why
It seems that auto expects the token to be provided through GH_TOKEN instead of GITHUB_TOKEN.

Todo:

- [ ] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [x] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
