### PR TITLE
Remove `text` from non-app authed slack response

### DIFF
--- a/plugins/slack/__tests__/__snapshots__/slack.test.ts.snap
+++ b/plugins/slack/__tests__/__snapshots__/slack.test.ts.snap
@@ -428,7 +428,6 @@ Object {
     },
   ],
   "link_names": true,
-  "text": "New Releases: 1.0.0 :tada:",
 }
 `;
 
@@ -476,7 +475,6 @@ Object {
     },
   ],
   "link_names": true,
-  "text": "New Releases: 1.0.0 :tada:",
 }
 `;
 
@@ -530,7 +528,6 @@ Object {
     },
   ],
   "link_names": true,
-  "text": "New Release:  :tada:",
 }
 `;
 
@@ -577,7 +574,6 @@ Object {
     },
   ],
   "link_names": true,
-  "text": "New Release:  :tada:",
 }
 `;
 
@@ -624,7 +620,6 @@ Object {
     },
   ],
   "link_names": true,
-  "text": "New Release:  :tada:",
 }
 `;
 
@@ -671,7 +666,6 @@ Object {
     },
   ],
   "link_names": true,
-  "text": "New Releases: 1.0.0 :tada:",
 }
 `;
 
@@ -718,7 +712,6 @@ Object {
     },
   ],
   "link_names": true,
-  "text": "New Releases: 1.0.0 :tada:",
 }
 `;
 
@@ -765,7 +758,6 @@ Object {
     },
   ],
   "link_names": true,
-  "text": "New Release:  :tada:",
 }
 `;
 
@@ -812,7 +804,6 @@ Object {
     },
   ],
   "link_names": true,
-  "text": "New Releases: 1.0.0 :tada:",
 }
 `;
 
@@ -864,6 +855,5 @@ Object {
     },
   ],
   "link_names": true,
-  "text": "New Releases: 1.0.0 :tada:",
 }
 `;

--- a/plugins/slack/src/index.ts
+++ b/plugins/slack/src/index.ts
@@ -446,7 +446,6 @@ export default class SlackPlugin implements IPlugin {
         body: JSON.stringify({
           ...userPostMessageOptions,
           link_names: true,
-          text: `${header} :tada:`,
           // If not in app auth only one message is constructed
           blocks: messages[0],
         }),


### PR DESCRIPTION
# What Changed

Trying to fix #1940. Haven't tested it yet. 

## Why

Todo:

- [ ] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux--canary.1947.24201.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux--canary.1947.24201.gz)  
[auto-macos--canary.1947.24201.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos--canary.1947.24201.gz)  
[auto-win.exe--canary.1947.24201.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe--canary.1947.24201.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.27.1--canary.1947.24201.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.27.1--canary.1947.24201.0
  npm install @auto-canary/auto@10.27.1--canary.1947.24201.0
  npm install @auto-canary/core@10.27.1--canary.1947.24201.0
  npm install @auto-canary/package-json-utils@10.27.1--canary.1947.24201.0
  npm install @auto-canary/all-contributors@10.27.1--canary.1947.24201.0
  npm install @auto-canary/brew@10.27.1--canary.1947.24201.0
  npm install @auto-canary/chrome@10.27.1--canary.1947.24201.0
  npm install @auto-canary/cocoapods@10.27.1--canary.1947.24201.0
  npm install @auto-canary/conventional-commits@10.27.1--canary.1947.24201.0
  npm install @auto-canary/crates@10.27.1--canary.1947.24201.0
  npm install @auto-canary/docker@10.27.1--canary.1947.24201.0
  npm install @auto-canary/exec@10.27.1--canary.1947.24201.0
  npm install @auto-canary/first-time-contributor@10.27.1--canary.1947.24201.0
  npm install @auto-canary/gem@10.27.1--canary.1947.24201.0
  npm install @auto-canary/gh-pages@10.27.1--canary.1947.24201.0
  npm install @auto-canary/git-tag@10.27.1--canary.1947.24201.0
  npm install @auto-canary/gradle@10.27.1--canary.1947.24201.0
  npm install @auto-canary/jira@10.27.1--canary.1947.24201.0
  npm install @auto-canary/magic-zero@10.27.1--canary.1947.24201.0
  npm install @auto-canary/maven@10.27.1--canary.1947.24201.0
  npm install @auto-canary/microsoft-teams@10.27.1--canary.1947.24201.0
  npm install @auto-canary/npm@10.27.1--canary.1947.24201.0
  npm install @auto-canary/omit-commits@10.27.1--canary.1947.24201.0
  npm install @auto-canary/omit-release-notes@10.27.1--canary.1947.24201.0
  npm install @auto-canary/pr-body-labels@10.27.1--canary.1947.24201.0
  npm install @auto-canary/released@10.27.1--canary.1947.24201.0
  npm install @auto-canary/s3@10.27.1--canary.1947.24201.0
  npm install @auto-canary/slack@10.27.1--canary.1947.24201.0
  npm install @auto-canary/twitter@10.27.1--canary.1947.24201.0
  npm install @auto-canary/upload-assets@10.27.1--canary.1947.24201.0
  npm install @auto-canary/vscode@10.27.1--canary.1947.24201.0
  # or 
  yarn add @auto-canary/bot-list@10.27.1--canary.1947.24201.0
  yarn add @auto-canary/auto@10.27.1--canary.1947.24201.0
  yarn add @auto-canary/core@10.27.1--canary.1947.24201.0
  yarn add @auto-canary/package-json-utils@10.27.1--canary.1947.24201.0
  yarn add @auto-canary/all-contributors@10.27.1--canary.1947.24201.0
  yarn add @auto-canary/brew@10.27.1--canary.1947.24201.0
  yarn add @auto-canary/chrome@10.27.1--canary.1947.24201.0
  yarn add @auto-canary/cocoapods@10.27.1--canary.1947.24201.0
  yarn add @auto-canary/conventional-commits@10.27.1--canary.1947.24201.0
  yarn add @auto-canary/crates@10.27.1--canary.1947.24201.0
  yarn add @auto-canary/docker@10.27.1--canary.1947.24201.0
  yarn add @auto-canary/exec@10.27.1--canary.1947.24201.0
  yarn add @auto-canary/first-time-contributor@10.27.1--canary.1947.24201.0
  yarn add @auto-canary/gem@10.27.1--canary.1947.24201.0
  yarn add @auto-canary/gh-pages@10.27.1--canary.1947.24201.0
  yarn add @auto-canary/git-tag@10.27.1--canary.1947.24201.0
  yarn add @auto-canary/gradle@10.27.1--canary.1947.24201.0
  yarn add @auto-canary/jira@10.27.1--canary.1947.24201.0
  yarn add @auto-canary/magic-zero@10.27.1--canary.1947.24201.0
  yarn add @auto-canary/maven@10.27.1--canary.1947.24201.0
  yarn add @auto-canary/microsoft-teams@10.27.1--canary.1947.24201.0
  yarn add @auto-canary/npm@10.27.1--canary.1947.24201.0
  yarn add @auto-canary/omit-commits@10.27.1--canary.1947.24201.0
  yarn add @auto-canary/omit-release-notes@10.27.1--canary.1947.24201.0
  yarn add @auto-canary/pr-body-labels@10.27.1--canary.1947.24201.0
  yarn add @auto-canary/released@10.27.1--canary.1947.24201.0
  yarn add @auto-canary/s3@10.27.1--canary.1947.24201.0
  yarn add @auto-canary/slack@10.27.1--canary.1947.24201.0
  yarn add @auto-canary/twitter@10.27.1--canary.1947.24201.0
  yarn add @auto-canary/upload-assets@10.27.1--canary.1947.24201.0
  yarn add @auto-canary/vscode@10.27.1--canary.1947.24201.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
