### PR TITLE
only remove labels if they exist on the PR

### DIFF
--- a/plugins/pr-body-labels/__tests__/pr-body-labels.test.ts
+++ b/plugins/pr-body-labels/__tests__/pr-body-labels.test.ts
@@ -15,7 +15,7 @@ describe("Pr-Body-Labels Plugin", () => {
     } as any);
 
     await hooks.prCheck.promise({
-      pr: { body: "- [x] `unknown-label`" },
+      pr: { body: "- [x] `unknown-label`", labels: [{ name: "patch" }] },
     } as any);
     expect(addLabelToPr).not.toHaveBeenCalled();
   });
@@ -32,7 +32,7 @@ describe("Pr-Body-Labels Plugin", () => {
     } as any);
 
     await hooks.prCheck.promise({
-      pr: { body: "- [x] `patch`", number: 1 },
+      pr: { body: "- [x] `patch`", number: 1, labels: [{ name: "patch" }] },
     } as any);
     expect(addLabelToPr).toHaveBeenCalledWith(1, "patch");
   });
@@ -49,7 +49,7 @@ describe("Pr-Body-Labels Plugin", () => {
     } as any);
 
     await hooks.prCheck.promise({
-      pr: { body: "- [X] `patch`", number: 1 },
+      pr: { body: "- [X] `patch`", number: 1, labels: [{ name: "patch" }] },
     } as any);
     expect(addLabelToPr).toHaveBeenCalledWith(1, "patch");
   });
@@ -66,7 +66,7 @@ describe("Pr-Body-Labels Plugin", () => {
     } as any);
 
     await hooks.prCheck.promise({
-      pr: { body: "- [ ] `patch`", number: 1 },
+      pr: { body: "- [ ] `patch`", number: 1, labels: [{ name: "patch" }] },
     } as any);
     expect(removeLabel).toHaveBeenCalledWith(1, "patch");
   });
@@ -83,7 +83,7 @@ describe("Pr-Body-Labels Plugin", () => {
     } as any);
 
     await hooks.prCheck.promise({
-      pr: { body: "- [ ] `patch`", number: 1 },
+      pr: { body: "- [ ] `patch`", number: 1, labels: [{ name: "patch" }] },
     } as any);
     expect(removeLabel).not.toHaveBeenCalledWith(1, "patch");
   });
@@ -100,7 +100,7 @@ describe("Pr-Body-Labels Plugin", () => {
     } as any);
 
     await hooks.prCheck.promise({
-      pr: { body: "- [x] `patch`", number: 1 },
+      pr: { body: "- [x] `patch`", number: 1, labels: [{ name: "patch" }] },
     } as any);
     expect(addLabelToPr).not.toHaveBeenCalled();
   });

--- a/plugins/pr-body-labels/src/index.ts
+++ b/plugins/pr-body-labels/src/index.ts
@@ -35,6 +35,9 @@ export default class PrBodyLabelsPlugin implements IPlugin {
 
       await Promise.all(
         auto.labels.map(async (label) => {
+          const hasLabelOnPr = pr.labels
+            .map((l) => l.name)
+            .includes(label.name);
           const hasUnchecked = pr.body?.includes(`- [ ] \`${label.name}\``);
           const hasCheckedLabel =
             pr.body?.includes(`- [x] \`${label.name}\``) ||
@@ -47,7 +50,7 @@ export default class PrBodyLabelsPlugin implements IPlugin {
             await auto.git?.addLabelToPr(pr.number, label.name);
           }
 
-          if (hasUnchecked && this.options.removeStaleLabels) {
+          if (hasUnchecked && this.options.removeStaleLabels && hasLabelOnPr) {
             await auto.git?.removeLabel(pr.number, label.name);
           }
         })


### PR DESCRIPTION
# What Changed

## Why

Maybe its just our enterprise github, but when updating to 11.x in one project, `pr-check` was failing with a 404, root cause being `pr-body-labels` trying to remove labels that arent applied to the PR, throwing up to the `prCheck` hook

Todo:

- [ ] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
