### PR TITLE
feat: push multiple podspecs

### DIFF
--- a/plugins/cocoapods/README.md
+++ b/plugins/cocoapods/README.md
@@ -38,6 +38,29 @@ yarn add -D @auto-it/cocoapods
 }
 ```
 
+Or with multiple podspecs:
+
+```json
+{
+  "plugins": [
+    [
+      "cocoapods",
+      {
+        // Required, the relative path to your podspec file
+        "podspecPath": ["./Test.podspec", "./Test2.podspec"],
+        // Optional, the specs repo to push to
+        "specsRepo": "https://github.com/intuit/TestSpecs.git",
+        // Optional, flags to pass to the `pod repo push` command
+        "flags": ["--sources=https://github.com/SpecRepo.git"],
+        // Optional, specify a different executable for `pod`
+        "podCommand": "bundle exec pod"
+      }
+    ]
+    // other plugins
+  ]
+}
+```
+
 ## Requirements
 
 ### General

--- a/plugins/cocoapods/__tests__/cocoapods.test.ts
+++ b/plugins/cocoapods/__tests__/cocoapods.test.ts
@@ -226,6 +226,21 @@ describe("Cocoapods Plugin", () => {
       );
     });
   });
+  describe("validateConfig hook", () => {
+    test("should validate options", async () => {
+      expect(
+        ((await hooks.validateConfig.promise("cocoapods", {})) || [])
+      ).toHaveLength(1);
+      expect(
+        ((await hooks.validateConfig.promise("cocoapods", options)) || [])
+          
+      ).toHaveLength(0);
+      expect(
+        ((await hooks.validateConfig.promise("cocoapods", multiOptions)) || [])
+          
+      ).toHaveLength(0);
+    });
+  });
   describe("modifyConfig hook", () => {
     test("should set noVersionPrefix to true", async () => {
       const config = {};

--- a/plugins/cocoapods/src/index.ts
+++ b/plugins/cocoapods/src/index.ts
@@ -168,9 +168,8 @@ export default class CocoapodsPlugin implements IPlugin {
     if (typeof this.options.podspecPath === "string") {
       return [this.options.podspecPath];
     }
- 
-      return this.options.podspecPath;
-    
+
+    return this.options.podspecPath;
   }
 
   /** Initialize the plugin with it's options */
@@ -373,7 +372,7 @@ export default class CocoapodsPlugin implements IPlugin {
                 path,
               ])
             ),
-          Promise.resolve()
+          Promise.resolve("")
         );
       }
     });
@@ -409,7 +408,7 @@ export default class CocoapodsPlugin implements IPlugin {
               ...podLogLevel,
             ])
           ),
-        Promise.resolve()
+        Promise.resolve("")
       );
       return;
     }
@@ -463,7 +462,7 @@ export default class CocoapodsPlugin implements IPlugin {
               ...podLogLevel,
             ])
           ),
-        Promise.resolve()
+        Promise.resolve("")
       );
     } catch (error) {
       this.logger?.log.error(


### PR DESCRIPTION
# What Changed

`podspecPath` can now be an array of paths to podspecs that will all get pushed and versioned the same

## Why

Feature request from a user, since it's git backed we need to keep them all the same version, using the plugin multiple times would cause duplicate tags in git

Todo:

- [x] Add tests
- [x] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux--canary.1982.24234.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux--canary.1982.24234.gz)  
[auto-macos--canary.1982.24234.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos--canary.1982.24234.gz)  
[auto-win.exe--canary.1982.24234.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe--canary.1982.24234.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.28.0--canary.1982.24234.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.28.0--canary.1982.24234.0
  npm install @auto-canary/auto@10.28.0--canary.1982.24234.0
  npm install @auto-canary/core@10.28.0--canary.1982.24234.0
  npm install @auto-canary/package-json-utils@10.28.0--canary.1982.24234.0
  npm install @auto-canary/all-contributors@10.28.0--canary.1982.24234.0
  npm install @auto-canary/brew@10.28.0--canary.1982.24234.0
  npm install @auto-canary/chrome@10.28.0--canary.1982.24234.0
  npm install @auto-canary/cocoapods@10.28.0--canary.1982.24234.0
  npm install @auto-canary/conventional-commits@10.28.0--canary.1982.24234.0
  npm install @auto-canary/crates@10.28.0--canary.1982.24234.0
  npm install @auto-canary/docker@10.28.0--canary.1982.24234.0
  npm install @auto-canary/exec@10.28.0--canary.1982.24234.0
  npm install @auto-canary/first-time-contributor@10.28.0--canary.1982.24234.0
  npm install @auto-canary/gem@10.28.0--canary.1982.24234.0
  npm install @auto-canary/gh-pages@10.28.0--canary.1982.24234.0
  npm install @auto-canary/git-tag@10.28.0--canary.1982.24234.0
  npm install @auto-canary/gradle@10.28.0--canary.1982.24234.0
  npm install @auto-canary/jira@10.28.0--canary.1982.24234.0
  npm install @auto-canary/magic-zero@10.28.0--canary.1982.24234.0
  npm install @auto-canary/maven@10.28.0--canary.1982.24234.0
  npm install @auto-canary/microsoft-teams@10.28.0--canary.1982.24234.0
  npm install @auto-canary/npm@10.28.0--canary.1982.24234.0
  npm install @auto-canary/omit-commits@10.28.0--canary.1982.24234.0
  npm install @auto-canary/omit-release-notes@10.28.0--canary.1982.24234.0
  npm install @auto-canary/pr-body-labels@10.28.0--canary.1982.24234.0
  npm install @auto-canary/released@10.28.0--canary.1982.24234.0
  npm install @auto-canary/s3@10.28.0--canary.1982.24234.0
  npm install @auto-canary/sbt@10.28.0--canary.1982.24234.0
  npm install @auto-canary/slack@10.28.0--canary.1982.24234.0
  npm install @auto-canary/twitter@10.28.0--canary.1982.24234.0
  npm install @auto-canary/upload-assets@10.28.0--canary.1982.24234.0
  npm install @auto-canary/vscode@10.28.0--canary.1982.24234.0
  # or 
  yarn add @auto-canary/bot-list@10.28.0--canary.1982.24234.0
  yarn add @auto-canary/auto@10.28.0--canary.1982.24234.0
  yarn add @auto-canary/core@10.28.0--canary.1982.24234.0
  yarn add @auto-canary/package-json-utils@10.28.0--canary.1982.24234.0
  yarn add @auto-canary/all-contributors@10.28.0--canary.1982.24234.0
  yarn add @auto-canary/brew@10.28.0--canary.1982.24234.0
  yarn add @auto-canary/chrome@10.28.0--canary.1982.24234.0
  yarn add @auto-canary/cocoapods@10.28.0--canary.1982.24234.0
  yarn add @auto-canary/conventional-commits@10.28.0--canary.1982.24234.0
  yarn add @auto-canary/crates@10.28.0--canary.1982.24234.0
  yarn add @auto-canary/docker@10.28.0--canary.1982.24234.0
  yarn add @auto-canary/exec@10.28.0--canary.1982.24234.0
  yarn add @auto-canary/first-time-contributor@10.28.0--canary.1982.24234.0
  yarn add @auto-canary/gem@10.28.0--canary.1982.24234.0
  yarn add @auto-canary/gh-pages@10.28.0--canary.1982.24234.0
  yarn add @auto-canary/git-tag@10.28.0--canary.1982.24234.0
  yarn add @auto-canary/gradle@10.28.0--canary.1982.24234.0
  yarn add @auto-canary/jira@10.28.0--canary.1982.24234.0
  yarn add @auto-canary/magic-zero@10.28.0--canary.1982.24234.0
  yarn add @auto-canary/maven@10.28.0--canary.1982.24234.0
  yarn add @auto-canary/microsoft-teams@10.28.0--canary.1982.24234.0
  yarn add @auto-canary/npm@10.28.0--canary.1982.24234.0
  yarn add @auto-canary/omit-commits@10.28.0--canary.1982.24234.0
  yarn add @auto-canary/omit-release-notes@10.28.0--canary.1982.24234.0
  yarn add @auto-canary/pr-body-labels@10.28.0--canary.1982.24234.0
  yarn add @auto-canary/released@10.28.0--canary.1982.24234.0
  yarn add @auto-canary/s3@10.28.0--canary.1982.24234.0
  yarn add @auto-canary/sbt@10.28.0--canary.1982.24234.0
  yarn add @auto-canary/slack@10.28.0--canary.1982.24234.0
  yarn add @auto-canary/twitter@10.28.0--canary.1982.24234.0
  yarn add @auto-canary/upload-assets@10.28.0--canary.1982.24234.0
  yarn add @auto-canary/vscode@10.28.0--canary.1982.24234.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
