### PR TITLE
fix(npm): Prevents canary releases with double dashed version numbers

### DIFF
--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -1005,6 +1005,9 @@ export default class NPMPlugin implements IPlugin {
           }
         };
 
+        canaryIdentifier = canaryIdentifier.replace(/^-/, "")
+
+
         if (isMonorepo()) {
           const isIndependent = getLernaJson().version === "independent";
           auto.logger.verbose.info("Detected monorepo, using lerna");
@@ -1054,7 +1057,7 @@ export default class NPMPlugin implements IPlugin {
               "--exact",
               "--ignore-scripts",
               "--preid",
-              canaryIdentifier.replace(/^-/, ""),
+              canaryIdentifier,
               ...verboseArgs,
             ]);
 
@@ -1080,7 +1083,7 @@ export default class NPMPlugin implements IPlugin {
             "--no-git-tag-version", // no need to tag and commit,
             "--exact", // do not add ^ to canary versions, this can result in `npm i` resolving the wrong canary version
             ...(isIndependent
-              ? ["--preid", canaryIdentifier.replace(/^-/, "")]
+              ? ["--preid", canaryIdentifier]
               : []),
             ...verboseArgs,
           ]);


### PR DESCRIPTION
# What Changed

Removed leading dash on all `npm` canary releases.

## Why

Since upgrading to `auto@10.x`, our canary releases are creating versions like `10.1.0--canary.1379.2451.0` with a double-dash on the pre-id.

The other instances in the `canary` hook were already stripping off the leading `-`, so I've extended this to the last 2 instances.

Todo:

- [ ] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux--canary.1997.24321.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux--canary.1997.24321.gz)  
[auto-macos--canary.1997.24321.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos--canary.1997.24321.gz)  
[auto-win.exe--canary.1997.24321.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe--canary.1997.24321.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.29.1-canary.1997.24321.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.29.1-canary.1997.24321.0
  npm install @auto-canary/auto@10.29.1-canary.1997.24321.0
  npm install @auto-canary/core@10.29.1-canary.1997.24321.0
  npm install @auto-canary/package-json-utils@10.29.1-canary.1997.24321.0
  npm install @auto-canary/all-contributors@10.29.1-canary.1997.24321.0
  npm install @auto-canary/brew@10.29.1-canary.1997.24321.0
  npm install @auto-canary/chrome@10.29.1-canary.1997.24321.0
  npm install @auto-canary/cocoapods@10.29.1-canary.1997.24321.0
  npm install @auto-canary/conventional-commits@10.29.1-canary.1997.24321.0
  npm install @auto-canary/crates@10.29.1-canary.1997.24321.0
  npm install @auto-canary/docker@10.29.1-canary.1997.24321.0
  npm install @auto-canary/exec@10.29.1-canary.1997.24321.0
  npm install @auto-canary/first-time-contributor@10.29.1-canary.1997.24321.0
  npm install @auto-canary/gem@10.29.1-canary.1997.24321.0
  npm install @auto-canary/gh-pages@10.29.1-canary.1997.24321.0
  npm install @auto-canary/git-tag@10.29.1-canary.1997.24321.0
  npm install @auto-canary/gradle@10.29.1-canary.1997.24321.0
  npm install @auto-canary/jira@10.29.1-canary.1997.24321.0
  npm install @auto-canary/magic-zero@10.29.1-canary.1997.24321.0
  npm install @auto-canary/maven@10.29.1-canary.1997.24321.0
  npm install @auto-canary/microsoft-teams@10.29.1-canary.1997.24321.0
  npm install @auto-canary/npm@10.29.1-canary.1997.24321.0
  npm install @auto-canary/omit-commits@10.29.1-canary.1997.24321.0
  npm install @auto-canary/omit-release-notes@10.29.1-canary.1997.24321.0
  npm install @auto-canary/pr-body-labels@10.29.1-canary.1997.24321.0
  npm install @auto-canary/released@10.29.1-canary.1997.24321.0
  npm install @auto-canary/s3@10.29.1-canary.1997.24321.0
  npm install @auto-canary/sbt@10.29.1-canary.1997.24321.0
  npm install @auto-canary/slack@10.29.1-canary.1997.24321.0
  npm install @auto-canary/twitter@10.29.1-canary.1997.24321.0
  npm install @auto-canary/upload-assets@10.29.1-canary.1997.24321.0
  npm install @auto-canary/vscode@10.29.1-canary.1997.24321.0
  # or 
  yarn add @auto-canary/bot-list@10.29.1-canary.1997.24321.0
  yarn add @auto-canary/auto@10.29.1-canary.1997.24321.0
  yarn add @auto-canary/core@10.29.1-canary.1997.24321.0
  yarn add @auto-canary/package-json-utils@10.29.1-canary.1997.24321.0
  yarn add @auto-canary/all-contributors@10.29.1-canary.1997.24321.0
  yarn add @auto-canary/brew@10.29.1-canary.1997.24321.0
  yarn add @auto-canary/chrome@10.29.1-canary.1997.24321.0
  yarn add @auto-canary/cocoapods@10.29.1-canary.1997.24321.0
  yarn add @auto-canary/conventional-commits@10.29.1-canary.1997.24321.0
  yarn add @auto-canary/crates@10.29.1-canary.1997.24321.0
  yarn add @auto-canary/docker@10.29.1-canary.1997.24321.0
  yarn add @auto-canary/exec@10.29.1-canary.1997.24321.0
  yarn add @auto-canary/first-time-contributor@10.29.1-canary.1997.24321.0
  yarn add @auto-canary/gem@10.29.1-canary.1997.24321.0
  yarn add @auto-canary/gh-pages@10.29.1-canary.1997.24321.0
  yarn add @auto-canary/git-tag@10.29.1-canary.1997.24321.0
  yarn add @auto-canary/gradle@10.29.1-canary.1997.24321.0
  yarn add @auto-canary/jira@10.29.1-canary.1997.24321.0
  yarn add @auto-canary/magic-zero@10.29.1-canary.1997.24321.0
  yarn add @auto-canary/maven@10.29.1-canary.1997.24321.0
  yarn add @auto-canary/microsoft-teams@10.29.1-canary.1997.24321.0
  yarn add @auto-canary/npm@10.29.1-canary.1997.24321.0
  yarn add @auto-canary/omit-commits@10.29.1-canary.1997.24321.0
  yarn add @auto-canary/omit-release-notes@10.29.1-canary.1997.24321.0
  yarn add @auto-canary/pr-body-labels@10.29.1-canary.1997.24321.0
  yarn add @auto-canary/released@10.29.1-canary.1997.24321.0
  yarn add @auto-canary/s3@10.29.1-canary.1997.24321.0
  yarn add @auto-canary/sbt@10.29.1-canary.1997.24321.0
  yarn add @auto-canary/slack@10.29.1-canary.1997.24321.0
  yarn add @auto-canary/twitter@10.29.1-canary.1997.24321.0
  yarn add @auto-canary/upload-assets@10.29.1-canary.1997.24321.0
  yarn add @auto-canary/vscode@10.29.1-canary.1997.24321.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
