### PR TITLE
docs: fix publishFolder example

### DIFF
--- a/plugins/npm/README.md
+++ b/plugins/npm/README.md
@@ -196,7 +196,7 @@ When used with `lerna` in a monorepo, this functionality implements the `--conte
     [
       "npm",
       {
-        "publishFolder": "dist/some-dir"
+        "publishFolder": "./dist/some-dir"
       }
     ]
   ]


### PR DESCRIPTION
# What Changed

## Why
I tried using the `publishFolder` option and faced an issue where NPM thought that my folder name was the package name 🤔
<img width="1118" alt="image" src="https://user-images.githubusercontent.com/2678610/156900380-ea3bc929-ec01-4c56-9e9c-f5480f4bb8bb.png">

You can see the original config I was using here: https://github.com/ValentinH/react-easy-crop/pull/363/files?w=1#diff-12d210183f4a079cb141d1de92ab4741014e1634d15e2cfef84a72b78a125e17

I fixed it by using `publishFolder: './dist'`


## Change Type

Indicate the type of change your pull request is:

- [x] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
