### PR TITLE
Add --from latest option to release and changelog commands

### DIFF
--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -236,7 +236,7 @@ const useVersion: AutoOption = {
   group: "main",
   description:
     "Version number to publish as. Defaults to reading from the package definition for the platform.",
-}
+};
 
 interface AutoCommand extends Command {
   /** Options for the command */
@@ -455,7 +455,7 @@ export const commands: AutoCommand[] = [
         type: String,
         group: "main",
         description:
-          "Tag to start changelog generation on. Defaults to latest tag.",
+          "Tag to start changelog generation on. Defaults to latest tag or if a prerelease the latest tag in the branch. Provide latest to override.",
       },
       {
         name: "to",
@@ -498,7 +498,7 @@ export const commands: AutoCommand[] = [
         type: String,
         group: "main",
         description:
-          "Git revision (tag, commit sha, ...) to start release notes from. Defaults to latest tag.",
+          "Tag to start changelog generation on. Defaults to latest tag or if a prerelease the latest tag in the branch. Provide latest to override.",
       },
       {
         name: "to",
@@ -518,7 +518,8 @@ export const commands: AutoCommand[] = [
       },
       {
         desc: "Create a GitHub release using provided commit range and version",
-        example: "{green $} auto release --from v0.20.1 --to HEAD --use-version v0.21.0",
+        example:
+          "{green $} auto release --from v0.20.1 --to HEAD --use-version v0.21.0",
       },
     ],
   },
@@ -538,7 +539,7 @@ export const commands: AutoCommand[] = [
       ...latestCommandArgs,
       {
         ...useVersion,
-        description: `${useVersion.description} Currently only supported for the **npm plugin**.`
+        description: `${useVersion.description} Currently only supported for the **npm plugin**.`,
       },
       {
         name: "only-graduate-with-release-label",

--- a/packages/core/src/__tests__/auto-make-changelog.test.ts
+++ b/packages/core/src/__tests__/auto-make-changelog.test.ts
@@ -39,6 +39,7 @@ jest.mock("@octokit/rest", () => {
 
     repos = {
       get: jest.fn().mockReturnValue(Promise.resolve({})),
+      getLatestRelease: jest.fn().mockReturnValue({ data: { tag_name: "" } }),
     };
 
     hook = {

--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -54,6 +54,7 @@ jest.mock("@octokit/rest", () => {
 
     repos = {
       get: jest.fn().mockReturnValue({}),
+      getLatestRelease: jest.fn().mockReturnValue({ data: { tag_name: "" } }),
     };
 
     hook = {
@@ -976,7 +977,6 @@ describe("Auto", () => {
       );
     });
 
-
     test("should use --to commit target", async () => {
       const auto = new Auto({ ...defaults, plugins: [] });
       auto.logger = dummyLog();
@@ -995,7 +995,7 @@ describe("Auto", () => {
       auto.hooks.afterRelease.tap("test", afterRelease);
       jest.spyOn(auto.release!, "getCommits").mockImplementation();
 
-      await auto.runRelease({ to: 'abc'});
+      await auto.runRelease({ to: "abc" });
 
       expect(auto.git!.publish).toHaveBeenCalledWith(
         "releaseNotes",

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1913,7 +1913,9 @@ export default class Auto {
       );
     }
 
-    const lastRelease = from || (await this.git.getLatestRelease());
+    const latestRelease = await this.git.getLatestRelease();
+    const lastRelease =
+      (from === "latest" && latestRelease) || from || latestRelease;
     const bump = await this.release.getSemverBump(lastRelease, to);
     const releaseNotes = await this.release.generateReleaseNotes(
       lastRelease,
@@ -1995,11 +1997,13 @@ export default class Auto {
       return process.exit(1);
     }
 
+    const latestRelease = await this.git.getLatestRelease();
     const isPrerelease = prerelease || this.inPrereleaseBranch();
     let lastRelease =
+      (from === "latest" && latestRelease) ||
       from ||
       (isPrerelease && (await this.git.getPreviousTagInBranch())) ||
-      (await this.git.getLatestRelease());
+      latestRelease;
 
     // Find base commit or latest release to generate the changelog to HEAD (new tag)
     this.logger.veryVerbose.info(`Using ${lastRelease} as previous release.`);


### PR DESCRIPTION
## Release notes

You can now use `--from latest` in both the `changelog`and `release` commands. 

This is useful if you want to generate a changelog for a prerelease that includes  all changes since the `latest` release.

```sh
auto release --from latest --prerelease
```
<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.gz)  
[auto-macos--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.gz)  
[auto-win.exe--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  npm install @auto-canary/auto@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  npm install @auto-canary/core@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  npm install @auto-canary/package-json-utils@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  npm install @auto-canary/all-contributors@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  npm install @auto-canary/brew@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  npm install @auto-canary/chrome@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  npm install @auto-canary/cocoapods@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  npm install @auto-canary/conventional-commits@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  npm install @auto-canary/crates@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  npm install @auto-canary/docker@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  npm install @auto-canary/exec@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  npm install @auto-canary/first-time-contributor@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  npm install @auto-canary/gem@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  npm install @auto-canary/gh-pages@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  npm install @auto-canary/git-tag@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  npm install @auto-canary/gradle@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  npm install @auto-canary/jira@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  npm install @auto-canary/magic-zero@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  npm install @auto-canary/maven@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  npm install @auto-canary/microsoft-teams@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  npm install @auto-canary/npm@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  npm install @auto-canary/omit-commits@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  npm install @auto-canary/omit-release-notes@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  npm install @auto-canary/pr-body-labels@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  npm install @auto-canary/protected-branch@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  npm install @auto-canary/released@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  npm install @auto-canary/s3@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  npm install @auto-canary/sbt@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  npm install @auto-canary/slack@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  npm install @auto-canary/twitter@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  npm install @auto-canary/upload-assets@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  npm install @auto-canary/version-file@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  npm install @auto-canary/vscode@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  # or 
  yarn add @auto-canary/bot-list@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  yarn add @auto-canary/auto@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  yarn add @auto-canary/core@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  yarn add @auto-canary/package-json-utils@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  yarn add @auto-canary/all-contributors@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  yarn add @auto-canary/brew@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  yarn add @auto-canary/chrome@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  yarn add @auto-canary/cocoapods@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  yarn add @auto-canary/conventional-commits@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  yarn add @auto-canary/crates@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  yarn add @auto-canary/docker@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  yarn add @auto-canary/exec@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  yarn add @auto-canary/first-time-contributor@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  yarn add @auto-canary/gem@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  yarn add @auto-canary/gh-pages@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  yarn add @auto-canary/git-tag@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  yarn add @auto-canary/gradle@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  yarn add @auto-canary/jira@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  yarn add @auto-canary/magic-zero@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  yarn add @auto-canary/maven@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  yarn add @auto-canary/microsoft-teams@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  yarn add @auto-canary/npm@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  yarn add @auto-canary/omit-commits@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  yarn add @auto-canary/omit-release-notes@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  yarn add @auto-canary/pr-body-labels@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  yarn add @auto-canary/protected-branch@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  yarn add @auto-canary/released@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  yarn add @auto-canary/s3@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  yarn add @auto-canary/sbt@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  yarn add @auto-canary/slack@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  yarn add @auto-canary/twitter@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  yarn add @auto-canary/upload-assets@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  yarn add @auto-canary/version-file@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  yarn add @auto-canary/vscode@10.46.0--canary.2356.1b0d45a9f717c228087cb43960e0d699923fa957.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
