### PR TITLE
Add filtering support to slack plugin

### DIFF
--- a/plugins/slack/src/index.ts
+++ b/plugins/slack/src/index.ts
@@ -223,6 +223,15 @@ const urlPluginOptions = t.intersection([
   basePluginOptions,
 ]);
 
+const messageFilterOptions = t.partial({
+  filter: t.partial({
+    /** Only post when these packages are changed */
+    packages: t.array(t.string),
+    /** Only post when these strings are found */
+    search: t.array(t.string),
+  }),
+});
+
 const appPluginOptions = t.intersection([
   t.interface({
     /** Marks we are gonna use app auth */
@@ -233,7 +242,10 @@ const appPluginOptions = t.intersection([
   basePluginOptions,
 ]);
 
-const pluginOptions = t.union([urlPluginOptions, appPluginOptions]);
+const pluginOptions = t.intersection([
+  t.union([urlPluginOptions, appPluginOptions]),
+  messageFilterOptions,
+]);
 
 export type ISlackPluginOptions = t.TypeOf<typeof pluginOptions>;
 
@@ -331,13 +343,24 @@ export default class SlackPlugin implements IPlugin {
         const proxyUrl = process.env.https_proxy || process.env.http_proxy;
         const agent = proxyUrl ? createHttpsProxyAgent(proxyUrl) : undefined;
 
-        await this.createPost(
-          auto,
-          header,
-          sanitizeMarkdown(releaseNotes),
-          releases,
-          agent
-        );
+        const sanitizedNotes = sanitizeMarkdown(releaseNotes);
+
+        if (
+          this.options.filter?.packages &&
+          !this.options.filter.packages.some((p) => releaseNotes.includes(p))
+        ) {
+          return;
+        }
+
+        // Only post if the search strings match the filter
+        if (
+          this.options.filter?.search &&
+          !this.options.filter.search.some((p) => releaseNotes.includes(p))
+        ) {
+          return;
+        }
+
+        await this.createPost(auto, header, sanitizedNotes, releases, agent);
       }
     );
   }


### PR DESCRIPTION
# What Changed

Adding the ability to filter out which messages should be posted to slack

## Why

We'd like to cross-post our release to multiple channels based on which packages changed, or for particular keywords. 

Todo:

- [ ] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.gz)  
[auto-macos--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.gz)  
[auto-win.exe--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  npm install @auto-canary/auto@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  npm install @auto-canary/core@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  npm install @auto-canary/package-json-utils@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  npm install @auto-canary/all-contributors@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  npm install @auto-canary/brew@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  npm install @auto-canary/chrome@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  npm install @auto-canary/cocoapods@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  npm install @auto-canary/conventional-commits@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  npm install @auto-canary/crates@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  npm install @auto-canary/docker@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  npm install @auto-canary/exec@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  npm install @auto-canary/first-time-contributor@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  npm install @auto-canary/gem@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  npm install @auto-canary/gh-pages@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  npm install @auto-canary/git-tag@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  npm install @auto-canary/gradle@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  npm install @auto-canary/jira@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  npm install @auto-canary/magic-zero@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  npm install @auto-canary/maven@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  npm install @auto-canary/microsoft-teams@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  npm install @auto-canary/npm@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  npm install @auto-canary/omit-commits@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  npm install @auto-canary/omit-release-notes@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  npm install @auto-canary/pr-body-labels@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  npm install @auto-canary/protected-branch@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  npm install @auto-canary/released@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  npm install @auto-canary/s3@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  npm install @auto-canary/sbt@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  npm install @auto-canary/slack@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  npm install @auto-canary/twitter@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  npm install @auto-canary/upload-assets@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  npm install @auto-canary/version-file@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  npm install @auto-canary/vscode@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  # or 
  yarn add @auto-canary/bot-list@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  yarn add @auto-canary/auto@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  yarn add @auto-canary/core@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  yarn add @auto-canary/package-json-utils@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  yarn add @auto-canary/all-contributors@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  yarn add @auto-canary/brew@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  yarn add @auto-canary/chrome@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  yarn add @auto-canary/cocoapods@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  yarn add @auto-canary/conventional-commits@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  yarn add @auto-canary/crates@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  yarn add @auto-canary/docker@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  yarn add @auto-canary/exec@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  yarn add @auto-canary/first-time-contributor@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  yarn add @auto-canary/gem@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  yarn add @auto-canary/gh-pages@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  yarn add @auto-canary/git-tag@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  yarn add @auto-canary/gradle@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  yarn add @auto-canary/jira@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  yarn add @auto-canary/magic-zero@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  yarn add @auto-canary/maven@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  yarn add @auto-canary/microsoft-teams@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  yarn add @auto-canary/npm@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  yarn add @auto-canary/omit-commits@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  yarn add @auto-canary/omit-release-notes@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  yarn add @auto-canary/pr-body-labels@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  yarn add @auto-canary/protected-branch@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  yarn add @auto-canary/released@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  yarn add @auto-canary/s3@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  yarn add @auto-canary/sbt@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  yarn add @auto-canary/slack@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  yarn add @auto-canary/twitter@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  yarn add @auto-canary/upload-assets@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  yarn add @auto-canary/version-file@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  yarn add @auto-canary/vscode@10.47.0--canary.2376.1f41411505f36958dfa6efe638f9ad6a1f24443c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
