### PR TITLE
Initialize plist plugin with core functionality, README, and tests

### DIFF
--- a/plugins/plist/README.md
+++ b/plugins/plist/README.md
@@ -1,0 +1,130 @@
+# Plist Plugin
+
+Use `auto` to version Apple platform projects by keeping a version key inside an `Info.plist` file in sync with the git tag.
+
+Works with iOS apps, macOS apps, frameworks, app extensions, and Swift package libraries that expose a runtime version through a plist.
+
+## Installation
+
+This plugin is included with the `auto` CLI so you do not have to install it separately. To install if you are using the `auto` API directly:
+
+```bash
+npm i --save-dev @auto-it/plist
+# or
+yarn add -D @auto-it/plist
+```
+
+> ⚠️ **You can only use one "package manager" plugin at a time.**  
+> Do not combine this plugin with `git-tag`, `cocoapods`, `npm`, or any other versioning plugin.
+
+## Usage
+
+### Minimal configuration
+
+```json
+{
+  "plugins": [
+    ["plist", { "plistPath": "Sources/MyLibrary/Info.plist" }]
+  ]
+}
+```
+
+### All options
+
+```json
+{
+  "plugins": [
+    [
+      "plist",
+      {
+        "plistPath": "Sources/MyLibrary/Info.plist",
+        "versionKey": "CFBundleShortVersionString",
+        "buildNumberKey": "CFBundleVersion",
+        "publishScript": "./scripts/publish.sh"
+      }
+    ]
+  ]
+}
+```
+
+Multiple plists (e.g. an app target and an embedded framework) are also supported:
+
+```json
+{
+  "plugins": [
+    [
+      "plist",
+      {
+        "plistPath": ["Sources/MyLibrary/Info.plist", "Sources/MyFramework/Info.plist"]
+      }
+    ]
+  ]
+}
+```
+
+## Options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `plistPath` | `string \| string[]` | **required** | Relative path(s) to the Info.plist file(s) to manage |
+| `versionKey` | `string` | `"CFBundleShortVersionString"` | The plist key whose value holds the version string |
+| `buildNumberKey` | `string` | — | An optional second key to update with the same version (e.g. `"CFBundleVersion"`) |
+| `publishScript` | `string` | — | Path to a script to invoke during `publish`, `canary`, and `next` hooks |
+
+## How it works
+
+On every release `auto` will:
+
+1. Read the current version from the plist key
+2. Calculate the next semver version based on PR labels
+3. Write the new version back into the plist file (preserving all other content)
+4. Commit the change with `[skip ci]` in the message
+5. Create an annotated git tag at that commit
+6. Push the commit and tag to your remote
+
+Canary and next (pre-release) versions are written to the plist temporarily during publishing and then reset — they are never committed.
+
+## Example Info.plist
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0.0</string>
+    <key>CFBundleVersion</key>
+    <string>1.0.0</string>
+</dict>
+</plist>
+```
+
+## Using a custom version key
+
+If your plist uses a non-standard key (common in Swift package libraries that don't need `CFBundleShortVersionString`):
+
+```json
+{
+  "plugins": [
+    ["plist", { "plistPath": "Sources/MyLibrary/Info.plist", "versionKey": "LibraryVersion" }]
+  ]
+}
+```
+
+## Using a publish script
+
+The optional `publishScript` is called with a single argument indicating the release type:
+
+| Hook | Argument |
+|---|---|
+| `publish` | `release` |
+| `canary` | `canary` |
+| `next` | `next` |
+
+```bash
+#!/bin/bash
+# scripts/publish.sh
+RELEASE_TYPE=$1  # "release", "canary", or "next"
+echo "Publishing $RELEASE_TYPE"
+# ... your custom publish steps ...
+```

--- a/plugins/plist/__tests__/plist.test.ts
+++ b/plugins/plist/__tests__/plist.test.ts
@@ -1,0 +1,602 @@
+import * as Auto from "@auto-it/core";
+import { dummyLog } from "@auto-it/core/dist/utils/logger";
+import { makeHooks } from "@auto-it/core/dist/utils/make-hooks";
+import * as utilities from "../src/utilities";
+import PlistPlugin, {
+  IPlistPluginOptions,
+  getVersion,
+  updatePlistVersion,
+} from "../src";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const plistWithVersion = (version: string, buildNumber?: string) => `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleShortVersionString</key>
+	<string>${version}</string>
+	<key>CFBundleVersion</key>
+	<string>${buildNumber ?? version}</string>
+</dict>
+</plist>`;
+
+const plistWithCustomKey = (version: string) => `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>LibraryVersion</key>
+	<string>${version}</string>
+</dict>
+</plist>`;
+
+const mockPlist = (contents: string) =>
+  jest.spyOn(utilities, "getPlistContents").mockReturnValue(contents);
+
+interface FakePlist {
+  path: string;
+  contents: string;
+}
+const mockPlists = (plists: FakePlist[]) =>
+  jest
+    .spyOn(utilities, "getPlistContents")
+    .mockImplementation(
+      (p) => plists.find((f) => f.path === p)!.contents
+    );
+
+let exec = jest.fn();
+// @ts-ignore
+jest.mock("../../../packages/core/dist/utils/exec-promise", () => (...args) =>
+  exec(...args)
+);
+
+const logger = dummyLog();
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Plist Plugin", () => {
+  let hooks: Auto.IAutoHooks;
+  let multiHooks: Auto.IAutoHooks;
+
+  const prefixRelease = (version: string) => `v${version}`;
+
+  const options: IPlistPluginOptions = {
+    plistPath: "./Info.plist",
+  };
+
+  const multiOptions: IPlistPluginOptions = {
+    plistPath: ["./Info.plist", "./Framework/Info.plist"],
+  };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    exec.mockClear();
+
+    const plugin = new PlistPlugin(options);
+    const multiPlugin = new PlistPlugin(multiOptions);
+    hooks = makeHooks();
+    multiHooks = makeHooks();
+
+    const apply = (p: PlistPlugin, h: Auto.IAutoHooks) => {
+      p.apply({
+        hooks: h,
+        logger,
+        prefixRelease,
+        config: { prereleaseBranches: ["next"] },
+        git: {
+          getLastTagNotInBaseBranch: async () => undefined,
+          getLatestRelease: async () => "0.0.1",
+        },
+        remote: "https://github.com/intuit/auto.git",
+        baseBranch: "main",
+        getCurrentVersion: async () => "0.0.1",
+      } as unknown as Auto.Auto);
+    };
+
+    apply(plugin, hooks);
+    apply(multiPlugin, multiHooks);
+  });
+
+  // -------------------------------------------------------------------------
+  // Utilities
+  // -------------------------------------------------------------------------
+
+  describe("getVersion", () => {
+    test("should return the version for the default key", () => {
+      mockPlist(plistWithVersion("1.2.3"));
+      expect(getVersion("./Info.plist", "CFBundleShortVersionString")).toBe("1.2.3");
+    });
+
+    test("should return a canary version string", () => {
+      mockPlist(plistWithVersion("1.2.3-canary.1.0.0"));
+      expect(
+        getVersion("./Info.plist", "CFBundleShortVersionString")
+      ).toBe("1.2.3-canary.1.0.0");
+    });
+
+    test("should return the version for a custom key", () => {
+      mockPlist(plistWithCustomKey("2.0.0"));
+      expect(getVersion("./Info.plist", "LibraryVersion")).toBe("2.0.0");
+    });
+
+    test("should throw when the key is not found", () => {
+      mockPlist(plistWithVersion("1.0.0"));
+      expect(() =>
+        getVersion("./Info.plist", "NonExistentKey")
+      ).toThrow('Version key "NonExistentKey" not found in plist: ./Info.plist');
+    });
+  });
+
+  describe("updatePlistVersion", () => {
+    test("should write the bumped version to the plist", () => {
+      mockPlist(plistWithVersion("1.0.0"));
+      const writeMock = jest.spyOn(utilities, "writePlistContents");
+
+      updatePlistVersion("./Info.plist", "1.0.1", "CFBundleShortVersionString");
+
+      expect(writeMock).toHaveBeenLastCalledWith(
+        expect.any(String),
+        plistWithVersion("1.0.1", "1.0.0")
+      );
+    });
+
+    test("should update both versionKey and buildNumberKey when provided", () => {
+      mockPlist(plistWithVersion("1.0.0"));
+      const writeMock = jest.spyOn(utilities, "writePlistContents");
+
+      updatePlistVersion(
+        "./Info.plist",
+        "1.0.1",
+        "CFBundleShortVersionString",
+        "CFBundleVersion"
+      );
+
+      expect(writeMock).toHaveBeenLastCalledWith(
+        expect.any(String),
+        plistWithVersion("1.0.1", "1.0.1")
+      );
+    });
+
+    test("should throw when the version key is missing from the file", () => {
+      mockPlist(plistWithCustomKey("1.0.0"));
+
+      expect(() =>
+        updatePlistVersion("./Info.plist", "1.0.1", "CFBundleShortVersionString")
+      ).toThrow('Could not update key "CFBundleShortVersionString" in plist: ./Info.plist');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // validateConfig hook
+  // -------------------------------------------------------------------------
+
+  describe("validateConfig hook", () => {
+    test("should fail validation when plistPath is missing", async () => {
+      const errors = (await hooks.validateConfig.promise("plist", {})) ?? [];
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    test("should pass validation with a single plistPath", async () => {
+      const errors =
+        (await hooks.validateConfig.promise("plist", options)) ?? [];
+      expect(errors).toHaveLength(0);
+    });
+
+    test("should pass validation with an array of plistPaths", async () => {
+      const errors =
+        (await hooks.validateConfig.promise("plist", multiOptions)) ?? [];
+      expect(errors).toHaveLength(0);
+    });
+
+    test("should pass validation with all optional fields", async () => {
+      const errors =
+        (await hooks.validateConfig.promise("plist", {
+          plistPath: "./Info.plist",
+          versionKey: "LibraryVersion",
+          buildNumberKey: "CFBundleVersion",
+          publishScript: "./scripts/publish.sh",
+        })) ?? [];
+      expect(errors).toHaveLength(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // modifyConfig hook
+  // -------------------------------------------------------------------------
+
+  describe("modifyConfig hook", () => {
+    test("should set noVersionPrefix to true", async () => {
+      const config = await hooks.modifyConfig.promise({} as any);
+      expect(config).toStrictEqual({ noVersionPrefix: true });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getPreviousVersion hook
+  // -------------------------------------------------------------------------
+
+  describe("getPreviousVersion hook", () => {
+    test("should return the version from the plist prefixed with v", async () => {
+      mockPlist(plistWithVersion("1.2.3"));
+      expect(await hooks.getPreviousVersion.promise()).toBe("v1.2.3");
+    });
+
+    test("should throw when the version key is missing", async () => {
+      mockPlist("<plist><dict></dict></plist>");
+      await expect(hooks.getPreviousVersion.promise()).rejects.toThrow();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // version hook
+  // -------------------------------------------------------------------------
+
+  describe("version hook", () => {
+    test("should log and skip git commands on dryRun", async () => {
+      mockPlist(plistWithVersion("0.0.1"));
+      const mockLog = jest.spyOn(logger.log, "info");
+
+      await hooks.version.promise({ bump: Auto.SEMVER.patch, dryRun: true });
+
+      expect(exec).toHaveBeenCalledTimes(0);
+      expect(mockLog).toHaveBeenCalledTimes(1);
+    });
+
+    test("should print to stdout on quiet dryRun", async () => {
+      mockPlist(plistWithVersion("0.0.1"));
+      const mockLog = jest.spyOn(logger.log, "info");
+      const mockConsole = jest.spyOn(console, "log");
+
+      await hooks.version.promise({
+        bump: Auto.SEMVER.patch,
+        dryRun: true,
+        quiet: true,
+      });
+
+      expect(exec).toHaveBeenCalledTimes(0);
+      expect(mockLog).toHaveBeenCalledTimes(0);
+      expect(mockConsole).toHaveBeenCalledTimes(1);
+    });
+
+    test("should bump patch version", async () => {
+      mockPlist(plistWithVersion("0.0.1"));
+      const writeMock = jest.spyOn(utilities, "writePlistContents");
+
+      await hooks.version.promise({ bump: Auto.SEMVER.patch });
+
+      expect(writeMock).toHaveBeenLastCalledWith(
+        expect.any(String),
+        plistWithVersion("0.0.2", "0.0.1")
+      );
+    });
+
+    test("should bump minor version", async () => {
+      mockPlist(plistWithVersion("0.0.1"));
+      const writeMock = jest.spyOn(utilities, "writePlistContents");
+
+      await hooks.version.promise({ bump: Auto.SEMVER.minor });
+
+      expect(writeMock).toHaveBeenLastCalledWith(
+        expect.any(String),
+        plistWithVersion("0.1.0", "0.0.1")
+      );
+    });
+
+    test("should bump major version", async () => {
+      mockPlist(plistWithVersion("0.0.1"));
+      const writeMock = jest.spyOn(utilities, "writePlistContents");
+
+      await hooks.version.promise({ bump: Auto.SEMVER.major });
+
+      expect(writeMock).toHaveBeenLastCalledWith(
+        expect.any(String),
+        plistWithVersion("1.0.0", "0.0.1")
+      );
+    });
+
+    test("should also update buildNumberKey when configured", async () => {
+      const plugin = new PlistPlugin({
+        plistPath: "./Info.plist",
+        buildNumberKey: "CFBundleVersion",
+      });
+      const h = makeHooks();
+      plugin.apply({
+        hooks: h,
+        logger,
+        prefixRelease,
+        config: { prereleaseBranches: ["next"] },
+        git: {
+          getLastTagNotInBaseBranch: async () => undefined,
+          getLatestRelease: async () => "0.0.1",
+        },
+        remote: "https://github.com/intuit/auto.git",
+        baseBranch: "main",
+        getCurrentVersion: async () => "0.0.1",
+      } as unknown as Auto.Auto);
+
+      mockPlist(plistWithVersion("0.0.1"));
+      const writeMock = jest.spyOn(utilities, "writePlistContents");
+
+      await h.version.promise({ bump: Auto.SEMVER.patch });
+
+      expect(writeMock).toHaveBeenLastCalledWith(
+        expect.any(String),
+        plistWithVersion("0.0.2", "0.0.2")
+      );
+    });
+
+    test("should update all plists when multiple paths are configured", async () => {
+      mockPlists([
+        { path: "./Info.plist", contents: plistWithVersion("0.0.1") },
+        { path: "./Framework/Info.plist", contents: plistWithVersion("0.0.1") },
+      ]);
+      const writeMock = jest.spyOn(utilities, "writePlistContents");
+
+      await multiHooks.version.promise({ bump: Auto.SEMVER.patch });
+
+      expect(writeMock).toHaveBeenCalledTimes(2);
+      expect(writeMock).toHaveBeenNthCalledWith(
+        1,
+        "./Info.plist",
+        plistWithVersion("0.0.2", "0.0.1")
+      );
+      expect(writeMock).toHaveBeenNthCalledWith(
+        2,
+        "./Framework/Info.plist",
+        plistWithVersion("0.0.2", "0.0.1")
+      );
+    });
+
+    test("should create a commit and a tag", async () => {
+      mockPlist(plistWithVersion("0.0.1"));
+      jest.spyOn(utilities, "writePlistContents").mockImplementation(() => {});
+
+      await hooks.version.promise({ bump: Auto.SEMVER.patch });
+
+      expect(exec).toHaveBeenCalledWith("git", [
+        "commit",
+        "-am",
+        '"update version: 0.0.2 [skip ci]"',
+        "--no-verify",
+      ]);
+      expect(exec).toHaveBeenCalledWith("git", [
+        "tag",
+        "0.0.2",
+        "-m",
+        '"Update version to 0.0.2"',
+      ]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // canary hook
+  // -------------------------------------------------------------------------
+
+  describe("canary hook", () => {
+    test("should log and skip on dryRun", async () => {
+      mockPlist(plistWithVersion("0.0.1"));
+      const mockLog = jest.spyOn(logger.log, "info");
+
+      await hooks.canary.promise({
+        bump: Auto.SEMVER.patch,
+        canaryIdentifier: "canary.1.0",
+        dryRun: true,
+      });
+
+      expect(exec).toHaveBeenCalledTimes(0);
+      expect(mockLog).toHaveBeenCalledTimes(1);
+    });
+
+    test("should print to stdout on quiet dryRun", async () => {
+      mockPlist(plistWithVersion("0.0.1"));
+      const mockConsole = jest.spyOn(console, "log");
+      const mockLog = jest.spyOn(logger.log, "info");
+
+      await hooks.canary.promise({
+        bump: Auto.SEMVER.patch,
+        canaryIdentifier: "canary.1.0",
+        dryRun: true,
+        quiet: true,
+      });
+
+      expect(exec).toHaveBeenCalledTimes(0);
+      expect(mockLog).toHaveBeenCalledTimes(0);
+      expect(mockConsole).toHaveBeenCalledTimes(1);
+    });
+
+    test("should write canary version and reset the file", async () => {
+      let contents = plistWithVersion("0.0.1");
+      jest
+        .spyOn(utilities, "getPlistContents")
+        .mockImplementation(() => contents);
+      const writeMock = jest
+        .spyOn(utilities, "writePlistContents")
+        .mockImplementation((_, c) => {
+          contents = c;
+        });
+
+      const result = await hooks.canary.promise({
+        bump: Auto.SEMVER.minor,
+        canaryIdentifier: "canary.1.2.3",
+      });
+
+      expect(result).toBe("0.1.0-canary.1.2.3");
+      expect(writeMock).toHaveBeenLastCalledWith(
+        expect.any(String),
+        plistWithVersion("0.1.0-canary.1.2.3", "0.0.1")
+      );
+      expect(exec).toHaveBeenCalledWith("git", ["checkout", "./Info.plist"]);
+    });
+
+    test("should reset all plists when multiple paths are configured", async () => {
+      const plists: Record<string, string> = {
+        "./Info.plist": plistWithVersion("0.0.1"),
+        "./Framework/Info.plist": plistWithVersion("0.0.1"),
+      };
+      jest
+        .spyOn(utilities, "getPlistContents")
+        .mockImplementation((p) => plists[p]);
+      jest
+        .spyOn(utilities, "writePlistContents")
+        .mockImplementation((p, c) => {
+          plists[p] = c;
+        });
+
+      await multiHooks.canary.promise({
+        bump: Auto.SEMVER.minor,
+        canaryIdentifier: "canary.1.2.3",
+      });
+
+      expect(exec).toHaveBeenCalledWith("git", ["checkout", "./Info.plist"]);
+      expect(exec).toHaveBeenCalledWith("git", [
+        "checkout",
+        "./Framework/Info.plist",
+      ]);
+    });
+
+    test("should call publishScript when configured", async () => {
+      const plugin = new PlistPlugin({
+        plistPath: "./Info.plist",
+        publishScript: "./scripts/publish.sh",
+      });
+      const h = makeHooks();
+      plugin.apply({
+        hooks: h,
+        logger,
+        prefixRelease,
+        config: { prereleaseBranches: ["next"] },
+        git: {
+          getLastTagNotInBaseBranch: async () => undefined,
+          getLatestRelease: async () => "0.0.1",
+        },
+        remote: "https://github.com/intuit/auto.git",
+        baseBranch: "main",
+        getCurrentVersion: async () => "0.0.1",
+      } as unknown as Auto.Auto);
+
+      mockPlist(plistWithVersion("0.0.1"));
+      jest.spyOn(utilities, "writePlistContents").mockImplementation(() => {});
+
+      await h.canary.promise({
+        bump: Auto.SEMVER.patch,
+        canaryIdentifier: "canary.1.0",
+      });
+
+      expect(exec).toHaveBeenCalledWith("./scripts/publish.sh", ["canary"]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // next hook
+  // -------------------------------------------------------------------------
+
+  describe("next hook", () => {
+    test("should return pre-release versions on dryRun", async () => {
+      mockPlist(plistWithVersion("0.0.1"));
+
+      const versions = await hooks.next.promise(["0.0.1"], {
+        bump: Auto.SEMVER.minor,
+        dryRun: true,
+        commits: [],
+        fullReleaseNotes: "",
+        releaseNotes: "",
+      });
+
+      expect(versions).toContain("0.1.0-next.0");
+      expect(exec).toHaveBeenCalledTimes(0);
+    });
+
+    test("should tag and push next version then reset plist", async () => {
+      jest.spyOn(Auto, "getCurrentBranch").mockReturnValue("next");
+      let contents = plistWithVersion("0.0.1");
+      jest
+        .spyOn(utilities, "getPlistContents")
+        .mockImplementation(() => contents);
+      const writeMock = jest
+        .spyOn(utilities, "writePlistContents")
+        .mockImplementation((_, c) => {
+          contents = c;
+        });
+
+      const versions = await hooks.next.promise([], {
+        bump: Auto.SEMVER.major,
+        dryRun: false,
+        commits: [],
+        fullReleaseNotes: "",
+        releaseNotes: "",
+      });
+
+      expect(versions).toContain("1.0.0-next.0");
+      expect(writeMock).toHaveBeenLastCalledWith(
+        expect.any(String),
+        plistWithVersion("1.0.0-next.0", "0.0.1")
+      );
+      expect(exec).toHaveBeenCalledWith("git", ["checkout", "./Info.plist"]);
+      expect(exec).toHaveBeenCalledWith("git", [
+        "tag",
+        "1.0.0-next.0",
+        "-m",
+        '"Tag pre-release: 1.0.0-next.0"',
+      ]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // publish hook
+  // -------------------------------------------------------------------------
+
+  describe("publish hook", () => {
+    test("should push tags to remote", async () => {
+      jest.spyOn(Auto, "getCurrentBranch").mockReturnValue("main");
+
+      await hooks.publish.promise();
+
+      expect(exec).toHaveBeenCalledWith("git", [
+        "push",
+        "--atomic",
+        "--follow-tags",
+        "--set-upstream",
+        "https://github.com/intuit/auto.git",
+        "main",
+      ]);
+    });
+
+    test("should call publishScript before pushing when configured", async () => {
+      jest.spyOn(Auto, "getCurrentBranch").mockReturnValue("main");
+
+      const plugin = new PlistPlugin({
+        plistPath: "./Info.plist",
+        publishScript: "./scripts/publish.sh",
+      });
+      const h = makeHooks();
+      plugin.apply({
+        hooks: h,
+        logger,
+        prefixRelease,
+        config: { prereleaseBranches: ["next"] },
+        git: {
+          getLastTagNotInBaseBranch: async () => undefined,
+          getLatestRelease: async () => "0.0.1",
+        },
+        remote: "https://github.com/intuit/auto.git",
+        baseBranch: "main",
+        getCurrentVersion: async () => "0.0.1",
+      } as unknown as Auto.Auto);
+
+      await h.publish.promise();
+
+      expect(exec).toHaveBeenCalledWith("./scripts/publish.sh", ["release"]);
+      expect(exec).toHaveBeenCalledWith("git", [
+        "push",
+        "--atomic",
+        "--follow-tags",
+        "--set-upstream",
+        "https://github.com/intuit/auto.git",
+        "main",
+      ]);
+    });
+  });
+});

--- a/plugins/plist/package.json
+++ b/plugins/plist/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@auto-it/plist",
+  "version": "11.3.6",
+  "main": "dist/index.js",
+  "description": "Use auto to version Apple platform projects via an Info.plist file",
+  "license": "MIT",
+  "author": {
+    "name": "Cassandra Zuria",
+    "email": "czuria1@gmail.com"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/intuit/auto"
+  },
+  "files": [
+    "dist"
+  ],
+  "keywords": [
+    "automation",
+    "semantic",
+    "release",
+    "github",
+    "labels",
+    "automated",
+    "continuous integration",
+    "changelog",
+    "plist",
+    "apple",
+    "ios",
+    "macos",
+    "swift"
+  ],
+  "scripts": {
+    "build": "tsc -b",
+    "start": "npm run build -- -w",
+    "lint": "eslint src --ext .ts",
+    "test": "jest --maxWorkers=2 --config ../../package.json"
+  },
+  "dependencies": {
+    "@auto-it/core": "link:../../packages/core",
+    "fp-ts": "^2.5.3",
+    "io-ts": "^2.1.2",
+    "semver": "^7.1.3",
+    "tslib": "2.1.0"
+  }
+}

--- a/plugins/plist/src/index.ts
+++ b/plugins/plist/src/index.ts
@@ -1,0 +1,332 @@
+import {
+  Auto,
+  IPlugin,
+  execPromise,
+  validatePluginConfiguration,
+  getCurrentBranch,
+  determineNextVersion,
+  DEFAULT_PRERELEASE_BRANCHES,
+} from "@auto-it/core";
+import { inc, ReleaseType } from "semver";
+import * as t from "io-ts";
+
+import {
+  plistValueRegex,
+  getPlistContents,
+  writePlistContents,
+} from "./utilities";
+
+/**
+ * Read the value of a version key from a plist file
+ *
+ * @param plistPath - Path to the plist file, relative to cwd
+ * @param versionKey - The plist key whose value holds the version string
+ */
+export function getVersion(plistPath: string, versionKey: string): string {
+  const contents = getPlistContents(plistPath);
+  const match = plistValueRegex(versionKey).exec(contents);
+
+  if (!match?.[2]) {
+    throw new Error(
+      `Version key "${versionKey}" not found in plist: ${plistPath}`
+    );
+  }
+
+  return match[2];
+}
+
+/**
+ * Write a new version into the plist file, preserving all other content.
+ * Optionally updates a second key (e.g. CFBundleVersion) with the same value.
+ *
+ * @param plistPath - Path to the plist file, relative to cwd
+ * @param version - The new version string to write
+ * @param versionKey - The plist key to update
+ * @param buildNumberKey - Optional secondary key to update (e.g. CFBundleVersion)
+ */
+export function updatePlistVersion(
+  plistPath: string,
+  version: string,
+  versionKey: string,
+  buildNumberKey?: string
+) {
+  let contents = getPlistContents(plistPath);
+
+  const updated = contents.replace(plistValueRegex(versionKey), `$1${version}$3`);
+
+  if (updated === contents) {
+    throw new Error(
+      `Could not update key "${versionKey}" in plist: ${plistPath}`
+    );
+  }
+
+  contents = updated;
+
+  if (buildNumberKey) {
+    contents = contents.replace(
+      plistValueRegex(buildNumberKey),
+      `$1${version}$3`
+    );
+  }
+
+  writePlistContents(plistPath, contents);
+}
+
+const pluginOptions = t.intersection([
+  t.interface({
+    /** Relative path to the Info.plist file, or an array of paths */
+    plistPath: t.union([t.string, t.array(t.string)]),
+  }),
+  t.partial({
+    /**
+     * The plist key that stores the human-readable version string.
+     * Defaults to "CFBundleShortVersionString".
+     */
+    versionKey: t.string,
+
+    /**
+     * An optional second plist key to keep in sync (e.g. "CFBundleVersion").
+     * When provided this key is updated with the same value as versionKey.
+     */
+    buildNumberKey: t.string,
+
+    /**
+     * Optional path to a script that runs your publish pipeline.
+     * Called during the publish, canary, and next hooks.
+     */
+    publishScript: t.string,
+  }),
+]);
+
+export type IPlistPluginOptions = t.TypeOf<typeof pluginOptions>;
+
+const DEFAULT_VERSION_KEY = "CFBundleShortVersionString";
+
+/** Use auto to version Apple platform projects via an Info.plist file */
+export default class PlistPlugin implements IPlugin {
+  /** The name of the plugin */
+  name = "plist";
+
+  /** Resolved plugin options */
+  readonly options: IPlistPluginOptions;
+
+  /** Normalised list of plist paths to update */
+  private get paths(): string[] {
+    return typeof this.options.plistPath === "string"
+      ? [this.options.plistPath]
+      : this.options.plistPath;
+  }
+
+  /** The plist key used for the version string */
+  private get versionKey(): string {
+    return this.options.versionKey ?? DEFAULT_VERSION_KEY;
+  }
+
+  constructor(options: IPlistPluginOptions) {
+    this.options = options;
+  }
+
+  /** Tap into auto plugin points */
+  apply(auto: Auto) {
+    const prereleaseBranches =
+      auto.config?.prereleaseBranches ?? DEFAULT_PRERELEASE_BRANCHES;
+
+    const branch = getCurrentBranch();
+    const prereleaseBranch =
+      branch && prereleaseBranches.includes(branch)
+        ? branch
+        : prereleaseBranches[0];
+
+    auto.hooks.validateConfig.tapPromise(this.name, async (name, options) => {
+      if (name === this.name || name === `@auto-it/${this.name}`) {
+        return validatePluginConfiguration(this.name, pluginOptions, options);
+      }
+    });
+
+    // Plist versions don't carry a "v" prefix
+    auto.hooks.modifyConfig.tap(this.name, (config) => ({
+      ...config,
+      noVersionPrefix: true,
+    }));
+
+    auto.hooks.getPreviousVersion.tapPromise(this.name, async () => {
+      return auto.prefixRelease(getVersion(this.paths[0], this.versionKey));
+    });
+
+    auto.hooks.version.tapPromise(
+      this.name,
+      async ({ bump, dryRun, quiet }) => {
+        const previousVersion = getVersion(this.paths[0], this.versionKey);
+        const releaseVersion = inc(previousVersion, bump as ReleaseType);
+
+        if (dryRun && releaseVersion) {
+          if (quiet) {
+            console.log(releaseVersion);
+          } else {
+            auto.logger.log.info(`Would have published: ${releaseVersion}`);
+          }
+
+          return;
+        }
+
+        if (!releaseVersion) {
+          throw new Error(
+            `Could not increment previous version: ${previousVersion}`
+          );
+        }
+
+        this.paths.forEach((p) => {
+          updatePlistVersion(
+            p,
+            releaseVersion,
+            this.versionKey,
+            this.options.buildNumberKey
+          );
+        });
+
+        await execPromise("git", [
+          "commit",
+          "-am",
+          `"update version: ${releaseVersion} [skip ci]"`,
+          "--no-verify",
+        ]);
+
+        await execPromise("git", [
+          "tag",
+          releaseVersion,
+          "-m",
+          `"Update version to ${releaseVersion}"`,
+        ]);
+      }
+    );
+
+    auto.hooks.canary.tapPromise(
+      this.name,
+      async ({ bump, canaryIdentifier, dryRun, quiet }) => {
+        if (!auto.git) {
+          return;
+        }
+
+        const lastRelease = await auto.git.getLatestRelease();
+        const current = await auto.getCurrentVersion(lastRelease);
+        const nextVersion = inc(current, bump as ReleaseType);
+        const canaryVersion = `${nextVersion}-${canaryIdentifier}`;
+
+        if (dryRun) {
+          if (quiet) {
+            console.log(canaryVersion);
+          } else {
+            auto.logger.log.info(`Would have published: ${canaryVersion}`);
+          }
+
+          return;
+        }
+
+        this.paths.forEach((p) => {
+          updatePlistVersion(
+            p,
+            canaryVersion,
+            this.versionKey,
+            this.options.buildNumberKey
+          );
+        });
+
+        if (this.options.publishScript) {
+          auto.logger.log.info(
+            `Calling publish script: ${this.options.publishScript}`
+          );
+          await execPromise(this.options.publishScript, ["canary"]);
+        }
+
+        // Reset temporary canary version — it should never be committed
+        await Promise.all(
+          this.paths.map((p) => execPromise("git", ["checkout", p]))
+        );
+
+        return canaryVersion;
+      }
+    );
+
+    auto.hooks.next.tapPromise(
+      this.name,
+      async (preReleaseVersions, { bump, dryRun }) => {
+        if (!auto.git) {
+          return preReleaseVersions;
+        }
+
+        const lastRelease = await auto.git.getLatestRelease();
+        const current =
+          (await auto.git.getLastTagNotInBaseBranch(prereleaseBranch)) ||
+          (await auto.getCurrentVersion(lastRelease));
+
+        const prerelease = determineNextVersion(
+          lastRelease,
+          current,
+          bump,
+          prereleaseBranch
+        );
+
+        preReleaseVersions.push(prerelease);
+
+        if (dryRun) {
+          return preReleaseVersions;
+        }
+
+        this.paths.forEach((p) => {
+          updatePlistVersion(
+            p,
+            prerelease,
+            this.versionKey,
+            this.options.buildNumberKey
+          );
+        });
+
+        if (this.options.publishScript) {
+          auto.logger.log.info(
+            `Calling publish script: ${this.options.publishScript}`
+          );
+          await execPromise(this.options.publishScript, ["next"]);
+        }
+
+        await execPromise("git", [
+          "tag",
+          prerelease,
+          "-m",
+          `"Tag pre-release: ${prerelease}"`,
+        ]);
+
+        await execPromise("git", [
+          "push",
+          auto.remote,
+          branch || auto.baseBranch,
+          "--tags",
+        ]);
+
+        // Reset — pre-release plist changes are not committed
+        await Promise.all(
+          this.paths.map((p) => execPromise("git", ["checkout", p]))
+        );
+
+        return preReleaseVersions;
+      }
+    );
+
+    auto.hooks.publish.tapPromise(this.name, async () => {
+      if (this.options.publishScript) {
+        auto.logger.log.info(
+          `Calling publish script: ${this.options.publishScript}`
+        );
+        await execPromise(this.options.publishScript, ["release"]);
+      }
+
+      await execPromise("git", [
+        "push",
+        "--atomic",
+        "--follow-tags",
+        "--set-upstream",
+        auto.remote,
+        getCurrentBranch() || auto.baseBranch,
+      ]);
+    });
+  }
+}

--- a/plugins/plist/src/utilities.ts
+++ b/plugins/plist/src/utilities.ts
@@ -1,0 +1,42 @@
+import path from "path";
+import fs from "fs";
+
+/** Escape special regex characters so key names are matched literally */
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Builds a regex that matches a plist key/string value pair, e.g.:
+ *   <key>CFBundleShortVersionString</key>
+ *   <string>1.0.0</string>
+ *
+ * Capture groups:
+ *   1 – everything up to and including the opening <string> tag
+ *   2 – the current version value
+ *   3 – the closing </string> tag
+ */
+export function plistValueRegex(key: string): RegExp {
+  return new RegExp(
+    `(<key>${escapeRegex(key)}<\\/key>\\s*<string>)([^<]+)(<\\/string>)`
+  );
+}
+
+/**
+ * Read the raw contents of a plist file
+ *
+ * @param plistPath - Path to the plist file, relative to cwd
+ */
+export function getPlistContents(plistPath: string): string {
+  return fs.readFileSync(path.join(process.cwd(), plistPath)).toString();
+}
+
+/**
+ * Write raw contents back to a plist file
+ *
+ * @param plistPath - Path to the plist file, relative to cwd
+ * @param contents - New file contents
+ */
+export function writePlistContents(plistPath: string, contents: string) {
+  fs.writeFileSync(path.join(process.cwd(), plistPath), contents);
+}

--- a/plugins/plist/tsconfig.json
+++ b/plugins/plist/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*", "../../typings/**/*"],
+
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+
+  "references": [
+    {
+      "path": "../../packages/core"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
This PR introduces a new `@auto-it/plist` plugin that manages versioning for Apple platform projects by reading and writing version strings directly inside `.plist` files.
## Motivation
You could technically accomplish the same outcome with the existing `version-file` plugin — it already knows how to read and write arbitrary version strings out of arbitrary files. This plugin exists because **`Info.plist` is the canonical version file for iOS, macOS, watchOS, and tvOS projects**, and treating it as a first-class citizen deserves dedicated tooling.
The goals here are analogous to what the `cocoapods` plugin does for CocoaPods-based libraries: keep the on-disk version artifact in sync with the git tag so that platform tooling always sees the right version. The key difference is the target workflow:
- **CocoaPods** generates an `Info.plist` for you as part of its build process, so teams using CocoaPods often rely on the `cocoapods` plugin to keep the `.podspec` version (and therefore the derived plist) in sync.
- **Swift Package Manager** has no equivalent code-generation step — there is no `.podspec`, and SPM does not produce an `Info.plist` for you. Teams that want to expose a runtime version string from their library (e.g. for logging, telemetry, or SDK version headers) need to maintain that plist themselves. This plugin automates keeping it in sync with the git tag, giving SPM libraries the same versioning automation that CocoaPods projects get from the `cocoapods` plugin.

In short: if you ship a Swift package and want `MySDK.version` in your code to always reflect the current release without manual edits, this is the plugin for that.
## What this plugin does
- Reads the current version from a configurable plist key (default: `CFBundleShortVersionString`)
- Calculates the next semver bump from PR labels
- Writes the new version back into the plist, preserving all other XML content
- Optionally syncs a second key (e.g. `CFBundleVersion`) with the same value
- Supports multiple plist paths (e.g. an app target + an embedded framework)
- Accepts an optional `publishScript` hook for custom distribution steps (xcframework upload, DocC hosting, etc.)
- Canary and next (pre-release) version writes are ephemeral — they are reset and never committed
## Relationship to other plugins
| Plugin | Version source | Primary use case |
|---|---|---|
| `version-file` | Any plain-text file | Generic / language-agnostic |
| `cocoapods` | `.podspec` | iOS/macOS libraries distributed via CocoaPods |
| **`plist`** (this PR) | `Info.plist` | iOS/macOS apps & SPM libraries that manage their own plist |

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`
