### PR TITLE
fix: handle Github API deprecations

### DIFF
--- a/packages/core/src/__tests__/git.test.ts
+++ b/packages/core/src/__tests__/git.test.ts
@@ -378,12 +378,13 @@ describe("github", () => {
 
     issuesAndPullRequests.mockReturnValueOnce({ data: true });
     await gh.searchRepo({
-      q: "is:pr is:open",
+      q: "is:pr AND is:open",
       order: "desc",
     });
 
     expect(issuesAndPullRequests).toHaveBeenCalledWith({
-      q: "repo:Adam Dierkens/test is:pr is:open",
+      advanced_search: true,
+      q: "repo:Adam Dierkens/test AND (is:pr AND is:open)",
       order: "desc",
     });
   });

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -518,7 +518,8 @@ export default class Git {
     options: RestEndpointMethodTypes["search"]["issuesAndPullRequests"]["parameters"]
   ) {
     const repo = `repo:${this.options.owner}/${this.options.repo}`;
-    options.q = `${repo} ${options.q}`;
+    options.q = `${repo} AND (${options.q})`;
+    options.advanced_search = true;
 
     this.logger.verbose.info("Searching repo using:\n", options);
 

--- a/packages/core/src/release.ts
+++ b/packages/core/src/release.ts
@@ -471,7 +471,7 @@ export default class Release {
     }
 
     const prsSinceLastRelease = await this.git.searchRepo({
-      q: `is:pr is:merged merged:>=${lastRelease.published_at}`,
+      q: `is:pr AND is:merged AND merged:>=${lastRelease.published_at}`,
     });
 
     if (!prsSinceLastRelease || !prsSinceLastRelease.items) {


### PR DESCRIPTION
Fix: https://github.com/intuit/auto/issues/2501

# What Changed

Handle Github API Deprecation warning

## Why

Todo:

- [x] Add tests
- [ ] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
