### PR TITLE
add canary target flag/option

### DIFF
--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -567,6 +567,15 @@ export const commands: AutoCommand[] = [
           "Build number to use to create the canary version. Detected in CI env",
       },
       {
+        name: "target",
+        type: String,
+        group: "main",
+        defaultValue: "pr-body",
+        description: "How the canary version should be attached to a PR",
+        typeLabel: "pr-body | comment | status",
+        config: true,
+      },
+      {
         ...message,
         description:
           "Message to comment on PR with. Defaults to 'Published PR with canary version: %v'. Pass false to disable the comment",

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1295,16 +1295,39 @@ export default class Auto {
     );
 
     if (options.message !== "false" && pr) {
+      const prNumber = Number(pr);
       const message =
         typeof result === "string"
           ? messageHeader
           : makeDetail(messageHeader, result.details);
 
-      await this.prBody({
-        pr: Number(pr),
-        context: "canary-version",
-        message,
-      });
+      switch (options.target) {
+        case "comment":
+          await this.comment({
+            pr: prNumber,
+            context: "canary-version",
+            message,
+          });
+          break;
+
+        case "status":
+          await this.prStatus({
+            pr: prNumber,
+            context: "canary-version",
+            description: messageHeader,
+            state: "success",
+            url: "buildUrl" in env ? env.buildUrl : "",
+          });
+          break;
+
+        default:
+          await this.prBody({
+            pr: prNumber,
+            context: "canary-version",
+            message,
+          });
+          break;
+      }
     }
 
     this.logger.log.success(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -117,6 +117,12 @@ export const globalOptions = t.partial({
     force: t.boolean,
     /** The message used when attaching the canary version to a PR */
     message: t.union([t.literal(false), t.string]),
+    /** How the canary version should be attached to a PR */
+    target: t.union([
+      t.literal("pr-body"),
+      t.literal("comment"),
+      t.literal("status"),
+    ]),
   }),
   /** Options to pass to "auto next" */
   next: t.partial({


### PR DESCRIPTION
## Why

closes #1753

Todo:

- [x] Add tests
- [x] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux--canary.1893.23221.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux--canary.1893.23221.gz)  
[auto-macos--canary.1893.23221.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos--canary.1893.23221.gz)  
[auto-win.exe--canary.1893.23221.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe--canary.1893.23221.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.21.0--canary.1893.23221.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.21.0--canary.1893.23221.0
  npm install @auto-canary/auto@10.21.0--canary.1893.23221.0
  npm install @auto-canary/core@10.21.0--canary.1893.23221.0
  npm install @auto-canary/package-json-utils@10.21.0--canary.1893.23221.0
  npm install @auto-canary/all-contributors@10.21.0--canary.1893.23221.0
  npm install @auto-canary/brew@10.21.0--canary.1893.23221.0
  npm install @auto-canary/chrome@10.21.0--canary.1893.23221.0
  npm install @auto-canary/cocoapods@10.21.0--canary.1893.23221.0
  npm install @auto-canary/conventional-commits@10.21.0--canary.1893.23221.0
  npm install @auto-canary/crates@10.21.0--canary.1893.23221.0
  npm install @auto-canary/docker@10.21.0--canary.1893.23221.0
  npm install @auto-canary/exec@10.21.0--canary.1893.23221.0
  npm install @auto-canary/first-time-contributor@10.21.0--canary.1893.23221.0
  npm install @auto-canary/gem@10.21.0--canary.1893.23221.0
  npm install @auto-canary/gh-pages@10.21.0--canary.1893.23221.0
  npm install @auto-canary/git-tag@10.21.0--canary.1893.23221.0
  npm install @auto-canary/gradle@10.21.0--canary.1893.23221.0
  npm install @auto-canary/jira@10.21.0--canary.1893.23221.0
  npm install @auto-canary/magic-zero@10.21.0--canary.1893.23221.0
  npm install @auto-canary/maven@10.21.0--canary.1893.23221.0
  npm install @auto-canary/microsoft-teams@10.21.0--canary.1893.23221.0
  npm install @auto-canary/npm@10.21.0--canary.1893.23221.0
  npm install @auto-canary/omit-commits@10.21.0--canary.1893.23221.0
  npm install @auto-canary/omit-release-notes@10.21.0--canary.1893.23221.0
  npm install @auto-canary/pr-body-labels@10.21.0--canary.1893.23221.0
  npm install @auto-canary/released@10.21.0--canary.1893.23221.0
  npm install @auto-canary/s3@10.21.0--canary.1893.23221.0
  npm install @auto-canary/slack@10.21.0--canary.1893.23221.0
  npm install @auto-canary/twitter@10.21.0--canary.1893.23221.0
  npm install @auto-canary/upload-assets@10.21.0--canary.1893.23221.0
  npm install @auto-canary/vscode@10.21.0--canary.1893.23221.0
  # or 
  yarn add @auto-canary/bot-list@10.21.0--canary.1893.23221.0
  yarn add @auto-canary/auto@10.21.0--canary.1893.23221.0
  yarn add @auto-canary/core@10.21.0--canary.1893.23221.0
  yarn add @auto-canary/package-json-utils@10.21.0--canary.1893.23221.0
  yarn add @auto-canary/all-contributors@10.21.0--canary.1893.23221.0
  yarn add @auto-canary/brew@10.21.0--canary.1893.23221.0
  yarn add @auto-canary/chrome@10.21.0--canary.1893.23221.0
  yarn add @auto-canary/cocoapods@10.21.0--canary.1893.23221.0
  yarn add @auto-canary/conventional-commits@10.21.0--canary.1893.23221.0
  yarn add @auto-canary/crates@10.21.0--canary.1893.23221.0
  yarn add @auto-canary/docker@10.21.0--canary.1893.23221.0
  yarn add @auto-canary/exec@10.21.0--canary.1893.23221.0
  yarn add @auto-canary/first-time-contributor@10.21.0--canary.1893.23221.0
  yarn add @auto-canary/gem@10.21.0--canary.1893.23221.0
  yarn add @auto-canary/gh-pages@10.21.0--canary.1893.23221.0
  yarn add @auto-canary/git-tag@10.21.0--canary.1893.23221.0
  yarn add @auto-canary/gradle@10.21.0--canary.1893.23221.0
  yarn add @auto-canary/jira@10.21.0--canary.1893.23221.0
  yarn add @auto-canary/magic-zero@10.21.0--canary.1893.23221.0
  yarn add @auto-canary/maven@10.21.0--canary.1893.23221.0
  yarn add @auto-canary/microsoft-teams@10.21.0--canary.1893.23221.0
  yarn add @auto-canary/npm@10.21.0--canary.1893.23221.0
  yarn add @auto-canary/omit-commits@10.21.0--canary.1893.23221.0
  yarn add @auto-canary/omit-release-notes@10.21.0--canary.1893.23221.0
  yarn add @auto-canary/pr-body-labels@10.21.0--canary.1893.23221.0
  yarn add @auto-canary/released@10.21.0--canary.1893.23221.0
  yarn add @auto-canary/s3@10.21.0--canary.1893.23221.0
  yarn add @auto-canary/slack@10.21.0--canary.1893.23221.0
  yarn add @auto-canary/twitter@10.21.0--canary.1893.23221.0
  yarn add @auto-canary/upload-assets@10.21.0--canary.1893.23221.0
  yarn add @auto-canary/vscode@10.21.0--canary.1893.23221.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
