### PR TITLE
Small gradle plugin enhancement

### DIFF
--- a/plugins/gradle/__tests__/gradle.test.ts
+++ b/plugins/gradle/__tests__/gradle.test.ts
@@ -192,6 +192,23 @@ describe("Gradle Plugin", () => {
       expect(canaryVersion).toBe("1.0.0-canary123")
     });
 
+    test("should update gradle version for publish - canary w/ default snapshot", async () => {
+      const properties = "version: 1.0.0-SNAPSHOT";
+      exec.mockReturnValueOnce(properties);
+      await hooks.beforeRun.promise({} as any);
+
+      const spy = jest.fn();
+      exec.mockReturnValueOnce(properties).mockImplementation(spy);
+
+      await hooks.canary.promise({ bump: Auto.SEMVER.patch, canaryIdentifier: "canary123" });
+
+      expect(spy).toHaveBeenCalledWith(expect.stringMatching("gradle"), [
+        "updateVersion",
+        "-Prelease.useAutomaticVersion=true",
+        `-Prelease.newVersion=1.0.0-canary123-SNAPSHOT`,
+      ]);
+    });
+
     test("should publish if available - canary", async () => {
       const properties = "publish: yes";
       exec.mockReturnValueOnce(properties);
@@ -256,7 +273,7 @@ describe("Gradle Plugin", () => {
       expect(nextVersion[0]).toBe("1.0.0-next.0")
     });
 
-    test("should version release with snapshot suffix - next", async () => {
+    test("should update gradle version for publish with snapshot suffix - next", async () => {
       const properties = "this doesn't matter";
       exec.mockReturnValueOnce(properties);
       await hooks.beforeRun.promise({} as any);
@@ -268,12 +285,9 @@ describe("Gradle Plugin", () => {
       await hooks.next.promise([], { bump: Auto.SEMVER.major, commits: [], fullReleaseNotes: "", releaseNotes: "" });
 
       expect(spy).toHaveBeenCalledWith(expect.stringMatching("gradle"), [
-        "release",
+        "updateVersion",
         "-Prelease.useAutomaticVersion=true",
         `-Prelease.newVersion=1.0.0-SNAPSHOT`,
-        "-x createReleaseTag",
-        "-x preTagCommit",
-        "-x commitNewVersion",
       ]);
     });
 

--- a/plugins/gradle/src/index.ts
+++ b/plugins/gradle/src/index.ts
@@ -106,8 +106,8 @@ export default class GradleReleasePluginPlugin implements IPlugin {
   private readonly updateGradleVersion = async (
     version: string,
     commitMsg?: string,
-    commit = true,
-    buildFlag = true
+    buildFlag = true,
+    commit = true
   ) => {
     if (buildFlag) {
       // don't create release, tag, or commit since auto will do this
@@ -259,6 +259,14 @@ export default class GradleReleasePluginPlugin implements IPlugin {
           return canaryVersion;
         }
 
+        const canaryReleaseVersion = `${canaryVersion}${defaultSnapshotSuffix}`
+        await this.updateGradleVersion(
+          canaryReleaseVersion,
+          `Prerelease version: ${canaryReleaseVersion} [skip ci]`,
+          false,
+          false
+        );
+
         const { publish } = this.properties;
 
         if (publish) {
@@ -317,6 +325,7 @@ export default class GradleReleasePluginPlugin implements IPlugin {
         await this.updateGradleVersion(
           preReleaseSnapshotVersion,
           `Prerelease version: ${preReleaseSnapshotVersion} [skip ci]`,
+          false,
           false
         );
 


### PR DESCRIPTION
Add canary identifier to differentiate canary release version, reverted order of flags in `updateGradleVersion` to avoid breaking original use cases, added tests

# What Changed

## Why

Todo:

- [x] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
