### PR TITLE
[CocoaPods] switch Promise.all for reduce to avoid git lock

### DIFF
--- a/plugins/cocoapods/__tests__/cocoapods.test.ts
+++ b/plugins/cocoapods/__tests__/cocoapods.test.ts
@@ -672,6 +672,7 @@ describe("Cocoapods Plugin", () => {
       expect(versions).toContain("1.0.0-next.0");
       expect(exec).toBeCalledTimes(6);
       expect(exec).toHaveBeenCalledWith("git", ["checkout", "./Test.podspec"]);
+      expect(exec).toHaveBeenCalledWith("git", ["checkout", "./Test2.podspec"]);
 
       expect(mock).toBeCalledTimes(2);
       expect(mock).toHaveBeenCalledWith(

--- a/plugins/cocoapods/src/index.ts
+++ b/plugins/cocoapods/src/index.ts
@@ -352,8 +352,12 @@ export default class CocoapodsPlugin implements IPlugin {
         await this.publishPodSpec(podLogLevel);
 
         // Reset changes to podspec file since it doesn't need to be committed
-        await Promise.all(
-          this.paths.map((path) => execPromise("git", ["checkout", path]))
+        await this.paths.reduce(
+          (promise, path) =>
+            promise.then(async () => {
+              await execPromise("git", ["checkout", path]);
+            }),
+          Promise.resolve()
         );
 
         return preReleaseVersions;


### PR DESCRIPTION
redo of https://github.com/intuit/auto/pull/2327 because fork build was not working right

# What Changed

Switched `Promise.all` to a reduce a promise chain to avoid git lock

I had done this [before](https://github.com/intuit/auto/pull/2169) for the `publish` hook but not for the `next` hook

## Why

git lock can be a race condition and sometimes `next` publish will fail

Todo:

- [ ] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux--canary.2328.9694a60d57e4c2d92b424dd32af7dfbbd99ca6cf.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux--canary.2328.9694a60d57e4c2d92b424dd32af7dfbbd99ca6cf.gz)  
[auto-macos--canary.2328.9694a60d57e4c2d92b424dd32af7dfbbd99ca6cf.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos--canary.2328.9694a60d57e4c2d92b424dd32af7dfbbd99ca6cf.gz)  
[auto-win.exe--canary.2328.9694a60d57e4c2d92b424dd32af7dfbbd99ca6cf.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe--canary.2328.9694a60d57e4c2d92b424dd32af7dfbbd99ca6cf.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->
