### PR TITLE
fix(conventional-commits): prevent PR commits from downgrading merge commit bump

### DIFF
--- a/plugins/conventional-commits/__tests__/conventional-commits.test.ts
+++ b/plugins/conventional-commits/__tests__/conventional-commits.test.ts
@@ -198,6 +198,39 @@ describe("parseCommit", () => {
     });
   });
 
+  test("should not downgrade merge commit bump with PR commit bumps", async () => {
+    const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
+    const autoHooks = makeHooks();
+    conventionalCommitsPlugin.apply({
+      hooks: autoHooks,
+      labels: defaultLabels,
+      semVerLabels: versionLabels,
+      logger: dummyLog(),
+      git: {
+        getCommitsForPR: () =>
+          Promise.resolve([
+            { sha: "1", commit: { message: "feat: add new feature" } },
+            { sha: "2", commit: { message: "chore: update config" } },
+          ]),
+      } as any,
+    } as Auto);
+
+    const logParseHooks = makeLogParseHooks();
+    autoHooks.onCreateLogParse.call({
+      hooks: logParseHooks,
+    } as LogParse);
+
+    const commit = makeCommitFromMsg("feat!: breaking change via squash merge", {
+      pullRequest: { number: 456 },
+    });
+    expect(
+      await logParseHooks.parseCommit.promise({ ...commit })
+    ).toStrictEqual({
+      ...commit,
+      labels: ["major"],
+    });
+  });
+
   test("should skip when not a fix/feat/breaking change commit", async () => {
     const conventionalCommitsPlugin = new ConventionalCommitsPlugin();
     const autoHooks = makeHooks();

--- a/plugins/conventional-commits/src/index.ts
+++ b/plugins/conventional-commits/src/index.ts
@@ -242,11 +242,18 @@ export default class ConventionalCommitsPlugin implements IPlugin {
               | SEMVER.minor
               | SEMVER.patch => Boolean(bump && bump !== "skip"));
 
-            if (prBumps.includes(SEMVER.major)) {
+            // Include the merge commit's own bump so that PR commit bumps
+            // can only upgrade the release type, never downgrade it.
+            // This prevents squash-merged PRs with e.g. "feat!:" title
+            // from being downgraded to "minor" by individual "feat:" commits.
+            const allBumps: (SEMVER.major | SEMVER.minor | SEMVER.patch)[] =
+              bump && bump !== "skip" ? [bump, ...prBumps] : prBumps;
+
+            if (allBumps.includes(SEMVER.major)) {
               bump = SEMVER.major;
-            } else if (prBumps.includes(SEMVER.minor)) {
+            } else if (allBumps.includes(SEMVER.minor)) {
               bump = SEMVER.minor;
-            } else if (prBumps.includes(SEMVER.patch)) {
+            } else if (allBumps.includes(SEMVER.patch)) {
               bump = SEMVER.patch;
             }
           }


### PR DESCRIPTION
## What Changed

When a PR without a dedicated bump label is squash-merged, the merge commit's bump (derived from the PR title, e.g. `feat!:` → `major`) is unconditionally overwritten by the highest bump from the individual pre-squash PR commits. This means a `feat!:` merge commit gets downgraded to `minor` if the individual commits only contain `feat:`.

The fix includes the merge commit's own bump in the comparison array so that PR commit bumps can only upgrade the release type, never downgrade it.

## Why

Fixes #2527

Squash-merge workflows rely on the PR title as the single source of truth for the release type. The current behaviour silently loses breaking change signals from the merge commit, causing incorrect version bumps.

Todo:

- [x] Add tests
- [x] Add docs

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
