### PR TITLE
Chore: Add lerna as peer dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -79,7 +79,8 @@
     "url-join": "^4.0.0"
   },
   "peerDependencies": {
-    "typescript": ">=2.7"
+    "typescript": ">=2.7",
+    "lerna": "^7.1.4"
   },
   "peerDependenciesMeta": {
     "@types/node": {
@@ -98,6 +99,7 @@
     "@types/signale": "^1.2.1",
     "@types/tinycolor2": "^1.4.1",
     "@types/url-join": "^4.0.0",
-    "graphql": "^15.0.0"
+    "graphql": "^15.0.0",
+    "lerna": "^7.1.4"
   }
 }

--- a/plugins/npm/package.json
+++ b/plugins/npm/package.json
@@ -58,6 +58,10 @@
     "@types/env-ci": "^3.1.0",
     "@types/semver": "^7.1.0",
     "@types/url-join": "^4.0.0",
-    "@types/user-home": "^2.0.0"
+    "@types/user-home": "^2.0.0",
+    "lerna": "^7.1.4"
+  },
+  "peerDependencies": {
+    "lerna": "^7.1.4"
   }
 }


### PR DESCRIPTION
# What Changed
Added lerna as a peerDependency to auto and auto/npm as they both internally call lerna with npx.

## Why

Calling lerna with npx without a local copy installed could cause bugs as it will either pull the latest version from the npm registry or use a locally cached version. By setting peer dependencies lerna will either be installed when auto is installed or show a warning telling the user that lerna is a missing dependency.

@hipstersmoothie not 💯 sure about the version of lerna to support here. Do we want to widen the semver range for something like `>6.0.0 < 8.0.0`? I'm also unsure which type of change this should be.

Todo:

- [ ] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
