### PR TITLE
Feat add `afterRun` hook

### DIFF
--- a/docs/pages/docs/plugins/configuration-hooks.mdx
+++ b/docs/pages/docs/plugins/configuration-hooks.mdx
@@ -139,3 +139,15 @@ auto.hooks.validateConfig.tapPromise("test", (name, options) => {
   }
 });
 ```
+
+## afterRun
+
+Happens after any command run.
+This is a great place to trigger post-actions.
+
+```ts
+auto.hooks.afterRun.tapPromise("afterCheck", async (config) => {
+    ...
+  }
+});
+```

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -136,6 +136,8 @@ export async function execute(command: string, args: ApiOptions) {
     }
 
     process.exit(1);
+  } finally {
+    await auto.teardown();
   }
 }
 

--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -1601,6 +1601,26 @@ describe("Auto", () => {
       expect(spy).not.toHaveBeenCalled();
     });
   });
+
+  describe("teardown", () => {
+    test("should throw when not initialized", async () => {
+      const auto = new Auto({ ...defaults, plugins: [] });
+      auto.logger = dummyLog();
+
+      await expect(auto.teardown()).rejects.not.toBeUndefined();
+    });
+
+    test("should call afterRun hooks", async () => {
+      const auto = new Auto({ ...defaults, plugins: [] });
+      auto.logger = dummyLog();
+
+      const afterRun = jest.fn();
+      auto.hooks.afterRun.tap("test", afterRun);
+      await auto.loadConfig();
+
+      await expect(auto.teardown()).resolves.toBeUndefined();
+    });
+  });
 });
 
 describe("hooks", () => {

--- a/packages/core/src/utils/make-hooks.ts
+++ b/packages/core/src/utils/make-hooks.ts
@@ -14,6 +14,7 @@ import { InteractiveInitHooks } from "../init";
 /** Make the hooks for "auto" */
 export const makeHooks = (): IAutoHooks => ({
   beforeRun: new AsyncSeriesHook(["config"]),
+  afterRun: new AsyncSeriesHook(["config"]),
   modifyConfig: new AsyncSeriesWaterfallHook(["config"]),
   validateConfig: new AsyncSeriesBailHook(["name", "options"]),
   beforeShipIt: new AsyncSeriesHook(["context"]),


### PR DESCRIPTION
# What Changed

Add new `afterRun` hook triggered after each command.

## Why

Because `beforeRun` exists ;-P  

Todo:

- [x] Add tests
- [x] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ]  `documentation`
- [ ]  `patch`
- [x]  `minor`
- [ ]  `major`
