### PR TITLE
handle capital X in semver bump list

### DIFF
--- a/plugins/pr-body-labels/__tests__/pr-body-labels.test.ts
+++ b/plugins/pr-body-labels/__tests__/pr-body-labels.test.ts
@@ -37,6 +37,23 @@ describe("Pr-Body-Labels Plugin", () => {
     expect(addLabelToPr).toHaveBeenCalledWith(1, "patch");
   });
 
+  test("add labels present in project capital X", async () => {
+    const plugin = new PrBodyLabels();
+    const hooks = makeHooks();
+    const addLabelToPr = jest.fn();
+
+    plugin.apply({
+      hooks,
+      labels: [{ name: "patch" }],
+      git: { addLabelToPr },
+    } as any);
+
+    await hooks.prCheck.promise({
+      pr: { body: "- [X] `patch`", number: 1 },
+    } as any);
+    expect(addLabelToPr).toHaveBeenCalledWith(1, "patch");
+  });
+
   test("not add labels in disabledLabels list", async () => {
     const plugin = new PrBodyLabels({ disabledLabels: ["patch"] });
     const hooks = makeHooks();

--- a/plugins/pr-body-labels/src/index.ts
+++ b/plugins/pr-body-labels/src/index.ts
@@ -32,8 +32,12 @@ export default class PrBodyLabelsPlugin implements IPlugin {
 
       await Promise.all(
         auto.labels.map(async (label) => {
+          const hasCheckedLabel =
+            pr.body?.includes(`- [x] \`${label.name}\``) ||
+            pr.body?.includes(`- [X] \`${label.name}\``);
+
           if (
-            pr.body?.includes(`- [x] \`${label.name}\``) &&
+            hasCheckedLabel &&
             !this.options.disabledLabels.includes(label.name)
           ) {
             await auto.git?.addLabelToPr(pr.number, label.name);


### PR DESCRIPTION
## Why

The plugin wouldn't pick up the check if it was capital

Todo:

- [x] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux-canary.1849.22770.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux-canary.1849.22770.gz)  
[auto-macos-canary.1849.22770.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos-canary.1849.22770.gz)  
[auto-win.exe-canary.1849.22770.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe-canary.1849.22770.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->
