### PR TITLE
fix(git): #2049 removes the use of deprecated error.headers

### DIFF
--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -168,7 +168,6 @@ export default class Git {
         // narrow down the type
         if ("headers" in error && error.request.headers.authorization) {
           delete error.request.headers.authorization;
-          delete error.headers.authorization;
         }
       }
 


### PR DESCRIPTION
# What Changed

This PR removes the reference to `error.headers` that throws an error because it's deprecated on octokit

## Why
Fixes #2049. This issues, supposedly, was fixed in #2064 but there are reports of it still happening

Todo:

- [ ] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`