### PR TITLE
Get correct next version when using onlyGraduateWithReleaseLabel

### DIFF
--- a/plugins/version-file/src/index.ts
+++ b/plugins/version-file/src/index.ts
@@ -160,15 +160,23 @@ export default class VersionFilePlugin implements IPlugin {
 
       // Figure out next version
       const lastRelease = await auto.git!.getLatestRelease();
+      const currentBranch = await getCurrentBranch();
+
+      const latestTagInBranch = await (currentBranch === auto.baseBranch
+        ? auto.git?.getLatestTagInBranch()
+        : auto.git?.getLastTagNotInBaseBranch(prereleaseBranch));
+
       const latestTag =
-        (await auto.git?.getLastTagNotInBaseBranch(prereleaseBranch)) ||
+        latestTagInBranch ||
         (await getPreviousVersion(auto, this.versionFile));
+
       const nextVersion = determineNextVersion(
         lastRelease,
         latestTag,
         bump,
         prereleaseBranch
       );
+
       const prefixedVersion = auto.prefixRelease(nextVersion);
       preReleaseVersions.push(prefixedVersion);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13,10 +13,10 @@
   integrity sha512-K1kQv1BZVtMXQqdpNZt9Pgh85KwamsWX9gYyq1xG4cpyb+EacfMiNfumrju16piFXanCUrCR0P1DowPjV2qV/A==
 
 "@auto-it/bot-list@link:packages/bot-list":
-  version "10.36.2"
+  version "10.37.1"
 
 "@auto-it/core@link:packages/core":
-  version "10.36.2"
+  version "10.37.1"
   dependencies:
     "@auto-it/bot-list" "link:packages/bot-list"
     "@endemolshinegroup/cosmiconfig-typescript-loader" "^3.0.2"
@@ -59,7 +59,7 @@
     url-join "^4.0.0"
 
 "@auto-it/npm@link:plugins/npm":
-  version "10.36.2"
+  version "10.37.1"
   dependencies:
     "@auto-it/core" "link:packages/core"
     "@auto-it/package-json-utils" "link:packages/package-json-utils"
@@ -77,13 +77,13 @@
     user-home "^2.0.0"
 
 "@auto-it/package-json-utils@link:packages/package-json-utils":
-  version "10.36.2"
+  version "10.37.1"
   dependencies:
     parse-author "^2.0.0"
     parse-github-url "1.0.2"
 
 "@auto-it/released@link:plugins/released":
-  version "10.36.2"
+  version "10.37.1"
   dependencies:
     "@auto-it/bot-list" "link:packages/bot-list"
     "@auto-it/core" "link:packages/core"
@@ -91,6 +91,15 @@
     fp-ts "^2.5.3"
     io-ts "^2.1.2"
     tslib "2.1.0"
+
+"@auto-it/version-file@link:plugins/version-file":
+  version "10.37.1"
+  dependencies:
+    "@auto-it/core" "link:packages/core"
+    fp-ts "^2.5.3"
+    io-ts "^2.1.2"
+    semver "^7.0.0"
+    tslib "1.10.0"
 
 "@babel/code-frame@7.12.11":
   version "7.12.11"
@@ -11531,12 +11540,7 @@ path-key@^3.0.0, path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-path-parse@^1.0.5, path-parse@^1.0.6:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
-  integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
-
-path-parse@^1.0.7:
+path-parse@^1.0.5, path-parse@^1.0.6, path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==


### PR DESCRIPTION
When using the onlyGraduateWithReleaseLabel for shipit the next prerelease version was being calculated as the latest tag not present in the main branch. This is problematic when the prerelease and main branch are the same (as is the case for onlyGraduateWithReleaseLabel)

This would cause auto to always create the -next.0 tag for a release (since it's based off of the latest release in the repo), and publishing would fail due to conflicting versions being published.

This change update the calculation in the version-file plugin to use getLatestTagInBranch() when the current and main branch are the same.

A similar change (or broken out into a standalone util) may be needed for other versioning plugins
