### PR TITLE
Respect `noVersionPrefix` option in the Version File plugin

### DIFF
--- a/plugins/version-file/__tests__/version-file.test.ts
+++ b/plugins/version-file/__tests__/version-file.test.ts
@@ -1,7 +1,7 @@
 import Auto, { SEMVER } from '@auto-it/core';
 import mockFs from "mock-fs";
 import fs from "fs";
-import BazelPlugin from '../src';
+import VersionFilePlugin from '../src';
 import { makeHooks } from '@auto-it/core/dist/utils/make-hooks';
 import { dummyLog } from "@auto-it/core/dist/utils/logger";
 
@@ -27,7 +27,7 @@ describe('Version File Read Operations', () => {
     mockFs({
       "VERSION": `1.0.0`,
     });
-    const plugin = new BazelPlugin({});
+    const plugin = new VersionFilePlugin({});
     const hooks = makeHooks();
 
     plugin.apply({
@@ -44,7 +44,7 @@ describe('Version File Read Operations', () => {
     mockFs({
       "VERSIONFILE": `1.0.0`,
     });
-    const plugin = new BazelPlugin({versionFile: "VERSIONFILE"});
+    const plugin = new VersionFilePlugin({versionFile: "VERSIONFILE"});
     const hooks = makeHooks();
 
     plugin.apply({
@@ -63,14 +63,19 @@ describe("Version File Write Operations", () => {
     mockFs({
       "VERSION": `1.0.0`,
     });
-    const plugin = new BazelPlugin({});
+    const plugin = new VersionFilePlugin({});
     const hooks = makeHooks();
+
+    const prefixRelease: (a: string) => string = (version: string) => {
+      return `v${version}`;
+    };
 
     plugin.apply({
       hooks,
       remote: "origin",
       baseBranch: "main",
       logger: dummyLog(),
+      prefixRelease
     } as Auto);
 
     await hooks.version.promise({bump: SEMVER.major})
@@ -84,14 +89,19 @@ describe("Version File Write Operations", () => {
     mockFs({
       "VERSION": `1.0.0`,
     });
-    const plugin = new BazelPlugin({});
+    const plugin = new VersionFilePlugin({});
     const hooks = makeHooks();
+
+    const prefixRelease: (a: string) => string = (version: string) => {
+      return `v${version}`;
+    };
 
     plugin.apply({
       hooks,
       remote: "origin",
       baseBranch: "main",
       logger: dummyLog(),
+      prefixRelease
     } as Auto);
 
     await hooks.version.promise({bump: SEMVER.minor})
@@ -105,14 +115,19 @@ describe("Version File Write Operations", () => {
     mockFs({
       "VERSION": `1.0.0`,
     });
-    const plugin = new BazelPlugin({});
+    const plugin = new VersionFilePlugin({});
     const hooks = makeHooks();
+
+    const prefixRelease: (a: string) => string = (version: string) => {
+      return `v${version}`;
+    };
 
     plugin.apply({
       hooks,
       remote: "origin",
       baseBranch: "main",
       logger: dummyLog(),
+      prefixRelease
     } as Auto);
 
     await hooks.version.promise({bump: SEMVER.patch})
@@ -121,6 +136,32 @@ describe("Version File Write Operations", () => {
     expect(execPromise).toHaveBeenNthCalledWith(1, "git", ["commit", "-am", "\"Bump version to: v1.0.1 [skip ci]\""]);
     expect(execPromise).toHaveBeenNthCalledWith(2, "git", ["tag", "v1.0.1"]);
   });
+
+  test("It should version the file properly for without a prefix", async () => {
+    mockFs({
+      "VERSION": `1.0.0`,
+    });
+    const plugin = new VersionFilePlugin({});
+    const hooks = makeHooks();
+
+    const prefixRelease: (a: string) => string = (version: string) => {
+      return `${version}`;
+    };
+
+    plugin.apply({
+      hooks,
+      remote: "origin",
+      baseBranch: "main",
+      logger: dummyLog(),
+      prefixRelease
+    } as Auto);
+
+    await hooks.version.promise({bump: SEMVER.patch})
+    expect(fs.readFileSync("VERSION", "utf-8")).toStrictEqual("1.0.1");
+    // check that the proper git operations were performed
+    expect(execPromise).toHaveBeenNthCalledWith(1, "git", ["commit", "-am", "\"Bump version to: 1.0.1 [skip ci]\""]);
+    expect(execPromise).toHaveBeenNthCalledWith(2, "git", ["tag", "1.0.1"]);
+  });
 })
 
 describe("Test Release Types", () => {
@@ -128,7 +169,7 @@ describe("Test Release Types", () => {
     mockFs({
       "VERSION": `1.0.0`,
     });
-    const plugin = new BazelPlugin({});
+    const plugin = new VersionFilePlugin({});
     const hooks = makeHooks();
 
     plugin.apply({
@@ -148,7 +189,7 @@ describe("Test Release Types", () => {
     mockFs({
       "VERSION": `1.0.0`,
     });
-    const plugin = new BazelPlugin({publishScript:"./tools/release.sh"});
+    const plugin = new VersionFilePlugin({publishScript:"./tools/release.sh"});
     const hooks = makeHooks();
 
     plugin.apply({
@@ -171,7 +212,7 @@ describe("Test Release Types", () => {
     mockFs({
       "VERSION": `1.0.0`,
     });
-    const plugin = new BazelPlugin({});
+    const plugin = new VersionFilePlugin({});
     const hooks = makeHooks();
 
     plugin.apply(({
@@ -199,7 +240,7 @@ describe("Test Release Types", () => {
     mockFs({
       "VERSION": `1.0.0`,
     });
-    const plugin = new BazelPlugin({publishScript:"./tools/release.sh"});
+    const plugin = new VersionFilePlugin({publishScript:"./tools/release.sh"});
     const hooks = makeHooks();
 
     plugin.apply(({
@@ -235,7 +276,7 @@ describe("Test Release Types", () => {
     mockFs({
       "VERSION": `1.0.0`,
     });
-    const plugin = new BazelPlugin({});
+    const plugin = new VersionFilePlugin({});
     const hooks = makeHooks();
 
     plugin.apply(({
@@ -272,7 +313,7 @@ describe("Test Release Types", () => {
     mockFs({
       "VERSION": `1.0.0`,
     });
-    const plugin = new BazelPlugin({publishScript:"./tools/release.sh"});
+    const plugin = new VersionFilePlugin({publishScript:"./tools/release.sh"});
     const hooks = makeHooks();
 
     plugin.apply(({
@@ -311,7 +352,7 @@ describe("Test Release Types", () => {
     mockFs({
       VERSION: `1.0.0`,
     });
-     const plugin = new BazelPlugin({
+     const plugin = new VersionFilePlugin({
        publishScript: "./tools/release.sh",
        publishScriptReleaseTypeArgs: {
          publish: ["args", "for", "publish"],

--- a/plugins/version-file/src/index.ts
+++ b/plugins/version-file/src/index.ts
@@ -70,7 +70,7 @@ export default class VersionFilePlugin implements IPlugin {
   /** Release script location */
   readonly publishScript: string | undefined
 
-  /**  */
+  /** Args to pass to the release script based on release type */
   readonly publishScriptReleaseTypeArgs: ReleaseTypeArgs;
 
   /** Initialize the plugin with it's options */
@@ -123,7 +123,7 @@ export default class VersionFilePlugin implements IPlugin {
         await execPromise("git", ["commit", "-am", `"Bump version to: v${newVersion} [skip ci]"`]);
         await execPromise("git", [
           "tag",
-          `v${newVersion}`
+          auto.prefixRelease(newVersion)
         ]);
         auto.logger.verbose.info("Successfully versioned repo");
       } else {

--- a/plugins/version-file/src/index.ts
+++ b/plugins/version-file/src/index.ts
@@ -120,10 +120,11 @@ export default class VersionFilePlugin implements IPlugin {
       if (newVersion){
         // Seal versions via commit and tag
         await writeNewVersion(auto, newVersion, this.versionFile)
-        await execPromise("git", ["commit", "-am", `"Bump version to: v${newVersion} [skip ci]"`]);
+        const prefixedVersion = auto.prefixRelease(newVersion)
+        await execPromise("git", ["commit", "-am", `"Bump version to: ${prefixedVersion} [skip ci]"`]);
         await execPromise("git", [
           "tag",
-          auto.prefixRelease(newVersion)
+          prefixedVersion
         ]);
         auto.logger.verbose.info("Successfully versioned repo");
       } else {


### PR DESCRIPTION
# What Changed
Previously during a non-canary/next release, the version file plugin would always prepend a `v` to the tag that was created for the new version regardless of if the `noVersionPrefix` option was set. 

## Why
The `noVersionPrefix` option should be respected

Todo:

- [ ] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
