### PR TITLE
sbt: Avoid clobbering unrelated version settings

### DIFF
--- a/plugins/sbt/__tests__/sbt.test.ts
+++ b/plugins/sbt/__tests__/sbt.test.ts
@@ -98,7 +98,7 @@ describe("sbt plugin", () => {
       expect(exec).toHaveBeenCalledTimes(2);
       expect(exec).lastCalledWith("sbt", [
         "--client",
-        'set every version := \\"0.1.0\\"',
+        'set ThisBuild / version := \\"0.1.0\\"',
       ]);
     });
   });
@@ -159,7 +159,7 @@ describe("sbt plugin", () => {
 
       expect(exec).not.toHaveBeenCalledWith("sbt", [
         "--client",
-        'set every version := \\"0.1.0\\"',
+        'set ThisBuild / version := \\"0.1.0\\"',
       ]);
 
       expect(result).toMatchObject({
@@ -187,7 +187,7 @@ describe("sbt plugin", () => {
 
       expect(exec).toHaveBeenCalledWith("sbt", [
         "--client",
-        `set every version := \\"${newVersion}\\"`,
+        `set ThisBuild / version := \\"${newVersion}\\"`,
       ]);
 
       expect(result).toMatchObject({ newVersion });

--- a/plugins/sbt/src/index.ts
+++ b/plugins/sbt/src/index.ts
@@ -38,7 +38,7 @@ export async function sbtGetVersion(): Promise<string> {
 
 /** Set version in sbt to the given value */
 export async function sbtSetVersion(version: string): Promise<string> {
-  return sbtClient(`set every version := \\"${version}\\"`);
+  return sbtClient(`set ThisBuild / version := \\"${version}\\"`);
 }
 
 /** Run sbt publish */


### PR DESCRIPTION
Some sbt plugins have a version setting used for other purposes, like sbt-protobuf: https://github.com/sbt/sbt-protobuf/blob/v0.7.0/src/main/scala/sbtprotobuf/ProtobufPlugin.scala#L70

Setting "ThisBuild / version" instead of "every version" apparently leaves such settings alone.

# What Changed

## Why

Todo:

- [ ] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux--canary.2067.25145.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux--canary.2067.25145.gz)  
[auto-macos--canary.2067.25145.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos--canary.2067.25145.gz)  
[auto-win.exe--canary.2067.25145.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe--canary.2067.25145.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.32.4--canary.2067.25145.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.32.4--canary.2067.25145.0
  npm install @auto-canary/auto@10.32.4--canary.2067.25145.0
  npm install @auto-canary/core@10.32.4--canary.2067.25145.0
  npm install @auto-canary/package-json-utils@10.32.4--canary.2067.25145.0
  npm install @auto-canary/all-contributors@10.32.4--canary.2067.25145.0
  npm install @auto-canary/brew@10.32.4--canary.2067.25145.0
  npm install @auto-canary/chrome@10.32.4--canary.2067.25145.0
  npm install @auto-canary/cocoapods@10.32.4--canary.2067.25145.0
  npm install @auto-canary/conventional-commits@10.32.4--canary.2067.25145.0
  npm install @auto-canary/crates@10.32.4--canary.2067.25145.0
  npm install @auto-canary/docker@10.32.4--canary.2067.25145.0
  npm install @auto-canary/exec@10.32.4--canary.2067.25145.0
  npm install @auto-canary/first-time-contributor@10.32.4--canary.2067.25145.0
  npm install @auto-canary/gem@10.32.4--canary.2067.25145.0
  npm install @auto-canary/gh-pages@10.32.4--canary.2067.25145.0
  npm install @auto-canary/git-tag@10.32.4--canary.2067.25145.0
  npm install @auto-canary/gradle@10.32.4--canary.2067.25145.0
  npm install @auto-canary/jira@10.32.4--canary.2067.25145.0
  npm install @auto-canary/magic-zero@10.32.4--canary.2067.25145.0
  npm install @auto-canary/maven@10.32.4--canary.2067.25145.0
  npm install @auto-canary/microsoft-teams@10.32.4--canary.2067.25145.0
  npm install @auto-canary/npm@10.32.4--canary.2067.25145.0
  npm install @auto-canary/omit-commits@10.32.4--canary.2067.25145.0
  npm install @auto-canary/omit-release-notes@10.32.4--canary.2067.25145.0
  npm install @auto-canary/pr-body-labels@10.32.4--canary.2067.25145.0
  npm install @auto-canary/released@10.32.4--canary.2067.25145.0
  npm install @auto-canary/s3@10.32.4--canary.2067.25145.0
  npm install @auto-canary/sbt@10.32.4--canary.2067.25145.0
  npm install @auto-canary/slack@10.32.4--canary.2067.25145.0
  npm install @auto-canary/twitter@10.32.4--canary.2067.25145.0
  npm install @auto-canary/upload-assets@10.32.4--canary.2067.25145.0
  npm install @auto-canary/vscode@10.32.4--canary.2067.25145.0
  # or 
  yarn add @auto-canary/bot-list@10.32.4--canary.2067.25145.0
  yarn add @auto-canary/auto@10.32.4--canary.2067.25145.0
  yarn add @auto-canary/core@10.32.4--canary.2067.25145.0
  yarn add @auto-canary/package-json-utils@10.32.4--canary.2067.25145.0
  yarn add @auto-canary/all-contributors@10.32.4--canary.2067.25145.0
  yarn add @auto-canary/brew@10.32.4--canary.2067.25145.0
  yarn add @auto-canary/chrome@10.32.4--canary.2067.25145.0
  yarn add @auto-canary/cocoapods@10.32.4--canary.2067.25145.0
  yarn add @auto-canary/conventional-commits@10.32.4--canary.2067.25145.0
  yarn add @auto-canary/crates@10.32.4--canary.2067.25145.0
  yarn add @auto-canary/docker@10.32.4--canary.2067.25145.0
  yarn add @auto-canary/exec@10.32.4--canary.2067.25145.0
  yarn add @auto-canary/first-time-contributor@10.32.4--canary.2067.25145.0
  yarn add @auto-canary/gem@10.32.4--canary.2067.25145.0
  yarn add @auto-canary/gh-pages@10.32.4--canary.2067.25145.0
  yarn add @auto-canary/git-tag@10.32.4--canary.2067.25145.0
  yarn add @auto-canary/gradle@10.32.4--canary.2067.25145.0
  yarn add @auto-canary/jira@10.32.4--canary.2067.25145.0
  yarn add @auto-canary/magic-zero@10.32.4--canary.2067.25145.0
  yarn add @auto-canary/maven@10.32.4--canary.2067.25145.0
  yarn add @auto-canary/microsoft-teams@10.32.4--canary.2067.25145.0
  yarn add @auto-canary/npm@10.32.4--canary.2067.25145.0
  yarn add @auto-canary/omit-commits@10.32.4--canary.2067.25145.0
  yarn add @auto-canary/omit-release-notes@10.32.4--canary.2067.25145.0
  yarn add @auto-canary/pr-body-labels@10.32.4--canary.2067.25145.0
  yarn add @auto-canary/released@10.32.4--canary.2067.25145.0
  yarn add @auto-canary/s3@10.32.4--canary.2067.25145.0
  yarn add @auto-canary/sbt@10.32.4--canary.2067.25145.0
  yarn add @auto-canary/slack@10.32.4--canary.2067.25145.0
  yarn add @auto-canary/twitter@10.32.4--canary.2067.25145.0
  yarn add @auto-canary/upload-assets@10.32.4--canary.2067.25145.0
  yarn add @auto-canary/vscode@10.32.4--canary.2067.25145.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
