### PR TITLE
fixes "some peer dependencies are incorrectly met" when installing via yarn

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -78,10 +78,8 @@
     "typescript-memoize": "^1.0.0-alpha.3",
     "url-join": "^4.0.0"
   },
-  "peerDependenciesMeta": {
-    "typescript": {
-      "optional": true
-    }
+  "peerDependencies": {
+    "typescript": ">=2.7"
   },
   "devDependencies": {
     "@types/dotenv": "^8.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -81,6 +81,11 @@
   "peerDependencies": {
     "typescript": ">=2.7"
   },
+  "peerDependenciesMeta": {
+    "@types/node": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@types/dotenv": "^8.2.0",
     "@types/env-ci": "^3.1.0",


### PR DESCRIPTION
# What Changed

Adds unmet peer dependencies coming from bundled dependencies. 
Namely; `ts-node`, `@endemolshinegroup/cosmiconfig-typescript-loader`

## Why

Solves warnings when installing auto via yarn, see #2343

Todo:

- [ ] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
