### PR TITLE
private packages should be included in changelogs

### DIFF
--- a/packages/core/src/utils/__tests__/get-lerna-packages.test.ts
+++ b/packages/core/src/utils/__tests__/get-lerna-packages.test.ts
@@ -20,17 +20,3 @@ test("it shouldn't included version-less packages", async () => {
     },
   ]);
 });
-
-test("it shouldn't included private packages", async () => {
-  exec.mockReturnValue(endent`
-    /dir/a:a:0.3.0--canary.32.d54a0c4.0
-    /dir/b:b:0.3.0:PRIVATE
-  `);
-  expect(await getLernaPackages()).toStrictEqual([
-    {
-      name: "a",
-      path: "/dir/a",
-      version: "0.3.0--canary.32.d54a0c4.0",
-    },
-  ]);
-});

--- a/packages/core/src/utils/get-lerna-packages.ts
+++ b/packages/core/src/utils/get-lerna-packages.ts
@@ -15,9 +15,9 @@ export default async function getLernaPackages() {
   const response = await execPromise("npx", ["lerna", "ls", "-pla"]);
 
   response.split("\n").forEach((packageInfo) => {
-    const [packagePath, name, version, isPrivate] = packageInfo.split(":");
+    const [packagePath, name, version] = packageInfo.split(":");
 
-    if (version !== "MISSING" && isPrivate !== "PRIVATE") {
+    if (version !== "MISSING") {
       packages.push({ path: packagePath, name, version });
     }
   });


### PR DESCRIPTION
I think this code is a mistake. We have a lot of private packages and we def want them in the changelogs

Marking as minor since this could be considered a bigger change
<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.gz)  
[auto-macos--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.gz)  
[auto-win.exe--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>under canary scope @auto-canary@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @auto-canary/bot-list@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  npm install @auto-canary/auto@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  npm install @auto-canary/core@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  npm install @auto-canary/package-json-utils@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  npm install @auto-canary/all-contributors@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  npm install @auto-canary/brew@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  npm install @auto-canary/chrome@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  npm install @auto-canary/cocoapods@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  npm install @auto-canary/conventional-commits@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  npm install @auto-canary/crates@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  npm install @auto-canary/docker@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  npm install @auto-canary/exec@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  npm install @auto-canary/first-time-contributor@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  npm install @auto-canary/gem@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  npm install @auto-canary/gh-pages@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  npm install @auto-canary/git-tag@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  npm install @auto-canary/gradle@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  npm install @auto-canary/jira@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  npm install @auto-canary/magic-zero@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  npm install @auto-canary/maven@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  npm install @auto-canary/microsoft-teams@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  npm install @auto-canary/npm@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  npm install @auto-canary/omit-commits@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  npm install @auto-canary/omit-release-notes@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  npm install @auto-canary/pr-body-labels@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  npm install @auto-canary/protected-branch@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  npm install @auto-canary/released@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  npm install @auto-canary/s3@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  npm install @auto-canary/sbt@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  npm install @auto-canary/slack@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  npm install @auto-canary/twitter@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  npm install @auto-canary/upload-assets@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  npm install @auto-canary/version-file@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  npm install @auto-canary/vscode@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  # or 
  yarn add @auto-canary/bot-list@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  yarn add @auto-canary/auto@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  yarn add @auto-canary/core@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  yarn add @auto-canary/package-json-utils@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  yarn add @auto-canary/all-contributors@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  yarn add @auto-canary/brew@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  yarn add @auto-canary/chrome@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  yarn add @auto-canary/cocoapods@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  yarn add @auto-canary/conventional-commits@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  yarn add @auto-canary/crates@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  yarn add @auto-canary/docker@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  yarn add @auto-canary/exec@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  yarn add @auto-canary/first-time-contributor@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  yarn add @auto-canary/gem@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  yarn add @auto-canary/gh-pages@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  yarn add @auto-canary/git-tag@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  yarn add @auto-canary/gradle@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  yarn add @auto-canary/jira@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  yarn add @auto-canary/magic-zero@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  yarn add @auto-canary/maven@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  yarn add @auto-canary/microsoft-teams@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  yarn add @auto-canary/npm@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  yarn add @auto-canary/omit-commits@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  yarn add @auto-canary/omit-release-notes@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  yarn add @auto-canary/pr-body-labels@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  yarn add @auto-canary/protected-branch@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  yarn add @auto-canary/released@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  yarn add @auto-canary/s3@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  yarn add @auto-canary/sbt@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  yarn add @auto-canary/slack@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  yarn add @auto-canary/twitter@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  yarn add @auto-canary/upload-assets@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  yarn add @auto-canary/version-file@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  yarn add @auto-canary/vscode@11.3.0--canary.2478.87bcf4d47797ed8cc7152538b86fd742d8d19462.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
