### PR TITLE
fix(core): guard against empty release in graduation check

### DIFF
--- a/packages/core/src/__tests__/auto.test.ts
+++ b/packages/core/src/__tests__/auto.test.ts
@@ -1559,6 +1559,36 @@ describe("Auto", () => {
       expect(afterShipIt).toHaveBeenCalled();
     });
 
+    test("should not graduate with an empty release when onlyGraduateWithReleaseLabel is set", async () => {
+      const auto = new Auto({ ...defaults, plugins: [] });
+      // @ts-ignore
+      auto.checkClean = () => Promise.resolve(true);
+      auto.logger = dummyLog();
+      await auto.loadConfig();
+      auto.remote = "https://github.com/intuit/auto";
+
+      auto.git!.getLatestRelease = () => Promise.resolve("1.2.3");
+      // No commits in the release => head is empty
+      auto.release!.getCommitsInRelease = () => Promise.resolve([]);
+
+      // Stub the release-type handlers so the graduation check is the only
+      // thing under test (and we don't hit process.exit in the next path).
+      const latest = jest
+        .spyOn(auto, "latest")
+        .mockImplementation(() => Promise.resolve(undefined));
+      jest.spyOn(auto, "next").mockImplementation(() => Promise.resolve(undefined));
+      jest
+        .spyOn(auto, "canary")
+        .mockImplementation(() => Promise.resolve(undefined));
+
+      // Previously threw on `head[0].labels` when the release was empty.
+      // With no release label present, an empty release must not graduate.
+      await expect(
+        auto.shipit({ onlyGraduateWithReleaseLabel: true })
+      ).resolves.toBeUndefined();
+      expect(latest).not.toHaveBeenCalled();
+    });
+
     test("should not create changelog with noChangelog", async () => {
       const auto = new Auto({ ...defaults, plugins: [] });
       // @ts-ignore

--- a/packages/core/src/auto.ts
+++ b/packages/core/src/auto.ts
@@ -1624,6 +1624,7 @@ export default class Auto {
     const shouldGraduate =
       !options.onlyGraduateWithReleaseLabel ||
       (options.onlyGraduateWithReleaseLabel &&
+        head.length > 0 &&
         head[0].labels.some((l) =>
           this.semVerLabels?.get("release")?.includes(l)
         ));


### PR DESCRIPTION
Backport of the graduation-check guard from player-ui/player#885, applied to the TypeScript source (this repo is the source of `@auto-it/core`).

## Problem
`auto shipit --only-graduate-with-release-label` threw `TypeError: Cannot read properties of undefined (reading 'labels')` when the release contained no commits — `head[0]` is `undefined` and `.labels` blows up.

## Fix
Guard the access with `head.length > 0` before reading `head[0].labels`, so an empty release simply does not graduate.

## Test
Added a regression test in `packages/core/src/__tests__/auto.test.ts` ("should not graduate with an empty release when onlyGraduateWithReleaseLabel is set") that mocks an empty `getCommitsInRelease`, asserts `shipit` resolves without throwing, and that `latest()` is not called. Verified it fails without the guard and passes with it.
<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[auto-linux--canary.2531.2745a1a9810aac04cbd5119d35906eee96783e72.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-linux--canary.2531.2745a1a9810aac04cbd5119d35906eee96783e72.gz)  
[auto-macos--canary.2531.2745a1a9810aac04cbd5119d35906eee96783e72.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-macos--canary.2531.2745a1a9810aac04cbd5119d35906eee96783e72.gz)  
[auto-win.exe--canary.2531.2745a1a9810aac04cbd5119d35906eee96783e72.gz](https://github.com/intuit/auto/releases/download/v0.0.0-canary/auto-win.exe--canary.2531.2745a1a9810aac04cbd5119d35906eee96783e72.gz)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->
