### PR TITLE
docs: import INpmConfig from npm package, not from core

### DIFF
--- a/docs/pages/docs/configuration/autorc.mdx
+++ b/docs/pages/docs/configuration/autorc.mdx
@@ -31,7 +31,7 @@ You can write your `auto` configuration in a TypeScript file for easier validati
 ```ts
 import { AutoRc } from "auto";
 
-import { INpmConfig } from "@auto-it/core";
+import { INpmConfig } from "@auto-it/npm";
 import { IAllContributorsPluginOptions } from "@auto-it/all-contributors";
 
 const npmOptions: INpmConfig = {


### PR DESCRIPTION
Hey :wave: Firstly, thank you so much for Auto! It already simplifies maintaining Theme UI, and I'm not even using its full capabilities (I made a typo in config file name, don't ask :P). Really good work here! 

# What Changed

Updated example _auto.config.ts_ to properly import npm plugin options.

## Why

_INpmConfig_ is not exported from _@auto-it/core_

Todo:

- [ ] ~~Add tests~~
- [x] Add docs

## Change Type

Indicate the type of change your pull request is:

- [x] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`

---

BTW, I also can't import _AutoRc_ from _auto_, and had to grab it from _@auto-it/core_ instead, but it might be just my installation.

![image](https://user-images.githubusercontent.com/15332326/114929254-d80a3380-9e33-11eb-90e6-498d1753903f.png)

