### PR TITLE
fix: handle 404 status when deleting release branch in protected-branch plugin

### DIFF
--- a/plugins/protected-branch/src/index.ts
+++ b/plugins/protected-branch/src/index.ts
@@ -121,7 +121,8 @@ export default class ProtectedBranchPlugin implements IPlugin {
         });
       } catch (e) {
         // Silently ignore reference not found error since the ref might already be deleted
-        if (!e || e.status !== 422 || e.message !== "Reference does not exist") {
+        // GitHub API may return either 422 or 404 for non-existent references
+        if (!e || (e.status !== 422 && e.status !== 404) || e.message !== "Reference does not exist") {
           throw e;
         }
       }


### PR DESCRIPTION
# Why

The `protected-branch` plugin's `afterRelease` hook intermittently crashes the release process with:

```
ℹ  info      Getting previous comments on: 123         ← released plugin (parallel)
ℹ  info      Got commit SHA from HEAD: beda823c...     ← protected-branch plugin (parallel)
ℹ  info      Delete release branch 🗑️
ℹ  info      Tag v1.2.3 is available (attempt 1/10)
ℹ  info      Creating new comment                      ← released plugin resumes
ℹ  info      Creating new comment
✖  error     Received 404!                             ← deleteRef returns 404
✖  error     HttpError: Reference does not exist
```

### Root cause

`afterRelease` is an [`AsyncParallelHook`](https://github.com/intuit/auto/blob/e828cd1c30721565ccc07144c39bc7eb55ed0878/packages/core/src/utils/make-hooks.ts#L25), so all plugins run concurrently. The temporary release branch may already be gone by the time `protected-branch` calls `deleteRef` — e.g. cleaned up by GitHub's auto-delete on merge feature.

The [catch block introduced in `275b12c`](https://github.com/intuit/auto/commit/275b12c7e39a14a7be781b9e860e4b096f2fd987) silences status **422** for "Reference does not exist", but GitHub may also return **404** with the same message. The OR logic short-circuits on `e.status !== 422` and rethrows the error.

Manual retry always succeeds since the branch is already gone.