### PR TITLE
Next/Canary Support for Gradle

### DIFF
--- a/plugins/gradle/__tests__/gradle.test.ts
+++ b/plugins/gradle/__tests__/gradle.test.ts
@@ -151,11 +151,11 @@ describe("Gradle Plugin", () => {
 
       const canaryVersion = await hooks.canary.promise({ bump: Auto.SEMVER.patch, canaryIdentifier: "canary123" });
 
-      expect(canaryVersion).toBe("1.0.0-SNAPSHOT")
+      expect(canaryVersion).toBe("1.0.0-canary123")
     });
 
     test("should not increment version - canary w/ default snapshot", async () => {
-      const properties = "version: 1.0.0-SNAPSHOT";
+      const properties = "version: 1.0.0";
       exec.mockReturnValueOnce(properties);
       await hooks.beforeRun.promise({} as any);
 
@@ -164,7 +164,7 @@ describe("Gradle Plugin", () => {
 
       const canaryVersion = await hooks.canary.promise({ bump: Auto.SEMVER.patch, canaryIdentifier: "canary123" });
 
-      expect(canaryVersion).toBe("1.0.0-SNAPSHOT")
+      expect(canaryVersion).toBe("1.0.0-canary123")
     });
 
     test("should not increment version - next", async () => {

--- a/plugins/gradle/__tests__/gradle.test.ts
+++ b/plugins/gradle/__tests__/gradle.test.ts
@@ -141,6 +141,52 @@ describe("Gradle Plugin", () => {
       ]);
     });
 
+    test("should version release - canary w/ default snapshot", async () => {
+      const properties = "version: 1.0.0-SNAPSHOT";
+      exec.mockReturnValueOnce(properties);
+      await hooks.beforeRun.promise({} as any);
+
+      const spy = jest.fn();
+      exec.mockReturnValueOnce(properties).mockImplementation(spy);
+
+      const canaryVersion = await hooks.canary.promise({ bump: Auto.SEMVER.patch, canaryIdentifier: "canary123" });
+
+      expect(canaryVersion).toBe("1.0.0-SNAPSHOT")
+    });
+
+    test("should not increment version - next", async () => {
+      const properties = "version: 1.0.0-SNAPSHOT";
+      exec.mockReturnValueOnce(properties);
+      await hooks.beforeRun.promise({} as any);
+
+      const spy = jest.fn();
+    
+      exec.mockReturnValueOnce(properties).mockImplementation(spy);
+
+      const nextVersion = await hooks.next.promise([], { bump: Auto.SEMVER.patch, commits: [], fullReleaseNotes: "", releaseNotes: "" });
+
+      expect(nextVersion[0]).toBe("1.0.0-SNAPSHOT")
+    });
+
+    test("should tag release - next w/ default snapshot", async () => {
+      const properties = "version: 1.0.0-SNAPSHOT";
+      exec.mockReturnValueOnce(properties);
+      await hooks.beforeRun.promise({} as any);
+
+      const spy = jest.fn();
+    
+      exec.mockReturnValueOnce(properties).mockImplementation(spy);
+
+      await hooks.next.promise([], { bump: Auto.SEMVER.patch, commits: [], fullReleaseNotes: "", releaseNotes: "" });
+
+      expect(spy).toHaveBeenCalledWith(expect.stringMatching("git"), [
+        "tag",
+        "1.0.0-SNAPSHOT",
+        "-m",
+        "\"Tag pre-release: 1.0.0-SNAPSHOT\"",
+      ]);
+    });
+
     test("should version release - patch w/ custom snapshot", async () => {
       const properties = `
       version: 1.0.0.SNAP

--- a/plugins/gradle/__tests__/gradle.test.ts
+++ b/plugins/gradle/__tests__/gradle.test.ts
@@ -151,6 +151,21 @@ describe("Gradle Plugin", () => {
       ]);
     });
 
+    test("should only log on dryRun - canary", async () => {
+      const properties = "version: 1.0.0";
+      exec.mockReturnValueOnce(properties);
+      await hooks.beforeRun.promise({} as any);
+
+      const spy = jest.fn();
+      exec.mockReturnValueOnce(properties).mockImplementation(spy);
+      const mockLog = jest.spyOn(logger.log, "info");
+
+      await hooks.canary.promise({ bump: Auto.SEMVER.patch, canaryIdentifier: "canary123" , dryRun: true});
+
+      expect(spy).toHaveBeenCalledTimes(0)
+      expect(mockLog).toHaveBeenCalledTimes(1)
+    });
+
     test("should not increment version - canary", async () => {
       const properties = "version: 1.0.0";
       exec.mockReturnValueOnce(properties);
@@ -204,6 +219,19 @@ describe("Gradle Plugin", () => {
       await hooks.canary.promise({ bump: Auto.SEMVER.patch, canaryIdentifier: "canary123" });
 
       expect(mockLog).toHaveBeenCalledWith(expect.stringMatching("Publish task not found in gradle"));
+    });
+
+    test("do nothing on dryRun - canary", async () => {
+      const properties = "version: 1.0.0";
+      exec.mockReturnValueOnce(properties);
+      await hooks.beforeRun.promise({} as any);
+
+      const spy = jest.fn();
+      exec.mockReturnValueOnce(properties).mockImplementation(spy);
+
+      await hooks.next.promise([], { bump: Auto.SEMVER.minor, commits: [], fullReleaseNotes: "", releaseNotes: "", dryRun: true });
+
+      expect(spy).toHaveBeenCalledTimes(0)
     });
 
     test("version does not depend on project gradle properties - next", async () => {

--- a/plugins/gradle/__tests__/gradle.test.ts
+++ b/plugins/gradle/__tests__/gradle.test.ts
@@ -24,7 +24,15 @@ describe("Gradle Plugin", () => {
     exec.mockClear();
     const plugin = new GradleReleasePlugin(options);
     hooks = makeHooks();
-    plugin.apply({ hooks, logger: dummyLog(), prefixRelease } as Auto.Auto);
+    plugin.apply(({ 
+      hooks, 
+      logger: dummyLog(), 
+      prefixRelease, 
+      git: {
+        getLastTagNotInBaseBranch: async () => undefined,
+        getLatestRelease: async () => "0.0.1",
+      },
+      getCurrentVersion: async () => "0.0.1" } as unknown) as Auto.Auto);
   });
 
   describe("getPreviousVersion", () => {
@@ -176,13 +184,13 @@ describe("Gradle Plugin", () => {
     
       exec.mockReturnValueOnce(properties).mockImplementation(spy);
 
-      const nextVersion = await hooks.next.promise([], { bump: Auto.SEMVER.patch, commits: [], fullReleaseNotes: "", releaseNotes: "" });
+      const nextVersion = await hooks.next.promise([], { bump: Auto.SEMVER.major, commits: [], fullReleaseNotes: "", releaseNotes: "" });
 
-      expect(nextVersion[0]).toBe("1.0.0-SNAPSHOT")
+      expect(nextVersion[0]).toBe("1.0.0-next.0")
     });
 
     test("should not increment version - next w/ default snapshot", async () => {
-      const properties = "version: 1.0.0-SNAPSHOT";
+      const properties = "version: 1.1.0-SNAPSHOT";
       exec.mockReturnValueOnce(properties);
       await hooks.beforeRun.promise({} as any);
 
@@ -190,9 +198,9 @@ describe("Gradle Plugin", () => {
     
       exec.mockReturnValueOnce(properties).mockImplementation(spy);
 
-      const nextVersion = await hooks.next.promise([], { bump: Auto.SEMVER.patch, commits: [], fullReleaseNotes: "", releaseNotes: "" });
+      const nextVersion = await hooks.next.promise([], { bump: Auto.SEMVER.major, commits: [], fullReleaseNotes: "", releaseNotes: "" });
 
-      expect(nextVersion[0]).toBe("1.0.0-SNAPSHOT")
+      expect(nextVersion[0]).toBe("1.0.0-next.0")
     });
 
     test("should tag release - next w/ default snapshot", async () => {
@@ -204,13 +212,13 @@ describe("Gradle Plugin", () => {
     
       exec.mockReturnValueOnce(properties).mockImplementation(spy);
 
-      await hooks.next.promise([], { bump: Auto.SEMVER.patch, commits: [], fullReleaseNotes: "", releaseNotes: "" });
+      await hooks.next.promise([], { bump: Auto.SEMVER.major, commits: [], fullReleaseNotes: "", releaseNotes: "" });
 
       expect(spy).toHaveBeenCalledWith(expect.stringMatching("git"), [
         "tag",
-        "1.0.0-SNAPSHOT",
+        "1.0.0-next.0",
         "-m",
-        "\"Tag pre-release: 1.0.0-SNAPSHOT\"",
+        "\"Tag pre-release: 1.0.0-next.0\"",
       ]);
     });
 

--- a/plugins/gradle/__tests__/gradle.test.ts
+++ b/plugins/gradle/__tests__/gradle.test.ts
@@ -141,7 +141,20 @@ describe("Gradle Plugin", () => {
       ]);
     });
 
-    test("should version release - canary w/ default snapshot", async () => {
+    test("should not increment version - canary", async () => {
+      const properties = "version: 1.0.0";
+      exec.mockReturnValueOnce(properties);
+      await hooks.beforeRun.promise({} as any);
+
+      const spy = jest.fn();
+      exec.mockReturnValueOnce(properties).mockImplementation(spy);
+
+      const canaryVersion = await hooks.canary.promise({ bump: Auto.SEMVER.patch, canaryIdentifier: "canary123" });
+
+      expect(canaryVersion).toBe("1.0.0-SNAPSHOT")
+    });
+
+    test("should not increment version - canary w/ default snapshot", async () => {
       const properties = "version: 1.0.0-SNAPSHOT";
       exec.mockReturnValueOnce(properties);
       await hooks.beforeRun.promise({} as any);
@@ -155,6 +168,20 @@ describe("Gradle Plugin", () => {
     });
 
     test("should not increment version - next", async () => {
+      const properties = "version: 1.0.0";
+      exec.mockReturnValueOnce(properties);
+      await hooks.beforeRun.promise({} as any);
+
+      const spy = jest.fn();
+    
+      exec.mockReturnValueOnce(properties).mockImplementation(spy);
+
+      const nextVersion = await hooks.next.promise([], { bump: Auto.SEMVER.patch, commits: [], fullReleaseNotes: "", releaseNotes: "" });
+
+      expect(nextVersion[0]).toBe("1.0.0-SNAPSHOT")
+    });
+
+    test("should not increment version - next w/ default snapshot", async () => {
       const properties = "version: 1.0.0-SNAPSHOT";
       exec.mockReturnValueOnce(properties);
       await hooks.beforeRun.promise({} as any);

--- a/plugins/gradle/src/index.ts
+++ b/plugins/gradle/src/index.ts
@@ -300,13 +300,16 @@ export default class GradleReleasePluginPlugin implements IPlugin {
           preReleaseVersions.push(nextVersion);
         }
 
+        const nextRegex = /(-next).*/;
+        const preReleaseSnapshotVersion = nextVersion.replace(nextRegex, defaultSnapshotSuffix)
+
         if (dryRun) {
-          auto.logger.log.info(`Would have published: ${nextVersion}`);
+          auto.logger.log.info(`Would have published: ${preReleaseSnapshotVersion}`);
           return preReleaseVersions;
         }
 
         await this.updateGradleVersion(
-          nextVersion,
+          preReleaseSnapshotVersion,
           `Prerelease version: ${nextVersion} [skip ci]`
         );
 
@@ -317,13 +320,7 @@ export default class GradleReleasePluginPlugin implements IPlugin {
           `"Tag pre-release: ${nextVersion}"`,
         ]);
 
-        await execPromise("git", [
-          "push",
-          "--follow-tags",
-          "--set-upstream",
-          auto.remote,
-          auto.baseBranch,
-        ]);
+        await execPromise("git", ["push", auto.remote, branch, "--tags"]);
 
         const { publish } = this.properties;
 

--- a/plugins/gradle/src/index.ts
+++ b/plugins/gradle/src/index.ts
@@ -246,7 +246,7 @@ export default class GradleReleasePluginPlugin implements IPlugin {
 
     auto.hooks.canary.tapPromise(
       this.name,
-      async ({ dryRun, quiet, canaryIdentifier }) => {
+      async ({ dryRun, canaryIdentifier }) => {
         const releaseVersion = await getVersion(
           this.options.gradleCommand,
           this.options.gradleOptions

--- a/plugins/gradle/src/index.ts
+++ b/plugins/gradle/src/index.ts
@@ -255,7 +255,7 @@ export default class GradleReleasePluginPlugin implements IPlugin {
           if (quiet) {
             console.log(canaryVersion);
           } else {
-            auto.logger.log.info(`Would have published: ${releaseVersion}`);
+            auto.logger.log.info(`Would have published Canary: ${releaseVersion}`);
           }
 
           return canaryVersion;
@@ -304,7 +304,7 @@ export default class GradleReleasePluginPlugin implements IPlugin {
         const preReleaseSnapshotVersion = nextVersion.replace(nextRegex, defaultSnapshotSuffix)
 
         if (dryRun) {
-          auto.logger.log.info(`Would have published: ${preReleaseSnapshotVersion}`);
+          auto.logger.log.info(`Would have published Next: ${preReleaseSnapshotVersion}`);
           return preReleaseVersions;
         }
 

--- a/plugins/gradle/src/index.ts
+++ b/plugins/gradle/src/index.ts
@@ -255,10 +255,7 @@ export default class GradleReleasePluginPlugin implements IPlugin {
         const canaryVersion = `${releaseVersion}-${canaryIdentifier}`;
 
         if (dryRun) {
-          if (quiet) {
-            console.log(canaryVersion);
-          }
-
+          auto.logger.log.info(`Would have published: ${canaryVersion}`);
           return canaryVersion;
         }
 

--- a/plugins/gradle/src/index.ts
+++ b/plugins/gradle/src/index.ts
@@ -318,11 +318,6 @@ export default class GradleReleasePluginPlugin implements IPlugin {
 
     auto.hooks.afterShipIt.tapPromise(this.name, async ({ dryRun }) => {
       if (!this.snapshotRelease || dryRun) {
-        if (dryRun) {
-          auto.logger.log.info(`+++++AFTERSHIPIT
-            `);
-        }
-
         return;
       }
 

--- a/plugins/gradle/src/index.ts
+++ b/plugins/gradle/src/index.ts
@@ -339,7 +339,7 @@ export default class GradleReleasePluginPlugin implements IPlugin {
     );
 
     auto.hooks.afterShipIt.tapPromise(this.name, async ({ dryRun, context }) => {
-      if (!this.snapshotRelease || dryRun || context != "latest") {
+      if (!this.snapshotRelease || dryRun || context !== "latest") {
         return;
       }
 


### PR DESCRIPTION
# What Changed

Tap into canary and next hooks in Gradle plugin to handle canary and prerelease

## Why

Todo:

- [x] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux-canary.1842.22803.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux-canary.1842.22803.gz)  
[auto-macos-canary.1842.22803.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos-canary.1842.22803.gz)  
[auto-win.exe-canary.1842.22803.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe-canary.1842.22803.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.18.4-canary.1842.22803.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.18.4-canary.1842.22803.0
  npm install @auto-canary/auto@10.18.4-canary.1842.22803.0
  npm install @auto-canary/core@10.18.4-canary.1842.22803.0
  npm install @auto-canary/package-json-utils@10.18.4-canary.1842.22803.0
  npm install @auto-canary/all-contributors@10.18.4-canary.1842.22803.0
  npm install @auto-canary/brew@10.18.4-canary.1842.22803.0
  npm install @auto-canary/chrome@10.18.4-canary.1842.22803.0
  npm install @auto-canary/cocoapods@10.18.4-canary.1842.22803.0
  npm install @auto-canary/conventional-commits@10.18.4-canary.1842.22803.0
  npm install @auto-canary/crates@10.18.4-canary.1842.22803.0
  npm install @auto-canary/docker@10.18.4-canary.1842.22803.0
  npm install @auto-canary/exec@10.18.4-canary.1842.22803.0
  npm install @auto-canary/first-time-contributor@10.18.4-canary.1842.22803.0
  npm install @auto-canary/gem@10.18.4-canary.1842.22803.0
  npm install @auto-canary/gh-pages@10.18.4-canary.1842.22803.0
  npm install @auto-canary/git-tag@10.18.4-canary.1842.22803.0
  npm install @auto-canary/gradle@10.18.4-canary.1842.22803.0
  npm install @auto-canary/jira@10.18.4-canary.1842.22803.0
  npm install @auto-canary/magic-zero@10.18.4-canary.1842.22803.0
  npm install @auto-canary/maven@10.18.4-canary.1842.22803.0
  npm install @auto-canary/microsoft-teams@10.18.4-canary.1842.22803.0
  npm install @auto-canary/npm@10.18.4-canary.1842.22803.0
  npm install @auto-canary/omit-commits@10.18.4-canary.1842.22803.0
  npm install @auto-canary/omit-release-notes@10.18.4-canary.1842.22803.0
  npm install @auto-canary/pr-body-labels@10.18.4-canary.1842.22803.0
  npm install @auto-canary/released@10.18.4-canary.1842.22803.0
  npm install @auto-canary/s3@10.18.4-canary.1842.22803.0
  npm install @auto-canary/slack@10.18.4-canary.1842.22803.0
  npm install @auto-canary/twitter@10.18.4-canary.1842.22803.0
  npm install @auto-canary/upload-assets@10.18.4-canary.1842.22803.0
  npm install @auto-canary/vscode@10.18.4-canary.1842.22803.0
  # or 
  yarn add @auto-canary/bot-list@10.18.4-canary.1842.22803.0
  yarn add @auto-canary/auto@10.18.4-canary.1842.22803.0
  yarn add @auto-canary/core@10.18.4-canary.1842.22803.0
  yarn add @auto-canary/package-json-utils@10.18.4-canary.1842.22803.0
  yarn add @auto-canary/all-contributors@10.18.4-canary.1842.22803.0
  yarn add @auto-canary/brew@10.18.4-canary.1842.22803.0
  yarn add @auto-canary/chrome@10.18.4-canary.1842.22803.0
  yarn add @auto-canary/cocoapods@10.18.4-canary.1842.22803.0
  yarn add @auto-canary/conventional-commits@10.18.4-canary.1842.22803.0
  yarn add @auto-canary/crates@10.18.4-canary.1842.22803.0
  yarn add @auto-canary/docker@10.18.4-canary.1842.22803.0
  yarn add @auto-canary/exec@10.18.4-canary.1842.22803.0
  yarn add @auto-canary/first-time-contributor@10.18.4-canary.1842.22803.0
  yarn add @auto-canary/gem@10.18.4-canary.1842.22803.0
  yarn add @auto-canary/gh-pages@10.18.4-canary.1842.22803.0
  yarn add @auto-canary/git-tag@10.18.4-canary.1842.22803.0
  yarn add @auto-canary/gradle@10.18.4-canary.1842.22803.0
  yarn add @auto-canary/jira@10.18.4-canary.1842.22803.0
  yarn add @auto-canary/magic-zero@10.18.4-canary.1842.22803.0
  yarn add @auto-canary/maven@10.18.4-canary.1842.22803.0
  yarn add @auto-canary/microsoft-teams@10.18.4-canary.1842.22803.0
  yarn add @auto-canary/npm@10.18.4-canary.1842.22803.0
  yarn add @auto-canary/omit-commits@10.18.4-canary.1842.22803.0
  yarn add @auto-canary/omit-release-notes@10.18.4-canary.1842.22803.0
  yarn add @auto-canary/pr-body-labels@10.18.4-canary.1842.22803.0
  yarn add @auto-canary/released@10.18.4-canary.1842.22803.0
  yarn add @auto-canary/s3@10.18.4-canary.1842.22803.0
  yarn add @auto-canary/slack@10.18.4-canary.1842.22803.0
  yarn add @auto-canary/twitter@10.18.4-canary.1842.22803.0
  yarn add @auto-canary/upload-assets@10.18.4-canary.1842.22803.0
  yarn add @auto-canary/vscode@10.18.4-canary.1842.22803.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
