### PR TITLE
allow channel to be passed to slack plugin

### DIFF
--- a/plugins/slack/src/index.ts
+++ b/plugins/slack/src/index.ts
@@ -215,6 +215,14 @@ const basePluginOptions = t.partial({
   iconEmoji: t.string,
 });
 
+const urlPluginOptions = t.intersection([
+  t.partial({
+    /** Channels to post */
+    channel: t.string,
+  }),
+  basePluginOptions,
+]);
+
 const appPluginOptions = t.intersection([
   t.interface({
     /** Marks we are gonna use app auth */
@@ -225,7 +233,7 @@ const appPluginOptions = t.intersection([
   basePluginOptions,
 ]);
 
-const pluginOptions = t.union([basePluginOptions, appPluginOptions]);
+const pluginOptions = t.union([urlPluginOptions, appPluginOptions]);
 
 export type ISlackPluginOptions = t.TypeOf<typeof pluginOptions>;
 
@@ -450,6 +458,7 @@ export default class SlackPlugin implements IPlugin {
           link_names: true,
           // If not in app auth only one message is constructed
           blocks: messages[0],
+          channel: this.options.channel,
         }),
         headers: { "Content-Type": "application/json" },
         agent,


### PR DESCRIPTION
Pretty sure this can be passed in and let the hook post to a specific channel with legacy url. gonna test and document if it works
<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.gz)  
[auto-macos--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.gz)  
[auto-win.exe--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  npm install @auto-canary/auto@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  npm install @auto-canary/core@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  npm install @auto-canary/package-json-utils@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  npm install @auto-canary/all-contributors@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  npm install @auto-canary/brew@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  npm install @auto-canary/chrome@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  npm install @auto-canary/cocoapods@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  npm install @auto-canary/conventional-commits@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  npm install @auto-canary/crates@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  npm install @auto-canary/docker@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  npm install @auto-canary/exec@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  npm install @auto-canary/first-time-contributor@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  npm install @auto-canary/gem@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  npm install @auto-canary/gh-pages@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  npm install @auto-canary/git-tag@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  npm install @auto-canary/gradle@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  npm install @auto-canary/jira@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  npm install @auto-canary/magic-zero@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  npm install @auto-canary/maven@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  npm install @auto-canary/microsoft-teams@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  npm install @auto-canary/npm@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  npm install @auto-canary/omit-commits@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  npm install @auto-canary/omit-release-notes@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  npm install @auto-canary/pr-body-labels@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  npm install @auto-canary/protected-branch@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  npm install @auto-canary/released@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  npm install @auto-canary/s3@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  npm install @auto-canary/sbt@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  npm install @auto-canary/slack@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  npm install @auto-canary/twitter@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  npm install @auto-canary/upload-assets@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  npm install @auto-canary/version-file@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  npm install @auto-canary/vscode@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  # or 
  yarn add @auto-canary/bot-list@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  yarn add @auto-canary/auto@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  yarn add @auto-canary/core@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  yarn add @auto-canary/package-json-utils@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  yarn add @auto-canary/all-contributors@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  yarn add @auto-canary/brew@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  yarn add @auto-canary/chrome@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  yarn add @auto-canary/cocoapods@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  yarn add @auto-canary/conventional-commits@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  yarn add @auto-canary/crates@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  yarn add @auto-canary/docker@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  yarn add @auto-canary/exec@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  yarn add @auto-canary/first-time-contributor@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  yarn add @auto-canary/gem@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  yarn add @auto-canary/gh-pages@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  yarn add @auto-canary/git-tag@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  yarn add @auto-canary/gradle@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  yarn add @auto-canary/jira@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  yarn add @auto-canary/magic-zero@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  yarn add @auto-canary/maven@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  yarn add @auto-canary/microsoft-teams@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  yarn add @auto-canary/npm@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  yarn add @auto-canary/omit-commits@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  yarn add @auto-canary/omit-release-notes@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  yarn add @auto-canary/pr-body-labels@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  yarn add @auto-canary/protected-branch@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  yarn add @auto-canary/released@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  yarn add @auto-canary/s3@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  yarn add @auto-canary/sbt@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  yarn add @auto-canary/slack@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  yarn add @auto-canary/twitter@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  yarn add @auto-canary/upload-assets@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  yarn add @auto-canary/version-file@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  yarn add @auto-canary/vscode@10.44.1--canary.2352.b2639bf755b86283f20cfeb9c41e86cc4c25ae43.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
