### PR TITLE
chore: add repository for all packages.json

### DIFF
--- a/packages/bot-list/package.json
+++ b/packages/bot-list/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/intuit/auto"
+    "url": "https://github.com/intuit/auto.git",
+    "directory": "packages/bot-list"
   },
   "files": [
     "dist"
@@ -38,5 +39,6 @@
     "start": "npm run build -- -w",
     "lint": "eslint src --ext .ts",
     "test": "jest --maxWorkers=2"
-  }
+  },
+  "homepage": "https://intuit.github.io/auto/"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,7 +19,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/intuit/auto"
+    "url": "https://github.com/intuit/auto.git",
+    "directory": "packages/cli"
   },
   "files": [
     "dist"
@@ -64,5 +65,6 @@
   "devDependencies": {
     "@types/signale": "^1.2.1",
     "pkg": "^4.4.0"
-  }
+  },
+  "homepage": "https://intuit.github.io/auto/"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/intuit/auto"
+    "url": "https://github.com/intuit/auto.git",
+    "directory": "packages/core"
   },
   "files": [
     "dist"
@@ -95,5 +96,6 @@
     "@types/tinycolor2": "^1.4.1",
     "@types/url-join": "^4.0.0",
     "graphql": "^15.0.0"
-  }
+  },
+  "homepage": "https://intuit.github.io/auto/"
 }

--- a/packages/package-json-utils/package.json
+++ b/packages/package-json-utils/package.json
@@ -15,7 +15,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/intuit/auto"
+    "url": "https://github.com/intuit/auto.git",
+    "directory": "packages/package-json-utils"
   },
   "files": [
     "dist"
@@ -46,5 +47,6 @@
   },
   "devDependencies": {
     "@types/parse-github-url": "1.0.0"
-  }
+  },
+  "homepage": "https://intuit.github.io/auto/"
 }

--- a/plugins/all-contributors/package.json
+++ b/plugins/all-contributors/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/intuit/auto"
+    "url": "https://github.com/intuit/auto.git",
+    "directory": "plugins/all-contributors"
   },
   "files": [
     "dist"
@@ -49,5 +50,6 @@
     "fromentries": "^1.2.0",
     "io-ts": "^2.1.2",
     "tslib": "2.1.0"
-  }
+  },
+  "homepage": "https://intuit.github.io/auto/"
 }

--- a/plugins/brew/package.json
+++ b/plugins/brew/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/intuit/auto"
+    "url": "https://github.com/intuit/auto.git",
+    "directory": "plugins/brew"
   },
   "files": [
     "dist"
@@ -40,5 +41,6 @@
     "fp-ts": "^2.5.3",
     "io-ts": "^2.1.2",
     "tslib": "2.1.0"
-  }
+  },
+  "homepage": "https://intuit.github.io/auto/"
 }

--- a/plugins/chrome/package.json
+++ b/plugins/chrome/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/intuit/auto"
+    "url": "https://github.com/intuit/auto.git",
+    "directory": "plugins/chrome"
   },
   "files": [
     "dist"
@@ -47,5 +48,6 @@
   },
   "devDependencies": {
     "@types/semver": "^7.1.0"
-  }
+  },
+  "homepage": "https://intuit.github.io/auto/"
 }

--- a/plugins/cocoapods/package.json
+++ b/plugins/cocoapods/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/intuit/auto"
+    "url": "https://github.com/intuit/auto.git",
+    "directory": "plugins/cocoapods"
   },
   "files": [
     "dist"
@@ -41,5 +42,6 @@
     "io-ts": "^2.1.2",
     "semver": "^7.1.3",
     "tslib": "2.1.0"
-  }
+  },
+  "homepage": "https://intuit.github.io/auto/"
 }

--- a/plugins/conventional-commits/package.json
+++ b/plugins/conventional-commits/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/intuit/auto"
+    "url": "https://github.com/intuit/auto.git",
+    "directory": "plugins/conventional-commits"
   },
   "files": [
     "dist"
@@ -51,5 +52,6 @@
     "@types/conventional-changelog-core": "^4.1.1",
     "@types/conventional-changelog-preset-loader": "^2.3.1",
     "@types/conventional-commits-parser": "^3.0.0"
-  }
+  },
+  "homepage": "https://intuit.github.io/auto/"
 }

--- a/plugins/crates/package.json
+++ b/plugins/crates/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/intuit/auto"
+    "url": "https://github.com/intuit/auto.git",
+    "directory": "plugins/crates"
   },
   "files": [
     "dist"
@@ -44,5 +45,6 @@
     "toml": "^3.0.0",
     "tslib": "2.1.0",
     "user-home": "^2.0.0"
-  }
+  },
+  "homepage": "https://intuit.github.io/auto/"
 }

--- a/plugins/docker/package.json
+++ b/plugins/docker/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/intuit/auto"
+    "url": "https://github.com/intuit/auto.git",
+    "directory": "plugins/docker"
   },
   "files": [
     "dist"
@@ -42,5 +43,6 @@
     "io-ts": "^2.1.2",
     "semver": "^7.0.0",
     "tslib": "2.1.0"
-  }
+  },
+  "homepage": "https://intuit.github.io/auto/"
 }

--- a/plugins/exec/package.json
+++ b/plugins/exec/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/intuit/auto"
+    "url": "https://github.com/intuit/auto.git",
+    "directory": "plugins/exec"
   },
   "files": [
     "dist"
@@ -42,5 +43,6 @@
     "fromentries": "^1.2.0",
     "io-ts": "^2.1.2",
     "tslib": "2.1.0"
-  }
+  },
+  "homepage": "https://intuit.github.io/auto/"
 }

--- a/plugins/first-time-contributor/package.json
+++ b/plugins/first-time-contributor/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/intuit/auto"
+    "url": "https://github.com/intuit/auto.git",
+    "directory": "plugins/first-time-contributor"
   },
   "files": [
     "dist"
@@ -46,5 +47,6 @@
   "devDependencies": {
     "@octokit/rest": "^18.0.0",
     "@types/array.prototype.flatmap": "^1.2.0"
-  }
+  },
+  "homepage": "https://intuit.github.io/auto/"
 }

--- a/plugins/gem/package.json
+++ b/plugins/gem/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/intuit/auto"
+    "url": "https://github.com/intuit/auto.git",
+    "directory": "plugins/gem"
   },
   "files": [
     "dist"
@@ -48,5 +49,6 @@
   },
   "devDependencies": {
     "jest-when": "^3.2.1"
-  }
+  },
+  "homepage": "https://intuit.github.io/auto/"
 }

--- a/plugins/gh-pages/package.json
+++ b/plugins/gh-pages/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/intuit/auto"
+    "url": "https://github.com/intuit/auto.git",
+    "directory": "plugins/gh-pages"
   },
   "files": [
     "dist"
@@ -42,5 +43,6 @@
     "io-ts": "^2.1.2",
     "push-dir": "^0.4.1",
     "tslib": "2.1.0"
-  }
+  },
+  "homepage": "https://intuit.github.io/auto/"
 }

--- a/plugins/git-tag/package.json
+++ b/plugins/git-tag/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/intuit/auto"
+    "url": "https://github.com/intuit/auto.git",
+    "directory": "plugins/git-tag"
   },
   "files": [
     "dist"
@@ -42,5 +43,6 @@
   },
   "devDependencies": {
     "@types/semver": "^7.1.0"
-  }
+  },
+  "homepage": "https://intuit.github.io/auto/"
 }

--- a/plugins/gradle/package.json
+++ b/plugins/gradle/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/intuit/auto"
+    "url": "https://github.com/intuit/auto.git",
+    "directory": "plugins/gradle"
   },
   "files": [
     "dist"
@@ -41,5 +42,6 @@
     "io-ts": "^2.1.2",
     "semver": "^7.0.0",
     "tslib": "2.1.0"
-  }
+  },
+  "homepage": "https://intuit.github.io/auto/"
 }

--- a/plugins/jira/package.json
+++ b/plugins/jira/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/intuit/auto"
+    "url": "https://github.com/intuit/auto.git",
+    "directory": "plugins/jira"
   },
   "files": [
     "dist"
@@ -46,5 +47,6 @@
   },
   "devDependencies": {
     "@types/url-join": "^4.0.0"
-  }
+  },
+  "homepage": "https://intuit.github.io/auto/"
 }

--- a/plugins/magic-zero/package.json
+++ b/plugins/magic-zero/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/intuit/auto"
+    "url": "https://github.com/intuit/auto.git",
+    "directory": "plugins/magic-zero"
   },
   "files": [
     "dist"
@@ -41,5 +42,6 @@
     "io-ts": "^2.1.2",
     "semver": "^7.0.0",
     "tslib": "2.1.0"
-  }
+  },
+  "homepage": "https://intuit.github.io/auto/"
 }

--- a/plugins/maven/package.json
+++ b/plugins/maven/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/intuit/auto"
+    "url": "https://github.com/intuit/auto.git",
+    "directory": "plugins/maven"
   },
   "files": [
     "dist"
@@ -54,5 +55,6 @@
     "@types/jsdom": "^16.2.3",
     "@types/prettier": "^2.0.1",
     "ts-jest": "^26.1.3"
-  }
+  },
+  "homepage": "https://intuit.github.io/auto/"
 }

--- a/plugins/microsoft-teams/package.json
+++ b/plugins/microsoft-teams/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/intuit/auto"
+    "url": "https://github.com/intuit/auto.git",
+    "directory": "plugins/microsoft-teams"
   },
   "files": [
     "dist"
@@ -47,5 +48,6 @@
   },
   "devDependencies": {
     "@types/jsesc": "^2.5.1"
-  }
+  },
+  "homepage": "https://intuit.github.io/auto/"
 }

--- a/plugins/npm/package.json
+++ b/plugins/npm/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/intuit/auto"
+    "url": "https://github.com/intuit/auto.git",
+    "directory": "plugins/npm"
   },
   "files": [
     "dist"
@@ -59,5 +60,6 @@
     "@types/semver": "^7.1.0",
     "@types/url-join": "^4.0.0",
     "@types/user-home": "^2.0.0"
-  }
+  },
+  "homepage": "https://intuit.github.io/auto/"
 }

--- a/plugins/omit-commits/package.json
+++ b/plugins/omit-commits/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/intuit/auto"
+    "url": "https://github.com/intuit/auto.git",
+    "directory": "plugins/omit-commits"
   },
   "files": [
     "dist"
@@ -42,5 +43,6 @@
     "fp-ts": "^2.5.3",
     "io-ts": "^2.1.2",
     "tslib": "2.1.0"
-  }
+  },
+  "homepage": "https://intuit.github.io/auto/"
 }

--- a/plugins/omit-release-notes/package.json
+++ b/plugins/omit-release-notes/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/intuit/auto"
+    "url": "https://github.com/intuit/auto.git",
+    "directory": "plugins/omit-release-notes"
   },
   "files": [
     "dist"
@@ -42,5 +43,6 @@
     "fp-ts": "^2.5.3",
     "io-ts": "^2.1.2",
     "tslib": "2.1.0"
-  }
+  },
+  "homepage": "https://intuit.github.io/auto/"
 }

--- a/plugins/pr-body-labels/package.json
+++ b/plugins/pr-body-labels/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/intuit/auto"
+    "url": "https://github.com/intuit/auto.git",
+    "directory": "plugins/pr-body-labels"
   },
   "files": [
     "dist"
@@ -40,5 +41,6 @@
     "fp-ts": "^2.5.3",
     "io-ts": "^2.1.2",
     "tslib": "2.1.0"
-  }
+  },
+  "homepage": "https://intuit.github.io/auto/"
 }

--- a/plugins/released/package.json
+++ b/plugins/released/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/intuit/auto"
+    "url": "https://github.com/intuit/auto.git",
+    "directory": "plugins/released"
   },
   "files": [
     "dist"
@@ -47,5 +48,6 @@
   },
   "devDependencies": {
     "@octokit/rest": "^18.0.0"
-  }
+  },
+  "homepage": "https://intuit.github.io/auto/"
 }

--- a/plugins/s3/package.json
+++ b/plugins/s3/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/intuit/auto"
+    "url": "https://github.com/intuit/auto.git",
+    "directory": "plugins/s3"
   },
   "files": [
     "dist"
@@ -41,5 +42,6 @@
     "fp-ts": "^2.5.3",
     "io-ts": "^2.1.2",
     "tslib": "^2.0.0"
-  }
+  },
+  "homepage": "https://intuit.github.io/auto/"
 }

--- a/plugins/sbt/package.json
+++ b/plugins/sbt/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/intuit/auto"
+    "url": "https://github.com/intuit/auto.git",
+    "directory": "plugins/sbt"
   },
   "files": [
     "dist"
@@ -44,5 +45,6 @@
     "semver": "^7.0.0",
     "strip-ansi": "^6.0.0",
     "tslib": "1.10.0"
-  }
+  },
+  "homepage": "https://intuit.github.io/auto/"
 }

--- a/plugins/slack/package.json
+++ b/plugins/slack/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/intuit/auto"
+    "url": "https://github.com/intuit/auto.git",
+    "directory": "plugins/slack"
   },
   "files": [
     "dist"
@@ -49,5 +50,6 @@
   "devDependencies": {
     "@types/node-fetch": "2.5.8",
     "@types/url-join": "^4.0.0"
-  }
+  },
+  "homepage": "https://intuit.github.io/auto/"
 }

--- a/plugins/twitter/package.json
+++ b/plugins/twitter/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/intuit/auto"
+    "url": "https://github.com/intuit/auto.git",
+    "directory": "plugins/twitter"
   },
   "files": [
     "dist"
@@ -50,5 +51,6 @@
   },
   "devDependencies": {
     "@types/semver": "^7.1.0"
-  }
+  },
+  "homepage": "https://intuit.github.io/auto/"
 }

--- a/plugins/upload-assets/package.json
+++ b/plugins/upload-assets/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/intuit/auto"
+    "url": "https://github.com/intuit/auto.git",
+    "directory": "plugins/upload-assets"
   },
   "files": [
     "dist"
@@ -49,5 +50,6 @@
   },
   "devDependencies": {
     "@octokit/rest": "^18.0.0"
-  }
+  },
+  "homepage": "https://intuit.github.io/auto/"
 }

--- a/plugins/vscode/package.json
+++ b/plugins/vscode/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/intuit/auto"
+    "url": "https://github.com/intuit/auto.git",
+    "directory": "plugins/vscode"
   },
   "files": [
     "dist"
@@ -43,5 +44,6 @@
     "semver": "^7.0.0",
     "tslib": "2.1.0",
     "vsce": "^1.83.0"
-  }
+  },
+  "homepage": "https://intuit.github.io/auto/"
 }


### PR DESCRIPTION
> If the package.json for your package is not in the root directory (for example if it is part of a monorepo), you can specify the directory in which it lives:
> ```json
> "repository": {
>   "type" : "git",
>   "url" : "https://github.com/facebook/react.git",
>   "directory": "packages/react-dom"
> }
> ```
> — https://docs.npmjs.com/cli/v6/configuring-npm/package-json#repository

I use a lot https://njt.vercel.app/ to jump to different packages information,
and with this PR we can know exactly what package in what folder lives

Made the changes with a script to make it easier 🙂

https://gist.github.com/iamandrewluca/5cc85b56a595056f0099d04ed6dd8a79
