### PR TITLE
Add leading hyphen to canary identifier so that canaries always sort before any other release type

### DIFF
--- a/packages/core/src/__tests__/auto-canary-local.test.ts
+++ b/packages/core/src/__tests__/auto-canary-local.test.ts
@@ -50,7 +50,7 @@ test("shipit should publish canary in locally when not on baseBranch", async () 
   expect(canary).toHaveBeenCalledWith(
     expect.objectContaining({
       bump: SEMVER.patch,
-      canaryIdentifier: "canary.abcdefg",
+      canaryIdentifier: "-canary.abcdefg",
     })
   );
 });

--- a/packages/core/src/__tests__/auto-in-pr-ci.test.ts
+++ b/packages/core/src/__tests__/auto-in-pr-ci.test.ts
@@ -68,7 +68,7 @@ describe("canary in ci", () => {
     expect(canary).toHaveBeenCalledWith(
       expect.objectContaining({
         bump: SEMVER.patch,
-        canaryIdentifier: "canary.123.1",
+        canaryIdentifier: "-canary.123.1",
       })
     );
   });
@@ -153,7 +153,7 @@ describe("canary in ci", () => {
     );
 
     const version = await auto.canary({ pr: 456, build: 5 });
-    expect(version!.newVersion).toBe("1.2.4-canary.456.5");
+    expect(version!.newVersion).toBe("1.2.4--canary.456.5");
   });
 });
 
@@ -177,7 +177,7 @@ describe("shipit in ci", () => {
     expect(canary).toHaveBeenCalledWith(
       expect.objectContaining({
         bump: SEMVER.patch,
-        canaryIdentifier: "canary.123.1",
+        canaryIdentifier: "-canary.123.1",
       })
     );
   });

--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -1172,7 +1172,7 @@ describe("Auto", () => {
       expect(canary).toHaveBeenCalledWith(
         expect.objectContaining({
           bump: SEMVER.patch,
-          canaryIdentifier: "canary.123.1",
+          canaryIdentifier: "-canary.123.1",
         })
       );
       expect(auto.git!.addToPrBody).toHaveBeenCalled();
@@ -1197,7 +1197,7 @@ describe("Auto", () => {
       expect(canary).toHaveBeenCalledWith(
         expect.objectContaining({
           bump: SEMVER.patch,
-          canaryIdentifier: "canary.abc",
+          canaryIdentifier: "-canary.abc",
         })
       );
     });
@@ -1241,7 +1241,7 @@ describe("Auto", () => {
       expect(canary).toHaveBeenCalledWith(
         expect.objectContaining({
           bump: SEMVER.patch,
-          canaryIdentifier: "canary.abcd",
+          canaryIdentifier: "-canary.abcd",
         })
       );
     });
@@ -1290,7 +1290,7 @@ describe("Auto", () => {
       expect(canary).toHaveBeenCalledWith(
         expect.objectContaining({
           bump: SEMVER.patch,
-          canaryIdentifier: "canary.abcd",
+          canaryIdentifier: "-canary.abcd",
         })
       );
     });

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1257,7 +1257,7 @@ export default class Auto {
       ).slice(0, 7)}`;
     }
 
-    canaryIdentifier = `canary${canaryIdentifier}`;
+    canaryIdentifier = `-canary${canaryIdentifier}`;
 
     this.logger.verbose.info("Calling canary hook");
     const result = await this.hooks.canary.promise({


### PR DESCRIPTION
# What Changed

see title

## Why

canary version would sort after certain prerelease tags, making it so that a version range for that prerelease might install a canary

Todo:

- [x] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux--canary.1851.22784.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux--canary.1851.22784.gz)  
[auto-macos--canary.1851.22784.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos--canary.1851.22784.gz)  
[auto-win.exe--canary.1851.22784.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe--canary.1851.22784.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.18.3--canary.1851.22784.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.18.3--canary.1851.22784.0
  npm install @auto-canary/auto@10.18.3--canary.1851.22784.0
  npm install @auto-canary/core@10.18.3--canary.1851.22784.0
  npm install @auto-canary/package-json-utils@10.18.3--canary.1851.22784.0
  npm install @auto-canary/all-contributors@10.18.3--canary.1851.22784.0
  npm install @auto-canary/brew@10.18.3--canary.1851.22784.0
  npm install @auto-canary/chrome@10.18.3--canary.1851.22784.0
  npm install @auto-canary/cocoapods@10.18.3--canary.1851.22784.0
  npm install @auto-canary/conventional-commits@10.18.3--canary.1851.22784.0
  npm install @auto-canary/crates@10.18.3--canary.1851.22784.0
  npm install @auto-canary/docker@10.18.3--canary.1851.22784.0
  npm install @auto-canary/exec@10.18.3--canary.1851.22784.0
  npm install @auto-canary/first-time-contributor@10.18.3--canary.1851.22784.0
  npm install @auto-canary/gem@10.18.3--canary.1851.22784.0
  npm install @auto-canary/gh-pages@10.18.3--canary.1851.22784.0
  npm install @auto-canary/git-tag@10.18.3--canary.1851.22784.0
  npm install @auto-canary/gradle@10.18.3--canary.1851.22784.0
  npm install @auto-canary/jira@10.18.3--canary.1851.22784.0
  npm install @auto-canary/magic-zero@10.18.3--canary.1851.22784.0
  npm install @auto-canary/maven@10.18.3--canary.1851.22784.0
  npm install @auto-canary/microsoft-teams@10.18.3--canary.1851.22784.0
  npm install @auto-canary/npm@10.18.3--canary.1851.22784.0
  npm install @auto-canary/omit-commits@10.18.3--canary.1851.22784.0
  npm install @auto-canary/omit-release-notes@10.18.3--canary.1851.22784.0
  npm install @auto-canary/pr-body-labels@10.18.3--canary.1851.22784.0
  npm install @auto-canary/released@10.18.3--canary.1851.22784.0
  npm install @auto-canary/s3@10.18.3--canary.1851.22784.0
  npm install @auto-canary/slack@10.18.3--canary.1851.22784.0
  npm install @auto-canary/twitter@10.18.3--canary.1851.22784.0
  npm install @auto-canary/upload-assets@10.18.3--canary.1851.22784.0
  npm install @auto-canary/vscode@10.18.3--canary.1851.22784.0
  # or 
  yarn add @auto-canary/bot-list@10.18.3--canary.1851.22784.0
  yarn add @auto-canary/auto@10.18.3--canary.1851.22784.0
  yarn add @auto-canary/core@10.18.3--canary.1851.22784.0
  yarn add @auto-canary/package-json-utils@10.18.3--canary.1851.22784.0
  yarn add @auto-canary/all-contributors@10.18.3--canary.1851.22784.0
  yarn add @auto-canary/brew@10.18.3--canary.1851.22784.0
  yarn add @auto-canary/chrome@10.18.3--canary.1851.22784.0
  yarn add @auto-canary/cocoapods@10.18.3--canary.1851.22784.0
  yarn add @auto-canary/conventional-commits@10.18.3--canary.1851.22784.0
  yarn add @auto-canary/crates@10.18.3--canary.1851.22784.0
  yarn add @auto-canary/docker@10.18.3--canary.1851.22784.0
  yarn add @auto-canary/exec@10.18.3--canary.1851.22784.0
  yarn add @auto-canary/first-time-contributor@10.18.3--canary.1851.22784.0
  yarn add @auto-canary/gem@10.18.3--canary.1851.22784.0
  yarn add @auto-canary/gh-pages@10.18.3--canary.1851.22784.0
  yarn add @auto-canary/git-tag@10.18.3--canary.1851.22784.0
  yarn add @auto-canary/gradle@10.18.3--canary.1851.22784.0
  yarn add @auto-canary/jira@10.18.3--canary.1851.22784.0
  yarn add @auto-canary/magic-zero@10.18.3--canary.1851.22784.0
  yarn add @auto-canary/maven@10.18.3--canary.1851.22784.0
  yarn add @auto-canary/microsoft-teams@10.18.3--canary.1851.22784.0
  yarn add @auto-canary/npm@10.18.3--canary.1851.22784.0
  yarn add @auto-canary/omit-commits@10.18.3--canary.1851.22784.0
  yarn add @auto-canary/omit-release-notes@10.18.3--canary.1851.22784.0
  yarn add @auto-canary/pr-body-labels@10.18.3--canary.1851.22784.0
  yarn add @auto-canary/released@10.18.3--canary.1851.22784.0
  yarn add @auto-canary/s3@10.18.3--canary.1851.22784.0
  yarn add @auto-canary/slack@10.18.3--canary.1851.22784.0
  yarn add @auto-canary/twitter@10.18.3--canary.1851.22784.0
  yarn add @auto-canary/upload-assets@10.18.3--canary.1851.22784.0
  yarn add @auto-canary/vscode@10.18.3--canary.1851.22784.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
