### PR TITLE
Add `--no-git-commit` option to `changelog` command

### DIFF
--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -149,6 +149,13 @@ const dryRun: AutoOption = {
   group: "main",
 };
 
+const noGitCommit: AutoOption = {
+  name: "no-git-commit",
+  type: Boolean,
+  description: "Do not commit changes",
+  group: "main",
+};
+
 const url: AutoOption = {
   name: "url",
   type: String,
@@ -460,6 +467,7 @@ export const commands: AutoCommand[] = [
       changelogCommitMessage,
       baseBranch,
       quiet,
+      noGitCommit,
     ],
     examples: [
       {

--- a/packages/core/src/auto-args.ts
+++ b/packages/core/src/auto-args.ts
@@ -57,6 +57,11 @@ export interface DryRunOption {
   dryRun?: boolean;
 }
 
+export interface NoGitCommit {
+  /** Do not commit the changes */
+  noGitCommit?: boolean;
+}
+
 interface ChangelogTitle {
   /** Override the title use in the addition to the CHANGELOG.md. */
   title?: string;
@@ -70,13 +75,14 @@ export type IChangelogOptions = BaseBranch &
   QuietOption &
   DryRunOption &
   NoVersionPrefix &
+  NoGitCommit &
   Partial<AuthorInformation> & {
     /** Commit to start calculating the changelog from */
     from?: string;
     /** Commit to start calculating the changelog to */
     to?: string;
-    /** Don't commit the changelog */
-    noCommit?: boolean;
+    /** Do not make any changes to changelog file */
+    noChanges?: boolean;
   };
 
 export type IReleaseOptions = BaseBranch &

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1732,7 +1732,7 @@ export default class Auto {
     await this.makeChangelog({
       ...options,
       quiet: undefined,
-      noCommit: options.noChangelog,
+      noChanges: options.noChangelog,
     });
 
     if (!options.dryRun) {
@@ -1862,7 +1862,8 @@ export default class Auto {
       to,
       title,
       message = "Update CHANGELOG.md [skip ci]",
-      noCommit,
+      noGitCommit,
+      noChanges,
     } = options;
 
     if (!this.release || !this.git) {
@@ -1908,16 +1909,23 @@ export default class Auto {
       currentVersion,
     };
 
-    if (!noCommit) {
+    if (!noChanges) {
       await this.release.addToChangelog(
         releaseNotes,
         lastRelease,
         currentVersion
       );
 
-      await this.hooks.beforeCommitChangelog.promise(context);
-      await execPromise("git", ["commit", "-m", `"${message}"`, "--no-verify"]);
-      this.logger.verbose.info("Committed new changelog.");
+      if (!noGitCommit) {
+        await this.hooks.beforeCommitChangelog.promise(context);
+        await execPromise("git", [
+          "commit",
+          "-m",
+          `"${message}"`,
+          "--no-verify",
+        ]);
+        this.logger.verbose.info("Committed new changelog.");
+      }
     }
 
     await this.hooks.afterChangelog.promise(context);

--- a/packages/core/src/release.ts
+++ b/packages/core/src/release.ts
@@ -263,10 +263,12 @@ export default class Release {
         : `v${version}`;
     });
 
-    this.logger.verbose.info("Adding new changes to changelog.");
+    const fileName = "CHANGELOG.md";
+
+    this.logger.verbose.info(`Adding new changes to ${fileName}.`);
     const title = await this.hooks.createChangelogTitle.promise();
 
-    await this.updateChangelogFile(title || "", releaseNotes, "CHANGELOG.md");
+    await this.updateChangelogFile(title || "", releaseNotes, fileName);
   }
 
   /**


### PR DESCRIPTION
# What Changed

Add `--no-git-commit` option to `changelog` command.

With this new parameter it will be possible to change the `CHANGELOG.md` file without it doing the unwanted `git commit`.

![`changelog`](https://user-images.githubusercontent.com/673904/191571503-4c8255df-5ffe-4c06-aac2-3fa2c735f771.png) 

## Why

Following the [Do-It-Yourself](https://intuit.github.io/auto/docs/welcome/getting-started#do-it-yourself) topic in the documentation, I made [this script ](https://github.com/megatroom/components-to-markdown/blob/main/scripts/bump-version.sh) to customize my project's deployment. It's working fine, but it's generating two commits due to the `changelog` command committing without being able to avoid it.

![Commits-·-megatroom-components-to-markdown](https://user-images.githubusercontent.com/673904/191573923-ea8aeb4d-4565-463e-941b-30bf792e1ec6.png)

With this new parameter I will be able to make a single commit to save the changes to the `CHANGELOG.md` and `package.json` files.

Below is an example of a script using this new feature:

```bash
export PATH=$(npm bin):$PATH

# Exit immediately if a command fails
set -e

VERSION=`auto version`

## Support for label 'skip-release'
if [ ! -z "$VERSION" ]; then
  ## Update Changelog
  auto changelog --no-git-commit

  ## Generate new version
  TAG_NAME=$(npm --no-git-tag-version version $VERSION)
  VERSION_NUMBER=$(echo "$TAG_NAME" | cut -c2-)

  ## Publish Package
  npm publish

  ## Commit the changes
  git add CHANGELOG.md package.json
  git commit -m "[skip ci] Bump version to: $VERSION_NUMBER"
  git tag -a $TAG_NAME -m "Version $VERSION_NUMBER"

  ## Create GitHub Release
  git push --follow-tags --set-upstream origin $branch
  auto release --use-version=$TAG_NAME
fi
```

Todo:

- [x] Add tests
- [x] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`
