### PR TITLE
Fix rare issue with canary id from git sha

### DIFF
--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1311,6 +1311,9 @@ export default class Auto {
 
     if (!pr || !build) {
       const sha = await this.git.getSha();
+      // If the commit sha is a 7 digit number starting with zero
+      // SemVer will reject the version. Include enough of the sha
+      // to include at least one letter in that case.
       const endIndex  = /^0\d{6}/.test(sha) ?
           sha.search(/[a-zA-Z]/) + 1
           : 7;

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1310,9 +1310,11 @@ export default class Auto {
     }
 
     if (!pr || !build) {
-      canaryIdentifier = `${canaryIdentifier}.${(
-        await this.git.getSha(true)
-      ).slice(0, 7)}`;
+      const sha = await this.git.getSha();
+      const endIndex  = /^0\d{6}/.test(sha) ?
+          sha.search(/[a-zA-Z]/) + 1
+          : 7;
+      canaryIdentifier = `${canaryIdentifier}.${sha.slice(0, endIndex)}`;
     }
 
     canaryIdentifier = `-canary${canaryIdentifier}`;


### PR DESCRIPTION
In the rare case that the first 7 characters of a git sha contains only numbers and begins with 0, SemVer will reject the canary (due to this part of the canaryIdentifier) as an invalid version.

In such cases, make sure we include enough of the sha to get a letter.

Ignore the ~1:1.5billion chance that SHA is all numbers starting with 0, but optionally the sha could be replaced with the string `jackpot`


Todo:

- [ ] Add tests


## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
