### PR TITLE
[CocoaPods] switch Promise.all for reduce to avoid git lock

### DIFF
--- a/plugins/cocoapods/__tests__/cocoapods.test.ts
+++ b/plugins/cocoapods/__tests__/cocoapods.test.ts
@@ -672,6 +672,7 @@ describe("Cocoapods Plugin", () => {
       expect(versions).toContain("1.0.0-next.0");
       expect(exec).toBeCalledTimes(6);
       expect(exec).toHaveBeenCalledWith("git", ["checkout", "./Test.podspec"]);
+      expect(exec).toHaveBeenCalledWith("git", ["checkout", "./Test2.podspec"]);
 
       expect(mock).toBeCalledTimes(2);
       expect(mock).toHaveBeenCalledWith(

--- a/plugins/cocoapods/src/index.ts
+++ b/plugins/cocoapods/src/index.ts
@@ -352,8 +352,12 @@ export default class CocoapodsPlugin implements IPlugin {
         await this.publishPodSpec(podLogLevel);
 
         // Reset changes to podspec file since it doesn't need to be committed
-        await Promise.all(
-          this.paths.map((path) => execPromise("git", ["checkout", path]))
+        await this.paths.reduce(
+          (promise, path) =>
+            promise.then(async () => {
+              await execPromise("git", ["checkout", path]);
+            }),
+          Promise.resolve()
         );
 
         return preReleaseVersions;


### PR DESCRIPTION
# What Changed

Switched `Promise.all` to a reduce a promise chain to avoid git lock

I had done this [before](https://github.com/intuit/auto/pull/2169) for the `publish` hook but not for the `next` hook

## Why

git lock can be a race condition and sometimes `next` publish will fail

Todo:

- [ ] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
