### PR TITLE
Release Command: Tag creation fallback.

### DIFF
--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -503,7 +503,12 @@ export const commands: AutoCommand[] = [
     ],
     examples: [
       "{green $} auto release",
-      "{green $} auto release --from v0.20.1 --use-version v0.21.0",
+      {
+        desc:
+          "This command can be used in isolation easily. This example will: tag the release version at 'to' and create a GitHub release changelog over the commits range",
+        example:
+          "{green $} auto release --from v0.20.1 --to HEAD --use-version v0.21.0",
+      },
     ],
   },
   {

--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -470,7 +470,7 @@ export const commands: AutoCommand[] = [
     description: endent`
       Create a GitHub release for a tag. Defaults to last tag in branch.
       
-      > NOTE: The tag must already be pushed to GitHub. If it isn't GitHub will create a tag pointing to the HEAD of you default branch.
+      > NOTE: The tag must already be pushed to GitHub. If it isn't GitHub will create a tag pointing to the "to" option value.
     `,
     options: [
       dryRun,
@@ -489,7 +489,7 @@ export const commands: AutoCommand[] = [
         type: String,
         group: "main",
         description:
-          "Git revision (tag, commit sha, ...) to end release notes at. Defaults to HEAD",
+          "Git revision (tag, commit sha, ...) to end release notes at. Defaults to HEAD.",
       },
       {
         name: "use-version",

--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -467,7 +467,11 @@ export const commands: AutoCommand[] = [
   {
     name: "release",
     group: "Release Commands",
-    description: "Auto-generate a github release",
+    description: endent`
+      Create a GitHub release for a tag. Defaults to last tag in branch.
+      
+      > NOTE: The tag must already be pushed to GitHub. If it isn't GitHub will create a tag pointing to the HEAD of you default branch.
+    `,
     options: [
       dryRun,
       noVersionPrefix,

--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -959,6 +959,35 @@ describe("Auto", () => {
       );
     });
 
+
+    test("should use --to commit target", async () => {
+      const auto = new Auto({ ...defaults, plugins: [] });
+      auto.logger = dummyLog();
+      await auto.loadConfig();
+      auto.git!.getLatestRelease = () => Promise.resolve("1.2.3");
+
+      jest.spyOn(auto.git!, "publish").mockReturnValueOnce({ data: {} } as any);
+      jest
+        .spyOn(auto.release!, "generateReleaseNotes")
+        .mockImplementation(() => Promise.resolve("releaseNotes"));
+      auto.release!.getCommitsInRelease = () =>
+        Promise.resolve([makeCommitFromMsg("Test Commit")]);
+
+      auto.hooks.getPreviousVersion.tap("test", () => "1.2.4");
+      const afterRelease = jest.fn();
+      auto.hooks.afterRelease.tap("test", afterRelease);
+      jest.spyOn(auto.release!, "getCommits").mockImplementation();
+
+      await auto.runRelease({ to: 'abc'});
+
+      expect(auto.git!.publish).toHaveBeenCalledWith(
+        "releaseNotes",
+        "v1.2.4",
+        false,
+        "abc"
+      );
+    });
+
     test("should publish to a tag", async () => {
       const auto = new Auto({ ...defaults, plugins: [] });
       auto.logger = dummyLog();

--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -948,7 +948,8 @@ describe("Auto", () => {
       expect(auto.git!.publish).toHaveBeenCalledWith(
         "releaseNotes",
         "v1.2.4",
-        false
+        false,
+        ""
       );
       expect(afterRelease).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1013,7 +1014,8 @@ describe("Auto", () => {
       expect(auto.git!.publish).toHaveBeenCalledWith(
         "releaseNotes",
         "v1.2.4",
-        true
+        true,
+        ""
       );
       expect(afterRelease).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1052,7 +1054,8 @@ describe("Auto", () => {
       expect(auto.git!.publish).toHaveBeenCalledWith(
         "releaseNotes",
         "v1.2.4",
-        false
+        false,
+        ""
       );
       expect(afterRelease).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1091,7 +1094,8 @@ describe("Auto", () => {
       expect(auto.git!.publish).toHaveBeenCalledWith(
         "releaseNotes",
         "v1.3.0",
-        false
+        false,
+        ""
       );
       expect(afterRelease).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1130,7 +1134,8 @@ describe("Auto", () => {
       expect(auto.git!.publish).toHaveBeenCalledWith(
         "releaseNotes",
         "v1.2.3+1",
-        false
+        false,
+        ""
       );
       expect(afterRelease).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -193,6 +193,8 @@ export interface IAutoHooks {
       DryRunOption & {
         /** Commit to start calculating the version from */
         from: string;
+        /** Commit to end calculating the version from */
+        to: string;
         /** The version being released */
         newVersion: string;
         /** Whether the release being made is a prerelease */
@@ -551,7 +553,8 @@ export default class Auto {
         const release = await this.git!.publish(
           options.fullReleaseNotes,
           options.newVersion,
-          options.isPrerelease
+          options.isPrerelease,
+          options.to
         );
 
         this.logger.log.info(release.data.html_url);
@@ -1472,6 +1475,7 @@ export default class Auto {
     const release = await this.hooks.makeRelease.promise({
       commits,
       from: lastTag,
+      to: await this.git.getSha(),
       isPrerelease: true,
       newVersion,
       fullReleaseNotes: releaseNotes,
@@ -1983,6 +1987,7 @@ export default class Auto {
     const release = await this.hooks.makeRelease.promise({
       dryRun,
       from: lastRelease,
+      to: to || (await this.git.getSha()),
       isPrerelease,
       newVersion,
       fullReleaseNotes: releaseNotes,

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -845,13 +845,19 @@ export default class Git {
   }
 
   /** Create a release for the GitHub project */
-  async publish(releaseNotes: string, tag: string, prerelease = false) {
+  async publish(
+    releaseNotes: string,
+    tag: string,
+    prerelease = false,
+    fallbackCommit?: string,
+  ) {
     this.logger.verbose.info("Creating release on GitHub for tag:", tag);
 
     const result = await this.github.repos.createRelease({
       owner: this.options.owner,
       repo: this.options.repo,
       tag_name: tag,
+      target_commitish: fallbackCommit,
       name: tag,
       body: releaseNotes,
       prerelease,


### PR DESCRIPTION
# Release Notes

When creating a release for a tag that isn't on the remote, fallback to creating a tag pointing at the --to option.

## Why

closes #1917

Todo:

- [x] Add tests
- [x] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux--canary.1929.23689.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux--canary.1929.23689.gz)  
[auto-macos--canary.1929.23689.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos--canary.1929.23689.gz)  
[auto-win.exe--canary.1929.23689.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe--canary.1929.23689.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.24.0--canary.1929.23688.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.24.0--canary.1929.23688.0
  npm install @auto-canary/auto@10.24.0--canary.1929.23688.0
  npm install @auto-canary/core@10.24.0--canary.1929.23688.0
  npm install @auto-canary/package-json-utils@10.24.0--canary.1929.23688.0
  npm install @auto-canary/all-contributors@10.24.0--canary.1929.23688.0
  npm install @auto-canary/brew@10.24.0--canary.1929.23688.0
  npm install @auto-canary/chrome@10.24.0--canary.1929.23688.0
  npm install @auto-canary/cocoapods@10.24.0--canary.1929.23688.0
  npm install @auto-canary/conventional-commits@10.24.0--canary.1929.23688.0
  npm install @auto-canary/crates@10.24.0--canary.1929.23688.0
  npm install @auto-canary/docker@10.24.0--canary.1929.23688.0
  npm install @auto-canary/exec@10.24.0--canary.1929.23688.0
  npm install @auto-canary/first-time-contributor@10.24.0--canary.1929.23688.0
  npm install @auto-canary/gem@10.24.0--canary.1929.23688.0
  npm install @auto-canary/gh-pages@10.24.0--canary.1929.23688.0
  npm install @auto-canary/git-tag@10.24.0--canary.1929.23688.0
  npm install @auto-canary/gradle@10.24.0--canary.1929.23688.0
  npm install @auto-canary/jira@10.24.0--canary.1929.23688.0
  npm install @auto-canary/magic-zero@10.24.0--canary.1929.23688.0
  npm install @auto-canary/maven@10.24.0--canary.1929.23688.0
  npm install @auto-canary/microsoft-teams@10.24.0--canary.1929.23688.0
  npm install @auto-canary/npm@10.24.0--canary.1929.23688.0
  npm install @auto-canary/omit-commits@10.24.0--canary.1929.23688.0
  npm install @auto-canary/omit-release-notes@10.24.0--canary.1929.23688.0
  npm install @auto-canary/pr-body-labels@10.24.0--canary.1929.23688.0
  npm install @auto-canary/released@10.24.0--canary.1929.23688.0
  npm install @auto-canary/s3@10.24.0--canary.1929.23688.0
  npm install @auto-canary/slack@10.24.0--canary.1929.23688.0
  npm install @auto-canary/twitter@10.24.0--canary.1929.23688.0
  npm install @auto-canary/upload-assets@10.24.0--canary.1929.23688.0
  npm install @auto-canary/vscode@10.24.0--canary.1929.23688.0
  # or 
  yarn add @auto-canary/bot-list@10.24.0--canary.1929.23688.0
  yarn add @auto-canary/auto@10.24.0--canary.1929.23688.0
  yarn add @auto-canary/core@10.24.0--canary.1929.23688.0
  yarn add @auto-canary/package-json-utils@10.24.0--canary.1929.23688.0
  yarn add @auto-canary/all-contributors@10.24.0--canary.1929.23688.0
  yarn add @auto-canary/brew@10.24.0--canary.1929.23688.0
  yarn add @auto-canary/chrome@10.24.0--canary.1929.23688.0
  yarn add @auto-canary/cocoapods@10.24.0--canary.1929.23688.0
  yarn add @auto-canary/conventional-commits@10.24.0--canary.1929.23688.0
  yarn add @auto-canary/crates@10.24.0--canary.1929.23688.0
  yarn add @auto-canary/docker@10.24.0--canary.1929.23688.0
  yarn add @auto-canary/exec@10.24.0--canary.1929.23688.0
  yarn add @auto-canary/first-time-contributor@10.24.0--canary.1929.23688.0
  yarn add @auto-canary/gem@10.24.0--canary.1929.23688.0
  yarn add @auto-canary/gh-pages@10.24.0--canary.1929.23688.0
  yarn add @auto-canary/git-tag@10.24.0--canary.1929.23688.0
  yarn add @auto-canary/gradle@10.24.0--canary.1929.23688.0
  yarn add @auto-canary/jira@10.24.0--canary.1929.23688.0
  yarn add @auto-canary/magic-zero@10.24.0--canary.1929.23688.0
  yarn add @auto-canary/maven@10.24.0--canary.1929.23688.0
  yarn add @auto-canary/microsoft-teams@10.24.0--canary.1929.23688.0
  yarn add @auto-canary/npm@10.24.0--canary.1929.23688.0
  yarn add @auto-canary/omit-commits@10.24.0--canary.1929.23688.0
  yarn add @auto-canary/omit-release-notes@10.24.0--canary.1929.23688.0
  yarn add @auto-canary/pr-body-labels@10.24.0--canary.1929.23688.0
  yarn add @auto-canary/released@10.24.0--canary.1929.23688.0
  yarn add @auto-canary/s3@10.24.0--canary.1929.23688.0
  yarn add @auto-canary/slack@10.24.0--canary.1929.23688.0
  yarn add @auto-canary/twitter@10.24.0--canary.1929.23688.0
  yarn add @auto-canary/upload-assets@10.24.0--canary.1929.23688.0
  yarn add @auto-canary/vscode@10.24.0--canary.1929.23688.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
