### PR TITLE
fix typo for empty git user message

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -2192,7 +2192,7 @@ export default class Auto {
       if (!user.name && !user.email) {
         this.logger.log.error(
           endent`
-            Could find a git name and email to commit with!
+            Could not find a git name and email to commit with!
 
             Name: ${user.name}
             Email: ${user.email}


### PR DESCRIPTION
# What Changed

Simple typo

## Why

Todo:

- [ ] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
