### PR TITLE
canary shouldn't make changes on dry run

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1245,7 +1245,7 @@ export default class Auto {
         bump = SEMVER.patch;
       } else {
         this.logger.log.info(
-          "Skipping canary release due to PR being specifying no release. Use `auto canary --force` to override this setting"
+          "Skipping canary release due to PR specifying no release. Use `auto canary --force` to override this setting"
         );
         return;
       }
@@ -1297,7 +1297,7 @@ export default class Auto {
         : `<code>${newVersion}</code>`
     );
 
-    if (options.message !== "false" && pr) {
+    if (!options.dryRun && options.message !== "false" && pr) {
       const prNumber = Number(pr);
       const message =
         typeof result === "string"
@@ -1333,15 +1333,18 @@ export default class Auto {
       }
     }
 
+    const verb = options.dryRun ? "Would have published" : "Published"
     this.logger.log.success(
-      `Published canary version${newVersion ? `: ${newVersion}` : ""}`
+      `${verb} canary version${newVersion ? `: ${newVersion}` : ""}`
     );
 
     if (args.quiet) {
       console.log(newVersion);
     }
 
-    await gitReset();
+    if (!options.dryRun) {
+      await gitReset();
+    }
 
     return { newVersion, commitsInRelease, context: "canary" };
   }


### PR DESCRIPTION
# What Changed

Make more use of `dry-run` option in the code of the canary action.

## Why

When running 

```
auto shipit --dry-run --quiet
```

on a PR, it creates the comment `📦 Published PR as canary version: ...`. A workaround is to add `--message false`, but it shouldn't create any comments claiming that things are published when it's just a dry-run (to get the version value, btw).

I also noticed when running

```
auto canary --dry-run --quiet
```

locally, it resets my unstaged Git changes 🤯 This is a destructive bug.

Todo:

- [ ] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
