### PR TITLE
rearrange to allow dryrun to leverage prefixed tag

### DIFF
--- a/plugins/git-tag/src/index.ts
+++ b/plugins/git-tag/src/index.ts
@@ -51,7 +51,7 @@ export default class GitTagPlugin implements IPlugin {
 
         const prefixedTag = auto.prefixRelease(newTag);
 
-        if (dryRun && prefixedTag) {
+        if (dryRun) {
           if (quiet) {
             console.log(prefixedTag);
           } else {

--- a/plugins/git-tag/src/index.ts
+++ b/plugins/git-tag/src/index.ts
@@ -44,22 +44,22 @@ export default class GitTagPlugin implements IPlugin {
         const lastTag = await getTag();
         const newTag = inc(lastTag, bump as ReleaseType);
 
-        if (dryRun && newTag) {
-          if (quiet) {
-            console.log(newTag);
-          } else {
-            auto.logger.log.info(`Would have published: ${newTag}`);
-          }
-
-          return;
-        }
-
         if (!newTag) {
           auto.logger.log.info("No release found, doing nothing");
           return;
         }
 
         const prefixedTag = auto.prefixRelease(newTag);
+
+        if (dryRun && prefixedTag) {
+          if (quiet) {
+            console.log(prefixedTag);
+          } else {
+            auto.logger.log.info(`Would have published: ${prefixedTag}`);
+          }
+
+          return;
+        }
 
         auto.logger.log.info(`Tagging new tag: ${lastTag} => ${prefixedTag}`);
         await execPromise("git", [


### PR DESCRIPTION
# What Changed

Rearrange the order in `git-tag` version hook so that `!newTag` is checked first, allowing `dryRun` & `quiet` to received the potential prefixed version.

## Why

Ensures the `dryRun` and normal flows both output the same version string.

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
