### PR TITLE
fix examples for release command

### DIFF
--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -512,12 +512,13 @@ export const commands: AutoCommand[] = [
       prerelease,
     ],
     examples: [
-      "{green $} auto release",
       {
-        desc:
-          "This command can be used in isolation easily. This example will: tag the release version at 'to' and create a GitHub release changelog over the commits range",
-        example:
-          "{green $} auto release --from v0.20.1 --to HEAD --use-version v0.21.0",
+        desc: "Create a GitHub release",
+        example: "{green $} auto release",
+      },
+      {
+        desc: "Create a GitHub release using provided commit range and version",
+        example: "{green $} auto release --from v0.20.1 --to HEAD --use-version v0.21.0",
       },
     ],
   },


### PR DESCRIPTION
# What Changed
Examples for the `release` CLI command to be an array of plain objects

## Why
Currently, running `auto release --help` fails with the following error:
```
/workspaces/csm/node_modules/command-line-usage/lib/section/content.js:82
      throw new Error(message)
            ^
Error: invalid input - 'content' must be a string, array of strings, or array of plain objects:

["{green $} auto release",{"desc":"Create a GitHub release over the specified commits range and using a specific version","example":"{green $} auto release --from v0.20.1 --to HEAD --use-version v0.21.0"}]
    at getContentLines (/workspaces/csm/node_modules/command-line-usage/lib/section/content.js:82:13)
    at new ContentSection (/workspaces/csm/node_modules/command-line-usage/lib/section/content.js:18:18)
    at /workspaces/csm/node_modules/command-line-usage/index.js:21:16
    at Array.map (<anonymous>)
    at Object.commandLineUsage [as default] (/workspaces/csm/node_modules/command-line-usage/index.js:17:29)
    at printUsage (/workspaces/csm/node_modules/command-line-application/src/index.ts:187:31)
    at parseCommand (/workspaces/csm/node_modules/command-line-application/src/index.ts:351:5)
    at app (/workspaces/csm/node_modules/command-line-application/src/index.ts:409:12)
    at Object.app (/workspaces/csm/node_modules/command-line-application/src/index.ts:434:22)
    at Object.parseArgs [as default] (/workspaces/csm/node_modules/auto/src/parse-args.ts:648:23)
```

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
