### PR TITLE
fix PR label calculation

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1224,7 +1224,7 @@ export default class Auto {
 
     if (pr) {
       const prLabels = await this.git.getLabels(Number(pr));
-      labels.push(prLabels);
+      labels.unshift(prLabels);
     }
 
     let bump = calculateSemVerBump(labels, this.semVerLabels!, this.config);


### PR DESCRIPTION
# What Changed

Was making the wrong set of labels head.

## Why

Issue came up in https://github.com/intuit/auto/discussions/1861

Todo:

- [x] Add tests

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux--canary.1865.22897.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux--canary.1865.22897.gz)  
[auto-macos--canary.1865.22897.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos--canary.1865.22897.gz)  
[auto-win.exe--canary.1865.22897.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe--canary.1865.22897.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.18.5--canary.1865.22897.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.18.5--canary.1865.22897.0
  npm install @auto-canary/auto@10.18.5--canary.1865.22897.0
  npm install @auto-canary/core@10.18.5--canary.1865.22897.0
  npm install @auto-canary/package-json-utils@10.18.5--canary.1865.22897.0
  npm install @auto-canary/all-contributors@10.18.5--canary.1865.22897.0
  npm install @auto-canary/brew@10.18.5--canary.1865.22897.0
  npm install @auto-canary/chrome@10.18.5--canary.1865.22897.0
  npm install @auto-canary/cocoapods@10.18.5--canary.1865.22897.0
  npm install @auto-canary/conventional-commits@10.18.5--canary.1865.22897.0
  npm install @auto-canary/crates@10.18.5--canary.1865.22897.0
  npm install @auto-canary/docker@10.18.5--canary.1865.22897.0
  npm install @auto-canary/exec@10.18.5--canary.1865.22897.0
  npm install @auto-canary/first-time-contributor@10.18.5--canary.1865.22897.0
  npm install @auto-canary/gem@10.18.5--canary.1865.22897.0
  npm install @auto-canary/gh-pages@10.18.5--canary.1865.22897.0
  npm install @auto-canary/git-tag@10.18.5--canary.1865.22897.0
  npm install @auto-canary/gradle@10.18.5--canary.1865.22897.0
  npm install @auto-canary/jira@10.18.5--canary.1865.22897.0
  npm install @auto-canary/magic-zero@10.18.5--canary.1865.22897.0
  npm install @auto-canary/maven@10.18.5--canary.1865.22897.0
  npm install @auto-canary/microsoft-teams@10.18.5--canary.1865.22897.0
  npm install @auto-canary/npm@10.18.5--canary.1865.22897.0
  npm install @auto-canary/omit-commits@10.18.5--canary.1865.22897.0
  npm install @auto-canary/omit-release-notes@10.18.5--canary.1865.22897.0
  npm install @auto-canary/pr-body-labels@10.18.5--canary.1865.22897.0
  npm install @auto-canary/released@10.18.5--canary.1865.22897.0
  npm install @auto-canary/s3@10.18.5--canary.1865.22897.0
  npm install @auto-canary/slack@10.18.5--canary.1865.22897.0
  npm install @auto-canary/twitter@10.18.5--canary.1865.22897.0
  npm install @auto-canary/upload-assets@10.18.5--canary.1865.22897.0
  npm install @auto-canary/vscode@10.18.5--canary.1865.22897.0
  # or 
  yarn add @auto-canary/bot-list@10.18.5--canary.1865.22897.0
  yarn add @auto-canary/auto@10.18.5--canary.1865.22897.0
  yarn add @auto-canary/core@10.18.5--canary.1865.22897.0
  yarn add @auto-canary/package-json-utils@10.18.5--canary.1865.22897.0
  yarn add @auto-canary/all-contributors@10.18.5--canary.1865.22897.0
  yarn add @auto-canary/brew@10.18.5--canary.1865.22897.0
  yarn add @auto-canary/chrome@10.18.5--canary.1865.22897.0
  yarn add @auto-canary/cocoapods@10.18.5--canary.1865.22897.0
  yarn add @auto-canary/conventional-commits@10.18.5--canary.1865.22897.0
  yarn add @auto-canary/crates@10.18.5--canary.1865.22897.0
  yarn add @auto-canary/docker@10.18.5--canary.1865.22897.0
  yarn add @auto-canary/exec@10.18.5--canary.1865.22897.0
  yarn add @auto-canary/first-time-contributor@10.18.5--canary.1865.22897.0
  yarn add @auto-canary/gem@10.18.5--canary.1865.22897.0
  yarn add @auto-canary/gh-pages@10.18.5--canary.1865.22897.0
  yarn add @auto-canary/git-tag@10.18.5--canary.1865.22897.0
  yarn add @auto-canary/gradle@10.18.5--canary.1865.22897.0
  yarn add @auto-canary/jira@10.18.5--canary.1865.22897.0
  yarn add @auto-canary/magic-zero@10.18.5--canary.1865.22897.0
  yarn add @auto-canary/maven@10.18.5--canary.1865.22897.0
  yarn add @auto-canary/microsoft-teams@10.18.5--canary.1865.22897.0
  yarn add @auto-canary/npm@10.18.5--canary.1865.22897.0
  yarn add @auto-canary/omit-commits@10.18.5--canary.1865.22897.0
  yarn add @auto-canary/omit-release-notes@10.18.5--canary.1865.22897.0
  yarn add @auto-canary/pr-body-labels@10.18.5--canary.1865.22897.0
  yarn add @auto-canary/released@10.18.5--canary.1865.22897.0
  yarn add @auto-canary/s3@10.18.5--canary.1865.22897.0
  yarn add @auto-canary/slack@10.18.5--canary.1865.22897.0
  yarn add @auto-canary/twitter@10.18.5--canary.1865.22897.0
  yarn add @auto-canary/upload-assets@10.18.5--canary.1865.22897.0
  yarn add @auto-canary/vscode@10.18.5--canary.1865.22897.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
