### PR TITLE
wrap canary identifier in quotes so terminal understands it's an argument to the --preid flag

### DIFF
--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -1053,7 +1053,7 @@ export default class NPMPlugin implements IPlugin {
               "--exact",
               "--ignore-scripts",
               "--preid",
-              canaryIdentifier,
+              `"${canaryIdentifier}"`,
               ...verboseArgs,
             ]);
 
@@ -1078,7 +1078,7 @@ export default class NPMPlugin implements IPlugin {
             "--no-git-reset", // so we can get the version that just published
             "--no-git-tag-version", // no need to tag and commit,
             "--exact", // do not add ^ to canary versions, this can result in `npm i` resolving the wrong canary version
-            ...(isIndependent ? ["--preid", canaryIdentifier] : []),
+            ...(isIndependent ? ["--preid", `"${canaryIdentifier}"`] : []),
             ...verboseArgs,
           ]);
 

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -1053,7 +1053,7 @@ export default class NPMPlugin implements IPlugin {
               "--exact",
               "--ignore-scripts",
               "--preid",
-              `"${canaryIdentifier}"`,
+              canaryIdentifier.replace(/^-/, ''),
               ...verboseArgs,
             ]);
 
@@ -1078,7 +1078,7 @@ export default class NPMPlugin implements IPlugin {
             "--no-git-reset", // so we can get the version that just published
             "--no-git-tag-version", // no need to tag and commit,
             "--exact", // do not add ^ to canary versions, this can result in `npm i` resolving the wrong canary version
-            ...(isIndependent ? ["--preid", `"${canaryIdentifier}"`] : []),
+            ...(isIndependent ? ["--preid", canaryIdentifier.replace(/^-/, '')] : []),
             ...verboseArgs,
           ]);
 


### PR DESCRIPTION
# What Changed

## Why

closes #1863

Todo:

- [ ] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux--canary.1864.22906.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux--canary.1864.22906.gz)  
[auto-macos--canary.1864.22906.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos--canary.1864.22906.gz)  
[auto-win.exe--canary.1864.22906.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe--canary.1864.22906.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.18.5--canary.1864.22906.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.18.5--canary.1864.22906.0
  npm install @auto-canary/auto@10.18.5--canary.1864.22906.0
  npm install @auto-canary/core@10.18.5--canary.1864.22906.0
  npm install @auto-canary/package-json-utils@10.18.5--canary.1864.22906.0
  npm install @auto-canary/all-contributors@10.18.5--canary.1864.22906.0
  npm install @auto-canary/brew@10.18.5--canary.1864.22906.0
  npm install @auto-canary/chrome@10.18.5--canary.1864.22906.0
  npm install @auto-canary/cocoapods@10.18.5--canary.1864.22906.0
  npm install @auto-canary/conventional-commits@10.18.5--canary.1864.22906.0
  npm install @auto-canary/crates@10.18.5--canary.1864.22906.0
  npm install @auto-canary/docker@10.18.5--canary.1864.22906.0
  npm install @auto-canary/exec@10.18.5--canary.1864.22906.0
  npm install @auto-canary/first-time-contributor@10.18.5--canary.1864.22906.0
  npm install @auto-canary/gem@10.18.5--canary.1864.22906.0
  npm install @auto-canary/gh-pages@10.18.5--canary.1864.22906.0
  npm install @auto-canary/git-tag@10.18.5--canary.1864.22906.0
  npm install @auto-canary/gradle@10.18.5--canary.1864.22906.0
  npm install @auto-canary/jira@10.18.5--canary.1864.22906.0
  npm install @auto-canary/magic-zero@10.18.5--canary.1864.22906.0
  npm install @auto-canary/maven@10.18.5--canary.1864.22906.0
  npm install @auto-canary/microsoft-teams@10.18.5--canary.1864.22906.0
  npm install @auto-canary/npm@10.18.5--canary.1864.22906.0
  npm install @auto-canary/omit-commits@10.18.5--canary.1864.22906.0
  npm install @auto-canary/omit-release-notes@10.18.5--canary.1864.22906.0
  npm install @auto-canary/pr-body-labels@10.18.5--canary.1864.22906.0
  npm install @auto-canary/released@10.18.5--canary.1864.22906.0
  npm install @auto-canary/s3@10.18.5--canary.1864.22906.0
  npm install @auto-canary/slack@10.18.5--canary.1864.22906.0
  npm install @auto-canary/twitter@10.18.5--canary.1864.22906.0
  npm install @auto-canary/upload-assets@10.18.5--canary.1864.22906.0
  npm install @auto-canary/vscode@10.18.5--canary.1864.22906.0
  # or 
  yarn add @auto-canary/bot-list@10.18.5--canary.1864.22906.0
  yarn add @auto-canary/auto@10.18.5--canary.1864.22906.0
  yarn add @auto-canary/core@10.18.5--canary.1864.22906.0
  yarn add @auto-canary/package-json-utils@10.18.5--canary.1864.22906.0
  yarn add @auto-canary/all-contributors@10.18.5--canary.1864.22906.0
  yarn add @auto-canary/brew@10.18.5--canary.1864.22906.0
  yarn add @auto-canary/chrome@10.18.5--canary.1864.22906.0
  yarn add @auto-canary/cocoapods@10.18.5--canary.1864.22906.0
  yarn add @auto-canary/conventional-commits@10.18.5--canary.1864.22906.0
  yarn add @auto-canary/crates@10.18.5--canary.1864.22906.0
  yarn add @auto-canary/docker@10.18.5--canary.1864.22906.0
  yarn add @auto-canary/exec@10.18.5--canary.1864.22906.0
  yarn add @auto-canary/first-time-contributor@10.18.5--canary.1864.22906.0
  yarn add @auto-canary/gem@10.18.5--canary.1864.22906.0
  yarn add @auto-canary/gh-pages@10.18.5--canary.1864.22906.0
  yarn add @auto-canary/git-tag@10.18.5--canary.1864.22906.0
  yarn add @auto-canary/gradle@10.18.5--canary.1864.22906.0
  yarn add @auto-canary/jira@10.18.5--canary.1864.22906.0
  yarn add @auto-canary/magic-zero@10.18.5--canary.1864.22906.0
  yarn add @auto-canary/maven@10.18.5--canary.1864.22906.0
  yarn add @auto-canary/microsoft-teams@10.18.5--canary.1864.22906.0
  yarn add @auto-canary/npm@10.18.5--canary.1864.22906.0
  yarn add @auto-canary/omit-commits@10.18.5--canary.1864.22906.0
  yarn add @auto-canary/omit-release-notes@10.18.5--canary.1864.22906.0
  yarn add @auto-canary/pr-body-labels@10.18.5--canary.1864.22906.0
  yarn add @auto-canary/released@10.18.5--canary.1864.22906.0
  yarn add @auto-canary/s3@10.18.5--canary.1864.22906.0
  yarn add @auto-canary/slack@10.18.5--canary.1864.22906.0
  yarn add @auto-canary/twitter@10.18.5--canary.1864.22906.0
  yarn add @auto-canary/upload-assets@10.18.5--canary.1864.22906.0
  yarn add @auto-canary/vscode@10.18.5--canary.1864.22906.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
