### PR TITLE
Slack message spacing + notification text

### DIFF
--- a/plugins/slack/README.md
+++ b/plugins/slack/README.md
@@ -218,7 +218,7 @@ There are a lot of steps to creating a Slack app and installing it.
 Let's go over what you'll need to do to get set up with app auth.
 
 1. [Create the app](https://api.slack.com/apps)
-2. From your app's `Basic Information` page go to `Permissions => Bot Token Scopes` and add `chat:write` and `file:write`
+2. From your app's `Basic Information` page go to `Permissions => Bot Token Scopes` and add `chat:write` and `file:write` (Optionally add `chat:write.customize` to use the `username` and `icon` options)
 3. Copy the `Bot User OAuth Access Token` into your `.env` file and store it as `SLACK_TOKEN`
 4. Install the app in the channels you want it to post to via the Slack UI
 

--- a/plugins/slack/__tests__/__snapshots__/slack.test.ts.snap
+++ b/plugins/slack/__tests__/__snapshots__/slack.test.ts.snap
@@ -316,6 +316,7 @@ Object {
     },
   ],
   "link_names": true,
+  "text": "New Releases: 1.0.0 :tada:",
 }
 `;
 
@@ -363,6 +364,7 @@ Object {
     },
   ],
   "link_names": true,
+  "text": "New Releases: 1.0.0 :tada:",
 }
 `;
 
@@ -416,6 +418,7 @@ Object {
     },
   ],
   "link_names": true,
+  "text": "New Release:  :tada:",
 }
 `;
 
@@ -462,6 +465,7 @@ Object {
     },
   ],
   "link_names": true,
+  "text": "New Release:  :tada:",
 }
 `;
 
@@ -508,6 +512,7 @@ Object {
     },
   ],
   "link_names": true,
+  "text": "New Release:  :tada:",
 }
 `;
 
@@ -554,6 +559,7 @@ Object {
     },
   ],
   "link_names": true,
+  "text": "New Releases: 1.0.0 :tada:",
 }
 `;
 
@@ -600,6 +606,7 @@ Object {
     },
   ],
   "link_names": true,
+  "text": "New Releases: 1.0.0 :tada:",
 }
 `;
 
@@ -646,6 +653,7 @@ Object {
     },
   ],
   "link_names": true,
+  "text": "New Release:  :tada:",
 }
 `;
 
@@ -692,6 +700,7 @@ Object {
     },
   ],
   "link_names": true,
+  "text": "New Releases: 1.0.0 :tada:",
 }
 `;
 
@@ -743,5 +752,6 @@ Object {
     },
   ],
   "link_names": true,
+  "text": "New Releases: 1.0.0 :tada:",
 }
 `;

--- a/plugins/slack/__tests__/__snapshots__/slack.test.ts.snap
+++ b/plugins/slack/__tests__/__snapshots__/slack.test.ts.snap
@@ -32,6 +32,13 @@ Array [
       "type": "section",
     },
     Object {
+      "text": Object {
+        "text": " ",
+        "type": "mrkdwn",
+      },
+      "type": "section",
+    },
+    Object {
       "type": "divider",
     },
     Object {
@@ -51,6 +58,13 @@ Array [
     },
     Object {
       "text": Object {
+        "text": " ",
+        "type": "mrkdwn",
+      },
+      "type": "section",
+    },
+    Object {
+      "text": Object {
         "text": "*📝 Documentation*",
         "type": "mrkdwn",
       },
@@ -59,6 +73,13 @@ Array [
     Object {
       "text": Object {
         "text": "• add automated TOC to hooks documentation <https://github.com/intuit/auto/pull/1801|#1801> (<https://github.com/hipstersmoothie|@hipstersmoothie>)",
+        "type": "mrkdwn",
+      },
+      "type": "section",
+    },
+    Object {
+      "text": Object {
+        "text": " ",
         "type": "mrkdwn",
       },
       "type": "section",
@@ -124,6 +145,13 @@ Array [
       "type": "section",
     },
     Object {
+      "text": Object {
+        "text": " ",
+        "type": "mrkdwn",
+      },
+      "type": "section",
+    },
+    Object {
       "type": "divider",
     },
     Object {
@@ -143,6 +171,13 @@ Array [
     },
     Object {
       "text": Object {
+        "text": " ",
+        "type": "mrkdwn",
+      },
+      "type": "section",
+    },
+    Object {
+      "text": Object {
         "text": "*📝 Documentation*",
         "type": "mrkdwn",
       },
@@ -151,6 +186,13 @@ Array [
     Object {
       "text": Object {
         "text": "• add automated TOC to hooks documentation <https://github.com/intuit/auto/pull/1801|#1801> (<https://github.com/hipstersmoothie|@hipstersmoothie>)",
+        "type": "mrkdwn",
+      },
+      "type": "section",
+    },
+    Object {
+      "text": Object {
+        "text": " ",
         "type": "mrkdwn",
       },
       "type": "section",
@@ -194,6 +236,13 @@ Array [
     Object {
       "text": Object {
         "text": "• build the s3 plugin <https://github.com/intuit/auto/pull/1804|#1804> (<https://github.com/hipstersmoothie|@hipstersmoothie>)",
+        "type": "mrkdwn",
+      },
+      "type": "section",
+    },
+    Object {
+      "text": Object {
+        "text": " ",
         "type": "mrkdwn",
       },
       "type": "section",
@@ -258,6 +307,13 @@ Object {
       },
       "type": "section",
     },
+    Object {
+      "text": Object {
+        "text": " ",
+        "type": "mrkdwn",
+      },
+      "type": "section",
+    },
   ],
   "link_names": true,
 }
@@ -294,6 +350,13 @@ Object {
       "text": Object {
         "text": "• PR <google.com|some link>
    • Another note",
+        "type": "mrkdwn",
+      },
+      "type": "section",
+    },
+    Object {
+      "text": Object {
+        "text": " ",
         "type": "mrkdwn",
       },
       "type": "section",
@@ -344,6 +407,13 @@ Object {
       },
       "type": "section",
     },
+    Object {
+      "text": Object {
+        "text": " ",
+        "type": "mrkdwn",
+      },
+      "type": "section",
+    },
   ],
   "link_names": true,
 }
@@ -379,6 +449,13 @@ Object {
     Object {
       "text": Object {
         "text": "• PR <google.com|some link>",
+        "type": "mrkdwn",
+      },
+      "type": "section",
+    },
+    Object {
+      "text": Object {
+        "text": " ",
         "type": "mrkdwn",
       },
       "type": "section",
@@ -422,6 +499,13 @@ Object {
       },
       "type": "section",
     },
+    Object {
+      "text": Object {
+        "text": " ",
+        "type": "mrkdwn",
+      },
+      "type": "section",
+    },
   ],
   "link_names": true,
 }
@@ -457,6 +541,13 @@ Object {
     Object {
       "text": Object {
         "text": "• PR <google.com|some link>",
+        "type": "mrkdwn",
+      },
+      "type": "section",
+    },
+    Object {
+      "text": Object {
+        "text": " ",
         "type": "mrkdwn",
       },
       "type": "section",
@@ -500,6 +591,13 @@ Object {
       },
       "type": "section",
     },
+    Object {
+      "text": Object {
+        "text": " ",
+        "type": "mrkdwn",
+      },
+      "type": "section",
+    },
   ],
   "link_names": true,
 }
@@ -539,6 +637,13 @@ Object {
       },
       "type": "section",
     },
+    Object {
+      "text": Object {
+        "text": " ",
+        "type": "mrkdwn",
+      },
+      "type": "section",
+    },
   ],
   "link_names": true,
 }
@@ -574,6 +679,13 @@ Object {
     Object {
       "text": Object {
         "text": "• PR <google.com|some link>",
+        "type": "mrkdwn",
+      },
+      "type": "section",
+    },
+    Object {
+      "text": Object {
+        "text": " ",
         "type": "mrkdwn",
       },
       "type": "section",

--- a/plugins/slack/src/index.ts
+++ b/plugins/slack/src/index.ts
@@ -371,13 +371,14 @@ export default class SlackPlugin implements IPlugin {
         await last;
 
         if (Array.isArray(message)) {
-          await channels.reduce(async (lastMessage, channel) => {
+          await channels.reduce(async (lastMessage, channel, index) => {
             await lastMessage;
             await fetch("https://slack.com/api/chat.postMessage", {
               method: "POST",
               body: JSON.stringify({
                 ...userPostMessageOptions,
                 channel,
+                text: index === 0 ? `${header} :tada:` : undefined,
                 blocks: message,
                 link_names: true,
               }),
@@ -414,6 +415,7 @@ export default class SlackPlugin implements IPlugin {
         body: JSON.stringify({
           ...userPostMessageOptions,
           link_names: true,
+          text: `${header} :tada:`,
           // If not in app auth only one message is constructed
           blocks: messages[0],
         }),

--- a/plugins/slack/src/index.ts
+++ b/plugins/slack/src/index.ts
@@ -48,6 +48,15 @@ const createSectionBlock = (text: string) => ({
   },
 });
 
+/** Create some space in the message */
+const createSpacerBlock = () => ({
+  type: "section" as const,
+  text: {
+    type: "mrkdwn",
+    text: " ",
+  },
+});
+
 /** Create slack header block */
 const createHeaderBlock = (text: string) => ({
   type: "header" as const,
@@ -96,6 +105,7 @@ export function convertToBlocks(
     if (line.startsWith("#")) {
       currentMessage.push(createSectionBlock(`*${line.replace(/^[#]+/, "")}*`));
     } else if (line === "---") {
+      currentMessage.push(createSpacerBlock());
       currentMessage.push(createDividerBlock());
     } else if (line.startsWith("```")) {
       const [, language] = line.match(/```(\S+)/) || ["", "detect"];
@@ -147,6 +157,7 @@ export function convertToBlocks(
       }
 
       currentMessage.push(createSectionBlock(lines.join("\n")));
+      currentMessage.push(createSpacerBlock());
     } else if (line) {
       currentMessage.push(createSectionBlock(line));
     }


### PR DESCRIPTION
# What Changed

Adds a bit more space to slack changelogs and fixes the notification text

## Why

It was displaying "cannot be displayed" in notification

Todo:

- [x] Add tests

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
