### PR TITLE
fix(npm): mark releases as latest with lerna

### DIFF
--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -50,8 +50,16 @@ const monorepoPackagesWithPrereleaseResult = [
   { path: "packages/c", name: "@packages/c", package: { version: "0.1.2" } },
   { path: "packages/d", name: "@packages/d", package: { version: "0.1.1" } },
   // This can happen if a new module is published with a breaking version
-  { path: "packages/e", name: "@packages/e", package: { version: "1.0.0-next.0" } },
-  { path: "packages/f", name: "@packages/f", package: { version: "1.0.0-next.0" } },
+  {
+    path: "packages/e",
+    name: "@packages/e",
+    package: { version: "1.0.0-next.0" },
+  },
+  {
+    path: "packages/f",
+    name: "@packages/f",
+    package: { version: "1.0.0-next.0" },
+  },
 ];
 
 const packageTemplate = ({
@@ -406,7 +414,7 @@ describe("getPreviousVersion", () => {
   });
 
   test("should ignore greatest published monorepo package in maintenance mode", async () => {
-    execPromise.mockClear()
+    execPromise.mockClear();
     mockFs({
       "lerna.json": `
         {
@@ -424,11 +432,10 @@ describe("getPreviousVersion", () => {
     // published version of test package
     execPromise.mockReturnValueOnce("2.1.0");
 
-    jest.spyOn(Auto, 'getCurrentBranch').mockReturnValueOnce('major-2')
-
+    jest.spyOn(Auto, "getCurrentBranch").mockReturnValueOnce("major-2");
 
     plugin.apply({
-      config: { prereleaseBranches: ["next"], versionBranches: 'major-' },
+      config: { prereleaseBranches: ["next"], versionBranches: "major-" },
       hooks,
       remote: "origin",
       baseBranch: "main",
@@ -436,9 +443,8 @@ describe("getPreviousVersion", () => {
       prefixRelease: (str) => str,
     } as Auto.Auto);
 
-
     expect(await hooks.getPreviousVersion.promise()).toBe("1.5.0");
-    expect(execPromise).not.toHaveBeenCalled()
+    expect(execPromise).not.toHaveBeenCalled();
   });
 });
 
@@ -681,7 +687,7 @@ describe("publish", () => {
       "--yes",
       "from-package",
       "--exact",
-      "--no-verify-access"
+      "--no-verify-access",
     ]);
   });
 
@@ -704,7 +710,7 @@ describe("publish", () => {
       "--yes",
       "from-package",
       false,
-      "--no-verify-access"
+      "--no-verify-access",
     ]);
   });
 
@@ -730,7 +736,7 @@ describe("publish", () => {
       false,
       "--legacy-auth",
       "abcd",
-      "--no-verify-access"
+      "--no-verify-access",
     ]);
   });
 
@@ -755,7 +761,7 @@ describe("publish", () => {
       false,
       "--contents",
       "dist/publish-folder",
-      "--no-verify-access"
+      "--no-verify-access",
     ]);
   });
 
@@ -1258,7 +1264,7 @@ describe("canary", () => {
       "--no-git-reset",
       "--no-git-tag-version",
       "--exact",
-      "--no-verify-access"
+      "--no-verify-access",
     ]);
   });
 
@@ -1429,7 +1435,7 @@ describe("canary", () => {
       "--no-git-reset",
       "--no-git-tag-version",
       "--exact",
-      "--no-verify-access"
+      "--no-verify-access",
     ]);
   });
 
@@ -1650,6 +1656,7 @@ describe("makeRelease", () => {
       logger: dummyLog(),
       prefixRelease: (str) => str,
       git: { publish } as any,
+      inOldVersionBranch: (bool: boolean) => bool,
       release: {
         makeChangelog: () => ({
           generateReleaseNotes: (commits: IExtendedCommit[]) =>
@@ -1661,6 +1668,7 @@ describe("makeRelease", () => {
     await hooks.makeRelease.promise({
       newVersion: "0.1.2",
       from: "",
+      to: "",
       isPrerelease: false,
       fullReleaseNotes: "",
       commits: [

--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -1684,12 +1684,16 @@ describe("makeRelease", () => {
     expect(publish).toHaveBeenCalledWith(
       "update package 1",
       "@packages/a",
-      false
+      false,
+      undefined,
+      true
     );
     expect(publish).toHaveBeenCalledWith(
       "update package 2",
       "@packages/b",
-      false
+      false,
+      undefined,
+      true
     );
   });
 });

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -1579,8 +1579,17 @@ export default class NPMPlugin implements IPlugin {
 
             auto.logger.log.info(`Using release notes:\n${releaseNotes}`);
 
+            const isLatestRelease =
+              !options.isPrerelease || !auto.inOldVersionBranch();
+
             // 2. make a release for just that package
-            return auto.git?.publish(releaseNotes, tag, options.isPrerelease, undefined, !options.isPrerelease);
+            return auto.git?.publish(
+              releaseNotes,
+              tag,
+              options.isPrerelease,
+              undefined,
+              isLatestRelease
+            );
           })
         );
 
@@ -1604,8 +1613,10 @@ export default class NPMPlugin implements IPlugin {
       await execPromise("npm", ["root"]);
     } catch (error) {
       if (
-        // eslint-disable-next-line no-template-curly-in-string
-        error.message?.includes("Failed to replace env in config: ${NPM_TOKEN}")
+        (error as Error).message?.includes(
+          // eslint-disable-next-line no-template-curly-in-string
+          "Failed to replace env in config: ${NPM_TOKEN}"
+        )
       ) {
         auto.logger.log.error(endent`
           Uh oh! It looks like you don\'t have a NPM_TOKEN available in your environment.

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -1580,7 +1580,7 @@ export default class NPMPlugin implements IPlugin {
             auto.logger.log.info(`Using release notes:\n${releaseNotes}`);
 
             // 2. make a release for just that package
-            return auto.git?.publish(releaseNotes, tag, options.isPrerelease);
+            return auto.git?.publish(releaseNotes, tag, options.isPrerelease, undefined, !options.isPrerelease);
           })
         );
 


### PR DESCRIPTION
# What Changed

Mark the releases as "latest" when releasing with the npm plugin with the independent mode.

## Why

Currently `auto` gets the latest release by looking for a release that is marked as "latest". The `npm` plugin does not update the "latest" tag when releasing with independent mode causing the releases to start diffing from the initial release.

Todo:

- [X] Add tests
- [x] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [X] `patch`
- [ ] `minor`
- [ ] `major`
