### PR TITLE
use strict check so SEMVER.noVersion can add skip-release

### DIFF
--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -258,7 +258,6 @@ export default class Git {
   }
 
   /** Get the labels for a PR */
-  @memoize()
   async getLabels(prNumber: number): Promise<string[]> {
     this.logger.verbose.info(`Getting labels for PR: ${prNumber}`);
 

--- a/plugins/conventional-commits/src/index.ts
+++ b/plugins/conventional-commits/src/index.ts
@@ -185,15 +185,19 @@ export default class ConventionalCommitsPlugin implements IPlugin {
         .reduce(getHigherSemverTag, SEMVER.noVersion);
 
       if (
-        !bump ||
+        bump === undefined ||
+        bump === null ||
         bump === SEMVER.premajor ||
         bump === SEMVER.preminor ||
         bump === SEMVER.prepatch
       ) {
+        
         return;
       }
+      
+      const bumpOrSkip = bump === SEMVER.noVersion ? 'skip' : bump;
 
-      const label = auto.semVerLabels?.get(bump);
+      const label = auto.semVerLabels?.get(bumpOrSkip);
 
       if (label) {
         await auto.git.addLabelToPr(pr.number, label[0]);


### PR DESCRIPTION
# What Changed

instead of `!bump` which catches `SEMVER.noVersion`, check for undefined or null

map `noVersion` to `skip`

remove `memoize` from `getLabels`, otherwise any labels added by plugins in `pr-check` don't get considered and check can fail

## Why

The default release type is `skip` but PR wont be labelled by the plugin if that's the calculation, so the `pr-check` still shows an error state in github

Todo:

- [x] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux--canary.2086.24847.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux--canary.2086.24847.gz)  
[auto-macos--canary.2086.24847.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos--canary.2086.24847.gz)  
[auto-win.exe--canary.2086.24847.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe--canary.2086.24847.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.32.1--canary.2086.24847.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.32.1--canary.2086.24847.0
  npm install @auto-canary/auto@10.32.1--canary.2086.24847.0
  npm install @auto-canary/core@10.32.1--canary.2086.24847.0
  npm install @auto-canary/package-json-utils@10.32.1--canary.2086.24847.0
  npm install @auto-canary/all-contributors@10.32.1--canary.2086.24847.0
  npm install @auto-canary/brew@10.32.1--canary.2086.24847.0
  npm install @auto-canary/chrome@10.32.1--canary.2086.24847.0
  npm install @auto-canary/cocoapods@10.32.1--canary.2086.24847.0
  npm install @auto-canary/conventional-commits@10.32.1--canary.2086.24847.0
  npm install @auto-canary/crates@10.32.1--canary.2086.24847.0
  npm install @auto-canary/docker@10.32.1--canary.2086.24847.0
  npm install @auto-canary/exec@10.32.1--canary.2086.24847.0
  npm install @auto-canary/first-time-contributor@10.32.1--canary.2086.24847.0
  npm install @auto-canary/gem@10.32.1--canary.2086.24847.0
  npm install @auto-canary/gh-pages@10.32.1--canary.2086.24847.0
  npm install @auto-canary/git-tag@10.32.1--canary.2086.24847.0
  npm install @auto-canary/gradle@10.32.1--canary.2086.24847.0
  npm install @auto-canary/jira@10.32.1--canary.2086.24847.0
  npm install @auto-canary/magic-zero@10.32.1--canary.2086.24847.0
  npm install @auto-canary/maven@10.32.1--canary.2086.24847.0
  npm install @auto-canary/microsoft-teams@10.32.1--canary.2086.24847.0
  npm install @auto-canary/npm@10.32.1--canary.2086.24847.0
  npm install @auto-canary/omit-commits@10.32.1--canary.2086.24847.0
  npm install @auto-canary/omit-release-notes@10.32.1--canary.2086.24847.0
  npm install @auto-canary/pr-body-labels@10.32.1--canary.2086.24847.0
  npm install @auto-canary/released@10.32.1--canary.2086.24847.0
  npm install @auto-canary/s3@10.32.1--canary.2086.24847.0
  npm install @auto-canary/sbt@10.32.1--canary.2086.24847.0
  npm install @auto-canary/slack@10.32.1--canary.2086.24847.0
  npm install @auto-canary/twitter@10.32.1--canary.2086.24847.0
  npm install @auto-canary/upload-assets@10.32.1--canary.2086.24847.0
  npm install @auto-canary/vscode@10.32.1--canary.2086.24847.0
  # or 
  yarn add @auto-canary/bot-list@10.32.1--canary.2086.24847.0
  yarn add @auto-canary/auto@10.32.1--canary.2086.24847.0
  yarn add @auto-canary/core@10.32.1--canary.2086.24847.0
  yarn add @auto-canary/package-json-utils@10.32.1--canary.2086.24847.0
  yarn add @auto-canary/all-contributors@10.32.1--canary.2086.24847.0
  yarn add @auto-canary/brew@10.32.1--canary.2086.24847.0
  yarn add @auto-canary/chrome@10.32.1--canary.2086.24847.0
  yarn add @auto-canary/cocoapods@10.32.1--canary.2086.24847.0
  yarn add @auto-canary/conventional-commits@10.32.1--canary.2086.24847.0
  yarn add @auto-canary/crates@10.32.1--canary.2086.24847.0
  yarn add @auto-canary/docker@10.32.1--canary.2086.24847.0
  yarn add @auto-canary/exec@10.32.1--canary.2086.24847.0
  yarn add @auto-canary/first-time-contributor@10.32.1--canary.2086.24847.0
  yarn add @auto-canary/gem@10.32.1--canary.2086.24847.0
  yarn add @auto-canary/gh-pages@10.32.1--canary.2086.24847.0
  yarn add @auto-canary/git-tag@10.32.1--canary.2086.24847.0
  yarn add @auto-canary/gradle@10.32.1--canary.2086.24847.0
  yarn add @auto-canary/jira@10.32.1--canary.2086.24847.0
  yarn add @auto-canary/magic-zero@10.32.1--canary.2086.24847.0
  yarn add @auto-canary/maven@10.32.1--canary.2086.24847.0
  yarn add @auto-canary/microsoft-teams@10.32.1--canary.2086.24847.0
  yarn add @auto-canary/npm@10.32.1--canary.2086.24847.0
  yarn add @auto-canary/omit-commits@10.32.1--canary.2086.24847.0
  yarn add @auto-canary/omit-release-notes@10.32.1--canary.2086.24847.0
  yarn add @auto-canary/pr-body-labels@10.32.1--canary.2086.24847.0
  yarn add @auto-canary/released@10.32.1--canary.2086.24847.0
  yarn add @auto-canary/s3@10.32.1--canary.2086.24847.0
  yarn add @auto-canary/sbt@10.32.1--canary.2086.24847.0
  yarn add @auto-canary/slack@10.32.1--canary.2086.24847.0
  yarn add @auto-canary/twitter@10.32.1--canary.2086.24847.0
  yarn add @auto-canary/upload-assets@10.32.1--canary.2086.24847.0
  yarn add @auto-canary/vscode@10.32.1--canary.2086.24847.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
