### PR TITLE
non-zero exit code if commit is behind

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -512,11 +512,11 @@ export default class Auto {
           );
         } catch (error) {
           // If we are behind or there is no match, exit and skip the release
-          this.logger.log.warn(
+          this.logger.log.error(
             "Current commit is behind, skipping the release to avoid collisions."
           );
-          this.logger.verbose.warn(error);
-          process.exit(0);
+          this.logger.verbose.error(error);
+          process.exit(1);
         }
       }
     );


### PR DESCRIPTION
# What Changed

When running auto within our CI pipelines, merges in quick succession can result in the state that the commit to be released is behind the HEAD. 

The current behaviour is to "silently" fail with logging a warning and exit code 0 from `auto shipit`. The proposed behaviour is a nonzero exit code in these cases where nothing is released.

## Why

In these cases on our CI the skipped release amounts to a failure that we need to capture and reflect as a failed CI run. When the run of `auto shipit` is considered a success, subsequent runs of our CI & CD workflows get out of sync with repository state if the release didn't really happen.

Todo:

- [ ] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`
