### PR TITLE
feat: add in beforeVersion lifecycle hook

### DIFF
--- a/docs/pages/docs/plugins/release-lifecycle-hooks.mdx
+++ b/docs/pages/docs/plugins/release-lifecycle-hooks.mdx
@@ -95,6 +95,19 @@ _Other examples:_
 
 - [all-contributors](../generated/all-contributors) - Make a commit for new contributions
 
+## beforeVersion
+
+Ran before the package has been versioned. Useful for iterating through the list of
+commits that are going to be included in the current release, and applying/overriding
+the version bump (major/minor/patch) labels applied to their corresponding PRs.
+
+```ts
+auto.hooks.beforeVersion.tapPromise(
+  "NPM",
+  async ({ dryRun, commits, from }) => {}
+);
+```
+
 ## version
 
 Increment the version the package.

--- a/docs/pages/docs/plugins/release-lifecycle-hooks.mdx
+++ b/docs/pages/docs/plugins/release-lifecycle-hooks.mdx
@@ -99,7 +99,7 @@ _Other examples:_
 
 Ran before the package has been versioned. Useful for iterating through the list of
 commits that are going to be included in the current release, and applying/overriding
-the version bump (major/minor/patch) labels applied to their corresponding PRs.
+the version bump (major/minor/patch) labels applied to the PRs corresponding to those commits.
 
 ```ts
 auto.hooks.beforeVersion.tapPromise(

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -238,6 +238,17 @@ export interface IAutoHooks {
       }
     ]
   >;
+  /** Ran before the package has been versioned. */
+  beforeVersion: AsyncSeriesHook<
+    [
+      DryRunOption & {
+        /** Commit to start calculating the version from */
+        from: string;
+        /** The commits included in the release */
+        commits: IExtendedCommit[];
+      }
+    ]
+  >;
   /** Version the package. This is a good opportunity to `git tag` the release also.  */
   version: AsyncSeriesHook<
     [
@@ -1713,6 +1724,18 @@ export default class Auto {
       throw this.createErrorMessage();
     }
 
+    const lastRelease = options.from || (await this.git.getLatestRelease());
+    const commitsInRelease = await this.release.getCommitsInRelease(
+      lastRelease
+    );
+
+    this.logger.verbose.info("Calling before version hook");
+    await this.hooks.beforeVersion.promise({
+      dryRun: options.dryRun,
+      commits: commitsInRelease,
+      from: lastRelease,
+    });
+
     const bump = await this.getVersion(options);
 
     this.logger.log.success(
@@ -1723,11 +1746,6 @@ export default class Auto {
       this.logger.log.info("No version published.");
       return;
     }
-
-    const lastRelease = options.from || (await this.git.getLatestRelease());
-    const commitsInRelease = await this.release.getCommitsInRelease(
-      lastRelease
-    );
 
     await this.makeChangelog({
       ...options,

--- a/packages/core/src/utils/make-hooks.ts
+++ b/packages/core/src/utils/make-hooks.ts
@@ -29,6 +29,7 @@ export const makeHooks = (): IAutoHooks => ({
   getPreviousVersion: new AsyncSeriesBailHook(),
   getRepository: new AsyncSeriesBailHook(),
   prCheck: new AsyncSeriesBailHook(["prInformation"]),
+  beforeVersion: new AsyncSeriesHook(["context"]),
   version: new AsyncSeriesHook(["version"]),
   afterVersion: new AsyncSeriesHook(["context"]),
   publish: new AsyncSeriesHook(["version"]),


### PR DESCRIPTION
# What Changed

## Why

Add in a `beforeVersion` hook that is useful for iterating through the list of commits that are going to be included in the current release, and applying/overriding the version bump (major/minor/patch) labels applied to the PRs corresponding to those commits.

Todo:

- [ ] Add tests
- [x] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [X] `minor`
- [ ] `major`
