### PR TITLE
Update docs for "afterAddToChangelog" → "afterChangelog" rename

### DIFF
--- a/docs/pages/docs/plugins/release-lifecycle-hooks.mdx
+++ b/docs/pages/docs/plugins/release-lifecycle-hooks.mdx
@@ -71,7 +71,7 @@ _Other examples:_
 - In Core: Create major version branches when `major` happens
 - [npm](../generated/npm) - Create sub-package changelogs
 
-## afterAddToChangelog
+## afterChangelog
 
 Ran after the `changelog` command adds the new release notes to `CHANGELOG.md`.
 Useful for getting extra commits into a release before publishing.
@@ -83,7 +83,7 @@ Useful for getting extra commits into a release before publishing.
 - `releaseNotes` - generated release notes for the release
 
 ```ts
-auto.hooks.afterAddToChangelog.tap(
+auto.hooks.afterChangelog.tap(
   "MyPlugin",
   async ({ currentVersion, commits, releaseNotes, lastRelease }) => {
     // do something


### PR DESCRIPTION
# What Changed

The "afterAddToChangelog" hook [was renamed in v10.0.0](https://github.com/intuit/auto/blob/main/CHANGELOG.md#v1000-thu-oct-29-2020) to just "afterChangelog".  This PR updates the documentation to use the new name.

## Why

Fixes #1945.

## Change Type

Indicate the type of change your pull request is:

- [x] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`