### PR TITLE
don't include private packages in canary install list

### DIFF
--- a/packages/core/src/utils/__tests__/get-lerna-packages.test.ts
+++ b/packages/core/src/utils/__tests__/get-lerna-packages.test.ts
@@ -1,0 +1,22 @@
+import endent from "endent";
+import execPromise from "../exec-promise";
+import getLernaPackages from "../get-lerna-packages";
+
+const exec = jest.fn();
+jest.mock("../exec-promise");
+// @ts-ignore
+execPromise.mockImplementation(exec);
+
+test("it shouldn't included private packages", async () => {
+  exec.mockReturnValue(endent`
+    /dir/a:a:0.3.0--canary.32.d54a0c4.0
+    /dir/b:b:MISSING:PRIVATE
+  `);
+  expect(await getLernaPackages()).toStrictEqual([
+    {
+      name: "a",
+      path: "/dir/a",
+      version: "0.3.0--canary.32.d54a0c4.0",
+    },
+  ]);
+});

--- a/packages/core/src/utils/get-lerna-packages.ts
+++ b/packages/core/src/utils/get-lerna-packages.ts
@@ -10,11 +10,17 @@ export interface LernaPackage {
 }
 
 /** Get all of the packages in the lerna monorepo */
-export default async function getLernaPackages(): Promise<LernaPackage[]> {
-  return execPromise("npx", ["lerna", "ls", "-pla"]).then((res) =>
-    res.split("\n").map((packageInfo) => {
-      const [packagePath, name, version] = packageInfo.split(":");
-      return { path: packagePath, name, version };
-    })
-  );
+export default async function getLernaPackages() {
+  const packages: LernaPackage[] = [];
+  const response = await execPromise("npx", ["lerna", "ls", "-pla"]);
+
+  response.split("\n").forEach((packageInfo) => {
+    const [packagePath, name, version] = packageInfo.split(":");
+
+    if (version !== "MISSING") {
+      packages.push({ path: packagePath, name, version });
+    }
+  });
+
+  return packages;
 }

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -1053,7 +1053,7 @@ export default class NPMPlugin implements IPlugin {
               "--exact",
               "--ignore-scripts",
               "--preid",
-              canaryIdentifier.replace(/^-/, ''),
+              canaryIdentifier.replace(/^-/, ""),
               ...verboseArgs,
             ]);
 
@@ -1078,7 +1078,9 @@ export default class NPMPlugin implements IPlugin {
             "--no-git-reset", // so we can get the version that just published
             "--no-git-tag-version", // no need to tag and commit,
             "--exact", // do not add ^ to canary versions, this can result in `npm i` resolving the wrong canary version
-            ...(isIndependent ? ["--preid", canaryIdentifier.replace(/^-/, '')] : []),
+            ...(isIndependent
+              ? ["--preid", canaryIdentifier.replace(/^-/, "")]
+              : []),
             ...verboseArgs,
           ]);
 


### PR DESCRIPTION
# What Changed

see title

## Why

Private packages were showing up in canary install list for lerna monorepos

Todo:

- [x] Add tests

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux--canary.1866.22926.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux--canary.1866.22926.gz)  
[auto-macos--canary.1866.22926.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos--canary.1866.22926.gz)  
[auto-win.exe--canary.1866.22926.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe--canary.1866.22926.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->
