### PR TITLE
add defaultReleaseType option

### DIFF
--- a/plugins/conventional-commits/README.md
+++ b/plugins/conventional-commits/README.md
@@ -35,6 +35,8 @@ yarn add -D @auto-it/conventional-commits
 
 ## Options
 
+### `preset`
+
 You can use any [conventional-changelog preset](https://www.npmjs.com/search?q=conventional-changelog%20preset%20) with this plugin.
 Using a preset will completely override this plugin's default behavior with whatever the preset defines.
 
@@ -43,6 +45,21 @@ Using a preset will completely override this plugin's default behavior with what
   "plugins": [
     "npm",
     ["conventional-commits", { "preset": "angular" }]
+    // other plugins
+  ]
+}
+```
+
+### `defaultReleaseType`
+
+The default release type to apply when the conventional commit isn't "fix", "feat" or "breaking" (ex: "chore:").
+Defaults to `skip`.
+
+```json
+{
+  "plugins": [
+    "npm",
+    ["conventional-commits", { "defaultReleaseType": "patch" }]
     // other plugins
   ]
 }

--- a/plugins/conventional-commits/__tests__/conventional-commits.test.ts
+++ b/plugins/conventional-commits/__tests__/conventional-commits.test.ts
@@ -160,6 +160,32 @@ describe("parseCommit", () => {
       labels: ["skip-release"],
     });
   });
+
+  test("should be able to configure the default release type", async () => {
+    const conventionalCommitsPlugin = new ConventionalCommitsPlugin({
+      defaultReleaseType: "patch",
+    });
+    const autoHooks = makeHooks();
+    conventionalCommitsPlugin.apply({
+      hooks: autoHooks,
+      labels: defaultLabels,
+      semVerLabels: versionLabels,
+      logger: dummyLog(),
+    } as Auto);
+
+    const logParseHooks = makeLogParseHooks();
+    autoHooks.onCreateLogParse.call({
+      hooks: logParseHooks,
+    } as LogParse);
+
+    const commit = makeCommitFromMsg("chore: i should not trigger a release");
+    expect(
+      await logParseHooks.parseCommit.promise({ ...commit })
+    ).toStrictEqual({
+      ...commit,
+      labels: ["patch"],
+    });
+  });
 });
 
 describe("normalizeCommit", () => {

--- a/plugins/conventional-commits/src/index.ts
+++ b/plugins/conventional-commits/src/index.ts
@@ -77,9 +77,11 @@ const defaultPreset = {
 const optionalOptions = t.partial({
   /** A path to the formula template */
   preset: t.string,
+  /** The default release type to apply when the conventional commit isn't "fix", "feat" or "breaking" */
+  defaultReleaseType: t.string,
 });
 
-const VERSIONS = [SEMVER.major, SEMVER.minor, SEMVER.patch, "skip"] as const;
+const VERSIONS = [SEMVER.major, SEMVER.minor, SEMVER.patch] as const;
 
 export type ConventionalCommitsOptions = t.TypeOf<typeof optionalOptions>;
 
@@ -103,7 +105,10 @@ export default class ConventionalCommitsPlugin implements IPlugin {
 
   /** Initialize the plugin with it's options */
   constructor(options: ConventionalCommitsOptions = {}) {
-    this.options = options;
+    this.options = {
+      defaultReleaseType: "skip",
+      ...options,
+    };
   }
 
   /** Tap into auto plugin points. */
@@ -128,7 +133,8 @@ export default class ConventionalCommitsPlugin implements IPlugin {
           const result = whatBump([conventionalCommit]);
 
           if (result?.level !== null && result?.level !== undefined) {
-            const bump = VERSIONS[result.level];
+            const bump =
+              VERSIONS[result.level] || this.options.defaultReleaseType;
             return bump;
           }
         };


### PR DESCRIPTION
# What Changed

Add the ability to control default release type when any non-semver conventional commit message is found

## Why

closes #1910

Todo:

- [x] Add tests
- [x] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux--canary.1911.23448.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux--canary.1911.23448.gz)  
[auto-macos--canary.1911.23448.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos--canary.1911.23448.gz)  
[auto-win.exe--canary.1911.23448.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe--canary.1911.23448.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.22.0--canary.1911.23448.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.22.0--canary.1911.23448.0
  npm install @auto-canary/auto@10.22.0--canary.1911.23448.0
  npm install @auto-canary/core@10.22.0--canary.1911.23448.0
  npm install @auto-canary/package-json-utils@10.22.0--canary.1911.23448.0
  npm install @auto-canary/all-contributors@10.22.0--canary.1911.23448.0
  npm install @auto-canary/brew@10.22.0--canary.1911.23448.0
  npm install @auto-canary/chrome@10.22.0--canary.1911.23448.0
  npm install @auto-canary/cocoapods@10.22.0--canary.1911.23448.0
  npm install @auto-canary/conventional-commits@10.22.0--canary.1911.23448.0
  npm install @auto-canary/crates@10.22.0--canary.1911.23448.0
  npm install @auto-canary/docker@10.22.0--canary.1911.23448.0
  npm install @auto-canary/exec@10.22.0--canary.1911.23448.0
  npm install @auto-canary/first-time-contributor@10.22.0--canary.1911.23448.0
  npm install @auto-canary/gem@10.22.0--canary.1911.23448.0
  npm install @auto-canary/gh-pages@10.22.0--canary.1911.23448.0
  npm install @auto-canary/git-tag@10.22.0--canary.1911.23448.0
  npm install @auto-canary/gradle@10.22.0--canary.1911.23448.0
  npm install @auto-canary/jira@10.22.0--canary.1911.23448.0
  npm install @auto-canary/magic-zero@10.22.0--canary.1911.23448.0
  npm install @auto-canary/maven@10.22.0--canary.1911.23448.0
  npm install @auto-canary/microsoft-teams@10.22.0--canary.1911.23448.0
  npm install @auto-canary/npm@10.22.0--canary.1911.23448.0
  npm install @auto-canary/omit-commits@10.22.0--canary.1911.23448.0
  npm install @auto-canary/omit-release-notes@10.22.0--canary.1911.23448.0
  npm install @auto-canary/pr-body-labels@10.22.0--canary.1911.23448.0
  npm install @auto-canary/released@10.22.0--canary.1911.23448.0
  npm install @auto-canary/s3@10.22.0--canary.1911.23448.0
  npm install @auto-canary/slack@10.22.0--canary.1911.23448.0
  npm install @auto-canary/twitter@10.22.0--canary.1911.23448.0
  npm install @auto-canary/upload-assets@10.22.0--canary.1911.23448.0
  npm install @auto-canary/vscode@10.22.0--canary.1911.23448.0
  # or 
  yarn add @auto-canary/bot-list@10.22.0--canary.1911.23448.0
  yarn add @auto-canary/auto@10.22.0--canary.1911.23448.0
  yarn add @auto-canary/core@10.22.0--canary.1911.23448.0
  yarn add @auto-canary/package-json-utils@10.22.0--canary.1911.23448.0
  yarn add @auto-canary/all-contributors@10.22.0--canary.1911.23448.0
  yarn add @auto-canary/brew@10.22.0--canary.1911.23448.0
  yarn add @auto-canary/chrome@10.22.0--canary.1911.23448.0
  yarn add @auto-canary/cocoapods@10.22.0--canary.1911.23448.0
  yarn add @auto-canary/conventional-commits@10.22.0--canary.1911.23448.0
  yarn add @auto-canary/crates@10.22.0--canary.1911.23448.0
  yarn add @auto-canary/docker@10.22.0--canary.1911.23448.0
  yarn add @auto-canary/exec@10.22.0--canary.1911.23448.0
  yarn add @auto-canary/first-time-contributor@10.22.0--canary.1911.23448.0
  yarn add @auto-canary/gem@10.22.0--canary.1911.23448.0
  yarn add @auto-canary/gh-pages@10.22.0--canary.1911.23448.0
  yarn add @auto-canary/git-tag@10.22.0--canary.1911.23448.0
  yarn add @auto-canary/gradle@10.22.0--canary.1911.23448.0
  yarn add @auto-canary/jira@10.22.0--canary.1911.23448.0
  yarn add @auto-canary/magic-zero@10.22.0--canary.1911.23448.0
  yarn add @auto-canary/maven@10.22.0--canary.1911.23448.0
  yarn add @auto-canary/microsoft-teams@10.22.0--canary.1911.23448.0
  yarn add @auto-canary/npm@10.22.0--canary.1911.23448.0
  yarn add @auto-canary/omit-commits@10.22.0--canary.1911.23448.0
  yarn add @auto-canary/omit-release-notes@10.22.0--canary.1911.23448.0
  yarn add @auto-canary/pr-body-labels@10.22.0--canary.1911.23448.0
  yarn add @auto-canary/released@10.22.0--canary.1911.23448.0
  yarn add @auto-canary/s3@10.22.0--canary.1911.23448.0
  yarn add @auto-canary/slack@10.22.0--canary.1911.23448.0
  yarn add @auto-canary/twitter@10.22.0--canary.1911.23448.0
  yarn add @auto-canary/upload-assets@10.22.0--canary.1911.23448.0
  yarn add @auto-canary/vscode@10.22.0--canary.1911.23448.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
