### PR TITLE
add noDefaultLabels config flag

### DIFF
--- a/docs/pages/docs/configuration/autorc.mdx
+++ b/docs/pages/docs/configuration/autorc.mdx
@@ -244,6 +244,19 @@ To customize your project's labels use the `labels` section in your `.autorc`.
 
 <DefaultLabelRenderer />
 
+#### Overriding default Labels
+
+By default Auto will add the labels you configured to the list of default labels. If you want to create only the labels you configured and ignore defaults, use `noDefaultLabels` option:
+
+```json
+{
+  "noDefaultLabels": true,
+  "labels": [
+    // custom labels
+  ]
+}
+```
+
 #### Label Customization
 
 You can customize everything about a label

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -43,7 +43,6 @@ export function normalizeLabels(config: ConfigObject): ILabelDefinition[] {
     }
 
     const userLabels: ILabelDefinition[] = config.labels.map(normalizeLabel);
-
     const baseLabels = defaultLabels.filter(
       (d) =>
         !userLabels.some(

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -36,9 +36,14 @@ export function normalizeLabel(
  * Go through all the labels in a config and make them
  * follow the same format.
  */
-export function normalizeLabels(config: ConfigObject) {
+export function normalizeLabels(config: ConfigObject): ILabelDefinition[] {
   if (config.labels) {
     const userLabels: ILabelDefinition[] = config.labels.map(normalizeLabel);
+
+    if (config.noDefaultLabels) {
+      return userLabels;
+    }
+
     const baseLabels = defaultLabels.filter(
       (d) =>
         !userLabels.some(

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -38,11 +38,11 @@ export function normalizeLabel(
  */
 export function normalizeLabels(config: ConfigObject): ILabelDefinition[] {
   if (config.labels) {
-    const userLabels: ILabelDefinition[] = config.labels.map(normalizeLabel);
-
     if (config.noDefaultLabels) {
-      return userLabels;
+      return config.labels as ILabelDefinition[];
     }
+
+    const userLabels: ILabelDefinition[] = config.labels.map(normalizeLabel);
 
     const baseLabels = defaultLabels.filter(
       (d) =>


### PR DESCRIPTION
# What Changed

New configuration flag: `noDefaultLabels: boolean`.

## Why

An attempt to fix #1955.

Instead of adding a flag to `create-labels` command, I added a configuration flag. I couldn't find where `create-labels` adds defaults to the configured labels, but I think that it happens in the configuration processing code. So I made a change there.

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`