### PR TITLE
Remove unchecked labels when pr-check runs

### DIFF
--- a/plugins/pr-body-labels/README.md
+++ b/plugins/pr-body-labels/README.md
@@ -50,3 +50,13 @@ Labels the user cannot apply through the PR.
   "plugins": [["pr-body-labels", { "disabledLabels": ["release"] }]]
 }
 ```
+
+### `removeStaleLabels`
+
+When using the plugin it will use the checklist in your PR body as the source of truth. This means that manually added label that are present in the pr-body will be removed when `pr-check` runs again. To disable this behavior use the `removeStaleLabels` option.
+
+```json
+{
+  "plugins": [["pr-body-labels", { "removeStaleLabels": false }]]
+}
+```

--- a/plugins/pr-body-labels/__tests__/pr-body-labels.test.ts
+++ b/plugins/pr-body-labels/__tests__/pr-body-labels.test.ts
@@ -54,6 +54,40 @@ describe("Pr-Body-Labels Plugin", () => {
     expect(addLabelToPr).toHaveBeenCalledWith(1, "patch");
   });
 
+  test("should remove labels if unchecked", async () => {
+    const plugin = new PrBodyLabels();
+    const hooks = makeHooks();
+    const removeLabel = jest.fn();
+
+    plugin.apply({
+      hooks,
+      labels: [{ name: "patch" }],
+      git: { removeLabel },
+    } as any);
+
+    await hooks.prCheck.promise({
+      pr: { body: "- [ ] `patch`", number: 1 },
+    } as any);
+    expect(removeLabel).toHaveBeenCalledWith(1, "patch");
+  });
+
+  test("should not remove labels if removeStaleLabels=false", async () => {
+    const plugin = new PrBodyLabels({ removeStaleLabels: false });
+    const hooks = makeHooks();
+    const removeLabel = jest.fn();
+
+    plugin.apply({
+      hooks,
+      labels: [{ name: "patch" }],
+      git: { removeLabel },
+    } as any);
+
+    await hooks.prCheck.promise({
+      pr: { body: "- [ ] `patch`", number: 1 },
+    } as any);
+    expect(removeLabel).not.toHaveBeenCalledWith(1, "patch");
+  });
+
   test("not add labels in disabledLabels list", async () => {
     const plugin = new PrBodyLabels({ disabledLabels: ["patch"] });
     const hooks = makeHooks();


### PR DESCRIPTION
fixes #2097
<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux--canary.2173.25875.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux--canary.2173.25875.gz)  
[auto-macos--canary.2173.25875.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos--canary.2173.25875.gz)  
[auto-win.exe--canary.2173.25875.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe--canary.2173.25875.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.36.2--canary.2173.25875.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.36.2--canary.2173.25875.0
  npm install @auto-canary/auto@10.36.2--canary.2173.25875.0
  npm install @auto-canary/core@10.36.2--canary.2173.25875.0
  npm install @auto-canary/package-json-utils@10.36.2--canary.2173.25875.0
  npm install @auto-canary/all-contributors@10.36.2--canary.2173.25875.0
  npm install @auto-canary/brew@10.36.2--canary.2173.25875.0
  npm install @auto-canary/chrome@10.36.2--canary.2173.25875.0
  npm install @auto-canary/cocoapods@10.36.2--canary.2173.25875.0
  npm install @auto-canary/conventional-commits@10.36.2--canary.2173.25875.0
  npm install @auto-canary/crates@10.36.2--canary.2173.25875.0
  npm install @auto-canary/docker@10.36.2--canary.2173.25875.0
  npm install @auto-canary/exec@10.36.2--canary.2173.25875.0
  npm install @auto-canary/first-time-contributor@10.36.2--canary.2173.25875.0
  npm install @auto-canary/gem@10.36.2--canary.2173.25875.0
  npm install @auto-canary/gh-pages@10.36.2--canary.2173.25875.0
  npm install @auto-canary/git-tag@10.36.2--canary.2173.25875.0
  npm install @auto-canary/gradle@10.36.2--canary.2173.25875.0
  npm install @auto-canary/jira@10.36.2--canary.2173.25875.0
  npm install @auto-canary/magic-zero@10.36.2--canary.2173.25875.0
  npm install @auto-canary/maven@10.36.2--canary.2173.25875.0
  npm install @auto-canary/microsoft-teams@10.36.2--canary.2173.25875.0
  npm install @auto-canary/npm@10.36.2--canary.2173.25875.0
  npm install @auto-canary/omit-commits@10.36.2--canary.2173.25875.0
  npm install @auto-canary/omit-release-notes@10.36.2--canary.2173.25875.0
  npm install @auto-canary/pr-body-labels@10.36.2--canary.2173.25875.0
  npm install @auto-canary/released@10.36.2--canary.2173.25875.0
  npm install @auto-canary/s3@10.36.2--canary.2173.25875.0
  npm install @auto-canary/sbt@10.36.2--canary.2173.25875.0
  npm install @auto-canary/slack@10.36.2--canary.2173.25875.0
  npm install @auto-canary/twitter@10.36.2--canary.2173.25875.0
  npm install @auto-canary/upload-assets@10.36.2--canary.2173.25875.0
  npm install @auto-canary/vscode@10.36.2--canary.2173.25875.0
  # or 
  yarn add @auto-canary/bot-list@10.36.2--canary.2173.25875.0
  yarn add @auto-canary/auto@10.36.2--canary.2173.25875.0
  yarn add @auto-canary/core@10.36.2--canary.2173.25875.0
  yarn add @auto-canary/package-json-utils@10.36.2--canary.2173.25875.0
  yarn add @auto-canary/all-contributors@10.36.2--canary.2173.25875.0
  yarn add @auto-canary/brew@10.36.2--canary.2173.25875.0
  yarn add @auto-canary/chrome@10.36.2--canary.2173.25875.0
  yarn add @auto-canary/cocoapods@10.36.2--canary.2173.25875.0
  yarn add @auto-canary/conventional-commits@10.36.2--canary.2173.25875.0
  yarn add @auto-canary/crates@10.36.2--canary.2173.25875.0
  yarn add @auto-canary/docker@10.36.2--canary.2173.25875.0
  yarn add @auto-canary/exec@10.36.2--canary.2173.25875.0
  yarn add @auto-canary/first-time-contributor@10.36.2--canary.2173.25875.0
  yarn add @auto-canary/gem@10.36.2--canary.2173.25875.0
  yarn add @auto-canary/gh-pages@10.36.2--canary.2173.25875.0
  yarn add @auto-canary/git-tag@10.36.2--canary.2173.25875.0
  yarn add @auto-canary/gradle@10.36.2--canary.2173.25875.0
  yarn add @auto-canary/jira@10.36.2--canary.2173.25875.0
  yarn add @auto-canary/magic-zero@10.36.2--canary.2173.25875.0
  yarn add @auto-canary/maven@10.36.2--canary.2173.25875.0
  yarn add @auto-canary/microsoft-teams@10.36.2--canary.2173.25875.0
  yarn add @auto-canary/npm@10.36.2--canary.2173.25875.0
  yarn add @auto-canary/omit-commits@10.36.2--canary.2173.25875.0
  yarn add @auto-canary/omit-release-notes@10.36.2--canary.2173.25875.0
  yarn add @auto-canary/pr-body-labels@10.36.2--canary.2173.25875.0
  yarn add @auto-canary/released@10.36.2--canary.2173.25875.0
  yarn add @auto-canary/s3@10.36.2--canary.2173.25875.0
  yarn add @auto-canary/sbt@10.36.2--canary.2173.25875.0
  yarn add @auto-canary/slack@10.36.2--canary.2173.25875.0
  yarn add @auto-canary/twitter@10.36.2--canary.2173.25875.0
  yarn add @auto-canary/upload-assets@10.36.2--canary.2173.25875.0
  yarn add @auto-canary/vscode@10.36.2--canary.2173.25875.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
