### PR TITLE
add useVersion support to npm changelog

### DIFF
--- a/packages/core/src/auto-args.ts
+++ b/packages/core/src/auto-args.ts
@@ -83,6 +83,8 @@ export type IChangelogOptions = BaseBranch &
     to?: string;
     /** Do not make any changes to changelog file */
     noChanges?: boolean;
+    /** Override the version to release */
+    useVersion?: string;
   };
 
 export type IReleaseOptions = BaseBranch &

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -96,6 +96,8 @@ interface ChangelogLifecycle {
   currentVersion: string;
   /** The last version of the project */
   lastRelease: string;
+  /** Override the version to release */
+  useVersion?: string;
 }
 
 interface TestingToken {
@@ -1933,12 +1935,13 @@ export default class Auto {
     this.logger.log.info("New Release Notes\n", releaseNotes);
 
     const currentVersion = await this.getCurrentVersion(lastRelease);
-    const context = {
+    const context: ChangelogLifecycle = {
       bump,
       commits: await this.release.getCommits(lastRelease, to || undefined),
       releaseNotes,
       lastRelease,
       currentVersion,
+      useVersion: options.useVersion,
     };
 
     if (!noChanges) {

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -152,7 +152,6 @@ export async function getChangedPackages({
   return [...changed];
 }
 
-
 /** Get the package with the greatest version in a monorepo */
 export function getMonorepoPackage() {
   const packages = getPackages(process.cwd());
@@ -162,7 +161,9 @@ export function getMonorepoPackage() {
   }
 
   // Remove pre-releases so that released package versions take precedence
-  let releasedPackages = packages.filter(subPackage => prerelease(subPackage.package?.version || '') === null);
+  let releasedPackages = packages.filter(
+    (subPackage) => prerelease(subPackage.package?.version || "") === null
+  );
   // If doing this would remove all packages, this means were not any @latest releases yet
   // In that case, restore the original list of packages.
   if (releasedPackages.length === 0) {
@@ -219,10 +220,7 @@ interface GetArgsOptions {
 }
 
 /** Get the args to use legacy auth */
-function getLegacyAuthArgs(
-  useLegacy: boolean,
-  options: GetArgsOptions = {}
-) {
+function getLegacyAuthArgs(useLegacy: boolean, options: GetArgsOptions = {}) {
   if (!useLegacy) {
     return [];
   }
@@ -241,9 +239,7 @@ function getPublishFolderArgs(
     return [];
   }
 
-  return options.isMonorepo
-    ? ["--contents", publishFolder]
-    : [publishFolder];
+  return options.isMonorepo ? ["--contents", publishFolder] : [publishFolder];
 }
 
 /** Get the args to set the registry. Only used with lerna */
@@ -290,7 +286,11 @@ const markdownList = (lines: string[]) =>
   lines.map((line) => `- \`${line}\``).join("\n");
 
 /** Get the previous version. Typically from a package distribution description file. */
-async function getPreviousVersion(auto: Auto, prereleaseBranch: string, isMaintenanceBranch: boolean) {
+async function getPreviousVersion(
+  auto: Auto,
+  prereleaseBranch: string,
+  isMaintenanceBranch: boolean
+) {
   let previousVersion = "";
 
   if (isMonorepo()) {
@@ -307,7 +307,10 @@ async function getPreviousVersion(auto: Auto, prereleaseBranch: string, isMainte
     } else {
       const releasedPackage = getMonorepoPackage();
 
-      if (isMaintenanceBranch || (!releasedPackage.name && !releasedPackage.version)) {
+      if (
+        isMaintenanceBranch ||
+        (!releasedPackage.name && !releasedPackage.version)
+      ) {
         previousVersion = auto.prefixRelease(monorepoVersion);
       } else {
         previousVersion = await greaterRelease(
@@ -323,8 +326,8 @@ async function getPreviousVersion(auto: Auto, prereleaseBranch: string, isMainte
       "Using package.json to calculate previous version"
     );
     const { version, name } = await loadPackageJson();
-    if(isMaintenanceBranch && version) {
-      previousVersion = version
+    if (isMaintenanceBranch && version) {
+      previousVersion = version;
     } else {
       previousVersion = version
         ? await greaterRelease(
@@ -702,8 +705,12 @@ export default class NPMPlugin implements IPlugin {
 
     let isMaintenanceBranch = false;
 
-    if(auto.config?.versionBranches && branch) {
-      isMaintenanceBranch = branch.includes(typeof auto.config.versionBranches === "boolean" ? "version-" : auto.config.versionBranches)
+    if (auto.config?.versionBranches && branch) {
+      isMaintenanceBranch = branch.includes(
+        typeof auto.config.versionBranches === "boolean"
+          ? "version-"
+          : auto.config.versionBranches
+      );
     }
 
     auto.hooks.validateConfig.tapPromise(this.name, async (name, options) => {
@@ -810,10 +817,13 @@ export default class NPMPlugin implements IPlugin {
             }
 
             // Allows us to see the commit being assessed
-            auto.logger.veryVerbose.info(`Rendering changelog line for commit:`, commit)
+            auto.logger.veryVerbose.info(
+              `Rendering changelog line for commit:`,
+              commit
+            );
 
             // adds commits to changelog only if hash is resolvable
-            if(!commit || !commit.hash) {
+            if (!commit || !commit.hash) {
               return line;
             }
 
@@ -885,7 +895,7 @@ export default class NPMPlugin implements IPlugin {
 
     auto.hooks.beforeCommitChangelog.tapPromise(
       this.name,
-      async ({ commits, bump }) => {
+      async ({ commits, bump, useVersion }) => {
         if (!isMonorepo() || !auto.release || !this.subPackageChangelogs) {
           return;
         }
@@ -924,7 +934,9 @@ export default class NPMPlugin implements IPlugin {
           const includedCommits = commits.filter((commit) =>
             commit.files.some((file) => inFolder(lernaPackage.path, file))
           );
-          const title = `v${inc(lernaPackage.version, bump as ReleaseType)}`;
+          const title = `v${
+            useVersion || inc(lernaPackage.version, bump as ReleaseType)
+          }`;
           const releaseNotes = await changelog.generateReleaseNotes(
             includedCommits
           );
@@ -985,7 +997,9 @@ export default class NPMPlugin implements IPlugin {
 
               logVersion(canaryPackageList.join("\n"));
             } else {
-              logVersion(useVersion || inc(monorepoVersion, bump as ReleaseType) || bump);
+              logVersion(
+                useVersion || inc(monorepoVersion, bump as ReleaseType) || bump
+              );
             }
 
             return;
@@ -994,7 +1008,9 @@ export default class NPMPlugin implements IPlugin {
           const monorepoBump =
             isIndependent || !isBaseBranch
               ? useVersion || bump
-              : useVersion || (await bumpLatest(getMonorepoPackage(), bump)) || bump;
+              : useVersion ||
+                (await bumpLatest(getMonorepoPackage(), bump)) ||
+                bump;
 
           let commitMessage = isIndependent
             ? "Bump independent versions [skip ci]"
@@ -1028,7 +1044,9 @@ export default class NPMPlugin implements IPlugin {
         }
 
         const latestBump = isBaseBranch
-          ? useVersion || (await bumpLatest(await loadPackageJson(), bump)) || bump
+          ? useVersion ||
+            (await bumpLatest(await loadPackageJson(), bump)) ||
+            bump
           : useVersion || bump;
 
         if (dryRun) {
@@ -1260,7 +1278,11 @@ export default class NPMPlugin implements IPlugin {
         const lastRelease = await auto.git!.getLatestRelease();
         const latestTag =
           (await auto.git?.getLastTagNotInBaseBranch(prereleaseBranch)) ||
-          (await getPreviousVersion(auto, prereleaseBranch, isMaintenanceBranch));
+          (await getPreviousVersion(
+            auto,
+            prereleaseBranch,
+            isMaintenanceBranch
+          ));
 
         if (isMonorepo()) {
           auto.logger.verbose.info("Detected monorepo, using lerna");


### PR DESCRIPTION
# What Changed

I added the `useVersion` override parameter to the changelog lifecycle events so that changelogs can be compiled with the same version number as the packages themselves. I also made the npm plugin respect this option.

## Why

At the moment, if I pass `useVersion` it is used successfully when doing versioning and publishing but not when compiling the changelog, which ignores the override and uses the regular bumped version.

Todo:

- [x] Add tests
- [ ] Add docs (useVersion is not currently documented)

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
