### PR TITLE
docs: update GitHub Actions examples to use actions/checkout@v4 and actions/setup-node@v4

### DIFF
--- a/docs/pages/docs/build-platforms/github-actions.mdx
+++ b/docs/pages/docs/build-platforms/github-actions.mdx
@@ -21,12 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: '0'
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
           cache: 'npm' # or yarn, pnpn
@@ -49,7 +49,7 @@ If you are publishing to the Github Package Registry you will need to change a f
 
 ```yaml
 - name: Setup Node
-  uses: actions/setup-node@v3
+  uses: actions/setup-node@v4
   with:
     node-version: 'lts/*'
     registry-url: "https://npm.pkg.github.com"
@@ -69,8 +69,8 @@ If you are publishing to the Github Package Registry you will need to change a f
     npx auto shipit
 ```
 
-The `NODE_AUTH_TOKEN` variable is required for the `.npmrc` that `actions/setup-node@v3` sets up.
-If you aren't using `actions/setup-node@v3` replace the variable name `NODE_AUTH_TOKEN` with `NPM_TOKEN` and the `.npmrc` `auto` will handle authentication instead.
+The `NODE_AUTH_TOKEN` variable is required for the `.npmrc` that `actions/setup-node@v4` sets up.
+If you aren't using `actions/setup-node@v4` replace the variable name `NODE_AUTH_TOKEN` with `NPM_TOKEN` and the `.npmrc` `auto` will handle authentication instead.
 
 ## Troubleshooting
 
@@ -87,7 +87,7 @@ You will need to create a token with admin access to your repo and modify your b
 
 ```yaml
 steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
     with:
       # Ensure that git uses your token with admin access to the repo
       token: ${{ secrets.ADMIN_TOKEN }}


### PR DESCRIPTION
# What Changed
Updated `actions/checkout` and `actions/setup-node` from v3 to v4 in the GitHub Actions documentation examples.

## Why
The v3 versions of these actions are outdated. v4 is the current supported version.

Fixes #2520

## Change Type
Indicate the type of change your pull request is:
- [x] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
