### PR TITLE
CocoaPods swap promise.all for reduce to avoid git locking problem

### DIFF
--- a/plugins/cocoapods/src/index.ts
+++ b/plugins/cocoapods/src/index.ts
@@ -294,9 +294,12 @@ export default class CocoapodsPlugin implements IPlugin {
         await this.publishPodSpec(podLogLevel);
 
         // Reset changes to podspec file since it doesn't need to be committed
-        await Promise.all(
-          this.paths.map((path) => execPromise("git", ["checkout", path]))
-        );
+        await this.paths.reduce(
+          (promise, path) => promise.then(async () => {
+            await execPromise("git", ["checkout", path])
+          }),
+          Promise.resolve()
+        )
 
         return canaryVersion;
       }


### PR DESCRIPTION
# What Changed

Changed `Promise.all` to a reduce into a chain

## Why

Running `git checkout` in parallel can cause a git error if the processes try to get the lock at the same time

Todo:

- [ ] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux--canary.2169.25725.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux--canary.2169.25725.gz)  
[auto-macos--canary.2169.25725.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos--canary.2169.25725.gz)  
[auto-win.exe--canary.2169.25725.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe--canary.2169.25725.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.34.2--canary.2169.25725.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.34.2--canary.2169.25725.0
  npm install @auto-canary/auto@10.34.2--canary.2169.25725.0
  npm install @auto-canary/core@10.34.2--canary.2169.25725.0
  npm install @auto-canary/package-json-utils@10.34.2--canary.2169.25725.0
  npm install @auto-canary/all-contributors@10.34.2--canary.2169.25725.0
  npm install @auto-canary/brew@10.34.2--canary.2169.25725.0
  npm install @auto-canary/chrome@10.34.2--canary.2169.25725.0
  npm install @auto-canary/cocoapods@10.34.2--canary.2169.25725.0
  npm install @auto-canary/conventional-commits@10.34.2--canary.2169.25725.0
  npm install @auto-canary/crates@10.34.2--canary.2169.25725.0
  npm install @auto-canary/docker@10.34.2--canary.2169.25725.0
  npm install @auto-canary/exec@10.34.2--canary.2169.25725.0
  npm install @auto-canary/first-time-contributor@10.34.2--canary.2169.25725.0
  npm install @auto-canary/gem@10.34.2--canary.2169.25725.0
  npm install @auto-canary/gh-pages@10.34.2--canary.2169.25725.0
  npm install @auto-canary/git-tag@10.34.2--canary.2169.25725.0
  npm install @auto-canary/gradle@10.34.2--canary.2169.25725.0
  npm install @auto-canary/jira@10.34.2--canary.2169.25725.0
  npm install @auto-canary/magic-zero@10.34.2--canary.2169.25725.0
  npm install @auto-canary/maven@10.34.2--canary.2169.25725.0
  npm install @auto-canary/microsoft-teams@10.34.2--canary.2169.25725.0
  npm install @auto-canary/npm@10.34.2--canary.2169.25725.0
  npm install @auto-canary/omit-commits@10.34.2--canary.2169.25725.0
  npm install @auto-canary/omit-release-notes@10.34.2--canary.2169.25725.0
  npm install @auto-canary/pr-body-labels@10.34.2--canary.2169.25725.0
  npm install @auto-canary/released@10.34.2--canary.2169.25725.0
  npm install @auto-canary/s3@10.34.2--canary.2169.25725.0
  npm install @auto-canary/sbt@10.34.2--canary.2169.25725.0
  npm install @auto-canary/slack@10.34.2--canary.2169.25725.0
  npm install @auto-canary/twitter@10.34.2--canary.2169.25725.0
  npm install @auto-canary/upload-assets@10.34.2--canary.2169.25725.0
  npm install @auto-canary/vscode@10.34.2--canary.2169.25725.0
  # or 
  yarn add @auto-canary/bot-list@10.34.2--canary.2169.25725.0
  yarn add @auto-canary/auto@10.34.2--canary.2169.25725.0
  yarn add @auto-canary/core@10.34.2--canary.2169.25725.0
  yarn add @auto-canary/package-json-utils@10.34.2--canary.2169.25725.0
  yarn add @auto-canary/all-contributors@10.34.2--canary.2169.25725.0
  yarn add @auto-canary/brew@10.34.2--canary.2169.25725.0
  yarn add @auto-canary/chrome@10.34.2--canary.2169.25725.0
  yarn add @auto-canary/cocoapods@10.34.2--canary.2169.25725.0
  yarn add @auto-canary/conventional-commits@10.34.2--canary.2169.25725.0
  yarn add @auto-canary/crates@10.34.2--canary.2169.25725.0
  yarn add @auto-canary/docker@10.34.2--canary.2169.25725.0
  yarn add @auto-canary/exec@10.34.2--canary.2169.25725.0
  yarn add @auto-canary/first-time-contributor@10.34.2--canary.2169.25725.0
  yarn add @auto-canary/gem@10.34.2--canary.2169.25725.0
  yarn add @auto-canary/gh-pages@10.34.2--canary.2169.25725.0
  yarn add @auto-canary/git-tag@10.34.2--canary.2169.25725.0
  yarn add @auto-canary/gradle@10.34.2--canary.2169.25725.0
  yarn add @auto-canary/jira@10.34.2--canary.2169.25725.0
  yarn add @auto-canary/magic-zero@10.34.2--canary.2169.25725.0
  yarn add @auto-canary/maven@10.34.2--canary.2169.25725.0
  yarn add @auto-canary/microsoft-teams@10.34.2--canary.2169.25725.0
  yarn add @auto-canary/npm@10.34.2--canary.2169.25725.0
  yarn add @auto-canary/omit-commits@10.34.2--canary.2169.25725.0
  yarn add @auto-canary/omit-release-notes@10.34.2--canary.2169.25725.0
  yarn add @auto-canary/pr-body-labels@10.34.2--canary.2169.25725.0
  yarn add @auto-canary/released@10.34.2--canary.2169.25725.0
  yarn add @auto-canary/s3@10.34.2--canary.2169.25725.0
  yarn add @auto-canary/sbt@10.34.2--canary.2169.25725.0
  yarn add @auto-canary/slack@10.34.2--canary.2169.25725.0
  yarn add @auto-canary/twitter@10.34.2--canary.2169.25725.0
  yarn add @auto-canary/upload-assets@10.34.2--canary.2169.25725.0
  yarn add @auto-canary/vscode@10.34.2--canary.2169.25725.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
