### PR TITLE
fix(npm): remove quote in commit message for standalone packages

### DIFF
--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -551,7 +551,7 @@ describe("publish", () => {
       Auto.SEMVER.patch,
       "--no-commit-hooks",
       "-m",
-      "'\"Bump version to: %s [skip ci]\"'",
+      "'Bump version to: %s [skip ci]'",
       "--loglevel",
       "silly",
     ]);
@@ -582,7 +582,7 @@ describe("publish", () => {
       Auto.SEMVER.patch,
       "--no-commit-hooks",
       "-m",
-      "'\"Bump version to: %s [skip ci]\"'",
+      "'Bump version to: %s [skip ci]'",
     ]);
   });
 
@@ -842,7 +842,7 @@ describe("publish", () => {
       "1.0.1",
       "--no-commit-hooks",
       "-m",
-      "'\"Bump version to: %s [skip ci]\"'",
+      "'Bump version to: %s [skip ci]'",
     ]);
   });
 

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -36,7 +36,6 @@ import setTokenOnCI, { getRegistry, DEFAULT_REGISTRY } from "./set-npm-token";
 import { writeFile, isMonorepo, readFile, getLernaJson } from "./utils";
 
 const { isCi } = envCi();
-const VERSION_COMMIT_MESSAGE = `'"Bump version to: %s [skip ci]"'`;
 
 /** Get the last published version for a npm package */
 async function getPublishedVersion(name: string) {
@@ -276,8 +275,8 @@ const pluginOptions = t.partial({
   legacyAuth: t.boolean,
   /** Whether to add package information to monorepo changelogs */
   monorepoChangelog: t.boolean,
-  /** 
-   * Path used when publishing packages. 
+  /**
+   * Path used when publishing packages.
    * When used with npm this is equivalent to npm publish <publishFolder>
    * When used with lerna this is equivalent to lerna publish --contents <publishFolder>
    */
@@ -1007,7 +1006,7 @@ export default class NPMPlugin implements IPlugin {
             "-m",
             isIndependent
               ? `'"Bump independent versions [skip ci]"'`
-              : VERSION_COMMIT_MESSAGE,
+              : `'"Bump version to: %s [skip ci]"'`,
             this.exact && "--exact",
             ...verboseArgs,
           ]);
@@ -1029,7 +1028,7 @@ export default class NPMPlugin implements IPlugin {
           latestBump,
           "--no-commit-hooks",
           "-m",
-          VERSION_COMMIT_MESSAGE,
+          "'Bump version to: %s [skip ci]'",
           ...verboseArgs,
         ]);
         auto.logger.verbose.info("Successfully versioned repo");


### PR DESCRIPTION
# What Changed

Using auto on a standalone npm package the node package upgrade commit message is : `"Bump version to: 1.1.0 [skip ci]"`

Switch back to a non quoted version.

![Capture d’écran 2022-03-07 à 17 44 58](https://user-images.githubusercontent.com/1336548/157079126-378af4ae-f7d8-4e97-83ed-d430354e0513.png)

## Why

Really strange to get quote in a commit message (non conventionnal).
Seems an issue in command between lerna based (`npx lerna version...`) , and pure npm package (`npm ...`)

Todo:

- [x] Add tests
- [ ] Add docs (N/A)

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
