### PR TITLE
feat: update broken markdown for gradle-release plugin link

### DIFF
--- a/plugins/gradle/README.md
+++ b/plugins/gradle/README.md
@@ -42,7 +42,7 @@ yarn add -D @auto-it/gradle
 
 ## Gradle Project Configuration
 
-This plugin uses the (gradle release plugin)[https://github.com/researchgate/gradle-release] to update the version. Make sure the the latest `gradle-release-plugin` is in your `build.gradle`.
+This plugin uses the [gradle release plugin](https://github.com/researchgate/gradle-release) to update the version. Make sure the the latest `gradle-release-plugin` is in your `build.gradle`.
 
 ```groovy
 plugins {


### PR DESCRIPTION
# What Changed

Updated broken markdown for gradle release plugin link

## Why

The markdown for gradle-release plugin had the incorrect format (text)[link] instead of [text](link)

Todo:

- [x] Add tests
- [x] Add docs

## Change Type

Indicate the type of change your pull request is:

- [x] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
