### PR TITLE
Fix loading object author from auto rc

### DIFF
--- a/packages/core/src/__tests__/validate-config.test.ts
+++ b/packages/core/src/__tests__/validate-config.test.ts
@@ -116,6 +116,17 @@ describe("validateConfig", () => {
     ).toStrictEqual([]);
   });
 
+  test("should allow author as an object", async () => {
+    expect(
+      await validateAutoRc({
+        author: {
+          name: "Andrew",
+          email: "test@email.com",
+        },
+      })
+    ).toStrictEqual([]);
+  });
+
   test("should catch errors in labels", async () => {
     expect(
       await validateAutoRc({
@@ -479,9 +490,11 @@ describe("validatePlugin", () => {
     // Check no validation issues with intersected options
     expect(
       await validatePlugins(hook, {
-        plugins: [["test-plugin", { auth: "app", channels: ['foo'], atTarget: 'foo' }]],
+        plugins: [
+          ["test-plugin", { auth: "app", channels: ["foo"], atTarget: "foo" }],
+        ],
       })
-      ).toStrictEqual([]);
+    ).toStrictEqual([]);
   });
 
   test("should validate plugin configuration - array of configurations", async () => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -4,7 +4,14 @@ import { ILabelDefinition, labelDefinition } from "./semver";
 
 const author = t.partial({
   /** The name and email of the author to make commits with */
-  author: t.string,
+  author: t.union([
+    t.string,
+    t.interface({
+      /** The name of the author to make commits with */ name: t.string,
+      /** The email of the author to make commits with */
+      email: t.string,
+    }),
+  ]),
   /** The name of the author to make commits with */
   name: t.string,
   /** The email of the author to make commits with */


### PR DESCRIPTION
Tested that it loads the config author on a local project.

Fixes #2140
<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux--canary.2172.25820.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux--canary.2172.25820.gz)  
[auto-macos--canary.2172.25820.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos--canary.2172.25820.gz)  
[auto-win.exe--canary.2172.25820.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe--canary.2172.25820.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.36.1--canary.2172.25820.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.36.1--canary.2172.25820.0
  npm install @auto-canary/auto@10.36.1--canary.2172.25820.0
  npm install @auto-canary/core@10.36.1--canary.2172.25820.0
  npm install @auto-canary/package-json-utils@10.36.1--canary.2172.25820.0
  npm install @auto-canary/all-contributors@10.36.1--canary.2172.25820.0
  npm install @auto-canary/brew@10.36.1--canary.2172.25820.0
  npm install @auto-canary/chrome@10.36.1--canary.2172.25820.0
  npm install @auto-canary/cocoapods@10.36.1--canary.2172.25820.0
  npm install @auto-canary/conventional-commits@10.36.1--canary.2172.25820.0
  npm install @auto-canary/crates@10.36.1--canary.2172.25820.0
  npm install @auto-canary/docker@10.36.1--canary.2172.25820.0
  npm install @auto-canary/exec@10.36.1--canary.2172.25820.0
  npm install @auto-canary/first-time-contributor@10.36.1--canary.2172.25820.0
  npm install @auto-canary/gem@10.36.1--canary.2172.25820.0
  npm install @auto-canary/gh-pages@10.36.1--canary.2172.25820.0
  npm install @auto-canary/git-tag@10.36.1--canary.2172.25820.0
  npm install @auto-canary/gradle@10.36.1--canary.2172.25820.0
  npm install @auto-canary/jira@10.36.1--canary.2172.25820.0
  npm install @auto-canary/magic-zero@10.36.1--canary.2172.25820.0
  npm install @auto-canary/maven@10.36.1--canary.2172.25820.0
  npm install @auto-canary/microsoft-teams@10.36.1--canary.2172.25820.0
  npm install @auto-canary/npm@10.36.1--canary.2172.25820.0
  npm install @auto-canary/omit-commits@10.36.1--canary.2172.25820.0
  npm install @auto-canary/omit-release-notes@10.36.1--canary.2172.25820.0
  npm install @auto-canary/pr-body-labels@10.36.1--canary.2172.25820.0
  npm install @auto-canary/released@10.36.1--canary.2172.25820.0
  npm install @auto-canary/s3@10.36.1--canary.2172.25820.0
  npm install @auto-canary/sbt@10.36.1--canary.2172.25820.0
  npm install @auto-canary/slack@10.36.1--canary.2172.25820.0
  npm install @auto-canary/twitter@10.36.1--canary.2172.25820.0
  npm install @auto-canary/upload-assets@10.36.1--canary.2172.25820.0
  npm install @auto-canary/vscode@10.36.1--canary.2172.25820.0
  # or 
  yarn add @auto-canary/bot-list@10.36.1--canary.2172.25820.0
  yarn add @auto-canary/auto@10.36.1--canary.2172.25820.0
  yarn add @auto-canary/core@10.36.1--canary.2172.25820.0
  yarn add @auto-canary/package-json-utils@10.36.1--canary.2172.25820.0
  yarn add @auto-canary/all-contributors@10.36.1--canary.2172.25820.0
  yarn add @auto-canary/brew@10.36.1--canary.2172.25820.0
  yarn add @auto-canary/chrome@10.36.1--canary.2172.25820.0
  yarn add @auto-canary/cocoapods@10.36.1--canary.2172.25820.0
  yarn add @auto-canary/conventional-commits@10.36.1--canary.2172.25820.0
  yarn add @auto-canary/crates@10.36.1--canary.2172.25820.0
  yarn add @auto-canary/docker@10.36.1--canary.2172.25820.0
  yarn add @auto-canary/exec@10.36.1--canary.2172.25820.0
  yarn add @auto-canary/first-time-contributor@10.36.1--canary.2172.25820.0
  yarn add @auto-canary/gem@10.36.1--canary.2172.25820.0
  yarn add @auto-canary/gh-pages@10.36.1--canary.2172.25820.0
  yarn add @auto-canary/git-tag@10.36.1--canary.2172.25820.0
  yarn add @auto-canary/gradle@10.36.1--canary.2172.25820.0
  yarn add @auto-canary/jira@10.36.1--canary.2172.25820.0
  yarn add @auto-canary/magic-zero@10.36.1--canary.2172.25820.0
  yarn add @auto-canary/maven@10.36.1--canary.2172.25820.0
  yarn add @auto-canary/microsoft-teams@10.36.1--canary.2172.25820.0
  yarn add @auto-canary/npm@10.36.1--canary.2172.25820.0
  yarn add @auto-canary/omit-commits@10.36.1--canary.2172.25820.0
  yarn add @auto-canary/omit-release-notes@10.36.1--canary.2172.25820.0
  yarn add @auto-canary/pr-body-labels@10.36.1--canary.2172.25820.0
  yarn add @auto-canary/released@10.36.1--canary.2172.25820.0
  yarn add @auto-canary/s3@10.36.1--canary.2172.25820.0
  yarn add @auto-canary/sbt@10.36.1--canary.2172.25820.0
  yarn add @auto-canary/slack@10.36.1--canary.2172.25820.0
  yarn add @auto-canary/twitter@10.36.1--canary.2172.25820.0
  yarn add @auto-canary/upload-assets@10.36.1--canary.2172.25820.0
  yarn add @auto-canary/vscode@10.36.1--canary.2172.25820.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
