### PR TITLE
version: take into account current PR labels

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1829,23 +1829,20 @@ export default class Auto {
 
     let calculatedBump = await this.release.getSemverBump(lastRelease);
 
-    // For next releases we also want to take into account any labels on
-    // the PR of next into main
-    if (isPrerelease) {
-      const pr = getPrNumberFromEnv();
+    // Take into account any labels on the PR
+    const pr = getPrNumberFromEnv();
 
-      if (pr && this.semVerLabels) {
-        const prLabels = await this.git.getLabels(pr);
-        this.logger.verbose.info(
-          `Found labels on prerelease branch PR`,
-          prLabels
-        );
-        calculatedBump = calculateSemVerBump(
-          [prLabels, [calculatedBump]],
-          this.semVerLabels,
-          this.config
-        );
-      }
+    if (pr && this.semVerLabels) {
+      const prLabels = await this.git.getLabels(pr);
+      this.logger.verbose.info(
+        `Found labels on prerelease branch PR`,
+        prLabels
+      );
+      calculatedBump = calculateSemVerBump(
+        [prLabels, [calculatedBump]],
+        this.semVerLabels,
+        this.config
+      );
     }
 
     const bump =


### PR DESCRIPTION
When running `auto version` from a PR, take into account its labels (not only for the next branch PRs).

# What Changed

I removed the `if (isPrerelease)` condition.

## Why

When I run `auto version` from CI on a PR, it doesn't take into account this PR labels:
- I'm working on a breaking change in a PR and add the `major` label
- run `auto version` from CI, expecting `major` in the output
- it returns default `patch` because it only looks at the commits on the branch and not the labels on the PR

TODO

- [ ] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux--canary.2252.26551.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux--canary.2252.26551.gz)  
[auto-macos--canary.2252.26551.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos--canary.2252.26551.gz)  
[auto-win.exe--canary.2252.26551.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe--canary.2252.26551.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.37.6--canary.2252.26551.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.37.6--canary.2252.26551.0
  npm install @auto-canary/auto@10.37.6--canary.2252.26551.0
  npm install @auto-canary/core@10.37.6--canary.2252.26551.0
  npm install @auto-canary/package-json-utils@10.37.6--canary.2252.26551.0
  npm install @auto-canary/all-contributors@10.37.6--canary.2252.26551.0
  npm install @auto-canary/brew@10.37.6--canary.2252.26551.0
  npm install @auto-canary/chrome@10.37.6--canary.2252.26551.0
  npm install @auto-canary/cocoapods@10.37.6--canary.2252.26551.0
  npm install @auto-canary/conventional-commits@10.37.6--canary.2252.26551.0
  npm install @auto-canary/crates@10.37.6--canary.2252.26551.0
  npm install @auto-canary/docker@10.37.6--canary.2252.26551.0
  npm install @auto-canary/exec@10.37.6--canary.2252.26551.0
  npm install @auto-canary/first-time-contributor@10.37.6--canary.2252.26551.0
  npm install @auto-canary/gem@10.37.6--canary.2252.26551.0
  npm install @auto-canary/gh-pages@10.37.6--canary.2252.26551.0
  npm install @auto-canary/git-tag@10.37.6--canary.2252.26551.0
  npm install @auto-canary/gradle@10.37.6--canary.2252.26551.0
  npm install @auto-canary/jira@10.37.6--canary.2252.26551.0
  npm install @auto-canary/magic-zero@10.37.6--canary.2252.26551.0
  npm install @auto-canary/maven@10.37.6--canary.2252.26551.0
  npm install @auto-canary/microsoft-teams@10.37.6--canary.2252.26551.0
  npm install @auto-canary/npm@10.37.6--canary.2252.26551.0
  npm install @auto-canary/omit-commits@10.37.6--canary.2252.26551.0
  npm install @auto-canary/omit-release-notes@10.37.6--canary.2252.26551.0
  npm install @auto-canary/pr-body-labels@10.37.6--canary.2252.26551.0
  npm install @auto-canary/released@10.37.6--canary.2252.26551.0
  npm install @auto-canary/s3@10.37.6--canary.2252.26551.0
  npm install @auto-canary/sbt@10.37.6--canary.2252.26551.0
  npm install @auto-canary/slack@10.37.6--canary.2252.26551.0
  npm install @auto-canary/twitter@10.37.6--canary.2252.26551.0
  npm install @auto-canary/upload-assets@10.37.6--canary.2252.26551.0
  npm install @auto-canary/version-file@10.37.6--canary.2252.26551.0
  npm install @auto-canary/vscode@10.37.6--canary.2252.26551.0
  # or 
  yarn add @auto-canary/bot-list@10.37.6--canary.2252.26551.0
  yarn add @auto-canary/auto@10.37.6--canary.2252.26551.0
  yarn add @auto-canary/core@10.37.6--canary.2252.26551.0
  yarn add @auto-canary/package-json-utils@10.37.6--canary.2252.26551.0
  yarn add @auto-canary/all-contributors@10.37.6--canary.2252.26551.0
  yarn add @auto-canary/brew@10.37.6--canary.2252.26551.0
  yarn add @auto-canary/chrome@10.37.6--canary.2252.26551.0
  yarn add @auto-canary/cocoapods@10.37.6--canary.2252.26551.0
  yarn add @auto-canary/conventional-commits@10.37.6--canary.2252.26551.0
  yarn add @auto-canary/crates@10.37.6--canary.2252.26551.0
  yarn add @auto-canary/docker@10.37.6--canary.2252.26551.0
  yarn add @auto-canary/exec@10.37.6--canary.2252.26551.0
  yarn add @auto-canary/first-time-contributor@10.37.6--canary.2252.26551.0
  yarn add @auto-canary/gem@10.37.6--canary.2252.26551.0
  yarn add @auto-canary/gh-pages@10.37.6--canary.2252.26551.0
  yarn add @auto-canary/git-tag@10.37.6--canary.2252.26551.0
  yarn add @auto-canary/gradle@10.37.6--canary.2252.26551.0
  yarn add @auto-canary/jira@10.37.6--canary.2252.26551.0
  yarn add @auto-canary/magic-zero@10.37.6--canary.2252.26551.0
  yarn add @auto-canary/maven@10.37.6--canary.2252.26551.0
  yarn add @auto-canary/microsoft-teams@10.37.6--canary.2252.26551.0
  yarn add @auto-canary/npm@10.37.6--canary.2252.26551.0
  yarn add @auto-canary/omit-commits@10.37.6--canary.2252.26551.0
  yarn add @auto-canary/omit-release-notes@10.37.6--canary.2252.26551.0
  yarn add @auto-canary/pr-body-labels@10.37.6--canary.2252.26551.0
  yarn add @auto-canary/released@10.37.6--canary.2252.26551.0
  yarn add @auto-canary/s3@10.37.6--canary.2252.26551.0
  yarn add @auto-canary/sbt@10.37.6--canary.2252.26551.0
  yarn add @auto-canary/slack@10.37.6--canary.2252.26551.0
  yarn add @auto-canary/twitter@10.37.6--canary.2252.26551.0
  yarn add @auto-canary/upload-assets@10.37.6--canary.2252.26551.0
  yarn add @auto-canary/version-file@10.37.6--canary.2252.26551.0
  yarn add @auto-canary/vscode@10.37.6--canary.2252.26551.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
