### PR TITLE
better error message for no NPM_token in CI

### DIFF
--- a/packages/core/src/utils/exec-promise.ts
+++ b/packages/core/src/utils/exec-promise.ts
@@ -81,7 +81,13 @@ export default async function execPromise(
       } else {
         // Tools can occasionally print to stderr but not fail, so print that just in case.
         if (allStderr.length) {
-          log.log.warn(allStderr);
+          if (allStderr.includes("Failed to replace env in config")) {
+            const error = new Error(allStderr);
+            error.stack = (error.stack || "") + callSite;
+            reject(error);
+          } else {
+            log.log.warn(allStderr);
+          }
         }
 
         // Resolve the string of the whole stdout

--- a/plugins/npm/__tests__/npm-next.test.ts
+++ b/plugins/npm/__tests__/npm-next.test.ts
@@ -262,6 +262,7 @@ describe("next", () => {
       },
     ]);
     execPromise.mockResolvedValueOnce("");
+    execPromise.mockResolvedValueOnce("");
     execPromise.mockResolvedValueOnce("1.2.4-next.0");
 
     plugin.apply(({
@@ -329,6 +330,7 @@ describe("next", () => {
       },
     ]);
     // isMonorepo
+    execPromise.mockResolvedValueOnce("");
     execPromise.mockResolvedValueOnce("");
     execPromise.mockResolvedValueOnce("1.2.4-next.0");
 

--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -824,7 +824,7 @@ describe("canary", () => {
       canaryIdentifier: "canary.123.1",
     });
     expect(execPromise.mock.calls[1]).toContain("npm");
-    expect(execPromise.mock.calls[1][1]).toContain("1.2.4-canary.123.1.0");
+    expect(execPromise.mock.calls[2][1]).toContain("1.2.4-canary.123.1.0");
   });
 
   test("prints canary version in dry run", async () => {
@@ -924,6 +924,7 @@ describe("canary", () => {
 
     // first version exists
     execPromise.mockReturnValueOnce(true);
+    execPromise.mockReturnValueOnce(true);
     // second doesn't
     execPromise.mockReturnValueOnce(false);
 
@@ -931,8 +932,8 @@ describe("canary", () => {
       bump: Auto.SEMVER.patch,
       canaryIdentifier: "canary.123.1",
     });
-    expect(execPromise.mock.calls[2]).toContain("npm");
-    expect(execPromise.mock.calls[2][1]).toContain("1.2.4-canary.123.1.1");
+    expect(execPromise.mock.calls[3]).toContain("npm");
+    expect(execPromise.mock.calls[3][1]).toContain("1.2.4-canary.123.1.1");
   });
 
   test("legacy auth work", async () => {
@@ -1000,8 +1001,8 @@ describe("canary", () => {
       bump: Auto.SEMVER.patch,
       canaryIdentifier: "canary.123.1",
     });
-    expect(execPromise.mock.calls[1]).toContain("npm");
-    expect(execPromise.mock.calls[1][1]).toContain("1.2.4-canary.123.1.0");
+    expect(execPromise.mock.calls[2]).toContain("npm");
+    expect(execPromise.mock.calls[2][1]).toContain("1.2.4-canary.123.1.0");
   });
 
   test("use lerna for monorepo package", async () => {
@@ -1040,7 +1041,7 @@ describe("canary", () => {
       bump: Auto.SEMVER.patch,
       canaryIdentifier: "",
     });
-    expect(execPromise.mock.calls[1][1]).toContain("lerna");
+    expect(execPromise.mock.calls[2][1]).toContain("lerna");
     // @ts-ignore
     expect(value.newVersion).toBe("1.2.3-canary.0");
   });

--- a/plugins/npm/package.json
+++ b/plugins/npm/package.json
@@ -41,6 +41,7 @@
     "@auto-it/core": "link:../../packages/core",
     "@auto-it/package-json-utils": "link:../../packages/package-json-utils",
     "await-to-js": "^2.1.1",
+    "endent": "^2.0.1",
     "env-ci": "^5.0.1",
     "fp-ts": "^2.5.3",
     "get-monorepo-packages": "^1.1.0",

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -1501,6 +1501,8 @@ export default class NPMPlugin implements IPlugin {
   private async setTokenOnCI(auto: Auto) {
     try {
       await setTokenOnCI(auto.logger);
+      // This will make NPM actually check if the npmrc is valid for the env
+      await execPromise("npm", ["root"]);
     } catch (error) {
       if (
         // eslint-disable-next-line no-template-curly-in-string


### PR DESCRIPTION
# What Changed

npm will exit with a 0 when there is a npmrc error. this makes it so auto will error for this and provide a nice error message

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux--canary.1878.23133.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux--canary.1878.23133.gz)  
[auto-macos--canary.1878.23133.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos--canary.1878.23133.gz)  
[auto-win.exe--canary.1878.23133.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe--canary.1878.23133.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.20.3--canary.1878.23133.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.20.3--canary.1878.23133.0
  npm install @auto-canary/auto@10.20.3--canary.1878.23133.0
  npm install @auto-canary/core@10.20.3--canary.1878.23133.0
  npm install @auto-canary/package-json-utils@10.20.3--canary.1878.23133.0
  npm install @auto-canary/all-contributors@10.20.3--canary.1878.23133.0
  npm install @auto-canary/brew@10.20.3--canary.1878.23133.0
  npm install @auto-canary/chrome@10.20.3--canary.1878.23133.0
  npm install @auto-canary/cocoapods@10.20.3--canary.1878.23133.0
  npm install @auto-canary/conventional-commits@10.20.3--canary.1878.23133.0
  npm install @auto-canary/crates@10.20.3--canary.1878.23133.0
  npm install @auto-canary/docker@10.20.3--canary.1878.23133.0
  npm install @auto-canary/exec@10.20.3--canary.1878.23133.0
  npm install @auto-canary/first-time-contributor@10.20.3--canary.1878.23133.0
  npm install @auto-canary/gem@10.20.3--canary.1878.23133.0
  npm install @auto-canary/gh-pages@10.20.3--canary.1878.23133.0
  npm install @auto-canary/git-tag@10.20.3--canary.1878.23133.0
  npm install @auto-canary/gradle@10.20.3--canary.1878.23133.0
  npm install @auto-canary/jira@10.20.3--canary.1878.23133.0
  npm install @auto-canary/magic-zero@10.20.3--canary.1878.23133.0
  npm install @auto-canary/maven@10.20.3--canary.1878.23133.0
  npm install @auto-canary/microsoft-teams@10.20.3--canary.1878.23133.0
  npm install @auto-canary/npm@10.20.3--canary.1878.23133.0
  npm install @auto-canary/omit-commits@10.20.3--canary.1878.23133.0
  npm install @auto-canary/omit-release-notes@10.20.3--canary.1878.23133.0
  npm install @auto-canary/pr-body-labels@10.20.3--canary.1878.23133.0
  npm install @auto-canary/released@10.20.3--canary.1878.23133.0
  npm install @auto-canary/s3@10.20.3--canary.1878.23133.0
  npm install @auto-canary/slack@10.20.3--canary.1878.23133.0
  npm install @auto-canary/twitter@10.20.3--canary.1878.23133.0
  npm install @auto-canary/upload-assets@10.20.3--canary.1878.23133.0
  npm install @auto-canary/vscode@10.20.3--canary.1878.23133.0
  # or 
  yarn add @auto-canary/bot-list@10.20.3--canary.1878.23133.0
  yarn add @auto-canary/auto@10.20.3--canary.1878.23133.0
  yarn add @auto-canary/core@10.20.3--canary.1878.23133.0
  yarn add @auto-canary/package-json-utils@10.20.3--canary.1878.23133.0
  yarn add @auto-canary/all-contributors@10.20.3--canary.1878.23133.0
  yarn add @auto-canary/brew@10.20.3--canary.1878.23133.0
  yarn add @auto-canary/chrome@10.20.3--canary.1878.23133.0
  yarn add @auto-canary/cocoapods@10.20.3--canary.1878.23133.0
  yarn add @auto-canary/conventional-commits@10.20.3--canary.1878.23133.0
  yarn add @auto-canary/crates@10.20.3--canary.1878.23133.0
  yarn add @auto-canary/docker@10.20.3--canary.1878.23133.0
  yarn add @auto-canary/exec@10.20.3--canary.1878.23133.0
  yarn add @auto-canary/first-time-contributor@10.20.3--canary.1878.23133.0
  yarn add @auto-canary/gem@10.20.3--canary.1878.23133.0
  yarn add @auto-canary/gh-pages@10.20.3--canary.1878.23133.0
  yarn add @auto-canary/git-tag@10.20.3--canary.1878.23133.0
  yarn add @auto-canary/gradle@10.20.3--canary.1878.23133.0
  yarn add @auto-canary/jira@10.20.3--canary.1878.23133.0
  yarn add @auto-canary/magic-zero@10.20.3--canary.1878.23133.0
  yarn add @auto-canary/maven@10.20.3--canary.1878.23133.0
  yarn add @auto-canary/microsoft-teams@10.20.3--canary.1878.23133.0
  yarn add @auto-canary/npm@10.20.3--canary.1878.23133.0
  yarn add @auto-canary/omit-commits@10.20.3--canary.1878.23133.0
  yarn add @auto-canary/omit-release-notes@10.20.3--canary.1878.23133.0
  yarn add @auto-canary/pr-body-labels@10.20.3--canary.1878.23133.0
  yarn add @auto-canary/released@10.20.3--canary.1878.23133.0
  yarn add @auto-canary/s3@10.20.3--canary.1878.23133.0
  yarn add @auto-canary/slack@10.20.3--canary.1878.23133.0
  yarn add @auto-canary/twitter@10.20.3--canary.1878.23133.0
  yarn add @auto-canary/upload-assets@10.20.3--canary.1878.23133.0
  yarn add @auto-canary/vscode@10.20.3--canary.1878.23133.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
