### PR TITLE
Fix release creation on oldVersions

### DIFF
--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -967,13 +967,53 @@ describe("Auto", () => {
         "releaseNotes",
         "v1.2.4",
         false,
-        ""
+        "",
+        true
       );
       expect(afterRelease).toHaveBeenCalledWith(
         expect.objectContaining({
           lastRelease: "v1.2.3",
           newVersion: "v1.2.4",
         })
+      );
+    });
+
+    test("should publish non latest release on inOldVersionBranch", async () => {
+      const auto = new Auto({ ...defaults, plugins: [] });
+      auto.logger = dummyLog();
+      await auto.loadConfig();
+      auto.git!.getLatestRelease = () => Promise.resolve("1.2.3");
+
+      jest.spyOn(auto.git!, "publish").mockReturnValueOnce({ data: {} } as any);
+      jest
+          .spyOn(auto.release!, "generateReleaseNotes")
+          .mockImplementation(() => Promise.resolve("releaseNotes"));
+      auto.release!.getCommitsInRelease = () =>
+          Promise.resolve([makeCommitFromMsg("Test Commit")]);
+
+      auto.hooks.getPreviousVersion.tap("test", () => "1.2.4");
+      const afterRelease = jest.fn();
+      auto.hooks.afterRelease.tap("test", afterRelease);
+      jest.spyOn(auto.release!, "getCommits").mockImplementation();
+
+      await auto.runRelease();
+      expect(auto.release!.generateReleaseNotes).toHaveBeenCalledWith(
+          "v1.2.3",
+          undefined,
+          undefined
+      );
+      expect(auto.git!.publish).toHaveBeenCalledWith(
+          "releaseNotes",
+          "v1.2.4",
+          false,
+          "",
+          true
+      );
+      expect(afterRelease).toHaveBeenCalledWith(
+          expect.objectContaining({
+            lastRelease: "v1.2.3",
+            newVersion: "v1.2.4",
+          })
       );
     });
 
@@ -1001,7 +1041,8 @@ describe("Auto", () => {
         "releaseNotes",
         "v1.2.4",
         false,
-        "abc"
+        "abc",
+        true
       );
     });
 
@@ -1061,7 +1102,8 @@ describe("Auto", () => {
         "releaseNotes",
         "v1.2.4",
         true,
-        ""
+        "",
+        false
       );
       expect(afterRelease).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1101,7 +1143,8 @@ describe("Auto", () => {
         "releaseNotes",
         "v1.2.4",
         false,
-        ""
+        "",
+        true
       );
       expect(afterRelease).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1141,7 +1184,8 @@ describe("Auto", () => {
         "releaseNotes",
         "v1.3.0",
         false,
-        ""
+        "",
+        true
       );
       expect(afterRelease).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1181,7 +1225,8 @@ describe("Auto", () => {
         "releaseNotes",
         "v1.2.3+1",
         false,
-        ""
+        "",
+        true
       );
       expect(afterRelease).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -579,7 +579,8 @@ export default class Auto {
           options.fullReleaseNotes,
           options.newVersion,
           options.isPrerelease,
-          options.to
+          options.to,
+          options.isPrerelease ? false: !this.inOldVersionBranch(),
         );
 
         this.logger.log.info(release.data.html_url);

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -855,7 +855,8 @@ export default class Git {
     releaseNotes: string,
     tag: string,
     prerelease = false,
-    fallbackCommit?: string
+    fallbackCommit?: string,
+    latestRelease = false
   ) {
     this.logger.verbose.info("Creating release on GitHub for tag:", tag);
 
@@ -867,6 +868,7 @@ export default class Git {
       name: tag,
       body: releaseNotes,
       prerelease,
+      make_latest: latestRelease,
     });
 
     this.logger.veryVerbose.info("Got response from createRelease\n", result);


### PR DESCRIPTION
# What Changed

Create a non latest release when working on oldVersions

## Why

GH Api behavior do not handle the latest flag implicitly based on semver. We have to pass it explicitly 

Ref : https://docs.github.com/en/free-pro-team@latest/rest/releases/releases?apiVersion=2022-11-28#create-a-release

- [x] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
