### PR TITLE
Expand default label configuration by default in Docs

### DIFF
--- a/docs/generate-command-docs.js
+++ b/docs/generate-command-docs.js
@@ -109,14 +109,11 @@ title: "Default Labels"
 layout: 'none'
 ---
 
-<details>
-
-<summary>Click here to see the default label configuration</summary>
+Here is the default label configuration
 
 \`\`\`json
 ${JSON.stringify(defaultLabels, null, 2)}
 \`\`\`
 
-</details>
 `
 );

--- a/docs/pages/docs/configuration/autorc.mdx
+++ b/docs/pages/docs/configuration/autorc.mdx
@@ -242,6 +242,8 @@ To customize your project's labels use the `labels` section in your `.autorc`.
 }
 ```
 
+#### Default Labels
+
 <DefaultLabelRenderer />
 
 #### Overriding default Labels


### PR DESCRIPTION
# What Changed
Default Label configurations are not hidden anymore, but clearly visible in the documentation. 

Fixes #2015 

## Why
The default label configuration was very easy to miss, although it probably will be interesting information for many devs.

Todo:

- [ ] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [x] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
