### PR TITLE
fix: init command add .env to .gitignore

### DIFF
--- a/packages/core/src/init.ts
+++ b/packages/core/src/init.ts
@@ -285,14 +285,14 @@ async function createEnv(hook: InteractiveInitHooks["createEnv"]) {
   let gitIgnore: string;
 
   try {
-    gitIgnore = readFileSync(".env", { encoding: "utf8" });
+    gitIgnore = readFileSync(".gitignore", { encoding: "utf8" });
   } catch (error) {
     gitIgnore = "";
   }
 
   // Add env to gitignore if not already there
   if (!gitIgnore.includes(".env")) {
-    writeFileSync(".env", gitIgnore ? `${gitIgnore}\n.env` : ".env");
+    writeFileSync(".gitignore", gitIgnore ? `${gitIgnore}\n.env\n` : `.env\n`);
   }
 }
 


### PR DESCRIPTION
# What Changed

Fixes 
- #2261 

## Why

### Before

#### .env
```
NPM_TOKEN=not-actual-npm-token
GH_TOKEN=not-actual-github-token

.env
```

### After

#### .env
```
NPM_TOKEN=not-actual-npm-token
GH_TOKEN=not-actual-github-token

```
#### .gitignore
```
.env

```

Todo:

- [x] Add tests. _I did not find tests for `init` command. Direct me to it if I did not look correctly!_
- [x] Add docs. _No need for documentation, fix doesn't change the scope of it_

To know if we should add `.env` to `.gitignore` we will now read the correct file. It will add it if not already included.

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
