### PR TITLE
fix(core): fix configuration extends overrides order

### DIFF
--- a/packages/core/src/__tests__/__snapshots__/auto.test.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/auto.test.ts.snap
@@ -82,10 +82,10 @@ exports[`Auto createLabels should create the labels 1`] = `
 }
 `;
 
-exports[`Auto should extend config 1`] = `
+exports[`Auto should extend config and keep overrides 1`] = `
 Object {
   "baseBranch": "main",
-  "extends": "@artsy/auto-config/package.json",
+  "extends": "@artsy",
   "labels": Array [
     Object {
       "changelogTitle": "💥 Breaking Change",
@@ -156,6 +156,7 @@ Object {
       "releaseType": "patch",
     },
   ],
+  "name": "extended",
   "onlyPublishWithReleaseLabel": true,
   "owner": "foo",
   "plugins": Array [
@@ -169,10 +170,10 @@ Object {
 }
 `;
 
-exports[`Auto should extend local config 1`] = `
+exports[`Auto should extend local config and keep overrides 1`] = `
 Object {
   "baseBranch": "main",
-  "extends": "<PROJECT_ROOT>fake.json",
+  "extends": "./fake.json",
   "labels": Array [
     Object {
       "changelogTitle": "💥 Breaking Change",
@@ -243,6 +244,7 @@ Object {
       "releaseType": "patch",
     },
   ],
+  "name": "extended",
   "noVersionPrefix": true,
   "owner": "foo",
   "plugins": Array [

--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -181,11 +181,11 @@ describe("Auto", () => {
     process.env.GH_TOKEN = "XXXX";
   });
 
-  test("should extend config", async () => {
-    search.mockReturnValueOnce({ config: { ...defaults, extends: "@artsy" } });
+  test("should extend config and keep overrides", async () => {
+    search.mockReturnValueOnce({ config: { ...defaults, extends: "@artsy", name: 'extended' } });
     importMock.mockImplementation((path) =>
       path === "@artsy/auto-config/package.json"
-        ? { auto: { onlyPublishWithReleaseLabel: true } }
+        ? { auto: { onlyPublishWithReleaseLabel: true }, name: '@artsy' }
         : undefined
     );
 
@@ -204,14 +204,14 @@ describe("Auto", () => {
     expect(process.exit).toHaveBeenCalled();
   });
 
-  test("should extend local config", async () => {
+  test("should extend local config and keep overrides", async () => {
     const orig = process.cwd;
     process.cwd = () => "/foo/";
     search.mockReturnValueOnce({
-      config: { ...defaults, extends: "./fake.json" },
+      config: { ...defaults, extends: "./fake.json", name: 'extended' },
     });
     importMock.mockImplementation((path) =>
-      path === "/foo/fake.json" ? { noVersionPrefix: true } : undefined
+      path === "/foo/fake.json" ? { noVersionPrefix: true, name: 'fake' } : undefined
     );
 
     const auto = new Auto();

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -105,8 +105,8 @@ export default class Config {
 
     if (rawConfig.extends) {
       rawConfig = merge(
-        rawConfig,
-        await this.loadExtendConfig(rawConfig.extends)
+        await this.loadExtendConfig(rawConfig.extends),
+        rawConfig
       );
     }
 


### PR DESCRIPTION
# What Changed

Change merge order for configuration when extending

## Why

When extending a remote configuration, it's intended to be able to override some key already set in extends, which is not available yet.

Checkout test snapshots for behavior details 

- [x] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
