### PR TITLE
feat: Add option to configure verifyAuth timeout

### DIFF
--- a/packages/cli/src/parse-args.ts
+++ b/packages/cli/src/parse-args.ts
@@ -124,6 +124,14 @@ const defaultOptions: AutoOption[] = [
     description: "Plugins to load auto with. (defaults to just npm)",
     group: "global",
   },
+  {
+    name: "github-auth-timeout",
+    type: Number,
+    description:
+      "Timeout in seconds for the `git push --dry-run` GitHub auth probe. Default: 5.",
+    group: "global",
+    config: true,
+  },
 ];
 
 const baseBranch: AutoOption = {

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -724,6 +724,7 @@ export default class Auto {
     const envVar = Object.keys(GIT_TOKENS).find((v) => process.env[v]) || "";
     const gitCredentials = GIT_TOKENS[envVar] || process.env.GH_TOKEN;
 
+    this.logger.verbose.info("Trying auth ssh URL");
     if (ssh_url && (await this.git.verifyAuth(ssh_url))) {
       this.logger.veryVerbose.note("Using ssh URL as remote");
       return ssh_url;
@@ -738,12 +739,14 @@ export default class Auto {
         host: `${hostname}${port ? `:${port}` : ""}`,
       });
 
+      this.logger.verbose.info("Trying auth token + HTTPS URL");
       if (await this.git.verifyAuth(urlWithAuth)) {
         this.logger.veryVerbose.note("Using token + html URL as remote");
         return urlWithAuth;
       }
     }
 
+    this.logger.verbose.info("Trying auth bare HTTPS URL");
     if (html_url && (await this.git.verifyAuth(html_url))) {
       this.logger.veryVerbose.note("Using bare html URL as remote");
       return html_url;

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -673,6 +673,7 @@ export default class Auto {
       agent: proxyUrl ? createHttpsProxyAgent(proxyUrl) : undefined,
       baseUrl: config.githubApi,
       graphqlBaseUrl: config.githubGraphqlApi,
+      githubAuthTimeout: config.githubAuthTimeout,
     };
 
     this.git = this.startGit(githubOptions as IGitOptions);
@@ -1858,6 +1859,7 @@ export default class Auto {
         baseBranch: this.baseBranch,
         graphqlBaseUrl: gitOptions.graphqlBaseUrl,
         agent: gitOptions.agent,
+        githubAuthTimeout: gitOptions.githubAuthTimeout,
       },
       this.logger
     );

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -724,7 +724,7 @@ export default class Auto {
     const envVar = Object.keys(GIT_TOKENS).find((v) => process.env[v]) || "";
     const gitCredentials = GIT_TOKENS[envVar] || process.env.GH_TOKEN;
 
-    this.logger.verbose.info("Trying auth ssh URL");
+    this.logger.verbose.info("Trying verifyAuth with ssh URL");
     if (ssh_url && (await this.git.verifyAuth(ssh_url))) {
       this.logger.veryVerbose.note("Using ssh URL as remote");
       return ssh_url;
@@ -739,14 +739,14 @@ export default class Auto {
         host: `${hostname}${port ? `:${port}` : ""}`,
       });
 
-      this.logger.verbose.info("Trying auth token + HTTPS URL");
+      this.logger.verbose.info("Trying verifyAuth with token + html URL");
       if (await this.git.verifyAuth(urlWithAuth)) {
         this.logger.veryVerbose.note("Using token + html URL as remote");
         return urlWithAuth;
       }
     }
 
-    this.logger.verbose.info("Trying auth bare HTTPS URL");
+    this.logger.verbose.info("Trying verifyAuth with bare HTTPS URL");
     if (html_url && (await this.git.verifyAuth(html_url))) {
       this.logger.veryVerbose.note("Using bare html URL as remote");
       return html_url;

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -746,7 +746,7 @@ export default class Auto {
       }
     }
 
-    this.logger.verbose.info("Trying verifyAuth with bare HTTPS URL");
+    this.logger.verbose.info("Trying verifyAuth with bare html URL");
     if (html_url && (await this.git.verifyAuth(html_url))) {
       this.logger.veryVerbose.note("Using bare html URL as remote");
       return html_url;

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -44,6 +44,8 @@ export interface IGitOptions {
   token?: string;
   /** An optional proxy agent to route requests through */
   agent?: HttpsProxyAgent;
+  /** Timeout (in seconds) for the `git push --dry-run` GitHub auth probe */
+  githubAuthTimeout?: number;
 }
 
 /** An error originating from the GitHub */
@@ -177,7 +179,11 @@ export default class Git {
 
   /** Verify the write access authorization to remote repository with push dry-run. */
   async verifyAuth(url: string) {
-    return verifyAuth(url, this.options.baseBranch);
+    return verifyAuth(
+      url,
+      this.options.baseBranch,
+      this.options.githubAuthTimeout
+    );
   }
 
   /** Get the "Latest Release" from GitHub */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -69,6 +69,8 @@ export const globalOptions = t.partial({
   prereleaseBranches: t.array(t.string),
   /** Configured auto plugins */
   plugins: t.array(t.union([t.string, t.tuple([t.string, t.any])])),
+  /** Timeout (in seconds) for the `git push --dry-run` GitHub auth probe used by verifyAuth. */
+  githubAuthTimeout: t.number,
   /** Whether to prefix the version with a "v" */
   noVersionPrefix: t.boolean,
   /**

--- a/packages/core/src/utils/__tests__/verify-auth.test.ts
+++ b/packages/core/src/utils/__tests__/verify-auth.test.ts
@@ -1,10 +1,21 @@
-import verifyAuth from "../verify-auth";
+import verifyAuth, { resolveTimeoutSeconds } from "../verify-auth";
 import childProcess from "child_process";
 
 const spawn = childProcess.spawn as jest.Mock;
 jest.mock("child_process");
 
+const mockWarn = jest.fn();
+jest.mock("../logger", () => () => ({
+  log: { warn: (...args: any[]) => mockWarn(...args) },
+  verbose: { info: jest.fn() },
+  veryVerbose: { info: jest.fn() },
+}));
+
 describe("verify-auth", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   test("should handle error", async () => {
     spawn.mockImplementationOnce(() => ({
       stderr: { on: () => {} },
@@ -35,5 +46,105 @@ describe("verify-auth", () => {
       on: (_: string, cb: () => void) => cb(),
     }));
     expect(await verifyAuth("bad", "main")).toBe(false);
+  });
+});
+
+describe("resolveTimeoutSeconds", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should return default 5 when value is undefined", () => {
+    expect(resolveTimeoutSeconds(undefined)).toBe(5);
+    expect(mockWarn).not.toHaveBeenCalled();
+  });
+
+  test("should return the value when it is a valid positive number", () => {
+    expect(resolveTimeoutSeconds(10)).toBe(10);
+    expect(mockWarn).not.toHaveBeenCalled();
+  });
+
+  test("should return the value when it is a valid fractional number", () => {
+    expect(resolveTimeoutSeconds(0.5)).toBe(0.5);
+    expect(mockWarn).not.toHaveBeenCalled();
+  });
+
+  test("should fall back to 5 and warn for a negative number", () => {
+    expect(resolveTimeoutSeconds(-3)).toBe(5);
+    expect(mockWarn).toHaveBeenCalledWith(
+      "Invalid githubAuthTimeout (-3); expected a positive number. Falling back to 5s."
+    );
+  });
+
+  test("should fall back to 5 and warn for zero", () => {
+    expect(resolveTimeoutSeconds(0)).toBe(5);
+    expect(mockWarn).toHaveBeenCalledWith(
+      "Invalid githubAuthTimeout (0); expected a positive number. Falling back to 5s."
+    );
+  });
+
+  test("should fall back to 5 and warn for NaN", () => {
+    expect(resolveTimeoutSeconds(NaN)).toBe(5);
+    expect(mockWarn).toHaveBeenCalledWith(
+      "Invalid githubAuthTimeout (NaN); expected a positive number. Falling back to 5s."
+    );
+  });
+
+  test("should fall back to 5 and warn for Infinity", () => {
+    expect(resolveTimeoutSeconds(Infinity)).toBe(5);
+    expect(mockWarn).toHaveBeenCalledWith(
+      "Invalid githubAuthTimeout (Infinity); expected a positive number. Falling back to 5s."
+    );
+  });
+
+  test("should fall back to 5 and warn for a non-number value", () => {
+    expect(resolveTimeoutSeconds("fast" as unknown as number)).toBe(5);
+    expect(mockWarn).toHaveBeenCalledWith(
+      "Invalid githubAuthTimeout (fast); expected a positive number. Falling back to 5s."
+    );
+  });
+});
+
+describe("verifyAuth timeout integration", () => {
+  const setTimeoutSpy = jest.spyOn(global, "setTimeout");
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should use default 5s timeout when no value is provided", async () => {
+    spawn.mockImplementationOnce(() => ({
+      stderr: { on: () => {} },
+      kill: () => {},
+      on: (_: string, cb: () => void) => cb(),
+    }));
+
+    await verifyAuth("origin", "main");
+
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 5000);
+  });
+
+  test("should use provided valid timeout value", async () => {
+    spawn.mockImplementationOnce(() => ({
+      stderr: { on: () => {} },
+      kill: () => {},
+      on: (_: string, cb: () => void) => cb(),
+    }));
+
+    await verifyAuth("origin", "main", 10);
+
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 10000);
+  });
+
+  test("should fall back to default 5s timeout for invalid value", async () => {
+    spawn.mockImplementationOnce(() => ({
+      stderr: { on: () => {} },
+      kill: () => {},
+      on: (_: string, cb: () => void) => cb(),
+    }));
+
+    await verifyAuth("origin", "main", -3);
+
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 5000);
   });
 });

--- a/packages/core/src/utils/verify-auth.ts
+++ b/packages/core/src/utils/verify-auth.ts
@@ -5,6 +5,13 @@ const log = createLog();
 
 const DEFAULT_TIMEOUT_SECONDS = 5;
 
+/**
+ * Redact credentials embedded in a remote URL so they are safe to log.
+ * Handles `https://user:password@host/...`
+ */
+export const redactRemote = (remote: string): string =>
+  remote.replace(/(https:\/\/)[^/@\s]+@/g, "$1****@");
+
 /** Coerce arbitrary input into a positive, finite number of seconds. */
 export const resolveTimeoutSeconds = (value: unknown): number => {
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
@@ -31,7 +38,10 @@ export default function verifyAuth(
   timeoutSecondsInput?: number
 ) {
   const timeoutSeconds = resolveTimeoutSeconds(timeoutSecondsInput);
-  log.veryVerbose.info(`verifyAuth using timeout of ${timeoutSeconds} seconds`);
+  const safeRemote = redactRemote(remote);
+  log.veryVerbose.info(
+    `verifyAuth using timeout of ${timeoutSeconds} seconds for remote ${safeRemote}`
+  );
 
   return new Promise<boolean>((resolve) => {
     let timeout: NodeJS.Timeout | null = null;
@@ -44,6 +54,8 @@ export default function verifyAuth(
     };
 
     try {
+      const startTime = Date.now();
+
       const child = spawn(
         `git push --dry-run --no-verify ${remote} HEAD:${branch} -q`,
         {
@@ -71,6 +83,12 @@ export default function verifyAuth(
 
       child.on("exit", () => {
         clear();
+        log.veryVerbose.info(
+          `verifyAuth for remote ${safeRemote} completed in ${
+            Date.now() - startTime
+          }ms`
+        );
+
         resolve(
           !err.startsWith("fatal: could not read Username") &&
             !err.startsWith("ssh_askpass") &&

--- a/packages/core/src/utils/verify-auth.ts
+++ b/packages/core/src/utils/verify-auth.ts
@@ -3,14 +3,35 @@ import createLog from "./logger";
 
 const log = createLog();
 
+const DEFAULT_TIMEOUT_SECONDS = 5;
+
+/** Coerce arbitrary input into a positive, finite number of seconds. */
+const resolveTimeoutSeconds = (value: unknown): number => {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    if (value !== undefined) {
+      log.log.warn(
+        `Invalid githubAuthTimeout (${String(
+          value
+        )}); expected a positive number. Falling back to ${DEFAULT_TIMEOUT_SECONDS}s.`
+      );
+    }
+
+    return DEFAULT_TIMEOUT_SECONDS;
+  }
+
+  return value;
+};
+
 /**
  *
  */
 export default function verifyAuth(
   remote: string,
   branch: string,
-  timeoutSeconds = 5
+  timeoutSecondsInput?: number
 ) {
+  const timeoutSeconds = resolveTimeoutSeconds(timeoutSecondsInput);
+
   return new Promise<boolean>((resolve) => {
     let timeout: NodeJS.Timeout | null = null;
 

--- a/packages/core/src/utils/verify-auth.ts
+++ b/packages/core/src/utils/verify-auth.ts
@@ -31,6 +31,7 @@ export default function verifyAuth(
   timeoutSecondsInput?: number
 ) {
   const timeoutSeconds = resolveTimeoutSeconds(timeoutSecondsInput);
+  log.veryVerbose.info(`verifyAuth using timeout of ${timeoutSeconds} seconds`);
 
   return new Promise<boolean>((resolve) => {
     let timeout: NodeJS.Timeout | null = null;

--- a/packages/core/src/utils/verify-auth.ts
+++ b/packages/core/src/utils/verify-auth.ts
@@ -1,9 +1,16 @@
 import { spawn } from "child_process";
+import createLog from "./logger";
+
+const log = createLog();
 
 /**
  *
  */
-export default function verifyAuth(remote: string, branch: string) {
+export default function verifyAuth(
+  remote: string,
+  branch: string,
+  timeoutSeconds = 5
+) {
   return new Promise<boolean>((resolve) => {
     let timeout: NodeJS.Timeout | null = null;
 
@@ -28,8 +35,11 @@ export default function verifyAuth(remote: string, branch: string) {
       timeout = setTimeout(() => {
         // Kill the spawned process and it's children
         process.kill(-child.pid);
+        log.veryVerbose.info(
+          `verifyAuth timed out after ${timeoutSeconds}s`
+        );
         resolve(false);
-      }, 5 * 1000);
+      }, timeoutSeconds * 1000);
 
       let err = "";
 

--- a/packages/core/src/utils/verify-auth.ts
+++ b/packages/core/src/utils/verify-auth.ts
@@ -6,7 +6,7 @@ const log = createLog();
 const DEFAULT_TIMEOUT_SECONDS = 5;
 
 /** Coerce arbitrary input into a positive, finite number of seconds. */
-const resolveTimeoutSeconds = (value: unknown): number => {
+export const resolveTimeoutSeconds = (value: unknown): number => {
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
     if (value !== undefined) {
       log.log.warn(


### PR DESCRIPTION
# What Changed

Make the `verifyAuth` `git push --dry-run` probe timeout configurable. Previously hardcoded to 5 seconds.

- New global option `githubAuthTimeout` in `.autorc` (number, in seconds).
- New CLI flag `--github-auth-timeout <seconds>`.
- Default behaviour unchanged: 5s when neither is set.

## Why

We noticed that on our Github enterprise at Intuit
- The 5s timeout is being exceeded for https token based validation in `verifyAuth`
- `auto` falls back to remote URL without any token
- Results in failure and falls back to other methods such ask pass, which is not configured
- Finally results in "Current commit is behind, skipping the release to avoid collisions" error.

To resolve this issue, we would like to make this timeout value configurable.

Files updated:

- `packages/core/src/types.ts` — register `githubAuthTimeout` in `globalOptions`.
- `packages/cli/src/parse-args.ts` — register `--github-auth-timeout` (group `global`, `config: true`).
- `packages/core/src/auto.ts` — forward `config.githubAuthTimeout` through `githubOptions` and `startGit`.
- `packages/core/src/git.ts` — extend `IGitOptions` and forward into the `verifyAuth` utility.
- `packages/core/src/utils/verify-auth.ts` — accept `timeoutSeconds` (default 5), use it for the kill timer, add the debug log.


## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`