### PR TITLE
fix: allow pr check on old version branches

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1005,7 +1005,7 @@ export default class Auto {
       // adding this command without resorting to bash if/else statements.
       if (
         env.isCi &&
-        (env.branch === this.baseBranch || this.inPrereleaseBranch())
+        (env.branch === this.baseBranch || this.inPrereleaseBranch() || this.inOldVersionBranch())
       ) {
         process.exit(0);
       }


### PR DESCRIPTION
# What Changed

Do not exit with code 1 when running prCheck on old version branches

## Why

To mimic the same behavior as for main or pre-release branches

Todo:

- [x] Add tests : Since code use `exit` seems hard to tests , and existing condition are not tested
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
