### PR TITLE
(docker plugin) fix git tagging command

### DIFF
--- a/plugins/docker/__tests__/docker.test.ts
+++ b/plugins/docker/__tests__/docker.test.ts
@@ -224,8 +224,9 @@ describe("Docker Plugin", () => {
       ]);
       expect(exec).toHaveBeenCalledWith("git", [
         "tag",
+        "-f",
         "latest",
-        "-mf",
+        "-m",
         '"Tag release alias: latest (1.0.1)"',
       ]);
       expect(exec).toHaveBeenCalledWith("docker", [
@@ -336,8 +337,9 @@ describe("Docker Plugin", () => {
       ]);
       expect(exec).toHaveBeenCalledWith("git", [
         "tag",
+        "-f",
         `pr-${prNumber}`,
-        "-mf",
+        "-m",
         `Tag pull request canary: pr-${prNumber} (1.0.1-canary.${prNumber}.1)`,
       ]);
       expect(exec).toHaveBeenCalledWith("git", [
@@ -415,8 +417,9 @@ describe("Docker Plugin", () => {
       ]);
       expect(exec).toHaveBeenCalledWith("git", [
         "tag",
+        "-f",
         "next",
-        "-mf",
+        "-m",
         '"Tag pre-release alias: next (1.0.1-next.0)"',
       ]);
       expect(exec).toHaveBeenCalledWith("git", [
@@ -481,8 +484,9 @@ describe("Docker Plugin", () => {
       ]);
       expect(exec).toHaveBeenCalledWith("git", [
         "tag",
+        "-f",
         expectedAlias,
-        "-mf",
+        "-m",
         `"Tag pre-release alias: ${expectedAlias} (1.0.1-${expectedAlias}.0)"`,
       ]);
       expect(exec).toHaveBeenCalledWith("git", [

--- a/plugins/docker/src/index.ts
+++ b/plugins/docker/src/index.ts
@@ -151,8 +151,9 @@ export default class DockerPlugin implements IPlugin {
         if (this.options.tagLatest) {
           await execPromise("git", [
             "tag",
+            "-f",
             aliasTag,
-            "-mf",
+            "-m",
             `"Tag release alias: ${aliasTag} (${prefixedTag})"`
           ]);
         }
@@ -209,7 +210,7 @@ export default class DockerPlugin implements IPlugin {
           const aliasImage = `${this.options.registry}:${canaryAliasVersion}`;
           await execPromise("docker", ["tag", this.options.image, aliasImage]);
           await execPromise("docker", ["push", aliasImage]);
-          await execPromise("git", ["tag", `${canaryAliasVersion}`, "-mf", `Tag pull request canary: ${canaryAliasVersion} (${canaryVersion})`]);
+          await execPromise("git", ["tag", "-f", `${canaryAliasVersion}`, "-m", `Tag pull request canary: ${canaryAliasVersion} (${canaryVersion})`]);
           await execPromise("git", ["push", auto.remote, `refs/tags/${canaryAliasVersion}`, "-f"]);
         }
 
@@ -269,8 +270,9 @@ export default class DockerPlugin implements IPlugin {
         if (this.options.tagPrereleaseAliases) {
           await execPromise("git", [
             "tag",
+            "-f",
             prereleaseAlias,
-            "-mf",
+            "-m",
             `"Tag pre-release alias: ${prereleaseAlias} (${prerelease})"`,
           ]);
           await execPromise("docker", ["tag", this.options.image, aliasImage]);


### PR DESCRIPTION
# What Changed

Fixes bug introduced with #2232 

## Why

Previous fix creates git tags with `git tag latest -mf "..."` which results in an error like this:

```
Error: Running command 'git' with args [tag, latest, -mf, "Tag release alias: latest (vX.Y.Z)"] failed
```

This changes the command to use correct syntax for latest, canaries, and prereleases:
```
git tag -f latest -m "..."
```

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
