### PR TITLE
fix(types): point to dist/index.d.ts instead of non-existing file

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,7 +2,7 @@
   "name": "auto",
   "bin": "dist/bin/auto.js",
   "main": "dist/bin/index.js",
-  "types": "dist/bin/index.d.ts",
+  "types": "dist/index.d.ts",
   "description": "CLI tools to help facilitate semantic versioning based on GitHub PR labels",
   "version": "10.25.0",
   "license": "MIT",


### PR DESCRIPTION
Hey @hipstersmoothie, I realized why that `auto` import didn't have types.

The path in `"types"` here points to a wrong place :)

# What Changed

Fixed package.json "types"

## Why

bin/index.d.ts doesn't even exist.

Todo:

- [ ] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
