### PR TITLE
(docker plugin) Additional tag alias support

### DIFF
--- a/plugins/docker/README.md
+++ b/plugins/docker/README.md
@@ -61,7 +61,7 @@ This will publish releases from the local docker image `someLocalImage:myLocalTa
 {
   "prereleaseBranches": ["develop", "someOtherPrereleaseBranch"],
   "plugins": [
-    ["docker", { "registry": "ghcr.io/my/app", "image": "someLocalImage:myLocalTag", "tagPrereleases": true, "prereleaseTagMapping": { "develop": "next" } }]
+    ["docker", { "registry": "ghcr.io/my/app", "image": "someLocalImage:myLocalTag", "tagPrereleaseAliases": true, "prereleaseAliasMapping": { "develop": "next" } }]
     // other plugins
   ]
 }
@@ -79,7 +79,7 @@ For pushes to `someOtherReleaseBranch` this will create the following tags:
 ```json
 {
   "plugins": [
-    ["docker", { "registry": "ghcr.io/my/app", "image": "someLocalImage:myLocalTag", "tagPullRequests": true }]
+    ["docker", { "registry": "ghcr.io/my/app", "image": "someLocalImage:myLocalTag", "tagPullRequestAliases": true }]
     // other plugins
   ]
 }

--- a/plugins/docker/README.md
+++ b/plugins/docker/README.md
@@ -18,33 +18,73 @@ yarn add -D @auto-it/docker
 
 ## Usage
 
-You must first must build the desired image to publish.
+**IMPORTANT:** You must first must build the desired image to publish.
 
-These environment variables tell `auto` what to publish.
+The following options are available for this plugin:
 
-- IMAGE - The image ID, digest, or tag of the locally available image to tag and publish. This is required unless you want to statically tag the local image, in which case you can provide it as an option.
+|option|required|default|environment variable|description|
+|-|-|-|-|-|
+| `image` | X | | `IMAGE` | The image ID, digest, or tag of the locally available image to tag and publish (must be built before this plugin is run) |
+| `registry` | X | | `REGISTRY` | Docker registry to publish to |
+| `tagLatest` | | `false` | `TAG_LATEST` | Tag latest release with `latest` tag |
+| `tagPullRequestAliases` | | `false` | `TAG_PULL_REQUEST_ALIASES` | Tag pull requests with `pr-<number>` tag |
+| `tagPrereleaseAliases` | | `false` | `TAG_PRERELEASE_ALIASES` | Tag prerelease branches
+| `prereleaseAliasMappings` | | `{}` | | Tag prerelease branches with different names (e.g. `{"develop": "next"}`) |
 
+### Example 1: Tag releases only
 ```json
 {
   "plugins": [
-    ["docker", { "registry": "ghcr.io/my/app" }]
+    ["docker", { "registry": "ghcr.io/my/app", "image": "someLocalImage:myLocalTag" }]
     // other plugins
   ]
 }
 ```
 
-If you'd like to tag releases with `latest` too, you can specify the `tagLatest` option:
+This will publish releases from the local docker image `someLocalImage:myLocalTag` to: - `ghcr.io/my/app:<version>`
 
+### Example 2: Tag latest releases
 ```json
 {
-  "plugins": [["docker", { "registry": "ghcr.io/my/app", "tagLatest": true }]]
+  "plugins": [
+    ["docker", { "registry": "ghcr.io/my/app", "image": "someLocalImage:myLocalTag", "tagLatest": true }]
+    // other plugins
+  ]
 }
 ```
 
-If you're tagging the locally built image in a static manner, you can also pass `image` instead of `IMAGE` as an environment variable.
+This will publish releases from the local docker image `someLocalImage:myLocalTag` to: - `ghcr.io/my/app:<version>`
+- `ghcr.io/my/app:latest`
 
+### Example 3: Tag Prereleases (with Custom Tags)
 ```json
 {
-  "plugins": [["docker", { "registry": "ghcr.io/my/app", "image": "myapp" }]]
+  "prereleaseBranches": ["develop", "someOtherPrereleaseBranch"],
+  "plugins": [
+    ["docker", { "registry": "ghcr.io/my/app", "image": "someLocalImage:myLocalTag", "tagPrereleases": true, "prereleaseTagMapping": { "develop": "next" } }]
+    // other plugins
+  ]
 }
 ```
+
+For pushes to `develop` branch this will create the following tags:
+- `ghcr.io/my/app:<prereleaseVersion>`
+- `ghcr.io/my/app:next`
+
+For pushes to `someOtherReleaseBranch` this will create the following tags:
+- `ghcr.io/my/app:<prereleaseVersion>`
+- `ghcr.io/my/app:someOtherReleaseBranch`
+
+### Example 4: Tag Pull Requests
+```json
+{
+  "plugins": [
+    ["docker", { "registry": "ghcr.io/my/app", "image": "someLocalImage:myLocalTag", "tagPullRequests": true }]
+    // other plugins
+  ]
+}
+```
+
+If this is run against a pull request the following tags will be created against `someLocalImage:myLocalTag`:
+- `ghcr.io/my/app:<canaryVersion>`
+- `ghcr.io/my/app:pr-<prNumber>`

--- a/plugins/docker/__tests__/docker.test.ts
+++ b/plugins/docker/__tests__/docker.test.ts
@@ -18,7 +18,8 @@ const registry = "registry.io/app";
 const setup = (
   mockGit?: any,
   options?: IDockerPluginOptions,
-  checkEnv?: jest.SpyInstance
+  checkEnv?: jest.SpyInstance,
+  prereleaseBranches: string[] = ["next"],
 ) => {
   const plugin = new DockerPlugin(options || { registry });
   const hooks = makeHooks();
@@ -30,7 +31,7 @@ const setup = (
     remote: "origin",
     logger: dummyLog(),
     prefixRelease: (r: string) => r,
-    config: { prereleaseBranches: ["next"] },
+    config: { prereleaseBranches },
     getCurrentVersion: () => "v1.0.0",
   } as unknown) as Auto.Auto);
 
@@ -65,7 +66,7 @@ describe("Docker Plugin", () => {
       await hooks.beforeRun.promise({
         plugins: [["docker", { registry }]],
       } as any);
-      expect(checkEnv).toBeCalled();
+      expect(checkEnv).toBeCalledWith('docker', 'IMAGE');
     });
 
     test("shouldn't check env with image", async () => {
@@ -74,7 +75,79 @@ describe("Docker Plugin", () => {
       await hooks.beforeRun.promise({
         plugins: [["docker", { registry, image: "test" }]],
       } as any);
-      expect(checkEnv).not.toBeCalled();
+      expect(checkEnv).not.toBeCalledWith('docker','IMAGE');
+    });
+
+    test("should check env without registry", async () => {
+      const checkEnv = jest.fn();
+      const hooks = setup(undefined, undefined, checkEnv);
+      await hooks.beforeRun.promise({
+        plugins: [["docker", { }]],
+      } as any);
+      expect(checkEnv).toHaveBeenCalledWith('docker','REGISTRY');
+    });
+
+    test("shouldn't check env with registry", async () => {
+      const checkEnv = jest.fn();
+      const hooks = setup(undefined, undefined, checkEnv);
+      await hooks.beforeRun.promise({
+        plugins: [["docker", { registry, image: "test" }]],
+      } as any);
+      expect(checkEnv).not.toHaveBeenCalledWith('docker','REGISTRY');
+    });
+
+    test("should check env without tagLatest", async () => {
+      const checkEnv = jest.fn();
+      const hooks = setup(undefined, undefined, checkEnv);
+      await hooks.beforeRun.promise({
+        plugins: [["docker", { }]],
+      } as any);
+      expect(checkEnv).toHaveBeenCalledWith('docker','TAG_LATEST');
+    });
+
+    test("shouldn't check env with tagLatest", async () => {
+      const checkEnv = jest.fn();
+      const hooks = setup(undefined, undefined, checkEnv);
+      await hooks.beforeRun.promise({
+        plugins: [["docker", { tagLatest: true }]],
+      } as any);
+      expect(checkEnv).not.toHaveBeenCalledWith('docker','TAG_LATEST');
+    });
+
+    test("should check env without tagPrereleases", async () => {
+      const checkEnv = jest.fn();
+      const hooks = setup(undefined, undefined, checkEnv);
+      await hooks.beforeRun.promise({
+        plugins: [["docker", { }]],
+      } as any);
+      expect(checkEnv).toHaveBeenCalledWith('docker','TAG_PRERELEASE_ALIASES');
+    });
+
+    test("shouldn't check env with tagPrereleases", async () => {
+      const checkEnv = jest.fn();
+      const hooks = setup(undefined, undefined, checkEnv);
+      await hooks.beforeRun.promise({
+        plugins: [["docker", { tagPrereleaseAliases: true }]],
+      } as any);
+      expect(checkEnv).not.toHaveBeenCalledWith('docker','TAG_PRERELEASE_ALIASES');
+    });
+
+    test("should check env without tagPullRequests", async () => {
+      const checkEnv = jest.fn();
+      const hooks = setup(undefined, undefined, checkEnv);
+      await hooks.beforeRun.promise({
+        plugins: [["docker", { }]],
+      } as any);
+      expect(checkEnv).toHaveBeenCalledWith('docker','TAG_PULL_REQUEST_ALIASES');
+    });
+
+    test("shouldn't check env with tagPullRequests", async () => {
+      const checkEnv = jest.fn();
+      const hooks = setup(undefined, undefined, checkEnv);
+      await hooks.beforeRun.promise({
+        plugins: [["docker", { tagPullRequestAliases: true }]],
+      } as any);
+      expect(checkEnv).not.toHaveBeenCalledWith('docker','TAG_PULL_REQUEST_ALIASES');
     });
   });
 
@@ -149,6 +222,12 @@ describe("Docker Plugin", () => {
         "-m",
         '"Update version to 1.0.1"',
       ]);
+      expect(exec).toHaveBeenCalledWith("git", [
+        "tag",
+        "latest",
+        "-mf",
+        '"Tag release alias: latest (1.0.1)"',
+      ]);
       expect(exec).toHaveBeenCalledWith("docker", [
         "tag",
         sourceImage,
@@ -192,6 +271,91 @@ describe("Docker Plugin", () => {
         "push",
         `${registry}:1.0.1-canary.123.1`,
       ]);
+      expect(exec).toBeCalledTimes(2);
+    });
+
+    test("should not tag canary version aliases if not a pull request", async () => {
+      const sourceImage = "app:sha-123";
+      const hooks = setup(
+        {
+          getLatestRelease: () => "v1.0.0",
+          getCurrentVersion: () => "v1.0.0",
+        },
+        { registry, image: sourceImage, tagPullRequestAliases: true }
+      );
+
+      const prSpy = jest.spyOn(Auto,"getPrNumberFromEnv").mockImplementation(jest.fn());
+
+      await hooks.canary.promise({
+        bump: Auto.SEMVER.patch,
+        canaryIdentifier: `canary.123.1`,
+      });
+
+      expect(prSpy).toBeCalled();
+
+      expect(exec).toHaveBeenCalledWith("docker", [
+        "tag",
+        sourceImage,
+        `${registry}:1.0.1-canary.123.1`,
+      ]);
+      expect(exec).toHaveBeenCalledWith("docker", [
+        "push",
+        `${registry}:1.0.1-canary.123.1`,
+      ]);
+      expect(exec).toBeCalledTimes(2);
+    });
+
+    test("should tag canary version aliases", async () => {
+      const prNumber = 123;
+      const sourceImage = "app:sha-123";
+      const hooks = setup(
+        {
+          getLatestRelease: () => "v1.0.0",
+          getCurrentVersion: () => "v1.0.0",
+        },
+        { registry, image: sourceImage, tagPullRequestAliases: true }
+      );
+
+      const prSpy = jest.spyOn(Auto,"getPrNumberFromEnv").mockImplementationOnce(() => prNumber);
+
+      await hooks.canary.promise({
+        bump: Auto.SEMVER.patch,
+        canaryIdentifier: `canary.${prNumber}.1`,
+      });
+
+      expect(prSpy).toBeCalled();
+
+      expect(exec).toHaveBeenCalledWith("docker", [
+        "tag",
+        sourceImage,
+        `${registry}:1.0.1-canary.${prNumber}.1`,
+      ]);
+      expect(exec).toHaveBeenCalledWith("docker", [
+        "push",
+        `${registry}:1.0.1-canary.${prNumber}.1`,
+      ]);
+      expect(exec).toHaveBeenCalledWith("git", [
+        "tag",
+        `pr-${prNumber}`,
+        "-mf",
+        `Tag pull request canary: pr-${prNumber} (1.0.1-canary.${prNumber}.1)`,
+      ]);
+      expect(exec).toHaveBeenCalledWith("git", [
+        "push",
+        "origin",
+        `refs/tags/pr-${prNumber}`,
+        "-f"
+      ])
+      expect(exec).toHaveBeenCalledWith("docker", [
+        "tag",
+        sourceImage,
+        `${registry}:pr-${prNumber}`,
+      ]);
+      expect(exec).toHaveBeenCalledWith("docker", [
+        "push",
+        `${registry}:pr-${prNumber}`,
+      ]);
+      expect(exec).toBeCalledTimes(6);
     });
 
     test("should print canary version in dry run", async () => {
@@ -227,6 +391,133 @@ describe("Docker Plugin", () => {
       expect(exec).not.toHaveBeenCalled();
     });
 
+    test("should tag next version with alias", async () => {
+      const sourceImage = "app:sha-123"
+      const hooks = setup(
+        {
+          getLatestRelease: () => "v0.1.0",
+          getLastTagNotInBaseBranch: () => "v1.0.0",
+        },
+        { 
+          registry,
+          image: sourceImage,
+          tagPrereleaseAliases: true
+        },
+      )
+
+      await hooks.next.promise([], { bump: Auto.SEMVER.patch } as any);
+
+      expect(exec).toHaveBeenCalledWith("git", [
+        "tag",
+        "1.0.1-next.0",
+        "-m",
+        '"Tag pre-release: 1.0.1-next.0"',
+      ]);
+      expect(exec).toHaveBeenCalledWith("git", [
+        "tag",
+        "next",
+        "-mf",
+        '"Tag pre-release alias: next (1.0.1-next.0)"',
+      ]);
+      expect(exec).toHaveBeenCalledWith("git", [
+        "push",
+        "origin",
+        "refs/tags/next",
+        "-f"
+      ])
+      expect(exec).toHaveBeenCalledWith("git", [
+        "push",
+        "origin",
+        "next",
+        "--tags",
+      ]);
+      expect(exec).toHaveBeenCalledWith("docker", [
+        "tag",
+        sourceImage,
+        `${registry}:1.0.1-next.0`,
+      ]);
+      expect(exec).toHaveBeenCalledWith("docker", [
+        "tag",
+        sourceImage,
+        `${registry}:next`,
+      ]);
+      expect(exec).toHaveBeenCalledWith("docker", [
+        "push",
+        `${registry}:1.0.1-next.0`,
+      ]);
+      expect(exec).toHaveBeenCalledWith("docker", [
+        "push",
+        `${registry}:next`,
+      ]);
+      expect(exec).toHaveBeenCalledTimes(8);
+    });
+
+    test("should tag next version with alias mappings", async () => {
+      const sourceImage = "app:sha-123";
+      const expectedAlias = "someOtherAlias";
+
+      const hooks = setup(
+        {
+          getLatestRelease: () => "v0.1.0",
+          getLastTagNotInBaseBranch: () => "v1.0.0",
+        },
+        { 
+          registry,
+          image: sourceImage,
+          tagPrereleaseAliases: true,
+          prereleaseAliasMappings: {
+            "next": expectedAlias
+          }
+        },
+      )
+
+      await hooks.next.promise([], { bump: Auto.SEMVER.patch } as any);
+
+      expect(exec).toHaveBeenCalledWith("git", [
+        "tag",
+        `1.0.1-${expectedAlias}.0`,
+        "-m",
+        `"Tag pre-release: 1.0.1-${expectedAlias}.0"`,
+      ]);
+      expect(exec).toHaveBeenCalledWith("git", [
+        "tag",
+        expectedAlias,
+        "-mf",
+        `"Tag pre-release alias: ${expectedAlias} (1.0.1-${expectedAlias}.0)"`,
+      ]);
+      expect(exec).toHaveBeenCalledWith("git", [
+        "push",
+        "origin",
+        `refs/tags/${expectedAlias}`,
+        "-f"
+      ])
+      expect(exec).toHaveBeenCalledWith("git", [
+        "push",
+        "origin",
+        "next",
+        "--tags",
+      ]);
+      expect(exec).toHaveBeenCalledWith("docker", [
+        "tag",
+        sourceImage,
+        `${registry}:1.0.1-${expectedAlias}.0`,
+      ]);
+      expect(exec).toHaveBeenCalledWith("docker", [
+        "tag",
+        sourceImage,
+        `${registry}:${expectedAlias}`,
+      ]);
+      expect(exec).toHaveBeenCalledWith("docker", [
+        "push",
+        `${registry}:1.0.1-${expectedAlias}.0`,
+      ]);
+      expect(exec).toHaveBeenCalledWith("docker", [
+        "push",
+        `${registry}:${expectedAlias}`,
+      ]);
+      expect(exec).toHaveBeenCalledTimes(8);
+    });
+
     test("should tag next version", async () => {
       const sourceImage = "app:sha-123";
       const hooks = setup(
@@ -260,6 +551,7 @@ describe("Docker Plugin", () => {
         "push",
         `${registry}:1.0.1-next.0`,
       ]);
+      expect(exec).toHaveBeenCalledTimes(4);
     });
 
     test("return next version in dry run", async () => {
@@ -316,6 +608,14 @@ describe("Docker Plugin", () => {
       await hooks.version.promise({ bump: Auto.SEMVER.patch });
 
       await hooks.publish.promise({ bump: Auto.SEMVER.patch });
+
+      expect(exec).toHaveBeenCalledWith("git", [
+        "push",
+        "origin",
+        "refs/tags/latest",
+        "-f"
+      ]);
+
       expect(exec).toHaveBeenCalledWith("docker", [
         "push",
         `${registry}:1.0.1`,


### PR DESCRIPTION
# What Changed
Thanks for creating this plugin! This PR does not change any existing behavior but does add some new functionality:

- All plugin configuration can now be passed in via environment variables
  - `IMAGE`, `REGISTRY`, `TAG_LATEST`, `TAG_PRERELEASE_ALIASES`, `TAG_PULL_REQUEST_ALIASES`
- README updates
- Added support for the following tag aliases
  - **prereleases**: pushes to any prerelease branch creates a `branch` tag in both `git` and `docker` (e.g. `myimage:<branchName>` docker tag and `<branchName>` git tag). Branch/Tag mapping can be configured via new `prereleaseAliasMappings` option
  - canary: creates `pr-<prNumber>` docker tag and `pr-<prNumber>` git tag
  - release: also creates a `latest` git tag (not just a `latest` docker tag)

## Why
This provides the following benefits:
- Alias tags (e.g. `pr-<prNumber>`, `latest`, `next`, etc) are only created AFTER docker image is pushed
- Simplifies cases where you want to reference the shortcut version rather than the explicit version (for example if you are publishing new docker images of your service to DockerHub but your customers only care about `latest`, `next`, etc)

This functionality may not be desired for all use cases and hence is disabled by default.

Todo:

- [x] Add tests
- [x] Add docs

## Change Type

Indicate the type of change your pull request is:

- [x] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`
