### PR TITLE
Allow load npm module as extends

### DIFF
--- a/docs/pages/docs/configuration/autorc.mdx
+++ b/docs/pages/docs/configuration/autorc.mdx
@@ -402,6 +402,7 @@ Auto can load `extends` configs in the following ways:
 - from a scoped package `@YOUR_SCOPE/auto-config` (under the `auto` key in the package.json)
 - from a package `auto-config-YOUR_NAME`
 - from a url `https://yourdomain.com/auto-config.json` (must return the content type `application/json`)
+- from a node module `auto-config-module` (this default export must be a plain object or a Promise of plain object)
 
 ### Formats
 
@@ -411,7 +412,7 @@ Auto can load `extends` configs in the following ways:
 }
 ```
 
-Will use the package `@YOUR_SCOPE/auto-config`
+Will use the package `@YOUR_SCOPE/auto-config` (the `auto` key in `package.json` file)
 
 ```json
 {
@@ -419,7 +420,16 @@ Will use the package `@YOUR_SCOPE/auto-config`
 }
 ```
 
-Will use the package `auto-config-joe`
+Will use the package `auto-config-joe` (the `auto` key in `package.json` file)
+
+
+```json
+{
+  "extends": "auto-config-module"
+}
+```
+
+Will use the default export of `auto-config-module` node package
 
 > :warning: If extending from a config package make sure it's a dependency of your project
 

--- a/packages/core/src/__tests__/config.test.ts
+++ b/packages/core/src/__tests__/config.test.ts
@@ -14,7 +14,9 @@ beforeEach(() => {
 const log = dummyLog();
 
 const importMock = jest.fn();
-jest.mock("import-cwd", () => (path: string) => importMock(path));
+jest.mock("import-cwd", () => {
+  return (path: any) => importMock(path);
+});
 
 describe("normalizeLabel", () => {
   test("should extend base label", () => {
@@ -146,6 +148,21 @@ describe("loadExtendConfig", () => {
 
     expect(await config.loadExtendConfig("fuego")).toStrictEqual({
       extends: "auto-config-fuego/package.json",
+      noVersionPrefix: true,
+    });
+  });
+
+  test("should load an npm module", async () => {
+    const config = new Config(log);
+
+    importMock.mockImplementation((path) =>
+        path === "auto-config-from-module"
+            ? { noVersionPrefix: true }
+            : undefined
+    );
+
+    expect(await config.loadExtendConfig("auto-config-from-module")).toStrictEqual({
+      extends: "auto-config-from-module",
       noVersionPrefix: true,
     });
   });

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -202,6 +202,15 @@ export default class Config {
     }
 
     if (!config) {
+      config = tryRequire(extend);
+      this.logger.verbose.note(`${extend} found: ${config}`);
+
+      if (config) {
+        config.extends = extend;
+      }
+    }
+
+    if (!config) {
       throw new Error(`Unable to load extended config ${extend}`);
     }
 


### PR DESCRIPTION
# What Changed

Allow to load npm module as config extends (not only based on package.json)

## Why

This allow to build opinionated shared configuration published under npm module. 
Would also mean that this config can load plugins regarding the context (as already possible with a local file reference)

Today this is possible by referencing `./node_module/my-shared-auto-config-module`

Todo:

- [x] Add tests
- [x] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`
