### PR TITLE
docs: fix typo "teh" → "the" in jira plugin JSDoc

### DIFF
--- a/plugins/jira/src/index.ts
+++ b/plugins/jira/src/index.ts
@@ -25,7 +25,7 @@ interface InputResponse<T = "string"> {
 interface IJiraCommit extends IExtendedCommit {
   /** The jira info for the commit */
   jira?: {
-    /** The jira story numbers attached to teh commit */
+    /** The jira story numbers attached to the commit */
     number: string[];
   };
 }


### PR DESCRIPTION
JSDoc-only typo fix in `plugins/jira/src/index.ts:28` on the `jira.number` field doc. No behavior change.