### PR TITLE
[Gradle] Fix canary version reporting

### DIFF
--- a/plugins/gradle/__tests__/gradle.test.ts
+++ b/plugins/gradle/__tests__/gradle.test.ts
@@ -175,7 +175,7 @@ describe("Gradle Plugin", () => {
       exec.mockReturnValueOnce(properties).mockImplementation(spy);
       const mockLog = jest.spyOn(logger.log, "info");
 
-      await hooks.canary.promise({ bump: Auto.SEMVER.patch, canaryIdentifier: "canary123" , dryRun: true});
+      await hooks.canary.promise({ bump: Auto.SEMVER.patch, canaryIdentifier: "-canary123" , dryRun: true});
 
       expect(spy).toHaveBeenCalledTimes(0)
       expect(mockLog).toHaveBeenCalledTimes(1)
@@ -189,9 +189,9 @@ describe("Gradle Plugin", () => {
       const spy = jest.fn();
       exec.mockReturnValueOnce(properties).mockImplementation(spy);
 
-      const canaryVersion = await hooks.canary.promise({ bump: Auto.SEMVER.patch, canaryIdentifier: "canary123" });
+      const canaryVersion = await hooks.canary.promise({ bump: Auto.SEMVER.patch, canaryIdentifier: "-canary123" });
 
-      expect(canaryVersion).toBe("1.0.0-canary123")
+      expect(canaryVersion).toBe("1.0.0-canary123-SNAPSHOT")
     });
 
     test("should not increment version - canary w/ default snapshot", async () => {
@@ -202,9 +202,9 @@ describe("Gradle Plugin", () => {
       const spy = jest.fn();
       exec.mockReturnValueOnce(properties).mockImplementation(spy);
 
-      const canaryVersion = await hooks.canary.promise({ bump: Auto.SEMVER.patch, canaryIdentifier: "canary123" });
+      const canaryVersion = await hooks.canary.promise({ bump: Auto.SEMVER.patch, canaryIdentifier: "-canary123" });
 
-      expect(canaryVersion).toBe("1.0.0-canary123")
+      expect(canaryVersion).toBe("1.0.0-canary123-SNAPSHOT")
     });
 
     test("should update gradle version for publish - canary w/ default snapshot", async () => {
@@ -232,7 +232,7 @@ describe("Gradle Plugin", () => {
       const spy = jest.fn();
       exec.mockReturnValueOnce(properties).mockImplementation(spy);
 
-      await hooks.canary.promise({ bump: Auto.SEMVER.patch, canaryIdentifier: "canary123" });
+      await hooks.canary.promise({ bump: Auto.SEMVER.patch, canaryIdentifier: "-canary123" });
 
       expect(spy).toHaveBeenCalledWith(expect.stringMatching("gradle"), [
         "publish",
@@ -248,7 +248,7 @@ describe("Gradle Plugin", () => {
       exec.mockReturnValueOnce(properties).mockImplementation(spy);
       const mockLog = jest.spyOn(logger.log, "warn");
 
-      await hooks.canary.promise({ bump: Auto.SEMVER.patch, canaryIdentifier: "canary123" });
+      await hooks.canary.promise({ bump: Auto.SEMVER.patch, canaryIdentifier: "-canary123" });
 
       expect(mockLog).toHaveBeenCalledWith(expect.stringMatching("Publish task not found in gradle"));
     });

--- a/plugins/gradle/__tests__/gradle.test.ts
+++ b/plugins/gradle/__tests__/gradle.test.ts
@@ -215,7 +215,7 @@ describe("Gradle Plugin", () => {
       const spy = jest.fn();
       exec.mockReturnValueOnce(properties).mockImplementation(spy);
 
-      await hooks.canary.promise({ bump: Auto.SEMVER.patch, canaryIdentifier: "canary123" });
+      await hooks.canary.promise({ bump: Auto.SEMVER.patch, canaryIdentifier: "-canary123" });
 
       expect(spy).toHaveBeenCalledWith(expect.stringMatching("gradle"), [
         "updateVersion",

--- a/plugins/gradle/src/index.ts
+++ b/plugins/gradle/src/index.ts
@@ -164,6 +164,7 @@ export default class GradleReleasePluginPlugin implements IPlugin {
       }
     });
 
+    // TODO: Is this where we can introspect PR files for .api?
     auto.hooks.beforeRun.tap(this.name, async () => {
       this.properties = await getProperties(
         this.options.gradleCommand,
@@ -284,6 +285,7 @@ export default class GradleReleasePluginPlugin implements IPlugin {
     );
 
     // TODO: We should at least report the correct version to GH -- which could include next
+    //       Maybe, we should publish to `version-SNAPSHOT` _and_ `version-next-SNAPSHOT`?
     auto.hooks.next.tapPromise(
       this.name,
       async (preReleaseVersions, { dryRun, bump }) => {

--- a/plugins/gradle/src/index.ts
+++ b/plugins/gradle/src/index.ts
@@ -144,6 +144,7 @@ export default class GradleReleasePluginPlugin implements IPlugin {
 
   /** Tap into auto plugin points. */
   apply(auto: Auto) {
+    /** Call gradle publish, if exists, otherwise log warning */
     const publish = async () => {
       const { publish } = this.properties;
   
@@ -242,7 +243,7 @@ export default class GradleReleasePluginPlugin implements IPlugin {
     );
 
     auto.hooks.publish.tapPromise(this.name, async () => {
-      publish();
+      await publish();
 
       await execPromise("git", [
         "push",
@@ -276,7 +277,7 @@ export default class GradleReleasePluginPlugin implements IPlugin {
           false
         );
 
-        publish();
+        await publish();
 
         return canaryVersion;
       }
@@ -330,7 +331,7 @@ export default class GradleReleasePluginPlugin implements IPlugin {
           false
         );
 
-        publish();
+        await publish();
 
         return preReleaseVersions;
       }


### PR DESCRIPTION
# What Changed

## Why

Todo:

- [ ] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux--canary.2160.25667.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux--canary.2160.25667.gz)  
[auto-macos--canary.2160.25667.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos--canary.2160.25667.gz)  
[auto-win.exe--canary.2160.25667.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe--canary.2160.25667.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.34.1--canary.2160.25667.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.34.1--canary.2160.25667.0
  npm install @auto-canary/auto@10.34.1--canary.2160.25667.0
  npm install @auto-canary/core@10.34.1--canary.2160.25667.0
  npm install @auto-canary/package-json-utils@10.34.1--canary.2160.25667.0
  npm install @auto-canary/all-contributors@10.34.1--canary.2160.25667.0
  npm install @auto-canary/brew@10.34.1--canary.2160.25667.0
  npm install @auto-canary/chrome@10.34.1--canary.2160.25667.0
  npm install @auto-canary/cocoapods@10.34.1--canary.2160.25667.0
  npm install @auto-canary/conventional-commits@10.34.1--canary.2160.25667.0
  npm install @auto-canary/crates@10.34.1--canary.2160.25667.0
  npm install @auto-canary/docker@10.34.1--canary.2160.25667.0
  npm install @auto-canary/exec@10.34.1--canary.2160.25667.0
  npm install @auto-canary/first-time-contributor@10.34.1--canary.2160.25667.0
  npm install @auto-canary/gem@10.34.1--canary.2160.25667.0
  npm install @auto-canary/gh-pages@10.34.1--canary.2160.25667.0
  npm install @auto-canary/git-tag@10.34.1--canary.2160.25667.0
  npm install @auto-canary/gradle@10.34.1--canary.2160.25667.0
  npm install @auto-canary/jira@10.34.1--canary.2160.25667.0
  npm install @auto-canary/magic-zero@10.34.1--canary.2160.25667.0
  npm install @auto-canary/maven@10.34.1--canary.2160.25667.0
  npm install @auto-canary/microsoft-teams@10.34.1--canary.2160.25667.0
  npm install @auto-canary/npm@10.34.1--canary.2160.25667.0
  npm install @auto-canary/omit-commits@10.34.1--canary.2160.25667.0
  npm install @auto-canary/omit-release-notes@10.34.1--canary.2160.25667.0
  npm install @auto-canary/pr-body-labels@10.34.1--canary.2160.25667.0
  npm install @auto-canary/released@10.34.1--canary.2160.25667.0
  npm install @auto-canary/s3@10.34.1--canary.2160.25667.0
  npm install @auto-canary/sbt@10.34.1--canary.2160.25667.0
  npm install @auto-canary/slack@10.34.1--canary.2160.25667.0
  npm install @auto-canary/twitter@10.34.1--canary.2160.25667.0
  npm install @auto-canary/upload-assets@10.34.1--canary.2160.25667.0
  npm install @auto-canary/vscode@10.34.1--canary.2160.25667.0
  # or 
  yarn add @auto-canary/bot-list@10.34.1--canary.2160.25667.0
  yarn add @auto-canary/auto@10.34.1--canary.2160.25667.0
  yarn add @auto-canary/core@10.34.1--canary.2160.25667.0
  yarn add @auto-canary/package-json-utils@10.34.1--canary.2160.25667.0
  yarn add @auto-canary/all-contributors@10.34.1--canary.2160.25667.0
  yarn add @auto-canary/brew@10.34.1--canary.2160.25667.0
  yarn add @auto-canary/chrome@10.34.1--canary.2160.25667.0
  yarn add @auto-canary/cocoapods@10.34.1--canary.2160.25667.0
  yarn add @auto-canary/conventional-commits@10.34.1--canary.2160.25667.0
  yarn add @auto-canary/crates@10.34.1--canary.2160.25667.0
  yarn add @auto-canary/docker@10.34.1--canary.2160.25667.0
  yarn add @auto-canary/exec@10.34.1--canary.2160.25667.0
  yarn add @auto-canary/first-time-contributor@10.34.1--canary.2160.25667.0
  yarn add @auto-canary/gem@10.34.1--canary.2160.25667.0
  yarn add @auto-canary/gh-pages@10.34.1--canary.2160.25667.0
  yarn add @auto-canary/git-tag@10.34.1--canary.2160.25667.0
  yarn add @auto-canary/gradle@10.34.1--canary.2160.25667.0
  yarn add @auto-canary/jira@10.34.1--canary.2160.25667.0
  yarn add @auto-canary/magic-zero@10.34.1--canary.2160.25667.0
  yarn add @auto-canary/maven@10.34.1--canary.2160.25667.0
  yarn add @auto-canary/microsoft-teams@10.34.1--canary.2160.25667.0
  yarn add @auto-canary/npm@10.34.1--canary.2160.25667.0
  yarn add @auto-canary/omit-commits@10.34.1--canary.2160.25667.0
  yarn add @auto-canary/omit-release-notes@10.34.1--canary.2160.25667.0
  yarn add @auto-canary/pr-body-labels@10.34.1--canary.2160.25667.0
  yarn add @auto-canary/released@10.34.1--canary.2160.25667.0
  yarn add @auto-canary/s3@10.34.1--canary.2160.25667.0
  yarn add @auto-canary/sbt@10.34.1--canary.2160.25667.0
  yarn add @auto-canary/slack@10.34.1--canary.2160.25667.0
  yarn add @auto-canary/twitter@10.34.1--canary.2160.25667.0
  yarn add @auto-canary/upload-assets@10.34.1--canary.2160.25667.0
  yarn add @auto-canary/vscode@10.34.1--canary.2160.25667.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
