### PR TITLE
[Version File] Remove assumption that canary and next should be snapshots

### DIFF
--- a/plugins/version-file/README.md
+++ b/plugins/version-file/README.md
@@ -17,7 +17,12 @@ yarn add -D @auto-it/version-file
 ## Options
 
 - versionFile (optional, default="VERSION"): Path to where the version is stored in the repository. It should be a file containing just the semver. 
-- releaseScript: (optional, default=None): Path to script that runs the publish actions in your repository. If not supplied nothing will be called. If supplied will be called during the `publish`,`canary` and `next` hooks. For the `publish` hook the first parameter passed to the script will be `release` to indicate that a regular release is being called. For `canary` and `next` hooks the first parameter will be `canary` or `next` to indicate a prerelease version, and let the consumer handle what to do for those types of releases. 
+- publishScript: (optional, default=None): Path to script that runs the publish actions in your repository. If not supplied nothing will be called. If supplied will be called during the `publish`,`canary` and `next` hooks with the arguments defined in `publishScriptReleaseTypeArgs` for that release type.
+- publishScriptReleaseTypeArgs: (optional, default={
+  "publish": ["release"],
+  "canary": ["snapshot"],
+  "next": ["snapshot"],
+}): Mapping of arguments to pass to the `publishScript` for each release type (`publish`, `canary`, `next`)
 
 ## Usage
 
@@ -34,6 +39,10 @@ yarn add -D @auto-it/version-file
 ```json
 {
   "plugins": [
-    "version-file", {"versionFile": "./tools/Version.txt", "releaseScript":"./tools/publish.sh"}
+    "version-file", {"versionFile": "./tools/Version.txt", "publishScript":"./tools/publish.sh", "publishScriptReleaseTypeArgs": {
+      "publish": ["release"], // (default)
+      "canary": ["snapshot"],
+      "next": ["some", "other", "args"],
+    }}
   ]
 }

--- a/plugins/version-file/README.md
+++ b/plugins/version-file/README.md
@@ -17,7 +17,7 @@ yarn add -D @auto-it/version-file
 ## Options
 
 - versionFile (optional, default="VERSION"): Path to where the version is stored in the repository. It should be a file containing just the semver. 
-- releaseScript: (optional, default=None): Path to script that runs the publish actions in your repository. If not supplied nothing will be called. If supplied will be called during the `publish`,`canary` and `next` hooks. For the `publish` hook the first parameter passed to the script will be `release` to indicate that a regular release is being called. For `canary` and `next` hooks the first parameter will be `snapshot` to indicate a prerelease version. 
+- releaseScript: (optional, default=None): Path to script that runs the publish actions in your repository. If not supplied nothing will be called. If supplied will be called during the `publish`,`canary` and `next` hooks. For the `publish` hook the first parameter passed to the script will be `release` to indicate that a regular release is being called. For `canary` and `next` hooks the first parameter will be `canary` or `next` to indicate a prerelease version, and let the consumer handle what to do for those types of releases. 
 
 ## Usage
 

--- a/plugins/version-file/README.md
+++ b/plugins/version-file/README.md
@@ -18,11 +18,11 @@ yarn add -D @auto-it/version-file
 
 - versionFile (optional, default="VERSION"): Path to where the version is stored in the repository. It should be a file containing just the semver. 
 - publishScript: (optional, default=None): Path to script that runs the publish actions in your repository. If not supplied nothing will be called. If supplied will be called during the `publish`,`canary` and `next` hooks with the arguments defined in `publishScriptReleaseTypeArgs` for that release type.
-- publishScriptReleaseTypeArgs: (optional, default={
+- publishScriptReleaseTypeArgs: (optional, default=```{
   "publish": ["release"],
   "canary": ["snapshot"],
-  "next": ["snapshot"],
-}): Mapping of arguments to pass to the `publishScript` for each release type (`publish`, `canary`, `next`)
+  "next": ["snapshot"]
+}```): Mapping of arguments to pass to the `publishScript` for each release type (`publish`, `canary`, `next`)
 
 ## Usage
 

--- a/plugins/version-file/__tests__/version-file.test.ts
+++ b/plugins/version-file/__tests__/version-file.test.ts
@@ -217,7 +217,7 @@ describe("Test Release Types", () => {
     await hooks.canary.promise({bump: SEMVER.minor, canaryIdentifier: "canary.368.1"})
 
     // check release script was called
-    expect(execPromise).toHaveBeenNthCalledWith(1, "./tools/release.sh", ["snapshot"]);
+    expect(execPromise).toHaveBeenNthCalledWith(1, "./tools/release.sh", ["canary"]);
 
     // check local changes were reverted
     expect(execPromise).toHaveBeenNthCalledWith(2, "git", ["reset", "--hard", "HEAD"]);
@@ -293,7 +293,7 @@ describe("Test Release Types", () => {
     await hooks.next.promise(["1.0.0"], {bump: SEMVER.major, fullReleaseNotes:"", releaseNotes:"", commits:[]})
 
     // check release script was called
-    expect(execPromise).toHaveBeenNthCalledWith(1, "./tools/release.sh", ["snapshot"]);
+    expect(execPromise).toHaveBeenNthCalledWith(1, "./tools/release.sh", ["next"]);
 
     // Check git ops
     expect(execPromise).toHaveBeenNthCalledWith(2, "git", ["tag", "v2.0.0-next.0"]);

--- a/plugins/version-file/src/index.ts
+++ b/plugins/version-file/src/index.ts
@@ -141,7 +141,7 @@ export default class VersionFilePlugin implements IPlugin {
       // Ship canary release if release script is provided
       if(this.publishScript){
         auto.logger.log.info(`Calling release script in repo at ${this.publishScript}`);
-        await execPromise(this.publishScript, ["snapshot"]);
+        await execPromise(this.publishScript, ["canary"]);
       } else {
         auto.logger.log.info("Skipping calling release script in repo since none was provided");
       }
@@ -188,7 +188,7 @@ export default class VersionFilePlugin implements IPlugin {
       // ship next release if release script is provided
       if(this.publishScript){
         auto.logger.log.info(`Calling release script in repo at ${this.publishScript}`);
-        await execPromise(this.publishScript, ["snapshot"]);
+        await execPromise(this.publishScript, ["next"]);
       } else {
         auto.logger.log.info("Skipping calling release script in repo since none was provided");
       }

--- a/plugins/version-file/src/index.ts
+++ b/plugins/version-file/src/index.ts
@@ -8,8 +8,11 @@ const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
 
 interface ReleaseTypeArgs {
+  /** Args to use when invoking the publishScript during the publish hook */
   publish: string[];
+  /** Args to use when invoking the publishScript during the canary hook */
   canary: string[];
+  /** Args to use when invoking the publishScript during the next hook */
   next: string[];
 }
 
@@ -134,7 +137,7 @@ export default class VersionFilePlugin implements IPlugin {
       // Call release script if provided
       if(this.publishScript){
         auto.logger.log.info(`Calling release script in repo at ${this.publishScript}`);
-        await execPromise(this.publishScript, this.publishScriptReleaseTypeArgs['publish'])
+        await execPromise(this.publishScript, this.publishScriptReleaseTypeArgs.publish)
       } else {
         auto.logger.log.info("Skipping calling release script in repo since none was provided");
       }
@@ -162,7 +165,7 @@ export default class VersionFilePlugin implements IPlugin {
       // Ship canary release if release script is provided
       if(this.publishScript){
         auto.logger.log.info(`Calling release script in repo at ${this.publishScript}`);
-        await execPromise(this.publishScript, this.publishScriptReleaseTypeArgs['canary']);
+        await execPromise(this.publishScript, this.publishScriptReleaseTypeArgs.canary);
       } else {
         auto.logger.log.info("Skipping calling release script in repo since none was provided");
       }
@@ -209,7 +212,7 @@ export default class VersionFilePlugin implements IPlugin {
       // ship next release if release script is provided
       if(this.publishScript){
         auto.logger.log.info(`Calling release script in repo at ${this.publishScript}`);
-        await execPromise(this.publishScript, this.publishScriptReleaseTypeArgs['next']);
+        await execPromise(this.publishScript, this.publishScriptReleaseTypeArgs.next);
       } else {
         auto.logger.log.info("Skipping calling release script in repo since none was provided");
       }

--- a/plugins/version-file/src/index.ts
+++ b/plugins/version-file/src/index.ts
@@ -7,13 +7,25 @@ import { inc, ReleaseType } from "semver";
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
 
+interface ReleaseTypeArgs {
+  publish: string[];
+  canary: string[];
+  next: string[];
+}
 
 const pluginOptions = t.partial({
   /** Path to file (from where auto is executed) where the version is stored */
   versionFile: t.string,
 
   /** Optional script that executes release pipeline stages */
-  publishScript: t.string
+  publishScript: t.string,
+
+  /** Optional publish script args mapping for each release hook, defaults `publish` to ["release"] and the others to ["snapshot"] */
+  publishScriptReleaseTypeArgs: t.partial({
+    publish: t.array(t.string),
+    canary: t.array(t.string),
+    next: t.array(t.string),
+  })
 });
 
 export type IVersionFilePluginOptions = t.TypeOf<typeof pluginOptions>;
@@ -55,10 +67,19 @@ export default class VersionFilePlugin implements IPlugin {
   /** Release script location */
   readonly publishScript: string | undefined
 
+  /**  */
+  readonly publishScriptReleaseTypeArgs: ReleaseTypeArgs;
+
   /** Initialize the plugin with it's options */
   constructor(options: IVersionFilePluginOptions) {
     this.versionFile = options.versionFile ?? "VERSION";
-    this.publishScript = options.publishScript
+    this.publishScript = options.publishScript;
+    this.publishScriptReleaseTypeArgs = {
+      publish: ['release'],
+      canary: ['snapshot'],
+      next: ['snapshot'],
+      ...options.publishScriptReleaseTypeArgs ?? {}
+    };
   }
 
 
@@ -113,7 +134,7 @@ export default class VersionFilePlugin implements IPlugin {
       // Call release script if provided
       if(this.publishScript){
         auto.logger.log.info(`Calling release script in repo at ${this.publishScript}`);
-        await execPromise(this.publishScript, ["release"])
+        await execPromise(this.publishScript, this.publishScriptReleaseTypeArgs['publish'])
       } else {
         auto.logger.log.info("Skipping calling release script in repo since none was provided");
       }
@@ -141,7 +162,7 @@ export default class VersionFilePlugin implements IPlugin {
       // Ship canary release if release script is provided
       if(this.publishScript){
         auto.logger.log.info(`Calling release script in repo at ${this.publishScript}`);
-        await execPromise(this.publishScript, ["canary"]);
+        await execPromise(this.publishScript, this.publishScriptReleaseTypeArgs['canary']);
       } else {
         auto.logger.log.info("Skipping calling release script in repo since none was provided");
       }
@@ -188,7 +209,7 @@ export default class VersionFilePlugin implements IPlugin {
       // ship next release if release script is provided
       if(this.publishScript){
         auto.logger.log.info(`Calling release script in repo at ${this.publishScript}`);
-        await execPromise(this.publishScript, ["next"]);
+        await execPromise(this.publishScript, this.publishScriptReleaseTypeArgs['next']);
       } else {
         auto.logger.log.info("Skipping calling release script in repo since none was provided");
       }


### PR DESCRIPTION
# What Changed

Remove the assumption that canary and next publishes should be done as snapshots. This is still the default, but you can now override the args to use when invoking the `publishScript`.

## Why

It's better to make less assumptions to provide more fine grain control of what consumers can do during publishing for different release types.

Todo:

- [x] Add tests
- [x] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.gz)  
[auto-macos--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.gz)  
[auto-win.exe--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  npm install @auto-canary/auto@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  npm install @auto-canary/core@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  npm install @auto-canary/package-json-utils@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  npm install @auto-canary/all-contributors@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  npm install @auto-canary/brew@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  npm install @auto-canary/chrome@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  npm install @auto-canary/cocoapods@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  npm install @auto-canary/conventional-commits@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  npm install @auto-canary/crates@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  npm install @auto-canary/docker@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  npm install @auto-canary/exec@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  npm install @auto-canary/first-time-contributor@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  npm install @auto-canary/gem@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  npm install @auto-canary/gh-pages@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  npm install @auto-canary/git-tag@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  npm install @auto-canary/gradle@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  npm install @auto-canary/jira@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  npm install @auto-canary/magic-zero@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  npm install @auto-canary/maven@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  npm install @auto-canary/microsoft-teams@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  npm install @auto-canary/npm@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  npm install @auto-canary/omit-commits@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  npm install @auto-canary/omit-release-notes@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  npm install @auto-canary/pr-body-labels@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  npm install @auto-canary/protected-branch@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  npm install @auto-canary/released@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  npm install @auto-canary/s3@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  npm install @auto-canary/sbt@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  npm install @auto-canary/slack@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  npm install @auto-canary/twitter@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  npm install @auto-canary/upload-assets@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  npm install @auto-canary/version-file@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  npm install @auto-canary/vscode@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  # or 
  yarn add @auto-canary/bot-list@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  yarn add @auto-canary/auto@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  yarn add @auto-canary/core@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  yarn add @auto-canary/package-json-utils@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  yarn add @auto-canary/all-contributors@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  yarn add @auto-canary/brew@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  yarn add @auto-canary/chrome@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  yarn add @auto-canary/cocoapods@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  yarn add @auto-canary/conventional-commits@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  yarn add @auto-canary/crates@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  yarn add @auto-canary/docker@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  yarn add @auto-canary/exec@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  yarn add @auto-canary/first-time-contributor@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  yarn add @auto-canary/gem@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  yarn add @auto-canary/gh-pages@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  yarn add @auto-canary/git-tag@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  yarn add @auto-canary/gradle@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  yarn add @auto-canary/jira@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  yarn add @auto-canary/magic-zero@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  yarn add @auto-canary/maven@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  yarn add @auto-canary/microsoft-teams@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  yarn add @auto-canary/npm@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  yarn add @auto-canary/omit-commits@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  yarn add @auto-canary/omit-release-notes@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  yarn add @auto-canary/pr-body-labels@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  yarn add @auto-canary/protected-branch@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  yarn add @auto-canary/released@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  yarn add @auto-canary/s3@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  yarn add @auto-canary/sbt@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  yarn add @auto-canary/slack@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  yarn add @auto-canary/twitter@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  yarn add @auto-canary/upload-assets@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  yarn add @auto-canary/version-file@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  yarn add @auto-canary/vscode@11.2.0--canary.2467.bb9bf1e8d1186bc73fa8deffb2f661a893697f58.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
