### PR TITLE
feat(plugins/npm): exclude pre-release branches from greaterRelease calculation

### DIFF
--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -183,6 +183,12 @@ describe("greaterRelease", () => {
       await greaterRelease(prefixRelease, "test-package-name", "1.0.0")
     ).toBe("1.0.1");
   });
+  test("should default to packageVersion if (publishedVersion is greater, but is a pre-release)", async () => {
+    execPromise.mockReturnValueOnce("1.0.1-next.0");
+    expect(
+      await greaterRelease(prefixRelease, "test-package-name", "1.0.0")
+    ).toBe("1.0.0");
+  });
 });
 
 describe("getAuthor", () => {

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -52,7 +52,7 @@ async function getPublishedVersion(name: string) {
 }
 
 /**
- * Determine the greatest version between last published version of a
+ * Determine the greatest version between @latest published version of a
  * package and the version in the package.json.
  */
 export async function greaterRelease(
@@ -64,6 +64,13 @@ export async function greaterRelease(
   const publishedVersion = await getPublishedVersion(name);
 
   if (!publishedVersion) {
+    return packageVersion;
+  }
+
+  // If @latest published version is a pre-release,
+  // this means the package has not been published as a stable tag yet
+  // Prefer local version to prevent a new package from adjusting the versions for a whole monorepo.
+  if (prerelease(publishedVersion) !== null) {
     return packageVersion;
   }
 


### PR DESCRIPTION
# What Changed

- Exclude the remote NPM version from the "greater" calculation if the `@latest` tag is for a pre-release version. 
   - This can happen if a new package is first published without a tag on `@latest`, AND that package happens to be the last alphabetically in `getMonoRepoPackage`, its version will drive up the next version for the entire monorepo because its "latest" version is ahead of all its siblings.

## Why

- Expanded on #2035 , which didn't have the full effect because it was only filtering on local package versions (it didn't include public versions)

I considered a few different places to add this check, but from testing this location in an auto config with only the 1 NPM plugin

- [x] `yarn run auto info ` 
- [x] `yarn run auto latest --dry-run`
- [x] `yarn run auto canary --dry-run`
- [x] `yarn run auto next --dry-run` ~(not working yet - for some reason this is still outputting the wrong version, investigating...~ (This was solved by deleting tags from the git remote which hadn't been removed yet)

Todo:

- [ ] Add tests
- [ ] Add docs


## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux--canary.2036.24610.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux--canary.2036.24610.gz)  
[auto-macos--canary.2036.24610.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos--canary.2036.24610.gz)  
[auto-win.exe--canary.2036.24610.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe--canary.2036.24610.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.31.0--canary.2036.24610.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.31.0--canary.2036.24610.0
  npm install @auto-canary/auto@10.31.0--canary.2036.24610.0
  npm install @auto-canary/core@10.31.0--canary.2036.24610.0
  npm install @auto-canary/package-json-utils@10.31.0--canary.2036.24610.0
  npm install @auto-canary/all-contributors@10.31.0--canary.2036.24610.0
  npm install @auto-canary/brew@10.31.0--canary.2036.24610.0
  npm install @auto-canary/chrome@10.31.0--canary.2036.24610.0
  npm install @auto-canary/cocoapods@10.31.0--canary.2036.24610.0
  npm install @auto-canary/conventional-commits@10.31.0--canary.2036.24610.0
  npm install @auto-canary/crates@10.31.0--canary.2036.24610.0
  npm install @auto-canary/docker@10.31.0--canary.2036.24610.0
  npm install @auto-canary/exec@10.31.0--canary.2036.24610.0
  npm install @auto-canary/first-time-contributor@10.31.0--canary.2036.24610.0
  npm install @auto-canary/gem@10.31.0--canary.2036.24610.0
  npm install @auto-canary/gh-pages@10.31.0--canary.2036.24610.0
  npm install @auto-canary/git-tag@10.31.0--canary.2036.24610.0
  npm install @auto-canary/gradle@10.31.0--canary.2036.24610.0
  npm install @auto-canary/jira@10.31.0--canary.2036.24610.0
  npm install @auto-canary/magic-zero@10.31.0--canary.2036.24610.0
  npm install @auto-canary/maven@10.31.0--canary.2036.24610.0
  npm install @auto-canary/microsoft-teams@10.31.0--canary.2036.24610.0
  npm install @auto-canary/npm@10.31.0--canary.2036.24610.0
  npm install @auto-canary/omit-commits@10.31.0--canary.2036.24610.0
  npm install @auto-canary/omit-release-notes@10.31.0--canary.2036.24610.0
  npm install @auto-canary/pr-body-labels@10.31.0--canary.2036.24610.0
  npm install @auto-canary/released@10.31.0--canary.2036.24610.0
  npm install @auto-canary/s3@10.31.0--canary.2036.24610.0
  npm install @auto-canary/sbt@10.31.0--canary.2036.24610.0
  npm install @auto-canary/slack@10.31.0--canary.2036.24610.0
  npm install @auto-canary/twitter@10.31.0--canary.2036.24610.0
  npm install @auto-canary/upload-assets@10.31.0--canary.2036.24610.0
  npm install @auto-canary/vscode@10.31.0--canary.2036.24610.0
  # or 
  yarn add @auto-canary/bot-list@10.31.0--canary.2036.24610.0
  yarn add @auto-canary/auto@10.31.0--canary.2036.24610.0
  yarn add @auto-canary/core@10.31.0--canary.2036.24610.0
  yarn add @auto-canary/package-json-utils@10.31.0--canary.2036.24610.0
  yarn add @auto-canary/all-contributors@10.31.0--canary.2036.24610.0
  yarn add @auto-canary/brew@10.31.0--canary.2036.24610.0
  yarn add @auto-canary/chrome@10.31.0--canary.2036.24610.0
  yarn add @auto-canary/cocoapods@10.31.0--canary.2036.24610.0
  yarn add @auto-canary/conventional-commits@10.31.0--canary.2036.24610.0
  yarn add @auto-canary/crates@10.31.0--canary.2036.24610.0
  yarn add @auto-canary/docker@10.31.0--canary.2036.24610.0
  yarn add @auto-canary/exec@10.31.0--canary.2036.24610.0
  yarn add @auto-canary/first-time-contributor@10.31.0--canary.2036.24610.0
  yarn add @auto-canary/gem@10.31.0--canary.2036.24610.0
  yarn add @auto-canary/gh-pages@10.31.0--canary.2036.24610.0
  yarn add @auto-canary/git-tag@10.31.0--canary.2036.24610.0
  yarn add @auto-canary/gradle@10.31.0--canary.2036.24610.0
  yarn add @auto-canary/jira@10.31.0--canary.2036.24610.0
  yarn add @auto-canary/magic-zero@10.31.0--canary.2036.24610.0
  yarn add @auto-canary/maven@10.31.0--canary.2036.24610.0
  yarn add @auto-canary/microsoft-teams@10.31.0--canary.2036.24610.0
  yarn add @auto-canary/npm@10.31.0--canary.2036.24610.0
  yarn add @auto-canary/omit-commits@10.31.0--canary.2036.24610.0
  yarn add @auto-canary/omit-release-notes@10.31.0--canary.2036.24610.0
  yarn add @auto-canary/pr-body-labels@10.31.0--canary.2036.24610.0
  yarn add @auto-canary/released@10.31.0--canary.2036.24610.0
  yarn add @auto-canary/s3@10.31.0--canary.2036.24610.0
  yarn add @auto-canary/sbt@10.31.0--canary.2036.24610.0
  yarn add @auto-canary/slack@10.31.0--canary.2036.24610.0
  yarn add @auto-canary/twitter@10.31.0--canary.2036.24610.0
  yarn add @auto-canary/upload-assets@10.31.0--canary.2036.24610.0
  yarn add @auto-canary/vscode@10.31.0--canary.2036.24610.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
