### PR TITLE
fix: handling of long strings in slack plugin

### DIFF
--- a/plugins/slack/src/index.ts
+++ b/plugins/slack/src/index.ts
@@ -91,16 +91,17 @@ interface Block {
 const CHANGELOG_LINE = /^\s*•/;
 type Messages = [Block[], ...Array<Block[] | FileUpload>];
 
-/** Split a long spring into chunks by character limit */
+/** Split a long string into chunks by character limit */
 const splitCharacterLimitAtNewline = (line: string, charLimit: number) => {
   const splitLines = [];
   let buffer = line;
 
   while (buffer) {
     // get the \n closest to the char limit
-    const newlineIndex = buffer.lastIndexOf("\n", charLimit) || charLimit;
-    splitLines.push(buffer.slice(0, newlineIndex));
-    buffer = buffer.slice(newlineIndex);
+    const newlineIndex = buffer.indexOf("\n", charLimit);
+    const endOfLine = newlineIndex >= 0 ? newlineIndex : charLimit;
+    splitLines.push(buffer.slice(0, endOfLine));
+    buffer = buffer.slice(endOfLine);
   }
 
   return splitLines;


### PR DESCRIPTION
# What Changed

Fixing the code to split long lines into shorter chunks in the slack plugin.

## Why

The code was broken and the failing tests made the CI pipeline fail as well.

This change solves the failing tests in https://github.com/intuit/auto/actions/runs/9039953720/job/24843604205#step:6:296 which should unblock the PR #2459

Todo:

- [x] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
