### PR TITLE
Fix: NPM GH release publishing should set latest

### DIFF
--- a/plugins/npm/__tests__/npm.test.ts
+++ b/plugins/npm/__tests__/npm.test.ts
@@ -1650,6 +1650,7 @@ describe("makeRelease", () => {
       logger: dummyLog(),
       prefixRelease: (str) => str,
       git: { publish } as any,
+      inOldVersionBranch: (bool) => bool,
       release: {
         makeChangelog: () => ({
           generateReleaseNotes: (commits: IExtendedCommit[]) =>
@@ -1661,6 +1662,7 @@ describe("makeRelease", () => {
     await hooks.makeRelease.promise({
       newVersion: "0.1.2",
       from: "",
+      to: "",
       isPrerelease: false,
       fullReleaseNotes: "",
       commits: [
@@ -1684,12 +1686,16 @@ describe("makeRelease", () => {
     expect(publish).toHaveBeenCalledWith(
       "update package 1",
       "@packages/a",
-      false
+      false,
+      undefined,
+      true
     );
     expect(publish).toHaveBeenCalledWith(
       "update package 2",
       "@packages/b",
-      false
+      false,
+      undefined,
+      true
     );
   });
 });

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -1580,7 +1580,7 @@ export default class NPMPlugin implements IPlugin {
             auto.logger.log.info(`Using release notes:\n${releaseNotes}`);
 
             // 2. make a release for just that package
-            return auto.git?.publish(releaseNotes, tag, options.isPrerelease);
+            return auto.git?.publish(releaseNotes, tag, options.isPrerelease, undefined, !auto.inOldVersionBranch());
           })
         );
 

--- a/plugins/npm/src/index.ts
+++ b/plugins/npm/src/index.ts
@@ -1580,7 +1580,13 @@ export default class NPMPlugin implements IPlugin {
             auto.logger.log.info(`Using release notes:\n${releaseNotes}`);
 
             // 2. make a release for just that package
-            return auto.git?.publish(releaseNotes, tag, options.isPrerelease, undefined, !auto.inOldVersionBranch());
+            return auto.git?.publish(
+              releaseNotes,
+              tag,
+              options.isPrerelease,
+              undefined,
+              !auto.inOldVersionBranch()
+            );
           })
         );
 


### PR DESCRIPTION
# What Changed

Updated the NPM plugin to set `nextRelease` flag when calling `git.publish`.

## Why

It looks like GH releases in the NPM plugin aren't using the `nextRelease` flag that was introduced in #2391

fixes: #2422

Todo:

- [ ] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
