### PR TITLE
feat(plugins/npm): permit lerna publish to use automation tokens

### DIFF
--- a/plugins/npm/README.md
+++ b/plugins/npm/README.md
@@ -49,24 +49,6 @@ No additional setup is required.
 
 > Do you have a package in your monorepo you don't want to publish but still want versioned?
 > Just set that `"private": true` you that package's `package.json`!
-
-### Using automation tokens from NPM
-
-If you have 2FA enabled and want to publish using an [automation token](https://github.blog/changelog/2020-10-02-npm-automation-tokens/) you _must_ add the following to your `lerna.json` for it to work.
-
-```json
-{
-  // ... other config here
-  "command": {
-    "publish": {
-      "verifyAccess": false
-    }
-  }
-}
-```
-
-Lerna's verify access step hits an npm api endpoint that treats automation tokens differently than regular user tokens. Disabling it will bypass that failure. See [this lerna issue](https://github.com/lerna/lerna/issues/2788) for more context.
-
 ## Options
 
 ### setRcToken

--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -1140,6 +1140,7 @@ describe("canary", () => {
       "--no-git-reset",
       "--no-git-tag-version",
       "--exact",
+      "--no-verify-access"
     ]);
   });
 

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -1079,6 +1079,7 @@ export default class NPMPlugin implements IPlugin {
             "--no-git-reset", // so we can get the version that just published
             "--no-git-tag-version", // no need to tag and commit,
             "--exact", // do not add ^ to canary versions, this can result in `npm i` resolving the wrong canary version
+            "--no-verify-access", // permit automation tokens https://github.com/lerna/lerna/issues/2788
             ...(isIndependent
               ? ["--preid", canaryIdentifier.replace(/^-/, "")]
               : []),
@@ -1257,6 +1258,7 @@ export default class NPMPlugin implements IPlugin {
             "--yes",
             // do not add ^ to next versions, this can result in `npm i` resolving the wrong next version
             "--exact",
+            "--no-verify-access", // permit automation tokens https://github.com/lerna/lerna/issues/2788
             "--no-commit-hooks",
             ...verboseArgs,
           ]);


### PR DESCRIPTION
# What Changed

- `lerna publish` was failing authentication even with a token that clearly had write access, as using `yarn npm publish` works. As a result, the canary build feature of `auto` wasn't working.
- Examining https://github.com/lerna/lerna/issues/2788 revealed the root issue, automation tokens fail the identity check used at the start of `lerna publish` unless a flag is passed.

- Updates locations in the `auto` code where `lerna publish` is called to not require the identify verification check.

## Why

- Using `auto` in a monorepo was failing, using a non-automation token is not an option for this project
- Alternately we could expose some config to opt in/out of having this flag, but I think having good behavior by default for automation tokens is desirable, especially for canary builds.

Todo:

- [ ] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`


## Testing

I'm not sure how to trigger a canary package publish within this repo (maybe a tag is necessary), so I've published a fork of this under [my own scope](https://www.npmjs.com/package/@hydrosquall/auto)  to test separately.

```bash
yarn add -D @hydrosquall/auto@10.29.3-cameron-1
```
