### PR TITLE
next: handle baseBranch not on remote on fresh repo

### DIFF
--- a/packages/core/src/__tests__/next.test.ts
+++ b/packages/core/src/__tests__/next.test.ts
@@ -1,0 +1,106 @@
+import { Auto } from "../auto";
+import { dummyLog } from "../utils/logger";
+import makeCommitFromMsg from "./make-commit-from-msg";
+import execPromise from "../utils/exec-promise";
+
+const exec = jest.fn();
+jest.mock("../utils/exec-promise");
+// @ts-ignore
+execPromise.mockImplementation(exec);
+exec.mockResolvedValue("");
+
+jest.mock("../utils/git-reset.ts");
+jest.mock("../utils/load-plugins.ts");
+jest.mock("env-ci", () => () => ({ isCi: false, branch: "next" }));
+
+const defaults = {
+  baseBranch: "main",
+  owner: "foo",
+  repo: "bar",
+};
+
+jest.mock("@octokit/rest", () => {
+  const Octokit = class MockOctokit {
+    static plugin = () => Octokit;
+
+    authenticate = () => undefined;
+
+    search = {
+      issuesAndPullRequests: () => ({ data: { items: [] } }),
+    };
+
+    repos = {
+      get: jest.fn().mockReturnValue({}),
+    };
+
+    hook = {
+      error: () => undefined,
+    };
+
+    issues = {
+      listLabelsOnIssue: jest.fn().mockReturnValue({ data: [] }),
+    };
+
+    users = {
+      getAuthenticated: jest.fn().mockResolvedValue({}),
+    };
+  };
+
+  return { Octokit };
+});
+
+// @ts-ignore
+jest.mock("gitlog", () => ({
+  gitlogPromise: () =>
+    Promise.resolve([
+      {
+        rawBody: "foo",
+        hash: "123",
+      },
+      {
+        rawBody: "foo",
+        hash: "456",
+      },
+    ]),
+}));
+
+test("falls back to local baseBranch if it doesn't exist on origin", async () => {
+  const auto = new Auto({ ...defaults, plugins: [] });
+
+  // @ts-ignore
+  auto.checkClean = () => Promise.resolve(true);
+  auto.logger = dummyLog();
+  await auto.loadConfig();
+  auto.remote = "origin";
+  auto.git!.publish = () => Promise.resolve({ data: {} } as any);
+  auto.git!.getLastTagNotInBaseBranch = () => Promise.reject(new Error("Test"));
+  auto.git!.getLatestTagInBranch = () => Promise.reject(new Error("Test"));
+  auto.git!.getLatestRelease = () => Promise.resolve("abcd");
+  auto.release!.generateReleaseNotes = () => Promise.resolve("notes");
+  auto.release!.getCommitsInRelease = () =>
+    Promise.resolve([
+      makeCommitFromMsg("Test Commit", { labels: ["skip-release"] }),
+    ]);
+
+  jest.spyOn(auto.release!, "getCommits").mockImplementation();
+  const next = jest.fn();
+  auto.hooks.next.tap("test", next);
+
+  await auto.next({});
+  expect(exec).toHaveBeenCalledWith("git", [
+    "rev-list",
+    "--boundary",
+    "next...origin/main",
+    "--left-only",
+  ]);
+
+  auto.git!.shaExists = () => Promise.resolve(false);
+
+  await auto.next({});
+  expect(exec).toHaveBeenCalledWith("git", [
+    "rev-list",
+    "--boundary",
+    "next...main",
+    "--left-only",
+  ]);
+});

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1362,11 +1362,15 @@ export default class Auto {
     );
 
     const currentBranch = getCurrentBranch();
+    const baseBranch = (await this.git.shaExists(`origin/${this.baseBranch}`))
+      ? `origin/${this.baseBranch}`
+      : this.baseBranch;
+
     const forkPoints = (
       await execPromise("git", [
         "rev-list",
         "--boundary",
-        `${currentBranch}...origin/${this.baseBranch}`,
+        `${currentBranch}...${baseBranch}`,
         "--left-only",
       ])
     )
@@ -1384,9 +1388,7 @@ export default class Auto {
     const [, latestTagInBranch] = await on(
       this.git.getLatestTagInBranch(currentBranch)
     );
-    const [, tagsInBaseBranch] = await on(
-      this.git.getTags(`origin/${this.baseBranch}`)
-    );
+    const [, tagsInBaseBranch] = await on(this.git.getTags(baseBranch));
     const [latestTagInBaseBranch] = (tagsInBaseBranch || []).reverse();
     const lastTag =
       lastTagNotInBaseBranch ||

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -901,9 +901,12 @@ export default class Git {
       first?: boolean;
     } = {}
   ) {
-    const baseTags = (
-      await this.getTags(`origin/${this.options.baseBranch}`)
-    ).reverse();
+    const baseBranch = (await this.shaExists(
+      `origin/${this.options.baseBranch}`
+    ))
+      ? `origin/${this.options.baseBranch}`
+      : this.options.baseBranch;
+    const baseTags = (await this.getTags(baseBranch)).reverse();
     let branchTags = (await this.getTags(`heads/${branch}`)).reverse();
     const branchTagsWithPrereleaseSuffix = branchTags.filter(
       (tag) => tag.indexOf(`-${branch.toLowerCase()}`) >= 0


### PR DESCRIPTION
# What Changed

It would break when there was no origin/main

## Why

Was to address #1852 but that's actually the correct behavior.

Todo:

- [x] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux--canary.1871.22954.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux--canary.1871.22954.gz)  
[auto-macos--canary.1871.22954.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos--canary.1871.22954.gz)  
[auto-win.exe--canary.1871.22954.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe--canary.1871.22954.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.18.9--canary.1871.22954.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.18.9--canary.1871.22954.0
  npm install @auto-canary/auto@10.18.9--canary.1871.22954.0
  npm install @auto-canary/core@10.18.9--canary.1871.22954.0
  npm install @auto-canary/package-json-utils@10.18.9--canary.1871.22954.0
  npm install @auto-canary/all-contributors@10.18.9--canary.1871.22954.0
  npm install @auto-canary/brew@10.18.9--canary.1871.22954.0
  npm install @auto-canary/chrome@10.18.9--canary.1871.22954.0
  npm install @auto-canary/cocoapods@10.18.9--canary.1871.22954.0
  npm install @auto-canary/conventional-commits@10.18.9--canary.1871.22954.0
  npm install @auto-canary/crates@10.18.9--canary.1871.22954.0
  npm install @auto-canary/docker@10.18.9--canary.1871.22954.0
  npm install @auto-canary/exec@10.18.9--canary.1871.22954.0
  npm install @auto-canary/first-time-contributor@10.18.9--canary.1871.22954.0
  npm install @auto-canary/gem@10.18.9--canary.1871.22954.0
  npm install @auto-canary/gh-pages@10.18.9--canary.1871.22954.0
  npm install @auto-canary/git-tag@10.18.9--canary.1871.22954.0
  npm install @auto-canary/gradle@10.18.9--canary.1871.22954.0
  npm install @auto-canary/jira@10.18.9--canary.1871.22954.0
  npm install @auto-canary/magic-zero@10.18.9--canary.1871.22954.0
  npm install @auto-canary/maven@10.18.9--canary.1871.22954.0
  npm install @auto-canary/microsoft-teams@10.18.9--canary.1871.22954.0
  npm install @auto-canary/npm@10.18.9--canary.1871.22954.0
  npm install @auto-canary/omit-commits@10.18.9--canary.1871.22954.0
  npm install @auto-canary/omit-release-notes@10.18.9--canary.1871.22954.0
  npm install @auto-canary/pr-body-labels@10.18.9--canary.1871.22954.0
  npm install @auto-canary/released@10.18.9--canary.1871.22954.0
  npm install @auto-canary/s3@10.18.9--canary.1871.22954.0
  npm install @auto-canary/slack@10.18.9--canary.1871.22954.0
  npm install @auto-canary/twitter@10.18.9--canary.1871.22954.0
  npm install @auto-canary/upload-assets@10.18.9--canary.1871.22954.0
  npm install @auto-canary/vscode@10.18.9--canary.1871.22954.0
  # or 
  yarn add @auto-canary/bot-list@10.18.9--canary.1871.22954.0
  yarn add @auto-canary/auto@10.18.9--canary.1871.22954.0
  yarn add @auto-canary/core@10.18.9--canary.1871.22954.0
  yarn add @auto-canary/package-json-utils@10.18.9--canary.1871.22954.0
  yarn add @auto-canary/all-contributors@10.18.9--canary.1871.22954.0
  yarn add @auto-canary/brew@10.18.9--canary.1871.22954.0
  yarn add @auto-canary/chrome@10.18.9--canary.1871.22954.0
  yarn add @auto-canary/cocoapods@10.18.9--canary.1871.22954.0
  yarn add @auto-canary/conventional-commits@10.18.9--canary.1871.22954.0
  yarn add @auto-canary/crates@10.18.9--canary.1871.22954.0
  yarn add @auto-canary/docker@10.18.9--canary.1871.22954.0
  yarn add @auto-canary/exec@10.18.9--canary.1871.22954.0
  yarn add @auto-canary/first-time-contributor@10.18.9--canary.1871.22954.0
  yarn add @auto-canary/gem@10.18.9--canary.1871.22954.0
  yarn add @auto-canary/gh-pages@10.18.9--canary.1871.22954.0
  yarn add @auto-canary/git-tag@10.18.9--canary.1871.22954.0
  yarn add @auto-canary/gradle@10.18.9--canary.1871.22954.0
  yarn add @auto-canary/jira@10.18.9--canary.1871.22954.0
  yarn add @auto-canary/magic-zero@10.18.9--canary.1871.22954.0
  yarn add @auto-canary/maven@10.18.9--canary.1871.22954.0
  yarn add @auto-canary/microsoft-teams@10.18.9--canary.1871.22954.0
  yarn add @auto-canary/npm@10.18.9--canary.1871.22954.0
  yarn add @auto-canary/omit-commits@10.18.9--canary.1871.22954.0
  yarn add @auto-canary/omit-release-notes@10.18.9--canary.1871.22954.0
  yarn add @auto-canary/pr-body-labels@10.18.9--canary.1871.22954.0
  yarn add @auto-canary/released@10.18.9--canary.1871.22954.0
  yarn add @auto-canary/s3@10.18.9--canary.1871.22954.0
  yarn add @auto-canary/slack@10.18.9--canary.1871.22954.0
  yarn add @auto-canary/twitter@10.18.9--canary.1871.22954.0
  yarn add @auto-canary/upload-assets@10.18.9--canary.1871.22954.0
  yarn add @auto-canary/vscode@10.18.9--canary.1871.22954.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
