### PR TITLE
better exclude for lerna private packages

### DIFF
--- a/packages/core/src/utils/__tests__/get-lerna-packages.test.ts
+++ b/packages/core/src/utils/__tests__/get-lerna-packages.test.ts
@@ -7,10 +7,24 @@ jest.mock("../exec-promise");
 // @ts-ignore
 execPromise.mockImplementation(exec);
 
-test("it shouldn't included private packages", async () => {
+test("it shouldn't included version-less packages", async () => {
   exec.mockReturnValue(endent`
     /dir/a:a:0.3.0--canary.32.d54a0c4.0
     /dir/b:b:MISSING:PRIVATE
+  `);
+  expect(await getLernaPackages()).toStrictEqual([
+    {
+      name: "a",
+      path: "/dir/a",
+      version: "0.3.0--canary.32.d54a0c4.0",
+    },
+  ]);
+});
+
+test("it shouldn't included private packages", async () => {
+  exec.mockReturnValue(endent`
+    /dir/a:a:0.3.0--canary.32.d54a0c4.0
+    /dir/b:b:0.3.0:PRIVATE
   `);
   expect(await getLernaPackages()).toStrictEqual([
     {

--- a/packages/core/src/utils/get-lerna-packages.ts
+++ b/packages/core/src/utils/get-lerna-packages.ts
@@ -15,9 +15,9 @@ export default async function getLernaPackages() {
   const response = await execPromise("npx", ["lerna", "ls", "-pla"]);
 
   response.split("\n").forEach((packageInfo) => {
-    const [packagePath, name, version] = packageInfo.split(":");
+    const [packagePath, name, version, isPrivate] = packageInfo.split(":");
 
-    if (version !== "MISSING") {
+    if (version !== "MISSING" && isPrivate !== "PRIVATE") {
       packages.push({ path: packagePath, name, version });
     }
   });


### PR DESCRIPTION
# What Changed

We were only excluding packages without a version, this now also exclude packages with a version but marked as private.

## Why

Discussion in https://github.com/intuit/auto/discussions/1861

Todo:

- [x] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux--canary.1876.23063.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux--canary.1876.23063.gz)  
[auto-macos--canary.1876.23063.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos--canary.1876.23063.gz)  
[auto-win.exe--canary.1876.23063.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe--canary.1876.23063.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->
