### PR TITLE
create major version at last release tag

### DIFF
--- a/packages/core/src/__tests__/major-version-branches.test.ts
+++ b/packages/core/src/__tests__/major-version-branches.test.ts
@@ -70,9 +70,14 @@ describe("Old Version Branches", () => {
     auto.hooks.getPreviousVersion.tap("test", () => "1.0.0");
     await auto.hooks.beforeCommitChangelog.promise({
       bump: SEMVER.major,
+      lastRelease: "1.0.0",
     } as any);
 
-    expect(execSpy).toHaveBeenCalledWith("git", ["branch", "version-1"]);
+    expect(execSpy).toHaveBeenCalledWith("git", [
+      "branch",
+      "version-1",
+      "1.0.0",
+    ]);
   });
 
   test("should be able to customize old version branches", async () => {
@@ -85,8 +90,9 @@ describe("Old Version Branches", () => {
     auto.hooks.getPreviousVersion.tap("test", () => "1.0.0");
     await auto.hooks.beforeCommitChangelog.promise({
       bump: SEMVER.major,
+      lastRelease: "1.0.0",
     } as any);
 
-    expect(execSpy).toHaveBeenCalledWith("git", ["branch", "v1"]);
+    expect(execSpy).toHaveBeenCalledWith("git", ["branch", "v1", "1.0.0"]);
   });
 });

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -459,13 +459,13 @@ export default class Auto {
     });
     this.hooks.beforeCommitChangelog.tapPromise(
       "Old Version Branches",
-      async ({ bump }) => {
+      async ({ bump, lastRelease }) => {
         if (bump === SEMVER.major && this.config?.versionBranches) {
           const branch = `${this.config.versionBranches}${major(
             await this.hooks.getPreviousVersion.promise()
           )}`;
 
-          await execPromise("git", ["branch", branch]);
+          await execPromise("git", ["branch", branch, lastRelease]);
           this.logger.log.success(`Created old version branch: ${branch}`);
           await execPromise("git", ["push", this.remote, branch]);
         }
@@ -1343,7 +1343,7 @@ export default class Auto {
       }
     }
 
-    const verb = options.dryRun ? "Would have published" : "Published"
+    const verb = options.dryRun ? "Would have published" : "Published";
     this.logger.log.success(
       `${verb} canary version${newVersion ? `: ${newVersion}` : ""}`
     );
@@ -1715,7 +1715,9 @@ export default class Auto {
 
     const bump = await this.getVersion(options);
 
-    this.logger.log.success(`Calculated version bump: ${options.useVersion || bump || "none"}`);
+    this.logger.log.success(
+      `Calculated version bump: ${options.useVersion || bump || "none"}`
+    );
 
     if (bump === "" && !options.useVersion) {
       this.logger.log.info("No version published.");
@@ -1751,7 +1753,7 @@ export default class Auto {
       this.logger.verbose.info("Calling publish hook");
       await this.hooks.publish.promise({
         bump,
-        useVersion: options.useVersion
+        useVersion: options.useVersion,
       });
       this.logger.verbose.info("Calling after publish hook");
       await this.hooks.afterPublish.promise();


### PR DESCRIPTION
Tested in a local repo that it works. The fix was surprisingly simple! Fixes #1651

<img width="230" alt="CleanShot 2022-03-20 at 17 28 48@2x" src="https://user-images.githubusercontent.com/1192452/159192582-79be2204-2ef2-48c6-95bc-e9fca0a2d69f.png">

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux--canary.2175.26002.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux--canary.2175.26002.gz)  
[auto-macos--canary.2175.26002.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos--canary.2175.26002.gz)  
[auto-win.exe--canary.2175.26002.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe--canary.2175.26002.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.36.5--canary.2175.26002.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.36.5--canary.2175.26002.0
  npm install @auto-canary/auto@10.36.5--canary.2175.26002.0
  npm install @auto-canary/core@10.36.5--canary.2175.26002.0
  npm install @auto-canary/package-json-utils@10.36.5--canary.2175.26002.0
  npm install @auto-canary/all-contributors@10.36.5--canary.2175.26002.0
  npm install @auto-canary/brew@10.36.5--canary.2175.26002.0
  npm install @auto-canary/chrome@10.36.5--canary.2175.26002.0
  npm install @auto-canary/cocoapods@10.36.5--canary.2175.26002.0
  npm install @auto-canary/conventional-commits@10.36.5--canary.2175.26002.0
  npm install @auto-canary/crates@10.36.5--canary.2175.26002.0
  npm install @auto-canary/docker@10.36.5--canary.2175.26002.0
  npm install @auto-canary/exec@10.36.5--canary.2175.26002.0
  npm install @auto-canary/first-time-contributor@10.36.5--canary.2175.26002.0
  npm install @auto-canary/gem@10.36.5--canary.2175.26002.0
  npm install @auto-canary/gh-pages@10.36.5--canary.2175.26002.0
  npm install @auto-canary/git-tag@10.36.5--canary.2175.26002.0
  npm install @auto-canary/gradle@10.36.5--canary.2175.26002.0
  npm install @auto-canary/jira@10.36.5--canary.2175.26002.0
  npm install @auto-canary/magic-zero@10.36.5--canary.2175.26002.0
  npm install @auto-canary/maven@10.36.5--canary.2175.26002.0
  npm install @auto-canary/microsoft-teams@10.36.5--canary.2175.26002.0
  npm install @auto-canary/npm@10.36.5--canary.2175.26002.0
  npm install @auto-canary/omit-commits@10.36.5--canary.2175.26002.0
  npm install @auto-canary/omit-release-notes@10.36.5--canary.2175.26002.0
  npm install @auto-canary/pr-body-labels@10.36.5--canary.2175.26002.0
  npm install @auto-canary/released@10.36.5--canary.2175.26002.0
  npm install @auto-canary/s3@10.36.5--canary.2175.26002.0
  npm install @auto-canary/sbt@10.36.5--canary.2175.26002.0
  npm install @auto-canary/slack@10.36.5--canary.2175.26002.0
  npm install @auto-canary/twitter@10.36.5--canary.2175.26002.0
  npm install @auto-canary/upload-assets@10.36.5--canary.2175.26002.0
  npm install @auto-canary/vscode@10.36.5--canary.2175.26002.0
  # or 
  yarn add @auto-canary/bot-list@10.36.5--canary.2175.26002.0
  yarn add @auto-canary/auto@10.36.5--canary.2175.26002.0
  yarn add @auto-canary/core@10.36.5--canary.2175.26002.0
  yarn add @auto-canary/package-json-utils@10.36.5--canary.2175.26002.0
  yarn add @auto-canary/all-contributors@10.36.5--canary.2175.26002.0
  yarn add @auto-canary/brew@10.36.5--canary.2175.26002.0
  yarn add @auto-canary/chrome@10.36.5--canary.2175.26002.0
  yarn add @auto-canary/cocoapods@10.36.5--canary.2175.26002.0
  yarn add @auto-canary/conventional-commits@10.36.5--canary.2175.26002.0
  yarn add @auto-canary/crates@10.36.5--canary.2175.26002.0
  yarn add @auto-canary/docker@10.36.5--canary.2175.26002.0
  yarn add @auto-canary/exec@10.36.5--canary.2175.26002.0
  yarn add @auto-canary/first-time-contributor@10.36.5--canary.2175.26002.0
  yarn add @auto-canary/gem@10.36.5--canary.2175.26002.0
  yarn add @auto-canary/gh-pages@10.36.5--canary.2175.26002.0
  yarn add @auto-canary/git-tag@10.36.5--canary.2175.26002.0
  yarn add @auto-canary/gradle@10.36.5--canary.2175.26002.0
  yarn add @auto-canary/jira@10.36.5--canary.2175.26002.0
  yarn add @auto-canary/magic-zero@10.36.5--canary.2175.26002.0
  yarn add @auto-canary/maven@10.36.5--canary.2175.26002.0
  yarn add @auto-canary/microsoft-teams@10.36.5--canary.2175.26002.0
  yarn add @auto-canary/npm@10.36.5--canary.2175.26002.0
  yarn add @auto-canary/omit-commits@10.36.5--canary.2175.26002.0
  yarn add @auto-canary/omit-release-notes@10.36.5--canary.2175.26002.0
  yarn add @auto-canary/pr-body-labels@10.36.5--canary.2175.26002.0
  yarn add @auto-canary/released@10.36.5--canary.2175.26002.0
  yarn add @auto-canary/s3@10.36.5--canary.2175.26002.0
  yarn add @auto-canary/sbt@10.36.5--canary.2175.26002.0
  yarn add @auto-canary/slack@10.36.5--canary.2175.26002.0
  yarn add @auto-canary/twitter@10.36.5--canary.2175.26002.0
  yarn add @auto-canary/upload-assets@10.36.5--canary.2175.26002.0
  yarn add @auto-canary/vscode@10.36.5--canary.2175.26002.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
