### PR TITLE
#2141: add missed --no-verify-access for lerna publish

### DIFF
--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -681,6 +681,7 @@ describe("publish", () => {
       "--yes",
       "from-package",
       "--exact",
+      "--no-verify-access"
     ]);
   });
 
@@ -703,6 +704,7 @@ describe("publish", () => {
       "--yes",
       "from-package",
       false,
+      "--no-verify-access"
     ]);
   });
 
@@ -728,6 +730,7 @@ describe("publish", () => {
       false,
       "--legacy-auth",
       "abcd",
+      "--no-verify-access"
     ]);
   });
 
@@ -752,6 +755,7 @@ describe("publish", () => {
       false,
       "--contents",
       "dist/publish-folder",
+      "--no-verify-access"
     ]);
   });
 

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -1447,6 +1447,7 @@ export default class NPMPlugin implements IPlugin {
           ...(await getRegistryArgs()),
           ...getPublishFolderArgs(this.publishFolder, { isMonorepo: true }),
           ...getLegacyAuthArgs(this.legacyAuth, { isMonorepo: true }),
+          "--no-verify-access", // permit automation tokens https://github.com/lerna/lerna/issues/2788
         ]);
       } else {
         const { private: isPrivate } = await loadPackageJson();


### PR DESCRIPTION
# What Changed
added missed --no-verify-access flag for lerna publish

## Why
to make publication with lerna work with npm Automation tokens

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux--canary.2205.26254.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux--canary.2205.26254.gz)  
[auto-macos--canary.2205.26254.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos--canary.2205.26254.gz)  
[auto-win.exe--canary.2205.26254.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe--canary.2205.26254.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.37.1--canary.2205.26254.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.37.1--canary.2205.26254.0
  npm install @auto-canary/auto@10.37.1--canary.2205.26254.0
  npm install @auto-canary/core@10.37.1--canary.2205.26254.0
  npm install @auto-canary/package-json-utils@10.37.1--canary.2205.26254.0
  npm install @auto-canary/all-contributors@10.37.1--canary.2205.26254.0
  npm install @auto-canary/brew@10.37.1--canary.2205.26254.0
  npm install @auto-canary/chrome@10.37.1--canary.2205.26254.0
  npm install @auto-canary/cocoapods@10.37.1--canary.2205.26254.0
  npm install @auto-canary/conventional-commits@10.37.1--canary.2205.26254.0
  npm install @auto-canary/crates@10.37.1--canary.2205.26254.0
  npm install @auto-canary/docker@10.37.1--canary.2205.26254.0
  npm install @auto-canary/exec@10.37.1--canary.2205.26254.0
  npm install @auto-canary/first-time-contributor@10.37.1--canary.2205.26254.0
  npm install @auto-canary/gem@10.37.1--canary.2205.26254.0
  npm install @auto-canary/gh-pages@10.37.1--canary.2205.26254.0
  npm install @auto-canary/git-tag@10.37.1--canary.2205.26254.0
  npm install @auto-canary/gradle@10.37.1--canary.2205.26254.0
  npm install @auto-canary/jira@10.37.1--canary.2205.26254.0
  npm install @auto-canary/magic-zero@10.37.1--canary.2205.26254.0
  npm install @auto-canary/maven@10.37.1--canary.2205.26254.0
  npm install @auto-canary/microsoft-teams@10.37.1--canary.2205.26254.0
  npm install @auto-canary/npm@10.37.1--canary.2205.26254.0
  npm install @auto-canary/omit-commits@10.37.1--canary.2205.26254.0
  npm install @auto-canary/omit-release-notes@10.37.1--canary.2205.26254.0
  npm install @auto-canary/pr-body-labels@10.37.1--canary.2205.26254.0
  npm install @auto-canary/released@10.37.1--canary.2205.26254.0
  npm install @auto-canary/s3@10.37.1--canary.2205.26254.0
  npm install @auto-canary/sbt@10.37.1--canary.2205.26254.0
  npm install @auto-canary/slack@10.37.1--canary.2205.26254.0
  npm install @auto-canary/twitter@10.37.1--canary.2205.26254.0
  npm install @auto-canary/upload-assets@10.37.1--canary.2205.26254.0
  npm install @auto-canary/version-file@10.37.1--canary.2205.26254.0
  npm install @auto-canary/vscode@10.37.1--canary.2205.26254.0
  # or 
  yarn add @auto-canary/bot-list@10.37.1--canary.2205.26254.0
  yarn add @auto-canary/auto@10.37.1--canary.2205.26254.0
  yarn add @auto-canary/core@10.37.1--canary.2205.26254.0
  yarn add @auto-canary/package-json-utils@10.37.1--canary.2205.26254.0
  yarn add @auto-canary/all-contributors@10.37.1--canary.2205.26254.0
  yarn add @auto-canary/brew@10.37.1--canary.2205.26254.0
  yarn add @auto-canary/chrome@10.37.1--canary.2205.26254.0
  yarn add @auto-canary/cocoapods@10.37.1--canary.2205.26254.0
  yarn add @auto-canary/conventional-commits@10.37.1--canary.2205.26254.0
  yarn add @auto-canary/crates@10.37.1--canary.2205.26254.0
  yarn add @auto-canary/docker@10.37.1--canary.2205.26254.0
  yarn add @auto-canary/exec@10.37.1--canary.2205.26254.0
  yarn add @auto-canary/first-time-contributor@10.37.1--canary.2205.26254.0
  yarn add @auto-canary/gem@10.37.1--canary.2205.26254.0
  yarn add @auto-canary/gh-pages@10.37.1--canary.2205.26254.0
  yarn add @auto-canary/git-tag@10.37.1--canary.2205.26254.0
  yarn add @auto-canary/gradle@10.37.1--canary.2205.26254.0
  yarn add @auto-canary/jira@10.37.1--canary.2205.26254.0
  yarn add @auto-canary/magic-zero@10.37.1--canary.2205.26254.0
  yarn add @auto-canary/maven@10.37.1--canary.2205.26254.0
  yarn add @auto-canary/microsoft-teams@10.37.1--canary.2205.26254.0
  yarn add @auto-canary/npm@10.37.1--canary.2205.26254.0
  yarn add @auto-canary/omit-commits@10.37.1--canary.2205.26254.0
  yarn add @auto-canary/omit-release-notes@10.37.1--canary.2205.26254.0
  yarn add @auto-canary/pr-body-labels@10.37.1--canary.2205.26254.0
  yarn add @auto-canary/released@10.37.1--canary.2205.26254.0
  yarn add @auto-canary/s3@10.37.1--canary.2205.26254.0
  yarn add @auto-canary/sbt@10.37.1--canary.2205.26254.0
  yarn add @auto-canary/slack@10.37.1--canary.2205.26254.0
  yarn add @auto-canary/twitter@10.37.1--canary.2205.26254.0
  yarn add @auto-canary/upload-assets@10.37.1--canary.2205.26254.0
  yarn add @auto-canary/version-file@10.37.1--canary.2205.26254.0
  yarn add @auto-canary/vscode@10.37.1--canary.2205.26254.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
