### PR TITLE
Add `lockPrs` option for released plugin

### DIFF
--- a/plugins/released/__tests__/released-label.test.ts
+++ b/plugins/released/__tests__/released-label.test.ts
@@ -9,6 +9,7 @@ import {
   makeLogParseHooks,
 } from "@auto-it/core/dist/utils/make-hooks";
 import botList from "@auto-it/bot-list";
+import { RestEndpointMethodTypes } from '@octokit/rest';
 
 import ReleasedLabelPlugin from "../src";
 
@@ -515,7 +516,7 @@ describe("release label plugin", () => {
   });
 
   test("should not lock Issues for canaries", async () => {
-    const releasedLabel = new ReleasedLabelPlugin();
+    const releasedLabel = new ReleasedLabelPlugin({ lockIssues: true });
     const autoHooks = makeHooks();
     releasedLabel.apply(({
       hooks: autoHooks,
@@ -534,6 +535,7 @@ describe("release label plugin", () => {
       newVersion: "1.0.0-canary",
       commits: await log.normalizeCommits([commit]),
       releaseNotes: "",
+      response: [{ data: { prerelease: true } } as RestEndpointMethodTypes["repos"]["createRelease"]["response"]],
     });
 
     expect(lockIssue).not.toHaveBeenCalled();

--- a/plugins/released/__tests__/released-label.test.ts
+++ b/plugins/released/__tests__/released-label.test.ts
@@ -540,4 +540,57 @@ describe("release label plugin", () => {
 
     expect(lockIssue).not.toHaveBeenCalled();
   });
+
+  test("should lock Prs", async () => {
+    const releasedLabel = new ReleasedLabelPlugin({ lockPrs: true });
+    const autoHooks = makeHooks();
+    releasedLabel.apply(({
+      hooks: autoHooks,
+      labels: defaultLabels,
+      logger: dummyLog(),
+      options: {},
+      comment,
+      git,
+    } as unknown) as Auto);
+
+    const commit = makeCommitFromMsg(
+        "normal commit with no bump (#123) closes #100",
+        { pullRequest: { number: 123 } },
+    );
+    await autoHooks.afterRelease.promise({
+      newVersion: "1.0.0",
+      lastRelease: "0.1.0",
+      commits: await log.normalizeCommits([commit]),
+      releaseNotes: "",
+    });
+
+    expect(lockIssue).toHaveBeenCalledWith(123);
+  });
+
+  test("should not lock Prs for canaries", async () => {
+    const releasedLabel = new ReleasedLabelPlugin({ lockPrs: true });
+    const autoHooks = makeHooks();
+    releasedLabel.apply(({
+      hooks: autoHooks,
+      labels: defaultLabels,
+      logger: dummyLog(),
+      options: {},
+      comment,
+      git,
+    } as unknown) as Auto);
+
+    const commit = makeCommitFromMsg(
+        "normal commit with no bump (#123) closes #100",
+        { pullRequest: { number: 123 } },
+    );
+    await autoHooks.afterRelease.promise({
+      lastRelease: "0.1.0",
+      newVersion: "1.0.0-canary",
+      commits: await log.normalizeCommits([commit]),
+      releaseNotes: "",
+      response: [{ data: { prerelease: true } } as RestEndpointMethodTypes["repos"]["createRelease"]["response"]],
+    });
+
+    expect(lockIssue).not.toHaveBeenCalled();
+  });
 });

--- a/plugins/released/src/index.ts
+++ b/plugins/released/src/index.ts
@@ -15,6 +15,8 @@ const pluginOptions = t.partial({
   prereleaseLabel: t.string,
   /** Whether to lock the issue once the pull request has been released */
   lockIssues: t.boolean,
+  /** Whether to lock the issue once the pull request has been released */
+  lockPrs: t.boolean,
   /** Whether to comment on PRs made by bots */
   includeBotPrs: t.boolean,
 });
@@ -27,6 +29,7 @@ const defaultOptions: Required<IReleasedLabelPluginOptions> = {
   label: "released",
   prereleaseLabel: "prerelease",
   lockIssues: false,
+  lockPrs: false,
   includeBotPrs: false,
   message: `:rocket: ${TYPE} was released in ${VERSION} :rocket:`,
 };
@@ -153,6 +156,9 @@ export default class ReleasedLabelPlugin implements IPlugin {
           isPrerelease,
           releases,
         });
+        if (this.options.lockPrs && !isPrerelease) {
+          await auto.git!.lockIssue(commit.pullRequest.number);
+        }
 
         pr.data.body?.split("\n").map((line) => messages.push(line));
 


### PR DESCRIPTION
# What Changed

Add `lockPrs` option for released plugin.  

## Why

For the same reason that we want to lock issues, add the availability to also lock PRs.
Could be the same options, but for compatibility reason , I choose to separate these options.

Todo:

- [x] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`
